### PR TITLE
feat(auth): tornar auth.init() resiliente e exibir banner de fallback

### DIFF
--- a/apps/ingresso/src/app/app.ts
+++ b/apps/ingresso/src/app/app.ts
@@ -1,10 +1,14 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { AuthErrorBannerComponent } from '@uniplus/shared-auth';
 
 @Component({
   selector: 'ing-root',
   standalone: true,
-  imports: [RouterOutlet],
-  template: `<router-outlet />`,
+  imports: [RouterOutlet, AuthErrorBannerComponent],
+  template: `
+    <auth-error-banner />
+    <router-outlet />
+  `,
 })
 export class AppComponent {}

--- a/apps/portal/src/app/app.ts
+++ b/apps/portal/src/app/app.ts
@@ -1,10 +1,14 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { AuthErrorBannerComponent } from '@uniplus/shared-auth';
 
 @Component({
   selector: 'ptl-root',
   standalone: true,
-  imports: [RouterOutlet],
-  template: `<router-outlet />`,
+  imports: [RouterOutlet, AuthErrorBannerComponent],
+  template: `
+    <auth-error-banner />
+    <router-outlet />
+  `,
 })
 export class AppComponent {}

--- a/apps/selecao/src/app/app.ts
+++ b/apps/selecao/src/app/app.ts
@@ -1,10 +1,14 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { AuthErrorBannerComponent } from '@uniplus/shared-auth';
 
 @Component({
   selector: 'sel-root',
   standalone: true,
-  imports: [RouterOutlet],
-  template: `<router-outlet />`,
+  imports: [RouterOutlet, AuthErrorBannerComponent],
+  template: `
+    <auth-error-banner />
+    <router-outlet />
+  `,
 })
 export class AppComponent {}

