### PR TITLE
feat(auth): aplicar authGuard e roleGuard nas rotas das 3 apps

### DIFF
--- a/apps/ingresso/src/app/app.routes.ts
+++ b/apps/ingresso/src/app/app.routes.ts
@@ -1,10 +1,14 @@
 import { Routes } from '@angular/router';
+import { authGuard, roleGuard } from '@uniplus/shared-auth';
 import { LayoutComponent } from './layout/layout';
 
 export const appRoutes: Routes = [
   {
+    // Backoffice Ingresso: todas as rotas exigem autenticação.
+    // Roles elegíveis nesta SPA: admin, gestor.
     path: '',
     component: LayoutComponent,
+    canActivate: [authGuard, roleGuard('admin', 'gestor')],
     children: [
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
       {

--- a/apps/portal/src/app/app.routes.ts
+++ b/apps/portal/src/app/app.routes.ts
@@ -1,4 +1,5 @@
 import { Routes } from '@angular/router';
+import { authGuard } from '@uniplus/shared-auth';
 import { LayoutComponent } from './layout/layout';
 
 export const appRoutes: Routes = [
@@ -8,27 +9,34 @@ export const appRoutes: Routes = [
     children: [
       { path: '', redirectTo: 'processos', pathMatch: 'full' },
       {
+        // Consulta pública de processos seletivos — sem autenticação.
         path: 'processos',
         loadChildren: () => import('./features/processos/processos.routes').then((m) => m.PROCESSOS_ROUTES),
       },
       {
+        // Áreas autenticadas do candidato — exigem authGuard.
         path: 'inscricao',
+        canActivate: [authGuard],
         loadChildren: () => import('./features/inscricao/inscricao.routes').then((m) => m.INSCRICAO_ROUTES),
       },
       {
         path: 'acompanhamento',
+        canActivate: [authGuard],
         loadChildren: () => import('./features/acompanhamento/acompanhamento.routes').then((m) => m.ACOMPANHAMENTO_ROUTES),
       },
       {
         path: 'recursos',
+        canActivate: [authGuard],
         loadChildren: () => import('./features/recursos/recursos.routes').then((m) => m.RECURSOS_ROUTES),
       },
       {
         path: 'documentos',
+        canActivate: [authGuard],
         loadChildren: () => import('./features/documentos/documentos.routes').then((m) => m.DOCUMENTOS_ROUTES),
       },
       {
         path: 'perfil',
+        canActivate: [authGuard],
         loadChildren: () => import('./features/perfil/perfil.routes').then((m) => m.PERFIL_ROUTES),
       },
     ],

--- a/apps/selecao/src/app/app.routes.ts
+++ b/apps/selecao/src/app/app.routes.ts
@@ -1,10 +1,14 @@
 import { Routes } from '@angular/router';
+import { authGuard, roleGuard } from '@uniplus/shared-auth';
 import { LayoutComponent } from './layout/layout';
 
 export const appRoutes: Routes = [
   {
+    // Backoffice Seleção: todas as rotas exigem autenticação.
+    // Roles elegíveis nesta SPA: admin, gestor, avaliador.
     path: '',
     component: LayoutComponent,
+    canActivate: [authGuard, roleGuard('admin', 'gestor', 'avaliador')],
     children: [
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
       {
@@ -13,22 +17,27 @@ export const appRoutes: Routes = [
       },
       {
         path: 'editais',
+        canActivate: [roleGuard('admin', 'gestor')],
         loadChildren: () => import('./features/editais/editais.routes').then((m) => m.EDITAIS_ROUTES),
       },
       {
         path: 'inscricoes',
+        canActivate: [roleGuard('admin', 'gestor')],
         loadChildren: () => import('./features/inscricoes/inscricoes.routes').then((m) => m.INSCRICOES_ROUTES),
       },
       {
         path: 'homologacao',
+        canActivate: [roleGuard('admin', 'gestor', 'avaliador')],
         loadChildren: () => import('./features/homologacao/homologacao.routes').then((m) => m.HOMOLOGACAO_ROUTES),
       },
       {
         path: 'notas',
+        canActivate: [roleGuard('admin', 'gestor', 'avaliador')],
         loadChildren: () => import('./features/notas/notas.routes').then((m) => m.NOTAS_ROUTES),
       },
       {
         path: 'classificacao',
+        canActivate: [roleGuard('admin', 'gestor')],
         loadChildren: () => import('./features/classificacao/classificacao.routes').then((m) => m.CLASSIFICACAO_ROUTES),
       },
     ],


### PR DESCRIPTION
## Objetivo

Task #39 da Story #5: aplicar guards nas rotas protegidas — finding B7 (continuação).

> Empilhada sobre #70 (#42 → #43 → #41 → #38 → #61 → #37 → #36).

## O que muda

- **\`apps/selecao/src/app/app.routes.ts\`** — \`authGuard + roleGuard('admin','gestor','avaliador')\` no layout; \`roleGuard\` mais restritivo em editais/inscrições/classificação (admin, gestor) e homologação/notas (admin, gestor, avaliador).
- **\`apps/ingresso/src/app/app.routes.ts\`** — \`authGuard + roleGuard('admin','gestor')\` no layout.
- **\`apps/portal/src/app/app.routes.ts\`** — rota \`/processos\` permanece pública; demais rotas do candidato recebem \`authGuard\` individual.

## Validação

\`\`\`
npx nx run-many --target=build --projects=selecao,ingresso,portal --configuration=development  # ✓
npx nx run-many --target=lint  --projects=selecao,ingresso,portal                              # ✓
\`\`\`

## Definition of Done

- [x] \`authGuard\` protege rotas que requerem login
- [x] \`roleGuard\` restringe por perfil nas áreas administrativas
- [x] Portal preserva \`/processos\` público (consulta de editais)
- [x] Build + lint OK

> Comportamento de \"autenticado sem role\" → 403 é tratado em Task #63 (próxima PR da pilha).

Closes #39
Part of #5