### PR TITLE
feat(auth): plugar provideAuth e tokenInterceptor nas 3 apps

### DIFF
--- a/apps/ingresso/project.json
+++ b/apps/ingresso/project.json
@@ -42,7 +42,13 @@
         "development": {
           "optimization": false,
           "extractLicenses": false,
-          "sourceMap": true
+          "sourceMap": true,
+          "fileReplacements": [
+            {
+              "replace": "apps/ingresso/src/environments/environment.ts",
+              "with": "apps/ingresso/src/environments/environment.development.ts"
+            }
+          ]
         }
       },
       "defaultConfiguration": "production"

--- a/apps/ingresso/src/app/app.config.ts
+++ b/apps/ingresso/src/app/app.config.ts
@@ -3,11 +3,21 @@ import { provideRouter, withComponentInputBinding } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { appRoutes } from './app.routes';
 import { errorInterceptor, loadingInterceptor } from '@uniplus/shared-core';
+import { provideAuth, tokenInterceptor } from '@uniplus/shared-auth';
+import { environment } from '../environments/environment';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(appRoutes, withComponentInputBinding()),
-    provideHttpClient(withInterceptors([errorInterceptor, loadingInterceptor])),
+    provideHttpClient(
+      withInterceptors([tokenInterceptor, loadingInterceptor, errorInterceptor]),
+    ),
+    provideAuth({
+      keycloakUrl: environment.keycloak.url,
+      realm: environment.keycloak.realm,
+      clientId: environment.keycloak.clientId,
+      allowedUrls: [environment.apiUrl, environment.keycloak.url],
+    }),
   ],
 };

--- a/apps/portal/project.json
+++ b/apps/portal/project.json
@@ -42,7 +42,13 @@
         "development": {
           "optimization": false,
           "extractLicenses": false,
-          "sourceMap": true
+          "sourceMap": true,
+          "fileReplacements": [
+            {
+              "replace": "apps/portal/src/environments/environment.ts",
+              "with": "apps/portal/src/environments/environment.development.ts"
+            }
+          ]
         }
       },
       "defaultConfiguration": "production"

--- a/apps/portal/src/app/app.config.ts
+++ b/apps/portal/src/app/app.config.ts
@@ -3,11 +3,21 @@ import { provideRouter, withComponentInputBinding } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { appRoutes } from './app.routes';
 import { errorInterceptor, loadingInterceptor } from '@uniplus/shared-core';
+import { provideAuth, tokenInterceptor } from '@uniplus/shared-auth';
+import { environment } from '../environments/environment';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(appRoutes, withComponentInputBinding()),
-    provideHttpClient(withInterceptors([errorInterceptor, loadingInterceptor])),
+    provideHttpClient(
+      withInterceptors([tokenInterceptor, loadingInterceptor, errorInterceptor]),
+    ),
+    provideAuth({
+      keycloakUrl: environment.keycloak.url,
+      realm: environment.keycloak.realm,
+      clientId: environment.keycloak.clientId,
+      allowedUrls: [environment.apiUrl, environment.keycloak.url],
+    }),
   ],
 };

--- a/apps/selecao/project.json
+++ b/apps/selecao/project.json
@@ -42,7 +42,13 @@
         "development": {
           "optimization": false,
           "extractLicenses": false,
-          "sourceMap": true
+          "sourceMap": true,
+          "fileReplacements": [
+            {
+              "replace": "apps/selecao/src/environments/environment.ts",
+              "with": "apps/selecao/src/environments/environment.development.ts"
+            }
+          ]
         }
       },
       "defaultConfiguration": "production"

--- a/apps/selecao/src/app/app.config.ts
+++ b/apps/selecao/src/app/app.config.ts
@@ -3,11 +3,24 @@ import { provideRouter, withComponentInputBinding } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { appRoutes } from './app.routes';
 import { errorInterceptor, loadingInterceptor } from '@uniplus/shared-core';
+import { provideAuth, tokenInterceptor } from '@uniplus/shared-auth';
+import { environment } from '../environments/environment';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(appRoutes, withComponentInputBinding()),
-    provideHttpClient(withInterceptors([errorInterceptor, loadingInterceptor])),
+    // Ordem dos interceptors: tokenInterceptor primeiro (anexa Bearer),
+    // loadingInterceptor para UX, errorInterceptor por último para
+    // capturar falhas de toda a pilha.
+    provideHttpClient(
+      withInterceptors([tokenInterceptor, loadingInterceptor, errorInterceptor]),
+    ),
+    provideAuth({
+      keycloakUrl: environment.keycloak.url,
+      realm: environment.keycloak.realm,
+      clientId: environment.keycloak.clientId,
+      allowedUrls: [environment.apiUrl, environment.keycloak.url],
+    }),
   ],
 };


### PR DESCRIPTION
## Objetivo

Task #38 da Story #5: conectar a integração Keycloak da \`shared-auth\` nas 3 apps (selecao, ingresso, portal) — finding B7 do review da PR #3.

> Empilhada sobre #66 (#61 → #37 → #36).

## O que muda

- **\`apps/{selecao,ingresso,portal}/project.json\`** — \`fileReplacements\` na configuração de \`development\` para alternar \`environment.ts → environment.development.ts\`.
- **\`apps/{selecao,ingresso,portal}/src/app/app.config.ts\`** — importa \`tokenInterceptor\` e \`provideAuth\` de \`@uniplus/shared-auth\`; chama \`provideAuth\` com URL, realm, clientId e \`allowedUrls\` derivados do environment.

Ordem dos interceptors adotada: \`[tokenInterceptor, loadingInterceptor, errorInterceptor]\` — Bearer anexado primeiro; errorInterceptor por último para capturar falhas de toda a pilha.

## Validação

\`\`\`
npx nx run-many --target=build --projects=selecao,ingresso,portal --configuration=development  # ✓
npx nx run-many --target=lint  --projects=selecao,ingresso,portal                              # ✓
\`\`\`

## Follow-ups conhecidos

- Ports atuais das apps (4200 / 4201 / 4202 em \`project.json\`) divergem dos redirect URIs configurados no realm (\`4200\` / \`4300\` / \`4100\`). Validação manual contra \`local/hardened-realm\` requer alinhamento (ajustar \`project.json\` ou atualizar realm). Fora do escopo desta task.

## Definition of Done

- [x] \`provideAuth(environment.keycloak)\` nas 3 apps
- [x] \`tokenInterceptor\` registrado antes do errorInterceptor
- [x] \`allowedUrls\` populado com \`apiUrl\` + \`keycloak.url\`
- [x] Build dev OK nas 3 apps
- [x] Lint OK nas 3 apps

Closes #38
Part of #5