### PR TITLE
feat(auth): adicionar silent-check-sso.html nos assets das 3 apps

### DIFF
--- a/apps/ingresso/public/assets/silent-check-sso.html
+++ b/apps/ingresso/public/assets/silent-check-sso.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="pt-br">
+  <head>
+    <meta charset="utf-8" />
+    <title>Silent SSO check</title>
+  </head>
+  <body>
+    <!--
+      Página auxiliar para Silent SSO check do Keycloak.
+      Carregada em iframe durante o init com `onLoad: 'check-sso'` e
+      `silentCheckSsoRedirectUri: /assets/silent-check-sso.html`.
+      Retransmite o hash/query com o resultado para a janela pai.
+      Não deve conter lógica adicional nem recursos externos.
+    -->
+    <script>
+      parent.postMessage(location.href, location.origin);
+    </script>
+  </body>
+</html>

--- a/apps/portal/public/assets/silent-check-sso.html
+++ b/apps/portal/public/assets/silent-check-sso.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="pt-br">
+  <head>
+    <meta charset="utf-8" />
+    <title>Silent SSO check</title>
+  </head>
+  <body>
+    <!--
+      Página auxiliar para Silent SSO check do Keycloak.
+      Carregada em iframe durante o init com `onLoad: 'check-sso'` e
+      `silentCheckSsoRedirectUri: /assets/silent-check-sso.html`.
+      Retransmite o hash/query com o resultado para a janela pai.
+      Não deve conter lógica adicional nem recursos externos.
+    -->
+    <script>
+      parent.postMessage(location.href, location.origin);
+    </script>
+  </body>
+</html>

--- a/apps/selecao/public/assets/silent-check-sso.html
+++ b/apps/selecao/public/assets/silent-check-sso.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="pt-br">
+  <head>
+    <meta charset="utf-8" />
+    <title>Silent SSO check</title>
+  </head>
+  <body>
+    <!--
+      Página auxiliar para Silent SSO check do Keycloak.
+      Carregada em iframe durante o init com `onLoad: 'check-sso'` e
+      `silentCheckSsoRedirectUri: /assets/silent-check-sso.html`.
+      Retransmite o hash/query com o resultado para a janela pai.
+      Não deve conter lógica adicional nem recursos externos.
+    -->
+    <script>
+      parent.postMessage(location.href, location.origin);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Objetivo

Task #43 da Story #5: criar \`silent-check-sso.html\` — página auxiliar exigida pelo fluxo Silent SSO do Keycloak — nos assets de selecao, ingresso e portal.

> Empilhada sobre #68 (#41 → #38 → #61 → #37 → #36).

## O que muda

- **\`apps/{selecao,ingresso,portal}/public/assets/silent-check-sso.html\`** — HTML mínimo que retransmite \`location.href\` para a janela pai via \`postMessage\`. Mesma convenção recomendada pela documentação oficial do keycloak-js.

## Validação

\`\`\`
npx nx run-many --target=build --projects=selecao,ingresso,portal --configuration=development  # ✓
ls dist/apps/{selecao,ingresso,portal}/browser/assets/silent-check-sso.html                    # ✓ copiado
\`\`\`

## Definition of Done

- [x] Arquivo presente nos assets das 3 apps
- [x] Caminho servido (\`/assets/silent-check-sso.html\`) casa com o \`silentCheckSsoRedirectUri\` usado pelo AuthService
- [x] Conteúdo mínimo, sem dependências externas

Closes #43
Part of #5