--- a/libs/shared-auth/src/lib/components/auth-error-banner.component.ts
+++ b/libs/shared-auth/src/lib/components/auth-error-banner.component.ts
@@ -1,0 +1,39 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { AuthService } from '../services/auth.service';
+
+/**
+ * Banner de fallback exibido quando `AuthService.init()` falha
+ * (ex.: Keycloak indisponível). É renderizado no shell do app
+ * (`AppComponent`) para garantir visibilidade mesmo antes do router.
+ *
+ * Acessibilidade: `role="alert"` + `aria-live="assertive"` para leitores
+ * de tela; cores e foco seguem tokens Gov.br DS (erro).
+ */
+@Component({
+  selector: 'auth-error-banner',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    @if (authService.initError(); as message) {
+      <div
+        role="alert"
+        aria-live="assertive"
+        class="flex items-start gap-3 border-b border-govbr-danger bg-govbr-danger-lightest px-6 py-3 text-govbr-danger"
+      >
+        <span aria-hidden="true" class="mt-0.5 text-lg">⚠</span>
+        <div class="flex-1 text-sm">
+          <strong class="block font-semibold">Serviço de autenticação indisponível</strong>
+          <span class="block">{{ message }}</span>
+          <span class="block text-xs opacity-80">
+            Você pode continuar navegando em áreas públicas. Recursos
+            protegidos ficarão indisponíveis até o restabelecimento do
+            serviço.
+          </span>
+        </div>
+      </div>
+    }
+  `,
+})
+export class AuthErrorBannerComponent {
+  protected readonly authService = inject(AuthService);
+}

--- a/libs/shared-auth/src/lib/index.ts
+++ b/libs/shared-auth/src/lib/index.ts
@@ -19,3 +19,6 @@ export { provideAuth } from './providers/auth.provider';
 
 // Tokens
 export { AUTH_ALLOWED_URLS } from './tokens/auth.tokens';
+
+// Components
+export { AuthErrorBannerComponent } from './components/auth-error-banner.component';

--- a/libs/shared-auth/src/lib/services/auth.service.init.spec.ts
+++ b/libs/shared-auth/src/lib/services/auth.service.init.spec.ts
@@ -1,0 +1,107 @@
+import { TestBed } from '@angular/core/testing';
+import type Keycloak from 'keycloak-js';
+import { AuthService } from './auth.service';
+import { AuthConfig } from '../models/auth-config.model';
+
+const config: AuthConfig = {
+  keycloakUrl: 'http://localhost:8080',
+  realm: 'unifesspa',
+  clientId: 'selecao-web',
+  allowedUrls: ['http://localhost:5000/api/v1', 'http://localhost:8080'],
+};
+
+function stubKeycloak(partial: Partial<Keycloak>): Keycloak {
+  return {
+    init: async () => false,
+    token: undefined,
+    authenticated: false,
+    realmAccess: undefined,
+    subject: undefined,
+    isTokenExpired: () => true,
+    updateToken: async () => false,
+    login: async () => undefined,
+    logout: async () => undefined,
+    loadUserProfile: async () => ({}),
+    ...partial,
+  } as unknown as Keycloak;
+}
+
+describe('AuthService.init — resiliência a Keycloak indisponível', () => {
+  let service: AuthService;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AuthService);
+  });
+
+  it('initError() começa null', () => {
+    expect(service.initError()).toBeNull();
+    expect(service.authenticated()).toBe(false);
+  });
+
+  it('captura erro do Keycloak.init() e NÃO propaga; expõe initError()', async () => {
+    vi.spyOn(service as unknown as { createKeycloak: () => Keycloak }, 'createKeycloak')
+      .mockReturnValue(stubKeycloak({
+        init: () => Promise.reject(new Error('Keycloak offline')),
+      }));
+
+    const result = await service.init(config);
+
+    expect(result).toBe(false);
+    expect(service.initError()).toBe('Keycloak offline');
+    expect(service.authenticated()).toBe(false);
+  });
+
+  it('propaga false (não autenticado) quando init() resolve com false, sem erro', async () => {
+    vi.spyOn(service as unknown as { createKeycloak: () => Keycloak }, 'createKeycloak')
+      .mockReturnValue(stubKeycloak({ init: async () => false }));
+
+    const result = await service.init(config);
+
+    expect(result).toBe(false);
+    expect(service.initError()).toBeNull();
+  });
+
+  it('init bem-sucedido limpa initError anterior', async () => {
+    const spy = vi.spyOn(
+      service as unknown as { createKeycloak: () => Keycloak },
+      'createKeycloak',
+    );
+
+    spy.mockReturnValueOnce(stubKeycloak({
+      init: () => Promise.reject(new Error('down')),
+    }));
+    await service.init(config);
+    expect(service.initError()).toBe('down');
+
+    spy.mockReturnValueOnce(stubKeycloak({ init: async () => false }));
+    const result = await service.init(config);
+
+    expect(result).toBe(false);
+    expect(service.initError()).toBeNull();
+  });
+
+  it('usa mensagem humanizada padrão quando o erro não tem descrição', async () => {
+    vi.spyOn(service as unknown as { createKeycloak: () => Keycloak }, 'createKeycloak')
+      .mockReturnValue(stubKeycloak({
+        init: () => Promise.reject({}),
+      }));
+
+    await service.init(config);
+
+    expect(service.initError()).toBe('Não foi possível contatar o provedor de autenticação.');
+  });
+
+  it('captura erro lançado pelo próprio construtor do Keycloak', async () => {
+    vi.spyOn(service as unknown as { createKeycloak: () => Keycloak }, 'createKeycloak')
+      .mockImplementation(() => {
+        throw new Error('cannot reach');
+      });
+
+    const result = await service.init(config);
+
+    expect(result).toBe(false);
+    expect(service.initError()).toBe('cannot reach');
+  });
+});

--- a/libs/shared-auth/src/lib/services/auth.service.ts
+++ b/libs/shared-auth/src/lib/services/auth.service.ts
@@ -15,6 +15,7 @@ export class AuthService {
   private keycloak: Keycloak | null = null;
   private readonly _authenticated = signal(false);
   private readonly _userProfile = signal<UserProfile | null>(null);
+  private readonly _initError = signal<string | null>(null);
 
   /**
    * Promise de refresh em voo — compartilhada entre chamadas concorrentes
@@ -27,27 +28,45 @@ export class AuthService {
   readonly authenticated = this._authenticated.asReadonly();
   readonly userProfile = this._userProfile.asReadonly();
   readonly roles = computed(() => this._userProfile()?.roles ?? []);
+  /**
+   * Mensagem de erro quando `init()` falha (ex.: Keycloak indisponível).
+   * `null` indica init bem-sucedido ou ainda não executado. Consumida
+   * por componentes de shell para exibir fallback ao usuário.
+   */
+  readonly initError = this._initError.asReadonly();
 
+  /**
+   * Inicializa o Keycloak. NUNCA lança — falhas são capturadas e
+   * expostas via `initError()`, permitindo que o bootstrap da app
+   * prossiga mesmo com o provedor de autenticação indisponível
+   * (finding I7). Nessa situação o app entra em modo "não autenticado"
+   * e o shell pode exibir um banner de fallback.
+   */
   async init(config: AuthConfig): Promise<boolean> {
-    this.keycloak = new Keycloak({
-      url: config.keycloakUrl,
-      realm: config.realm,
-      clientId: config.clientId,
-    });
+    this._initError.set(null);
+    try {
+      this.keycloak = this.createKeycloak(config);
 
-    const authenticated = await this.keycloak.init({
-      onLoad: 'check-sso',
-      silentCheckSsoRedirectUri: window.location.origin + '/assets/silent-check-sso.html',
-      checkLoginIframe: false,
-    });
+      const authenticated = await this.keycloak.init({
+        onLoad: 'check-sso',
+        silentCheckSsoRedirectUri: window.location.origin + '/assets/silent-check-sso.html',
+        checkLoginIframe: false,
+      });
 
-    this._authenticated.set(authenticated);
+      this._authenticated.set(authenticated);
 
-    if (authenticated) {
-      await this.loadProfile();
+      if (authenticated) {
+        await this.loadProfile();
+      }
+
+      return authenticated;
+    } catch (error) {
+      this.keycloak = null;
+      this._authenticated.set(false);
+      this._userProfile.set(null);
+      this._initError.set(describeInitError(error));
+      return false;
     }
-
-    return authenticated;
   }
 
   async login(): Promise<void> {
@@ -111,6 +130,18 @@ export class AuthService {
     return this.roles().includes(role);
   }
 
+  /**
+   * @internal Ponto de extensão para testes — substituído por spies
+   * que retornam duplos de Keycloak com `init()` estubado.
+   */
+  protected createKeycloak(config: AuthConfig): Keycloak {
+    return new Keycloak({
+      url: config.keycloakUrl,
+      realm: config.realm,
+      clientId: config.clientId,
+    });
+  }
+
   /** @internal Acesso somente para testes — expõe a promise em voo. */
   _getRefreshInFlight(): Promise<boolean> | null {
     return this.refreshInFlight;
@@ -133,6 +164,14 @@ export class AuthService {
       roles: realmRoles,
     });
   }
+}
+
+function describeInitError(error: unknown): string {
+  if (error instanceof Error && error.message) return error.message;
+  if (typeof error === 'string' && error.length > 0) return error;
+  const message = extractErrorDescription(error);
+  if (message) return message;
+  return 'Não foi possível contatar o provedor de autenticação.';
 }
 
 function isRefreshReuseError(error: unknown): boolean {


### PR DESCRIPTION
## Objetivo

Task #41 da Story #5 — finding I7: Keycloak indisponível não deve travar a app.

> Empilhada sobre #67 (#38 → #61 → #37 → #36).

## O que muda

- **\`auth.service.ts\`** — \`init()\` agora envolve a criação e o init do Keycloak em try/catch; falhas zeram estado e populam \`initError\`. Extrai \`createKeycloak(config)\` como método protegido (ponto de extensão para testes via spy).
- **\`auth.service.ts\`** — novo signal público \`initError: Signal<string | null>\`; \`describeInitError\` humaniza erros sem descrição.
- **\`auth-error-banner.component.ts\`** (novo) — banner standalone com \`role=\"alert\"\` + \`aria-live=\"assertive\"\`, cores \`govbr-danger\`, mensagem em pt-BR e orientação ao usuário.
- **\`apps/{selecao,ingresso,portal}/src/app/app.ts\`** — renderiza \`<auth-error-banner />\` no topo do shell.
- **\`auth.service.init.spec.ts\`** (novo) — 6 cenários cobrindo: init null inicial, erro no \`.init()\`, retorno \`false\` sem erro, limpeza de \`initError\` após sucesso, mensagem default humanizada, erro lançado no construtor.

## Validação

\`\`\`
npx nx vite:test shared-auth                                              # ✓ 24 testes
npx nx run-many --target=build --projects=shared-auth,selecao,ingresso,portal --configuration=development  # ✓
npx nx run-many --target=lint  --projects=shared-auth,selecao,ingresso,portal                              # ✓
\`\`\`

## Definition of Done

- [x] \`init()\` não propaga exceção mesmo com KC offline
- [x] Estado de autenticação é zerado em caso de falha
- [x] \`initError()\` exposto como signal público
- [x] UI de fallback (banner) visível em todas as 3 apps
- [x] Acessibilidade: role/aria corretos, cores govbr-danger

Closes #41
Part of #5