### PR TITLE
docs: atualizar CLAUDE.md e README com estratégia UI (PrimeNG unstyled + Gov.br DS) e rename para Uni+

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,35 +2,71 @@
 
 ## Visao geral
 
-Frontend do Sistema Unificado CEPS (UniPlus) da Unifesspa. Monorepo Nx com 3 aplicacoes Angular e 3 bibliotecas compartilhadas.
+Frontend do Uni+ (S2U) (UniPlus) da Unifesspa. Monorepo Nx com 3 aplicacoes Angular e 3 bibliotecas compartilhadas.
 
-## Stack e versoes
+## Stack e versões
 
 - **Angular** 21.x (standalone components, signals, OnPush)
 - **Nx** 22.x (monorepo, affected, caching)
-- **PrimeNG** 21.x (componentes UI)
-- **Tailwind CSS** 3.x (estilizacao utility-first)
-- **Keycloak** (autenticacao via keycloak-angular)
+- **PrimeNG** 21.x (modo unstyled + PassThrough com tokens Gov.br)
+- **@govbr-ds/core** 3.7.x (design tokens CSS — sem JS)
+- **Tailwind CSS** 4.x (estilização utility-first com @theme)
+- **Keycloak** (autenticação via keycloak-angular)
 - **Playwright** (testes E2E)
-- **Vitest** (testes unitarios via @analogjs/vitest-angular)
+- **Vitest** (testes unitários via @analogjs/vitest-angular)
 - **TypeScript** 5.9.x (strict mode)
 
 ## Estrutura do workspace
 
 ```
 apps/
-  selecao/        → Modulo Selecao (gestao de editais, inscricoes, homologacao, notas, classificacao)
+  selecao/        → Módulo Seleção (gestão de editais, inscrições, homologação, notas, classificação)
   selecao-e2e/    → Testes E2E do selecao
-  ingresso/       → Modulo Ingresso (chamadas, convocacoes, matriculas)
+  ingresso/       → Módulo Ingresso (chamadas, convocações, matrículas)
   ingresso-e2e/   → Testes E2E do ingresso
-  portal/         → Portal publico do candidato (inscricao, acompanhamento, documentos, recursos)
+  portal/         → Portal público do candidato (inscrição, acompanhamento, documentos, recursos)
   portal-e2e/     → Testes E2E do portal
+  poc-primeng/    → POC: PrimeNG unstyled + Gov.br DS + Tailwind (referência de implementação)
+  poc-primeng-e2e/→ Testes E2E da POC (46 testes de tokens + 17 de acessibilidade)
 
 libs/
-  shared-ui/      → Componentes reutilizaveis (cpf-input, data-table, file-upload, status-badge, etc.)
-  shared-auth/    → Autenticacao Keycloak (auth.service, guards, interceptor, providers)
-  shared-data/    → DTOs, API clients, utilitarios (cpf.util, date.util, api-error-handler)
+  shared-ui/      → Componentes reutilizáveis (cpf-input, data-table, file-upload, status-badge, etc.)
+  shared-auth/    → Autenticação Keycloak (auth.service, guards, interceptor, providers)
+  shared-data/    → DTOs, API clients, utilitários (cpf.util, date.util, api-error-handler)
 ```
