### PR TITLE
feat(auth): tratar role ausente como 403 forbidden (scope per-client)

### DIFF
--- a/apps/ingresso/src/app/app.routes.ts
+++ b/apps/ingresso/src/app/app.routes.ts
@@ -1,8 +1,12 @@
 import { Routes } from '@angular/router';
-import { authGuard, roleGuard } from '@uniplus/shared-auth';
+import { AccessDeniedComponent, authGuard, roleGuard } from '@uniplus/shared-auth';
 import { LayoutComponent } from './layout/layout';
 
 export const appRoutes: Routes = [
+  {
+    path: 'acesso-negado',
+    component: AccessDeniedComponent,
+  },
   {
     // Backoffice Ingresso: todas as rotas exigem autenticação.
     // Roles elegíveis nesta SPA: admin, gestor.

--- a/apps/portal/src/app/app.routes.ts
+++ b/apps/portal/src/app/app.routes.ts
@@ -1,8 +1,12 @@
 import { Routes } from '@angular/router';
-import { authGuard } from '@uniplus/shared-auth';
+import { AccessDeniedComponent, authGuard } from '@uniplus/shared-auth';
 import { LayoutComponent } from './layout/layout';
 
 export const appRoutes: Routes = [
+  {
+    path: 'acesso-negado',
+    component: AccessDeniedComponent,
+  },
   {
     path: '',
     component: LayoutComponent,

--- a/apps/selecao/src/app/app.routes.ts
+++ b/apps/selecao/src/app/app.routes.ts
@@ -1,8 +1,14 @@
 import { Routes } from '@angular/router';
-import { authGuard, roleGuard } from '@uniplus/shared-auth';
+import { AccessDeniedComponent, authGuard, roleGuard } from '@uniplus/shared-auth';
 import { LayoutComponent } from './layout/layout';
 
 export const appRoutes: Routes = [
+  {
+    // Página de 403 — acessível mesmo sem role específica (apenas
+    // exige autenticação prévia do Keycloak).
+    path: 'acesso-negado',
+    component: AccessDeniedComponent,
+  },
   {
     // Backoffice Seleção: todas as rotas exigem autenticação.
     // Roles elegíveis nesta SPA: admin, gestor, avaliador.

--- a/libs/shared-auth/src/lib/components/access-denied.component.ts
+++ b/libs/shared-auth/src/lib/components/access-denied.component.ts
@@ -1,0 +1,56 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { UserContextService } from '../services/user-context.service';
+
+/**
+ * Página de "Acesso negado" (HTTP 403). Exibida quando um usuário
+ * autenticado tenta acessar uma rota para a qual não possui a role
+ * requerida — cenário comum quando a SPA aplica `fullScopeAllowed=false`
+ * + `scopeMappings` por client (Story uniplus-api#67 / PR #87).
+ *
+ * Não redireciona para login automaticamente (diferente de 401):
+ * o usuário já está autenticado; precisa de outra conta ou de
+ * solicitação de papel.
+ */
+@Component({
+  selector: 'auth-access-denied',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <main
+      role="main"
+      class="mx-auto flex min-h-[60vh] max-w-xl flex-col items-center justify-center gap-6 p-6 text-center"
+    >
+      <span aria-hidden="true" class="text-5xl">🚫</span>
+      <div>
+        <h1 class="text-2xl font-bold text-govbr-danger">Acesso negado</h1>
+        <p class="mt-2 text-govbr-text">
+          Sua conta não possui permissão para acessar esta área.
+        </p>
+        @if (user(); as profile) {
+          <p class="mt-1 text-sm text-govbr-text-secondary">
+            Conectado como <strong>{{ profile.username }}</strong>.
+          </p>
+        }
+      </div>
+      <div class="flex flex-wrap justify-center gap-3">
+        <button
+          type="button"
+          class="rounded-govbr bg-govbr-primary px-4 py-2 text-white hover:bg-govbr-primary-hover"
+          (click)="voltar()"
+        >
+          Voltar ao início
+        </button>
+      </div>
+    </main>
+  `,
+})
+export class AccessDeniedComponent {
+  private readonly router = inject(Router);
+  private readonly userContext = inject(UserContextService);
+  protected readonly user = this.userContext.user;
+
+  protected voltar(): void {
+    void this.router.navigate(['/']);
+  }
+}

--- a/libs/shared-auth/src/lib/guards/role.guard.spec.ts
+++ b/libs/shared-auth/src/lib/guards/role.guard.spec.ts
@@ -1,0 +1,82 @@
+import { TestBed } from '@angular/core/testing';
+import { Router, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { signal } from '@angular/core';
+import { roleGuard } from './role.guard';
+import { AuthService } from '../services/auth.service';
+
+function runGuard(requiredRoles: string[]): boolean | UrlTree {
+  return TestBed.runInInjectionContext(() => {
+    const guard = roleGuard(...requiredRoles);
+    const result = guard(
+      {} as never,
+      {} as RouterStateSnapshot,
+    );
+    if (result instanceof Promise || typeof result === 'object' && result !== null && 'subscribe' in (result as object)) {
+      throw new Error('roleGuard should be sync');
+    }
+    return result as boolean | UrlTree;
+  });
+}
+
+describe('roleGuard', () => {
+  function setup(opts: { authenticated: boolean; roles?: string[] }) {
+    const login = vi.fn();
+    const authServiceMock = {
+      authenticated: signal(opts.authenticated).asReadonly(),
+      hasRole: (role: string) => (opts.roles ?? []).includes(role),
+      login,
+    } as unknown as AuthService;
+
+    const router = {
+      createUrlTree: vi.fn((segments: unknown[]) => ({ __urlTree: true, segments })),
+    };
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: AuthService, useValue: authServiceMock },
+        { provide: Router, useValue: router },
+      ],
+    });
+    return { login, router };
+  }
+
+  it('cenário 1 — não autenticado → dispara login() e bloqueia (401)', () => {
+    const { login, router } = setup({ authenticated: false });
+
+    const result = runGuard(['admin']);
+
+    expect(result).toBe(false);
+    expect(login).toHaveBeenCalledTimes(1);
+    expect(router.createUrlTree).not.toHaveBeenCalled();
+  });
+
+  it('cenário 2 — autenticado sem role esperada → redireciona para /acesso-negado (403)', () => {
+    const { login, router } = setup({ authenticated: true, roles: ['candidato'] });
+
+    const result = runGuard(['avaliador']);
+
+    expect(login).not.toHaveBeenCalled();
+    expect(router.createUrlTree).toHaveBeenCalledWith(['/acesso-negado']);
+    expect(result).toMatchObject({ __urlTree: true });
+  });
+
+  it('cenário 3 — autenticado e com role esperada → permite navegação', () => {
+    const { login, router } = setup({ authenticated: true, roles: ['admin', 'gestor'] });
+
+    const result = runGuard(['gestor']);
+
+    expect(result).toBe(true);
+    expect(login).not.toHaveBeenCalled();
+    expect(router.createUrlTree).not.toHaveBeenCalled();
+  });
+
+  it('aceita OR entre roles: qualquer uma delas passa', () => {
+    const { router } = setup({ authenticated: true, roles: ['avaliador'] });
+
+    const result = runGuard(['admin', 'gestor', 'avaliador']);
+
+    expect(result).toBe(true);
+    expect(router.createUrlTree).not.toHaveBeenCalled();
+  });
+});

--- a/libs/shared-auth/src/lib/guards/role.guard.ts
+++ b/libs/shared-auth/src/lib/guards/role.guard.ts
@@ -2,21 +2,39 @@ import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
 import { AuthService } from '../services/auth.service';
 
+/**
+ * Guard de autorização baseado em realm roles. Distingue três cenários:
+ *
+ * 1. **Não autenticado** → dispara `login()` (equivalente a HTTP 401).
+ * 2. **Autenticado, sem a role esperada** → redireciona para
+ *    `/acesso-negado` (equivalente a HTTP 403). Esse caso aparece
+ *    naturalmente em SPAs que aplicam `fullScopeAllowed=false`
+ *    + `scopeMappings` por client (Story `uniplus-api#67` / PR #87):
+ *    o mesmo user pode ter conjuntos diferentes de roles em cada
+ *    SPA, e um token válido sem a role requerida ainda é uma falha
+ *    de autorização (403), não de autenticação (401).
+ * 3. **Autenticado com role** → permite navegação.
+ *
+ * @param requiredRoles lista de realm roles aceitas (OR lógico).
+ */
 export function roleGuard(...requiredRoles: string[]): CanActivateFn {
   return () => {
     const authService = inject(AuthService);
     const router = inject(Router);
 
+    // Cenário 1 — não autenticado: 401.
     if (!authService.authenticated()) {
       void authService.login();
       return false;
     }
 
+    // Cenário 2 — autenticado sem role: 403.
     const hasRole = requiredRoles.some((role) => authService.hasRole(role));
     if (!hasRole) {
       return router.createUrlTree(['/acesso-negado']);
     }
 
+    // Cenário 3 — autorizado.
     return true;
   };
 }

--- a/libs/shared-auth/src/lib/index.ts
+++ b/libs/shared-auth/src/lib/index.ts
@@ -22,3 +22,4 @@ export { AUTH_ALLOWED_URLS } from './tokens/auth.tokens';
 
 // Components
 export { AuthErrorBannerComponent } from './components/auth-error-banner.component';
+export { AccessDeniedComponent } from './components/access-denied.component';


### PR DESCRIPTION
## Objetivo

Task #63 da Story #5 — hardening H3: roleGuard precisa distinguir \"não autenticado\" (401) de \"autenticado sem role\" (403) para lidar com \`fullScopeAllowed=false\` + \`scopeMappings\` por client.

> Empilhada sobre #71 (#39 → #42 → #43 → #41 → #38 → #61 → #37 → #36).

## O que muda

- **\`role.guard.ts\`** — JSDoc explicitando os 3 cenários. Lógica já estava correta (auth → 403, !auth → login); reforçado com docs.
- **\`components/access-denied.component.ts\`** (novo) — página \`/acesso-negado\` standalone em pt-BR, \`role=\"main\"\`, tokens Gov.br danger, mensagem, exibição do username do usuário logado e botão \"Voltar ao início\".
- **\`index.ts\`** — exporta \`AccessDeniedComponent\`.
- **\`apps/{selecao,ingresso,portal}/src/app/app.routes.ts\`** — registra rota \`/acesso-negado\` → \`AccessDeniedComponent\`.
- **\`role.guard.spec.ts\`** (novo) — 4 testes cobrindo: não autenticado → login (401), autenticado sem role → createUrlTree(['/acesso-negado']) (403), autenticado com role → true, OR de múltiplas roles.

## Validação

\`\`\`
npx nx vite:test shared-auth                                                                               # ✓ 29 testes
npx nx run-many --target=build --projects=shared-auth,selecao,ingresso,portal --configuration=development  # ✓
npx nx run-many --target=lint  --projects=shared-auth,selecao,ingresso,portal                              # ✓
\`\`\`

## Definition of Done

- [x] roleGuard distingue não autenticado (401) de sem role (403)
- [x] Rota \`/acesso-negado\` existe nas 3 apps
- [x] 3 cenários cobertos por testes unitários
- [ ] E2E: avaliador em ingresso-web → 403 (opcional, follow-up)

Closes #63
Part of #5