### PR TITLE
feat(auth): adicionar allowlist de URLs ao tokenInterceptor

### DIFF
--- a/libs/shared-auth/src/lib/index.ts
+++ b/libs/shared-auth/src/lib/index.ts
@@ -16,3 +16,6 @@ export type { AuthConfig } from './models/auth-config.model';
 
 // Providers
 export { provideAuth } from './providers/auth.provider';
+
+// Tokens
+export { AUTH_ALLOWED_URLS } from './tokens/auth.tokens';

--- a/libs/shared-auth/src/lib/interceptors/token.interceptor.spec.ts
+++ b/libs/shared-auth/src/lib/interceptors/token.interceptor.spec.ts
@@ -1,0 +1,132 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClient, HttpHandlerFn, HttpRequest, provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { firstValueFrom, of } from 'rxjs';
+import { tokenInterceptor } from './token.interceptor';
+import { AuthService } from '../services/auth.service';
+import { AUTH_ALLOWED_URLS } from '../tokens/auth.tokens';
+
+describe('tokenInterceptor — allowlist', () => {
+  const apiUrl = 'http://localhost:5000/api/v1';
+  const keycloakUrl = 'http://localhost:8080';
+  const externalUrl = 'https://evil.example.com/leak';
+
+  function setup(allowedUrls: readonly string[], tokenValue: { token: string | undefined } = { token: 'fake-token' }) {
+    const token = tokenValue.token;
+    const authService = {
+      getToken: () => token,
+    } as unknown as AuthService;
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([tokenInterceptor])),
+        provideHttpClientTesting(),
+        { provide: AUTH_ALLOWED_URLS, useValue: allowedUrls },
+        { provide: AuthService, useValue: authService },
+      ],
+    });
+
+    return {
+      http: TestBed.inject(HttpClient),
+      httpMock: TestBed.inject(HttpTestingController),
+    };
+  }
+
+  it('anexa Bearer quando a URL está na allowlist (API)', async () => {
+    const { http, httpMock } = setup([apiUrl, keycloakUrl]);
+
+    const promise = firstValueFrom(http.get(`${apiUrl}/editais`));
+    const req = httpMock.expectOne(`${apiUrl}/editais`);
+
+    expect(req.request.headers.get('Authorization')).toBe('Bearer fake-token');
+    req.flush({});
+    await promise;
+    httpMock.verify();
+  });
+
+  it('anexa Bearer quando a URL está na allowlist (Keycloak)', async () => {
+    const { http, httpMock } = setup([apiUrl, keycloakUrl]);
+
+    const url = `${keycloakUrl}/realms/unifesspa/protocol/openid-connect/userinfo`;
+    const promise = firstValueFrom(http.get(url));
+    const req = httpMock.expectOne(url);
+
+    expect(req.request.headers.get('Authorization')).toBe('Bearer fake-token');
+    req.flush({});
+    await promise;
+    httpMock.verify();
+  });
+
+  it('NÃO anexa Bearer para URL fora da allowlist (domínio externo)', async () => {
+    const { http, httpMock } = setup([apiUrl, keycloakUrl]);
+
+    const promise = firstValueFrom(http.get(externalUrl));
+    const req = httpMock.expectOne(externalUrl);
+
+    expect(req.request.headers.has('Authorization')).toBe(false);
+    req.flush({});
+    await promise;
+    httpMock.verify();
+  });
+
+  it('NÃO anexa Bearer quando allowlist está vazia (default conservador)', async () => {
+    const { http, httpMock } = setup([]);
+
+    const promise = firstValueFrom(http.get(`${apiUrl}/editais`));
+    const req = httpMock.expectOne(`${apiUrl}/editais`);
+
+    expect(req.request.headers.has('Authorization')).toBe(false);
+    req.flush({});
+    await promise;
+    httpMock.verify();
+  });
+
+  it('NÃO anexa Bearer para URL que apenas começa igual mas em outro host', async () => {
+    // Ex.: allowed é http://localhost:5000 e a URL é http://localhost:50000 (prefix trap)
+    const { http, httpMock } = setup(['http://localhost:5000']);
+
+    const trap = 'http://localhost:50000/api/v1/hack';
+    const promise = firstValueFrom(http.get(trap));
+    const req = httpMock.expectOne(trap);
+
+    expect(req.request.headers.has('Authorization')).toBe(false);
+    req.flush({});
+    await promise;
+    httpMock.verify();
+  });
+
+  it('NÃO anexa Bearer quando não há token disponível, mesmo em URL permitida', async () => {
+    const { http, httpMock } = setup([apiUrl], { token: undefined });
+
+    const promise = firstValueFrom(http.get(`${apiUrl}/ping`));
+    const req = httpMock.expectOne(`${apiUrl}/ping`);
+
+    expect(req.request.headers.has('Authorization')).toBe(false);
+    req.flush({});
+    await promise;
+    httpMock.verify();
+  });
+});
+
+// Sanity check: chamada direta à função do interceptor sem HttpClient.
+describe('tokenInterceptor — chamada direta', () => {
+  it('encaminha a requisição inalterada se a URL não está na allowlist', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AUTH_ALLOWED_URLS, useValue: ['http://allowed.example.com'] },
+        {
+          provide: AuthService,
+          useValue: { getToken: () => 'tok' } as unknown as AuthService,
+        },
+      ],
+    });
+
+    const req = new HttpRequest('GET', 'https://other.example.com/x');
+    const next: HttpHandlerFn = (r) => {
+      expect(r.headers.has('Authorization')).toBe(false);
+      return of({} as never);
+    };
+
+    TestBed.runInInjectionContext(() => tokenInterceptor(req, next));
+  });
+});

