### PR TITLE
feat(auth): serializar refreshToken concorrente e detectar reuse exceeded

### DIFF
--- a/libs/shared-auth/src/lib/services/auth.service.refresh.spec.ts
+++ b/libs/shared-auth/src/lib/services/auth.service.refresh.spec.ts
@@ -1,0 +1,128 @@
+import { TestBed } from '@angular/core/testing';
+import { AuthService } from './auth.service';
+
+interface KeycloakLike {
+  updateToken: (minValidity: number) => Promise<boolean>;
+  logout: () => Promise<void>;
+  token?: string;
+}
+
+/**
+ * Injeta um duplo de Keycloak no AuthService sem passar por `init()`
+ * (que depende do DOM e de rede). Usa a propriedade privada `keycloak`
+ * através de um cast controlado.
+ */
+function attachFakeKeycloak(service: AuthService, fake: KeycloakLike): void {
+  (service as unknown as { keycloak: KeycloakLike }).keycloak = fake;
+}
+
+describe('AuthService — serialização de refreshToken', () => {
+  let service: AuthService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AuthService);
+  });
+
+  it('compartilha uma única chamada de updateToken quando refreshToken é disparado em paralelo', async () => {
+    const updateToken = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          setTimeout(() => resolve(true), 10);
+        }),
+    );
+    attachFakeKeycloak(service, {
+      updateToken,
+      logout: async () => undefined,
+    });
+
+    const [a, b, c] = await Promise.all([
+      service.refreshToken(30),
+      service.refreshToken(30),
+      service.refreshToken(30),
+    ]);
+
+    expect(updateToken).toHaveBeenCalledTimes(1);
+    expect(a).toBe(true);
+    expect(b).toBe(true);
+    expect(c).toBe(true);
+  });
+
+  it('permite novo refresh após a promise em voo resolver', async () => {
+    const updateToken = vi.fn(async () => true);
+    attachFakeKeycloak(service, {
+      updateToken,
+      logout: async () => undefined,
+    });
+
+    await service.refreshToken(30);
+    await service.refreshToken(30);
+
+    expect(updateToken).toHaveBeenCalledTimes(2);
+  });
+
+  it('dispara logout() quando Keycloak retorna "reuse exceeded"', async () => {
+    const logout = vi.fn(async () => undefined);
+    attachFakeKeycloak(service, {
+      updateToken: async () => {
+        throw {
+          error: 'invalid_grant',
+          error_description: 'Maximum allowed refresh token reuse exceeded',
+        };
+      },
+      logout,
+    });
+
+    const result = await service.refreshToken(30);
+
+    expect(result).toBe(false);
+    expect(service.authenticated()).toBe(false);
+    // logout é disparado via `void this.logout()` — esperar microtask
+    await Promise.resolve();
+    expect(logout).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispara logout() quando Keycloak retorna "session not active"', async () => {
+    const logout = vi.fn(async () => undefined);
+    attachFakeKeycloak(service, {
+      updateToken: async () => {
+        throw { error: 'invalid_grant', error_description: 'Session not active' };
+      },
+      logout,
+    });
+
+    await service.refreshToken(30);
+    await Promise.resolve();
+
+    expect(logout).toHaveBeenCalledTimes(1);
+  });
+
+  it('NÃO dispara logout() para erros de rede genéricos', async () => {
+    const logout = vi.fn(async () => undefined);
+    attachFakeKeycloak(service, {
+      updateToken: async () => {
+        throw new Error('Network request failed');
+      },
+      logout,
+    });
+
+    const result = await service.refreshToken(30);
+
+    expect(result).toBe(false);
+    expect(service.authenticated()).toBe(false);
+    await Promise.resolve();
+    expect(logout).not.toHaveBeenCalled();
+  });
+
+  it('libera a promise em voo mesmo quando o refresh lança', async () => {
+    attachFakeKeycloak(service, {
+      updateToken: async () => {
+        throw new Error('Network fail');
+      },
+      logout: async () => undefined,
+    });
+
+    await service.refreshToken(30);
+    expect(service._getRefreshInFlight()).toBeNull();
+  });
+});

--- a/libs/shared-auth/src/lib/services/auth.service.ts
+++ b/libs/shared-auth/src/lib/services/auth.service.ts
@@ -3,11 +3,26 @@ import Keycloak from 'keycloak-js';
 import { AuthConfig } from '../models/auth-config.model';
 import { UserProfile } from '../models/user.model';
 
