### PR TITLE
fix(build): adicionar polyfills de Zone.js nas aplicações

### DIFF
--- a/apps/ingresso/project.json
+++ b/apps/ingresso/project.json
@@ -20,7 +20,8 @@
             "input": "apps/ingresso/public"
           }
         ],
-        "styles": ["apps/ingresso/src/styles.scss"]
+        "styles": ["apps/ingresso/src/styles.scss"],
+        "polyfills": ["zone.js"]
       },
       "configurations": {
         "production": {

--- a/apps/portal/project.json
+++ b/apps/portal/project.json
@@ -20,7 +20,8 @@
             "input": "apps/portal/public"
           }
         ],
-        "styles": ["apps/portal/src/styles.scss"]
+        "styles": ["apps/portal/src/styles.scss"],
+        "polyfills": ["zone.js"]
       },
       "configurations": {
         "production": {

--- a/apps/selecao/project.json
+++ b/apps/selecao/project.json
@@ -20,7 +20,8 @@
             "input": "apps/selecao/public"
           }
         ],
-        "styles": ["apps/selecao/src/styles.scss"]
+        "styles": ["apps/selecao/src/styles.scss"],
+        "polyfills": ["zone.js"]
       },
       "configurations": {
         "production": {


### PR DESCRIPTION
## Resumo

- Adiciona `"polyfills": ["zone.js"]` nos `project.json` das 3 aplicações (selecao, ingresso, portal)
- Corrige o erro `NG0908: In this configuration Angular requires Zone.js` que impedia todas as aplicações de iniciar

## Contexto

No Angular 21 com `@angular/build:application`, Zone.js precisa ser declarado explicitamente como polyfill. Os `project.json` gerados no scaffold não incluíam essa configuração.

A decisão de manter Zone.js (vs. modo zoneless) foi documentada na ADR-017 (unifesspa-edu-br/uniplus-docs#3).

## Plano de teste

- [x] `nx serve selecao` inicia sem erro NG0908
- [x] `nx serve ingresso` inicia sem erro NG0908
- [x] `nx serve portal` inicia sem erro NG0908

Closes #15