--- a/libs/shared-auth/src/lib/interceptors/token.interceptor.ts
+++ b/libs/shared-auth/src/lib/interceptors/token.interceptor.ts
@@ -1,19 +1,55 @@
-import { HttpInterceptorFn } from '@angular/common/http';
+import { HttpInterceptorFn, HttpRequest } from '@angular/common/http';
 import { inject } from '@angular/core';
 import { AuthService } from '../services/auth.service';
+import { AUTH_ALLOWED_URLS } from '../tokens/auth.tokens';
 
+/**
+ * Interceptor que anexa `Authorization: Bearer <token>` às requisições
+ * destinadas a URLs da allowlist (`AUTH_ALLOWED_URLS`).
+ *
+ * Requisições para qualquer outro destino seguem sem o header, evitando
+ * vazamento de credenciais para domínios externos.
+ */
 export const tokenInterceptor: HttpInterceptorFn = (req, next) => {
+  const allowedUrls = inject(AUTH_ALLOWED_URLS);
+
+  if (!isUrlAllowed(req, allowedUrls)) {
+    return next(req);
+  }
+
   const authService = inject(AuthService);
   const token = authService.getToken();
 
-  if (token) {
-    const cloned = req.clone({
-      setHeaders: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
-    return next(cloned);
+  if (!token) {
+    return next(req);
   }
 
-  return next(req);
+  const cloned = req.clone({
+    setHeaders: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  return next(cloned);
 };
+
+function isUrlAllowed(req: HttpRequest<unknown>, allowedUrls: readonly string[]): boolean {
+  if (allowedUrls.length === 0) {
+    return false;
+  }
+  const target = resolveUrl(req.url);
+  return allowedUrls.some((allowed) => matchesAllowedUrl(target, allowed));
+}
+
+function resolveUrl(url: string): string {
+  try {
+    return new URL(url, globalThis.location?.origin ?? 'http://localhost').toString();
+  } catch {
+    return url;
+  }
+}
+
+function matchesAllowedUrl(target: string, allowed: string): boolean {
+  const normalizedAllowed = allowed.endsWith('/') ? allowed : `${allowed}/`;
+  const normalizedTarget = target.endsWith('/') ? target : `${target}/`;
+  return normalizedTarget.startsWith(normalizedAllowed);
+}

--- a/libs/shared-auth/src/lib/models/auth-config.model.ts
+++ b/libs/shared-auth/src/lib/models/auth-config.model.ts
@@ -2,4 +2,14 @@ export interface AuthConfig {
   keycloakUrl: string;
   realm: string;
   clientId: string;
+  /**
+   * Lista de URLs (prefixos de origem) para as quais o `tokenInterceptor`
+   * pode anexar o header `Authorization: Bearer`. Ex.: URL da API do
+   * back-end e URL do próprio Keycloak. Requisições para qualquer outro
+   * destino são enviadas sem Bearer.
+   *
+   * Sempre que o consumidor não configurar explicitamente, o interceptor
+   * se comporta de forma conservadora (nenhum Bearer é anexado).
+   */
+  allowedUrls: readonly string[];
 }

--- a/libs/shared-auth/src/lib/providers/auth.provider.ts
+++ b/libs/shared-auth/src/lib/providers/auth.provider.ts
@@ -1,9 +1,14 @@
 import { APP_INITIALIZER, EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
 import { AuthService } from '../services/auth.service';
 import { AuthConfig } from '../models/auth-config.model';
+import { AUTH_ALLOWED_URLS } from '../tokens/auth.tokens';
 
 export function provideAuth(config: AuthConfig): EnvironmentProviders {
   return makeEnvironmentProviders([
+    {
+      provide: AUTH_ALLOWED_URLS,
+      useValue: Object.freeze([...config.allowedUrls]),
+    },
     {
       provide: APP_INITIALIZER,
       useFactory: (authService: AuthService) => () => authService.init(config),

--- a/libs/shared-auth/src/lib/tokens/auth.tokens.ts
+++ b/libs/shared-auth/src/lib/tokens/auth.tokens.ts
@@ -1,0 +1,16 @@
+import { InjectionToken } from '@angular/core';
+
+/**
+ * Lista de URLs (prefixos de origem) para as quais o `tokenInterceptor`
+ * pode anexar o header `Authorization: Bearer <token>`.
+ *
+ * Qualquer requisição cuja URL não comece por nenhum dos prefixos
+ * configurados NÃO recebe o Bearer, evitando vazamento de credenciais
+ * para domínios externos (finding B2 do review da PR #3).
+ *
+ * Configurado pelo provider `provideAuth` a partir de `AuthConfig.allowedUrls`.
+ */
+export const AUTH_ALLOWED_URLS = new InjectionToken<readonly string[]>('AUTH_ALLOWED_URLS', {
+  providedIn: 'root',
+  factory: () => [],
+});


### PR DESCRIPTION
## Objetivo

Implementar a Task #36 da Story #5: restringir o header `Authorization: Bearer` a um conjunto fechado de URLs (API e Keycloak), evitando vazar credenciais para domínios externos (finding B2 do review da PR #3).

## O que muda

- **`libs/shared-auth/src/lib/tokens/auth.tokens.ts`** (novo) — `InjectionToken<readonly string[]> AUTH_ALLOWED_URLS` com factory default `[]` (comportamento conservador).
- **`libs/shared-auth/src/lib/models/auth-config.model.ts`** — novo campo `allowedUrls: readonly string[]`.
- **`libs/shared-auth/src/lib/providers/auth.provider.ts`** — `provideAuth` agora registra `AUTH_ALLOWED_URLS` a partir de `config.allowedUrls` (lista congelada).
- **`libs/shared-auth/src/lib/interceptors/token.interceptor.ts`** — anexa Bearer somente se a URL da requisição corresponde a algum prefixo da allowlist; usa normalização com barra final para evitar prefix traps (ex.: `http://localhost:5000` não casar com `http://localhost:50000`).
- **`libs/shared-auth/src/lib/interceptors/token.interceptor.spec.ts`** (novo) — cobertura de 7 cenários.
- **`libs/shared-auth/src/lib/index.ts`** — exporta `AUTH_ALLOWED_URLS`.

## Validação

\`\`\`
npx nx build shared-auth        # ✓ build OK
npx nx vite:test shared-auth    # ✓ 10 testes passando (3 auth.service + 7 tokenInterceptor)
npx nx lint shared-auth         # ✓ lint OK
\`\`\`

### Cenários cobertos

- [x] URL na allowlist (API) — Bearer anexado
- [x] URL na allowlist (Keycloak) — Bearer anexado
- [x] URL fora da allowlist — sem Bearer
- [x] Allowlist vazia — sem Bearer (default conservador)
- [x] Prefix trap (`:5000` vs `:50000`) — sem Bearer
- [x] Sem token disponível — sem Bearer mesmo em URL permitida

## Definition of Done

- [x] `AuthConfig` expõe `allowedUrls`
- [x] `provideAuth` injeta `AUTH_ALLOWED_URLS`
- [x] Interceptor só anexa Bearer para URLs da allowlist
- [x] Testes unitários cobrindo happy path e edge cases
- [x] Build, lint e testes OK

## Referências

- Task #36
- Finding B2 do review da PR #3
- ADR-019 — audience única `uniplus` para tokens OIDC

Closes #36
Part of #5