+/**
+ * Padrão usado por Keycloak quando um refresh token é replayado:
+ * `error: "invalid_grant"`, `error_description: "... reuse exceeded ..."`
+ * com `revokeRefreshToken=true` + `refreshTokenMaxReuse=0`.
+ */
+const REFRESH_REUSE_MARKERS = ['reuse exceeded', 'session not active', 'token is not active'];
+
 @Injectable({ providedIn: 'root' })
 export class AuthService {
   private keycloak: Keycloak | null = null;
   private readonly _authenticated = signal(false);
   private readonly _userProfile = signal<UserProfile | null>(null);
+
+  /**
+   * Promise de refresh em voo — compartilhada entre chamadas concorrentes
+   * para evitar que duas requisições disparem dois refreshes paralelos.
+   * Com `refreshTokenMaxReuse=0`, o segundo refresh receberia
+   * `invalid_grant: reuse exceeded` e derrubaria a sessão.
+   */
+  private refreshInFlight: Promise<boolean> | null = null;
 
   readonly authenticated = this._authenticated.asReadonly();
   readonly userProfile = this._userProfile.asReadonly();
@@ -57,18 +72,48 @@ export class AuthService {
     return this.keycloak.isTokenExpired(minValidity);
   }
 
+  /**
+   * Renova o access token de forma **serializada**: múltiplas chamadas
+   * concorrentes compartilham a mesma Promise de rede, evitando que o
+   * Keycloak rejeite o segundo refresh com `invalid_grant: reuse
+   * exceeded` (Story uniplus-api#67 / PR #84 — `revokeRefreshToken=true`).
+   *
+   * Se a renovação falhar com marcador de replay/sessão morta, dispara
+   * `logout()` — a sessão está comprometida e um novo login é exigido.
+   */
   async refreshToken(minValidity = 30): Promise<boolean> {
+    if (this.refreshInFlight) {
+      return this.refreshInFlight;
+    }
+
+    this.refreshInFlight = this.runRefresh(minValidity).finally(() => {
+      this.refreshInFlight = null;
+    });
+
+    return this.refreshInFlight;
+  }
+
+  private async runRefresh(minValidity: number): Promise<boolean> {
     try {
       const refreshed = await this.keycloak?.updateToken(minValidity);
       return refreshed ?? false;
-    } catch {
+    } catch (error) {
       this._authenticated.set(false);
+      if (isRefreshReuseError(error)) {
+        // Replay/reuso detectado — sessão comprometida. Força logout.
+        void this.logout();
+      }
       return false;
     }
   }
 
   hasRole(role: string): boolean {
     return this.roles().includes(role);
+  }
+
+  /** @internal Acesso somente para testes — expõe a promise em voo. */
+  _getRefreshInFlight(): Promise<boolean> | null {
+    return this.refreshInFlight;
   }
 
   private async loadProfile(): Promise<void> {
@@ -88,4 +133,29 @@ export class AuthService {
       roles: realmRoles,
     });
   }
+}
+
+function isRefreshReuseError(error: unknown): boolean {
+  const description = extractErrorDescription(error).toLowerCase();
+  return REFRESH_REUSE_MARKERS.some((marker) => description.includes(marker));
+}
+
+function extractErrorDescription(error: unknown): string {
+  if (!error) return '';
+  if (typeof error === 'string') return error;
+  if (typeof error !== 'object') return '';
+
+  const candidates: unknown[] = [
+    (error as { error_description?: unknown }).error_description,
+    (error as { errorDescription?: unknown }).errorDescription,
+    (error as { description?: unknown }).description,
+    (error as { message?: unknown }).message,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.length > 0) {
+      return candidate;
+    }
+  }
+  return '';
 }


### PR DESCRIPTION
## Objetivo

Task #61 da Story #5 — hardening H1: com \`revokeRefreshToken=true\` + \`refreshTokenMaxReuse=0\` (uniplus-api PR #84), dois refreshes paralelos derrubariam a sessão. Esta PR serializa as chamadas.

> Empilhada sobre #65 (#37 → #36). Retargetará automaticamente quando as PRs anteriores mergearem.

## O que muda

- **\`auth.service.ts\`** — propriedade \`refreshInFlight: Promise<boolean> | null\`; método \`refreshToken\` retorna a promise em voo quando já existe; \`runRefresh\` isola a lógica de rede; detecção de marcadores de replay (\`reuse exceeded\`, \`session not active\`, \`token is not active\`) → dispara \`logout()\` automaticamente.
- **\`auth.service.refresh.spec.ts\`** (novo) — 6 cenários cobrindo serialização, retomada após conclusão, logout em reuse exceeded e session not active, ausência de logout em erros de rede, liberação da promise em voo em caso de falha.

## Validação

\`\`\`
npx nx vite:test shared-auth   # ✓ 18 testes (9 interceptor + 6 refresh + 3 service)
npx nx build shared-auth        # ✓
npx nx lint shared-auth         # ✓
\`\`\`

Validação manual contra \`local/hardened-realm\` fica pendente até o wiring nas apps (tasks #38, #39, #41).

## Definition of Done

- [x] 2+ chamadas concorrentes → 1 única chamada de rede a \`/token\`
- [x] Reuse exceeded → \`logout()\`, não loop
- [x] Erros de rede genéricos NÃO disparam logout
- [x] Promise em voo liberada em qualquer desfecho

Closes #61
Part of #5