### PR TITLE
feat(auth): configurar onTokenExpired para renovação periódica

### DIFF
--- a/libs/shared-auth/src/lib/services/auth.service.init.spec.ts
+++ b/libs/shared-auth/src/lib/services/auth.service.init.spec.ts
@@ -104,4 +104,31 @@ describe('AuthService.init — resiliência a Keycloak indisponível', () => {
     expect(result).toBe(false);
     expect(service.initError()).toBe('cannot reach');
   });
+
+  it('registra callback onTokenExpired que dispara refreshToken()', async () => {
+    let capturedCallback: (() => void) | undefined;
+    const kc = stubKeycloak({ init: async () => true });
+    // Captura de onTokenExpired via setter-ish
+    Object.defineProperty(kc, 'onTokenExpired', {
+      configurable: true,
+      get() {
+        return capturedCallback;
+      },
+      set(fn: () => void) {
+        capturedCallback = fn;
+      },
+    });
+
+    vi.spyOn(service as unknown as { createKeycloak: () => Keycloak }, 'createKeycloak')
+      .mockReturnValue(kc);
+    // loadProfile depende de loadUserProfile — stub já retorna {}
+    const refreshSpy = vi.spyOn(service, 'refreshToken').mockResolvedValue(true);
+
+    await service.init(config);
+
+    expect(capturedCallback).toBeInstanceOf(Function);
+    capturedCallback?.();
+    // `refreshToken` é chamado de forma fire-and-forget via `void`
+    expect(refreshSpy).toHaveBeenCalledWith(30);
+  });
 });

--- a/libs/shared-auth/src/lib/services/auth.service.ts
+++ b/libs/shared-auth/src/lib/services/auth.service.ts
@@ -53,6 +53,14 @@ export class AuthService {
         checkLoginIframe: false,
       });
 
+      // Renovação periódica: o keycloak-js dispara `onTokenExpired`
+      // quando o access token expira. Como `refreshToken()` é serializado
+      // (Task #61), é seguro chamá-lo aqui sem risco de corrida com
+      // refreshes disparados pelo interceptor.
+      this.keycloak.onTokenExpired = () => {
+        void this.refreshToken(30);
+      };
+
       this._authenticated.set(authenticated);
 
       if (authenticated) {


### PR DESCRIPTION
## Objetivo

Task #42 da Story #5 — finding I8: manter a sessão viva enquanto o usuário está ativo.

> Empilhada sobre #69 (#43 → #41 → #38 → #61 → #37 → #36).

## O que muda

- **\`auth.service.ts\`** — após \`keycloak.init()\` bem-sucedido, atribui \`keycloak.onTokenExpired = () => { void this.refreshToken(30); }\`. Como \`refreshToken\` é serializado (Task #61), a chamada é segura contra reuse exceeded.
- **\`auth.service.init.spec.ts\`** — novo teste que captura o setter de \`onTokenExpired\` via \`Object.defineProperty\` e verifica que invocá-lo dispara \`refreshToken(30)\`.

## Validação

\`\`\`
npx nx vite:test shared-auth   # ✓ 25 testes
npx nx build shared-auth       # ✓
npx nx lint shared-auth        # ✓
\`\`\`

## Definition of Done

- [x] \`onTokenExpired\` é registrado no init
- [x] Callback chama \`refreshToken(30)\`
- [x] Comportamento coberto por teste

Closes #42
Part of #5