+
+## Estratégia de UI — PrimeNG unstyled + Gov.br Design System
+
+**Validado via POC (`apps/poc-primeng/`).** Esta é a estratégia obrigatória para todos os componentes do sistema.
+
+### Arquitetura de estilização
+
+```
+@govbr-ds/core (tokens CSS) → Tailwind @theme (46 tokens) → PrimeNG PassThrough (classes por slot)
+```
+
+1. Tokens Gov.br importados de `@govbr-ds/core/dist/core-tokens.min.css` (somente CSS, sem runtime JS)
+2. Tokens mapeados como extensões do Tailwind via `@theme` (ex.: `bg-govbr-primary`, `text-govbr-danger`)
+3. PrimeNG em **modo unstyled** — estilos aplicados via objeto `govbrPassThrough` que define classes Tailwind para cada slot de cada componente
+4. Focus ring customizado: overlay `<span>` com borda dourada tracejada (4px #c2850c), compatível com WCAG 2.1 AA
+
+### Regras de estilização
+
+- **Sempre** usar PrimeNG em modo unstyled com PassThrough
+- **Sempre** usar tokens Gov.br via classes Tailwind (`bg-govbr-*`, `text-govbr-*`, `rounded-govbr-*`)
+- **Nunca** importar temas PrimeNG (Aura, Lara, etc.)
+- **Nunca** usar cores hardcoded — sempre tokens
+- **Nunca** sobrescrever focus ring nativo sem usar o overlay Gov.br
+- A POC (`apps/poc-primeng/`) é a **referência de implementação** — consultar antes de criar novos componentes
+
+### Arquivos de referência da POC
+
+| Arquivo | O que contém |
+|---------|-------------|
+| `apps/poc-primeng/src/styles.css` | Mapeamento completo de 46 tokens Gov.br → Tailwind @theme |
+| `apps/poc-primeng/src/main.ts` | Configuração PrimeNG unstyled + `govbrPassThrough` + focus ring overlay |
+| `apps/poc-primeng/src/app/` | Componentes de exemplo (formulário multi-step com validação) |
+| `apps/poc-primeng-e2e/src/` | Suíte E2E: `govbr-design-tokens.spec.ts` (46 testes) + `keyboard-a11y.spec.ts` (17 testes) |
 
 ## Path aliases
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
-# UniPlus Web — Sistema Unificado CEPS
+# UniPlus Web — Uni+ (S2U)
 
-Frontend do Sistema Unificado CEPS da Unifesspa, construido como monorepo Nx com Angular 21.
+Frontend do Uni+ (S2U) da Unifesspa, construido como monorepo Nx com Angular 21.
 
-## Aplicacoes
+## Aplicações
 
-| App | Descricao | Porta |
+| App | Descrição | Porta |
 |-----|-----------|-------|
-| **selecao** | Gestao de processos seletivos (editais, inscricoes, homologacao, notas, classificacao) | 4200 |
-| **ingresso** | Gestao de ingresso (chamadas, convocacoes, matriculas) | 4201 |
-| **portal** | Portal publico do candidato (inscricao, acompanhamento, documentos, recursos) | 4202 |
+| **selecao** | Gestão de processos seletivos (editais, inscrições, homologação, notas, classificação) | 4200 |
+| **ingresso** | Gestão de ingresso (chamadas, convocações, matrículas) | 4201 |
+| **portal** | Portal público do candidato (inscrição, acompanhamento, documentos, recursos) | 4202 |
+| **poc-primeng** | POC de validação — PrimeNG unstyled + Gov.br Design System + Tailwind | 4203 |
 
 ## Bibliotecas compartilhadas
 
@@ -72,12 +73,51 @@ docker build -f docker/Dockerfile.ingresso -t uniplus-ingresso .
 docker build -f docker/Dockerfile.portal -t uniplus-portal .
 ```
 
+## POC PrimeNG + Gov.br Design System
+
+A aplicação `apps/poc-primeng/` é uma prova de conceito que validou a estratégia de UI do projeto. Conclusões:
+
+**PrimeNG em modo unstyled + Gov.br DS é o caminho recomendado para desenvolvimento.**
+
+### O que foi validado
+
+- **PrimeNG unstyled mode**: componentes PrimeNG (Tabs, InputText, Select, RadioButton, Button, Dialog, ConfirmDialog, Message, DataTable) funcionam sem CSS próprio, recebendo estilos via PassThrough (`govbrPassThrough`)
+- **Gov.br Design System**: tokens do `@govbr-ds/core` (cores, tipografia, espaçamento, bordas, focus ring) integrados como variáveis CSS e expostos via Tailwind `@theme` — 46 tokens mapeados
+- **Acessibilidade**: focus ring dourado tracejado (4px #c2850c) validado em 7+ tipos de elementos interativos, navegação por teclado (Tab, Shift+Tab, Arrow keys, Enter, Escape), conformidade WCAG 2.1 AA
+- **Responsividade**: layout funcional de 375px (mobile) a desktop
+
+### Estratégia de estilização
+
+```
+@govbr-ds/core (tokens CSS) → Tailwind @theme (46 tokens) → PrimeNG PassThrough (classes Tailwind por slot)
+```
+
+1. **Importar tokens Gov.br**: `@govbr-ds/core/dist/core-tokens.min.css` (somente CSS, sem JS)
+2. **Mapear em Tailwind**: variáveis CSS viram classes utilitárias (`bg-govbr-primary`, `text-govbr-danger`, `rounded-govbr-pill`)
+3. **Aplicar no PrimeNG**: `govbrPassThrough` define classes Tailwind para cada slot de cada componente
+4. **Custom focus ring**: overlay `<span>` com borda dourada tracejada, nunca cortado por overflow
+
+### Cobertura de testes E2E (Playwright)
+
+- `govbr-design-tokens.spec.ts` — 46 testes (tipografia, cores, bordas, focus ring, hover, espaçamento, layout)
+- `keyboard-a11y.spec.ts` — 17 testes (navegação Tab/Shift+Tab, teclado em Select/Dialog/Tabs, consistência do focus ring)
+
+### Arquivos-chave da POC
+
+| Arquivo | Propósito |
+|---------|-----------|
+| `apps/poc-primeng/src/styles.css` | Tokens Gov.br → Tailwind @theme mapping |
+| `apps/poc-primeng/src/main.ts` | Configuração PrimeNG unstyled + govbrPassThrough + focus ring overlay |
+| `apps/poc-primeng/src/app/` | Componentes de formulário multi-step demonstrando a integração |
+| `apps/poc-primeng-e2e/` | Suíte E2E completa validando tokens e acessibilidade |
+
 ## Stack
 
 - Angular 21 / TypeScript 5.9
 - Nx 22 (monorepo)
-- PrimeNG 21 (componentes UI)
-- Tailwind CSS 3 (estilizacao)
-- Keycloak (autenticacao)
+- PrimeNG 21 (modo unstyled + PassThrough)
+- @govbr-ds/core 3.7 (design tokens — somente CSS)
+- Tailwind CSS 4.2 (estilização utility-first com @theme)
+- Keycloak (autenticação)
 - Playwright (testes E2E)
-- Vitest (testes unitarios)
+- Vitest (testes unitários)


### PR DESCRIPTION
Closes #59

## Summary

- Rename "Sistema Unificado CEPS" → "Uni+ (S2U)" alinhado com nomenclatura oficial do projeto (workspace CLAUDE.md)
- Documentar estratégia de UI validada pela POC em `apps/poc-primeng/`:
  - `@govbr-ds/core` 3.7.x → Tailwind `@theme` (46 tokens) → PrimeNG PassThrough
  - Focus ring customizado Gov.br (dourado tracejado, WCAG 2.1 AA)
- Incluir `poc-primeng` (e `poc-primeng-e2e`) na listagem de apps
- Refletir upgrade Tailwind 3 → 4
- Correções de acentuação gráfica (versão, gestão, utilitários, inscrição, etc.)

## Test plan

- [ ] Ler CLAUDE.md e validar alinhamento com o workspace CLAUDE.md
- [ ] Verificar que a seção 'Estratégia de UI' é compreensível para um dev novo no time
- [ ] Conferir ausência de typos em acentuação