### PR TITLE
feat(auth): tratar 401 e 403 no authErrorInterceptor

### DIFF
--- a/apps/ingresso/src/app/app.config.ts
+++ b/apps/ingresso/src/app/app.config.ts
@@ -3,7 +3,7 @@ import { provideRouter, withComponentInputBinding } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { appRoutes } from './app.routes';
 import { errorInterceptor, loadingInterceptor } from '@uniplus/shared-core';
-import { provideAuth, tokenInterceptor } from '@uniplus/shared-auth';
+import { authErrorInterceptor, provideAuth, tokenInterceptor } from '@uniplus/shared-auth';
 import { environment } from '../environments/environment';
 
 export const appConfig: ApplicationConfig = {
@@ -11,7 +11,12 @@ export const appConfig: ApplicationConfig = {
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(appRoutes, withComponentInputBinding()),
     provideHttpClient(
-      withInterceptors([tokenInterceptor, loadingInterceptor, errorInterceptor]),
+      withInterceptors([
+        tokenInterceptor,
+        loadingInterceptor,
+        authErrorInterceptor,
+        errorInterceptor,
+      ]),
     ),
     provideAuth({
       keycloakUrl: environment.keycloak.url,

--- a/apps/portal/src/app/app.config.ts
+++ b/apps/portal/src/app/app.config.ts
@@ -3,7 +3,7 @@ import { provideRouter, withComponentInputBinding } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { appRoutes } from './app.routes';
 import { errorInterceptor, loadingInterceptor } from '@uniplus/shared-core';
-import { provideAuth, tokenInterceptor } from '@uniplus/shared-auth';
+import { authErrorInterceptor, provideAuth, tokenInterceptor } from '@uniplus/shared-auth';
 import { environment } from '../environments/environment';
 
 export const appConfig: ApplicationConfig = {
@@ -11,7 +11,12 @@ export const appConfig: ApplicationConfig = {
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(appRoutes, withComponentInputBinding()),
     provideHttpClient(
-      withInterceptors([tokenInterceptor, loadingInterceptor, errorInterceptor]),
+      withInterceptors([
+        tokenInterceptor,
+        loadingInterceptor,
+        authErrorInterceptor,
+        errorInterceptor,
+      ]),
     ),
     provideAuth({
       keycloakUrl: environment.keycloak.url,

--- a/apps/selecao/src/app/app.config.ts
+++ b/apps/selecao/src/app/app.config.ts
@@ -3,7 +3,7 @@ import { provideRouter, withComponentInputBinding } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { appRoutes } from './app.routes';
 import { errorInterceptor, loadingInterceptor } from '@uniplus/shared-core';
-import { provideAuth, tokenInterceptor } from '@uniplus/shared-auth';
+import { authErrorInterceptor, provideAuth, tokenInterceptor } from '@uniplus/shared-auth';
 import { environment } from '../environments/environment';
 
 export const appConfig: ApplicationConfig = {
@@ -14,7 +14,12 @@ export const appConfig: ApplicationConfig = {
     // loadingInterceptor para UX, errorInterceptor por último para
     // capturar falhas de toda a pilha.
     provideHttpClient(
-      withInterceptors([tokenInterceptor, loadingInterceptor, errorInterceptor]),
+      withInterceptors([
+        tokenInterceptor,
+        loadingInterceptor,
+        authErrorInterceptor,
+        errorInterceptor,
+      ]),
     ),
     provideAuth({
       keycloakUrl: environment.keycloak.url,

--- a/libs/shared-auth/src/lib/index.ts
+++ b/libs/shared-auth/src/lib/index.ts
@@ -8,6 +8,7 @@ export { roleGuard } from './guards/role.guard';
 
 // Interceptors
 export { tokenInterceptor } from './interceptors/token.interceptor';
+export { authErrorInterceptor } from './interceptors/auth-error.interceptor';
 
 // Models
 export type { UserProfile } from './models/user.model';

--- a/libs/shared-auth/src/lib/interceptors/auth-error.interceptor.spec.ts
+++ b/libs/shared-auth/src/lib/interceptors/auth-error.interceptor.spec.ts
@@ -1,0 +1,89 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { Router } from '@angular/router';
+import { firstValueFrom } from 'rxjs';
+import { authErrorInterceptor } from './auth-error.interceptor';
+import { AuthService } from '../services/auth.service';
+
+describe('authErrorInterceptor', () => {
+  function setup() {
+    const login = vi.fn();
+    const navigate = vi.fn();
+    const authServiceMock = { login } as unknown as AuthService;
+    const routerMock = { navigate } as unknown as Router;
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([authErrorInterceptor])),
+        provideHttpClientTesting(),
+        { provide: AuthService, useValue: authServiceMock },
+        { provide: Router, useValue: routerMock },
+      ],
+    });
+
+    return {
+      http: TestBed.inject(HttpClient),
+      httpMock: TestBed.inject(HttpTestingController),
+      login,
+      navigate,
+    };
+  }
+
+  it('401 → chama authService.login() e propaga o erro', async () => {
+    const { http, httpMock, login, navigate } = setup();
+
+    const promise = firstValueFrom(http.get('/api/protegido')).catch((e) => e);
+    const req = httpMock.expectOne('/api/protegido');
+    req.flush({ message: 'Unauthorized' }, { status: 401, statusText: 'Unauthorized' });
+
+    const err = await promise;
+    expect(err.status).toBe(401);
+    expect(login).toHaveBeenCalledTimes(1);
+    expect(navigate).not.toHaveBeenCalled();
+    httpMock.verify();
+  });
+
+  it('403 → redireciona para /acesso-negado e propaga o erro', async () => {
+    const { http, httpMock, login, navigate } = setup();
+
+    const promise = firstValueFrom(http.get('/api/admin')).catch((e) => e);
+    const req = httpMock.expectOne('/api/admin');
+    req.flush({ message: 'Forbidden' }, { status: 403, statusText: 'Forbidden' });
+
+    const err = await promise;
+    expect(err.status).toBe(403);
+    expect(navigate).toHaveBeenCalledWith(['/acesso-negado']);
+    expect(login).not.toHaveBeenCalled();
+    httpMock.verify();
+  });
+
+  it('outros status (500, 404, 0) não disparam login nem navigate', async () => {
+    const { http, httpMock, login, navigate } = setup();
+
+    for (const status of [500, 404, 0]) {
+      const promise = firstValueFrom(http.get(`/api/x${status}`)).catch((e) => e);
+      const req = httpMock.expectOne(`/api/x${status}`);
+      req.flush({}, { status, statusText: 'error' });
+      await promise;
+    }
+
+    expect(login).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+    httpMock.verify();
+  });
+
+  it('resposta 2xx passa inalterada', async () => {
+    const { http, httpMock, login, navigate } = setup();
+
+    const promise = firstValueFrom(http.get<{ ok: boolean }>('/api/ok'));
+    const req = httpMock.expectOne('/api/ok');
+    req.flush({ ok: true });
+
+    const body = await promise;
+    expect(body.ok).toBe(true);
+    expect(login).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+    httpMock.verify();
+  });
+});

--- a/libs/shared-auth/src/lib/interceptors/auth-error.interceptor.ts
+++ b/libs/shared-auth/src/lib/interceptors/auth-error.interceptor.ts
@@ -1,0 +1,40 @@
+import { HttpErrorResponse, HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { catchError, throwError } from 'rxjs';
+import { AuthService } from '../services/auth.service';
+
+/**
+ * Interceptor de erros de autenticação/autorização:
+ *
+ * - **401 Unauthorized** → dispara `authService.login()` (redireciona
+ *   o usuário para o Keycloak). Usado quando o backend rejeita o token
+ *   (ex.: sessão revogada, clock skew, refresh falhou).
+ * - **403 Forbidden** → redireciona para `/acesso-negado`. O usuário
+ *   está autenticado mas não tem permissão para o recurso solicitado.
+ *
+ * Outros status não são tratados aqui — ficam a cargo do
+ * `errorInterceptor` de `@uniplus/shared-core` (0, 5xx) e de handlers
+ * específicos por feature.
+ *
+ * Deve ser registrado depois do `tokenInterceptor` e preferencialmente
+ * antes de interceptors que apresentam erros em UI (ex.: toasts),
+ * para que um 401 não exiba um toast antes de redirecionar.
+ */
+export const authErrorInterceptor: HttpInterceptorFn = (req, next) => {
+  const authService = inject(AuthService);
+  const router = inject(Router);
+
+  return next(req).pipe(
+    catchError((error: unknown) => {
+      if (error instanceof HttpErrorResponse) {
+        if (error.status === 401) {
+          void authService.login();
+        } else if (error.status === 403) {
+          void router.navigate(['/acesso-negado']);
+        }
+      }
+      return throwError(() => error);
+    }),
+  );
+};


### PR DESCRIPTION
## Objetivo

Task #40 da Story #5 — finding I6: tratar 401 (redirect login) e 403 (redirect /acesso-negado) em HttpInterceptor dedicado.

> Empilhada sobre #72 (#63 → #39 → #42 → #43 → #41 → #38 → #61 → #37 → #36).

## O que muda

- **\`libs/shared-auth/src/lib/interceptors/auth-error.interceptor.ts\`** (novo) — \`authErrorInterceptor\` faz: 401 → \`authService.login()\`; 403 → \`router.navigate(['/acesso-negado'])\`; outros status passam; erro é sempre re-propagado.
- **\`libs/shared-auth/src/lib/index.ts\`** — exporta \`authErrorInterceptor\`.
- **\`apps/{selecao,ingresso,portal}/src/app/app.config.ts\`** — inclui \`authErrorInterceptor\` na ordem \`[tokenInterceptor, loadingInterceptor, authErrorInterceptor, errorInterceptor]\` (auth antes das notificações genéricas de \`shared-core\`).
- **\`auth-error.interceptor.spec.ts\`** (novo) — 4 cenários: 401, 403, outros status (500/404/0), 2xx.

## Validação

\`\`\`
npx nx vite:test shared-auth                                                                               # ✓ 33 testes
npx nx run-many --target=build --projects=shared-auth,selecao,ingresso,portal --configuration=development  # ✓
npx nx run-many --target=lint  --projects=shared-auth,selecao,ingresso,portal                              # ✓
\`\`\`

## Decisão de arquitetura

Interceptor mora em \`shared-auth\` e não em \`shared-core\` para evitar dependência \`shared-core → shared-auth\`. \`shared-core\` continua cuidando de 0/5xx (conexão/servidor); \`shared-auth\` cuida de 401/403 (autenticação/autorização).

## Definition of Done

- [x] 401 redireciona para login
- [x] 403 redireciona para /acesso-negado
- [x] Outros status passam sem efeitos colaterais
- [x] Erro é sempre re-propagado (não engolido)
- [x] Wireado nas 3 apps

Closes #40
Part of #5