### PR TITLE
feat(auth): adicionar refresh automático de token no tokenInterceptor

### DIFF
--- a/libs/shared-auth/src/lib/interceptors/token.interceptor.spec.ts
+++ b/libs/shared-auth/src/lib/interceptors/token.interceptor.spec.ts
@@ -6,15 +6,34 @@ import { tokenInterceptor } from './token.interceptor';
 import { AuthService } from '../services/auth.service';
 import { AUTH_ALLOWED_URLS } from '../tokens/auth.tokens';
 
+// Utilitário: drena microtarefas para permitir que a cadeia
+// defer → Promise → switchMap do interceptor chegue ao backend.
+async function flushMicrotasks(times = 5): Promise<void> {
+  for (let i = 0; i < times; i += 1) {
+    await Promise.resolve();
+  }
+}
+
 describe('tokenInterceptor — allowlist', () => {
   const apiUrl = 'http://localhost:5000/api/v1';
   const keycloakUrl = 'http://localhost:8080';
   const externalUrl = 'https://evil.example.com/leak';
 
-  function setup(allowedUrls: readonly string[], tokenValue: { token: string | undefined } = { token: 'fake-token' }) {
-    const token = tokenValue.token;
+  function setup(
+    allowedUrls: readonly string[],
+    tokenValue: { token: string | undefined } = { token: 'fake-token' },
+    opts: { expired?: boolean; refresh?: () => Promise<boolean> } = {},
+  ) {
+    let token = tokenValue.token;
     const authService = {
       getToken: () => token,
+      isTokenExpired: () => opts.expired ?? false,
+      refreshToken: async (minValidity = 30) => {
+        void minValidity;
+        if (opts.refresh) return opts.refresh();
+        token = 'refreshed-token';
+        return true;
+      },
     } as unknown as AuthService;
 
     TestBed.configureTestingModule({
@@ -36,6 +55,7 @@ describe('tokenInterceptor — allowlist', () => {
     const { http, httpMock } = setup([apiUrl, keycloakUrl]);
 
     const promise = firstValueFrom(http.get(`${apiUrl}/editais`));
+    await flushMicrotasks();
     const req = httpMock.expectOne(`${apiUrl}/editais`);
 
     expect(req.request.headers.get('Authorization')).toBe('Bearer fake-token');
@@ -49,6 +69,7 @@ describe('tokenInterceptor — allowlist', () => {
 
     const url = `${keycloakUrl}/realms/unifesspa/protocol/openid-connect/userinfo`;
     const promise = firstValueFrom(http.get(url));
+    await flushMicrotasks();
     const req = httpMock.expectOne(url);
 
     expect(req.request.headers.get('Authorization')).toBe('Bearer fake-token');
@@ -82,7 +103,6 @@ describe('tokenInterceptor — allowlist', () => {
   });
 
   it('NÃO anexa Bearer para URL que apenas começa igual mas em outro host', async () => {
-    // Ex.: allowed é http://localhost:5000 e a URL é http://localhost:50000 (prefix trap)
     const { http, httpMock } = setup(['http://localhost:5000']);
 
     const trap = 'http://localhost:50000/api/v1/hack';
@@ -95,10 +115,52 @@ describe('tokenInterceptor — allowlist', () => {
     httpMock.verify();
   });
 
+  it('dispara refreshToken() e anexa o Bearer quando o token está expirado', async () => {
+    const refreshMock = vi.fn(async () => true);
+    const { http, httpMock } = setup(
+      [apiUrl],
+      { token: 'stale-token' },
+      { expired: true, refresh: refreshMock },
+    );
+
+    const promise = firstValueFrom(http.get(`${apiUrl}/refresh-before-attach`));
+    await flushMicrotasks();
+    const req = httpMock.expectOne(`${apiUrl}/refresh-before-attach`);
+
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+    // getToken() é relido após o refresh; como o mock refresh não rotaciona
+    // o valor local (função custom), o header carrega o token original —
+    // o essencial é validar que refresh foi disparado antes do envio.
+    expect(req.request.headers.get('Authorization')).toBe('Bearer stale-token');
+    req.flush({});
+    await promise;
+    httpMock.verify();
+  });
+
+  it('NÃO chama refreshToken() quando o token ainda é válido', async () => {
+    const refreshMock = vi.fn(async () => true);
+    const { http, httpMock } = setup(
+      [apiUrl],
+      { token: 'fresh-token' },
+      { expired: false, refresh: refreshMock },
+    );
+
+    const promise = firstValueFrom(http.get(`${apiUrl}/no-refresh`));
+    await flushMicrotasks();
+    const req = httpMock.expectOne(`${apiUrl}/no-refresh`);
+
+    expect(refreshMock).not.toHaveBeenCalled();
+    expect(req.request.headers.get('Authorization')).toBe('Bearer fresh-token');
+    req.flush({});
+    await promise;
+    httpMock.verify();
+  });
+
   it('NÃO anexa Bearer quando não há token disponível, mesmo em URL permitida', async () => {
     const { http, httpMock } = setup([apiUrl], { token: undefined });
 
     const promise = firstValueFrom(http.get(`${apiUrl}/ping`));
+    await flushMicrotasks();
     const req = httpMock.expectOne(`${apiUrl}/ping`);
 
     expect(req.request.headers.has('Authorization')).toBe(false);
@@ -116,7 +178,11 @@ describe('tokenInterceptor — chamada direta', () => {
         { provide: AUTH_ALLOWED_URLS, useValue: ['http://allowed.example.com'] },
         {
           provide: AuthService,
-          useValue: { getToken: () => 'tok' } as unknown as AuthService,
+          useValue: {
+            getToken: () => 'tok',
+            isTokenExpired: () => false,
+            refreshToken: async () => true,
+          } as unknown as AuthService,
         },
       ],
     });

--- a/libs/shared-auth/src/lib/interceptors/token.interceptor.ts
+++ b/libs/shared-auth/src/lib/interceptors/token.interceptor.ts
@@ -1,5 +1,6 @@
-import { HttpInterceptorFn, HttpRequest } from '@angular/common/http';
+import { HttpEvent, HttpHandlerFn, HttpInterceptorFn, HttpRequest } from '@angular/common/http';
 import { inject } from '@angular/core';
+import { Observable, defer, switchMap } from 'rxjs';
 import { AuthService } from '../services/auth.service';
 import { AUTH_ALLOWED_URLS } from '../tokens/auth.tokens';
 
@@ -7,8 +8,12 @@ import { AUTH_ALLOWED_URLS } from '../tokens/auth.tokens';
  * Interceptor que anexa `Authorization: Bearer <token>` às requisições
  * destinadas a URLs da allowlist (`AUTH_ALLOWED_URLS`).
  *
- * Requisições para qualquer outro destino seguem sem o header, evitando
- * vazamento de credenciais para domínios externos.
+ * Antes de anexar o token, verifica expiração (`isTokenExpired(30)`) e,
+ * se necessário, dispara `refreshToken()` — garantindo que nenhuma
+ * requisição viaje com um Bearer prestes a expirar.
+ *
+ * Requisições para domínios fora da allowlist seguem sem o header,
+ * evitando vazamento de credenciais.
  */
 export const tokenInterceptor: HttpInterceptorFn = (req, next) => {
   const allowedUrls = inject(AUTH_ALLOWED_URLS);
@@ -18,19 +23,38 @@ export const tokenInterceptor: HttpInterceptorFn = (req, next) => {
   }
 
   const authService = inject(AuthService);
-  const token = authService.getToken();
 
+  return defer(() => ensureFreshToken(authService)).pipe(
+    switchMap((token) => attach(req, next, token)),
+  );
+};
+
+async function ensureFreshToken(authService: AuthService): Promise<string | undefined> {
+  const current = authService.getToken();
+  if (!current) {
+    return undefined;
+  }
+
+  if (authService.isTokenExpired(30)) {
+    await authService.refreshToken(30);
+  }
+
+  return authService.getToken();
+}
+
+function attach(
+  req: HttpRequest<unknown>,
+  next: HttpHandlerFn,
+  token: string | undefined,
+): Observable<HttpEvent<unknown>> {
   if (!token) {
     return next(req);
   }
-
   const cloned = req.clone({
-    setHeaders: {
-      Authorization: `Bearer ${token}`,
-    },
+    setHeaders: { Authorization: `Bearer ${token}` },
   });
   return next(cloned);
-};
+}
 
 function isUrlAllowed(req: HttpRequest<unknown>, allowedUrls: readonly string[]): boolean {
   if (allowedUrls.length === 0) {

--- a/libs/shared-auth/src/lib/services/auth.service.ts
+++ b/libs/shared-auth/src/lib/services/auth.service.ts
@@ -47,6 +47,16 @@ export class AuthService {
     return this.keycloak?.token;
   }
 
+  /**
+   * Indica se o access token atual está expirado (ou expirará em menos
+   * de `minValidity` segundos). Retorna `true` quando não há Keycloak
+   * inicializado — o interceptor trata esse caso como "sem token".
+   */
+  isTokenExpired(minValidity = 30): boolean {
+    if (!this.keycloak) return true;
+    return this.keycloak.isTokenExpired(minValidity);
+  }
+
   async refreshToken(minValidity = 30): Promise<boolean> {
     try {
       const refreshed = await this.keycloak?.updateToken(minValidity);


### PR DESCRIPTION
## Objetivo

Task #37 da Story #5: antes de anexar `Authorization: Bearer`, checar se o token está expirado e disparar refresh (finding B3).

> Empilhada sobre #64 (Task #36). Quando #64 mergear em `main`, o GitHub retargetará automaticamente esta PR.

## O que muda

- **`auth.service.ts`** — novo método `isTokenExpired(minValidity = 30)` (wrapper de `keycloak.isTokenExpired`; se KC não inicializado, retorna `true` → o interceptor trata como "sem token").
- **`token.interceptor.ts`** — reescrito como pipeline `defer → switchMap`; `ensureFreshToken` verifica expiração e chama `refreshToken(30)` quando necessário antes de anexar o header.
- **`token.interceptor.spec.ts`** — novos cenários: refresh disparado quando expirado, refresh pulado quando ainda válido; helper `flushMicrotasks` para drenar a cadeia assíncrona com HttpTestingController.

## Validação

\`\`\`
npx nx build shared-auth        # ✓
npx nx vite:test shared-auth    # ✓ 12 testes
npx nx lint shared-auth         # ✓
\`\`\`

## Definition of Done

- [x] Interceptor chama `refreshToken()` quando token expirado antes de anexar Bearer
- [x] Interceptor NÃO chama `refreshToken()` quando token ainda válido
- [x] `AuthService.isTokenExpired()` exposto como API pública
- [x] Testes cobrindo os dois cenários

> Serialização de refreshes concorrentes (H1) é tratada em Task #61 (próxima PR da pilha).

Closes #37
Part of #5