### PR TITLE
feat(auth): distinguir conta bloqueada de credenciais inválidas no login

### DIFF
--- a/apps/ingresso/src/app/app.ts
+++ b/apps/ingresso/src/app/app.ts
@@ -1,13 +1,14 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { AuthErrorBannerComponent } from '@uniplus/shared-auth';
+import { AuthErrorBannerComponent, LoginErrorBannerComponent } from '@uniplus/shared-auth';
 
 @Component({
   selector: 'ing-root',
   standalone: true,
-  imports: [RouterOutlet, AuthErrorBannerComponent],
+  imports: [RouterOutlet, AuthErrorBannerComponent, LoginErrorBannerComponent],
   template: `
     <auth-error-banner />
+    <auth-login-error-banner />
     <router-outlet />
   `,
 })

--- a/apps/portal/src/app/app.ts
+++ b/apps/portal/src/app/app.ts
@@ -1,13 +1,14 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { AuthErrorBannerComponent } from '@uniplus/shared-auth';
+import { AuthErrorBannerComponent, LoginErrorBannerComponent } from '@uniplus/shared-auth';
 
 @Component({
   selector: 'ptl-root',
   standalone: true,
-  imports: [RouterOutlet, AuthErrorBannerComponent],
+  imports: [RouterOutlet, AuthErrorBannerComponent, LoginErrorBannerComponent],
   template: `
     <auth-error-banner />
+    <auth-login-error-banner />
     <router-outlet />
   `,
 })

--- a/apps/selecao/src/app/app.ts
+++ b/apps/selecao/src/app/app.ts
@@ -1,13 +1,14 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { AuthErrorBannerComponent } from '@uniplus/shared-auth';
+import { AuthErrorBannerComponent, LoginErrorBannerComponent } from '@uniplus/shared-auth';
 
 @Component({
   selector: 'sel-root',
   standalone: true,
-  imports: [RouterOutlet, AuthErrorBannerComponent],
+  imports: [RouterOutlet, AuthErrorBannerComponent, LoginErrorBannerComponent],
   template: `
     <auth-error-banner />
+    <auth-login-error-banner />
     <router-outlet />
   `,
 })

--- a/libs/shared-auth/src/lib/components/login-error-banner.component.ts
+++ b/libs/shared-auth/src/lib/components/login-error-banner.component.ts
@@ -1,0 +1,119 @@
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { filter, map, startWith } from 'rxjs/operators';
+import { LoginErrorCode, classifyLoginError } from '../models/login-error.model';
+
+/**
+ * Banner contextual exibido quando o Keycloak redireciona de volta à
+ * SPA com `error` / `error_description` na query string. Distingue
+ * credenciais inválidas de conta bloqueada (H2 — brute force protection)
+ * para cumprir a DoD da Task #62 sem exigir um formulário de login
+ * customizado (o login acontece 100% na UI hospedada do Keycloak).
+ *
+ * Acessibilidade: `role="alert"` + `aria-live="assertive"`, cores
+ * Gov.br danger/warning conforme severidade.
+ */
+@Component({
+  selector: 'auth-login-error-banner',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    @if (details(); as d) {
+      <div
+        role="alert"
+        aria-live="assertive"
+        [class.border-govbr-danger]="isDanger()"
+        [class.bg-govbr-danger-lightest]="isDanger()"
+        [class.text-govbr-danger]="isDanger()"
+        [class.border-govbr-warning]="!isDanger()"
+        [class.bg-govbr-warning-lightest]="!isDanger()"
+        [class.text-govbr-warning]="!isDanger()"
+        class="flex items-start gap-3 border-b px-6 py-3"
+      >
+        <span aria-hidden="true" class="mt-0.5 text-lg">
+          {{ isDanger() ? '⚠' : 'ℹ' }}
+        </span>
+        <div class="flex-1 text-sm">
+          <strong class="block font-semibold">{{ title() }}</strong>
+          <span class="block">{{ d.message }}</span>
+        </div>
+        <button
+          type="button"
+          class="text-xs underline opacity-80 hover:opacity-100"
+          (click)="dismiss()"
+          aria-label="Fechar mensagem"
+        >
+          Fechar
+        </button>
+      </div>
+    }
+  `,
+})
+export class LoginErrorBannerComponent {
+  private readonly router = inject(Router);
+  private readonly dismissed = signal(false);
+
+  /**
+   * Captura query params do URL inicial e de cada navegação. Emite
+   * uma tupla `[error, error_description]` sempre que houver mudança.
+   */
+  private readonly currentParams = toSignal(
+    this.router.events.pipe(
+      filter((event): event is NavigationEnd => event instanceof NavigationEnd),
+      startWith(null),
+      map(() => {
+        const url = this.router.url;
+        return extractErrorFromUrl(url);
+      }),
+    ),
+    { initialValue: extractErrorFromUrl(this.router.url) },
+  );
+
+  protected readonly details = computed(() => {
+    if (this.dismissed()) return null;
+    const params = this.currentParams();
+    if (!params) return null;
+    const [error, description] = params;
+    if (!error && !description) return null;
+    return classifyLoginError({ error, error_description: description });
+  });
+
+  protected readonly isDanger = computed(() => {
+    const d = this.details();
+    if (!d) return false;
+    return d.code === LoginErrorCode.InvalidCredentials || d.code === LoginErrorCode.UserLocked;
+  });
+
+  protected readonly title = computed(() => {
+    const d = this.details();
+    if (!d) return '';
+    switch (d.code) {
+      case LoginErrorCode.UserLocked:
+        return 'Conta bloqueada';
+      case LoginErrorCode.InvalidCredentials:
+        return 'Credenciais inválidas';
+      case LoginErrorCode.KeycloakUnavailable:
+        return 'Serviço indisponível';
+      case LoginErrorCode.AccessDenied:
+        return 'Acesso recusado';
+      default:
+        return 'Falha no login';
+    }
+  });
+
+  protected dismiss(): void {
+    this.dismissed.set(true);
+  }
+}
+
+function extractErrorFromUrl(url: string): [string | null, string | null] | null {
+  const queryIndex = url.indexOf('?');
+  if (queryIndex < 0) return null;
+  const query = url.slice(queryIndex + 1);
+  const params = new URLSearchParams(query);
+  const error = params.get('error');
+  const description = params.get('error_description');
+  if (!error && !description) return null;
+  return [error, description];
+}

--- a/libs/shared-auth/src/lib/index.ts
+++ b/libs/shared-auth/src/lib/index.ts
@@ -24,3 +24,8 @@ export { AUTH_ALLOWED_URLS } from './tokens/auth.tokens';
 // Components
 export { AuthErrorBannerComponent } from './components/auth-error-banner.component';
 export { AccessDeniedComponent } from './components/access-denied.component';
+export { LoginErrorBannerComponent } from './components/login-error-banner.component';
+
+// Models
+export { LoginErrorCode, classifyLoginError } from './models/login-error.model';
+export type { LoginErrorDetails } from './models/login-error.model';

--- a/libs/shared-auth/src/lib/models/login-error.model.spec.ts
+++ b/libs/shared-auth/src/lib/models/login-error.model.spec.ts
@@ -1,0 +1,49 @@
+import { LoginErrorCode, classifyLoginError } from './login-error.model';
+
+describe('classifyLoginError', () => {
+  it('detecta UserLocked a partir de error_description típico do Keycloak', () => {
+    const result = classifyLoginError({
+      error: 'invalid_grant',
+      error_description: 'Account is temporarily locked',
+    });
+    expect(result.code).toBe(LoginErrorCode.UserLocked);
+    expect(result.message).toContain('temporariamente bloqueada');
+  });
+
+  it('detecta UserLocked para "too many attempts"', () => {
+    const result = classifyLoginError('Too many login attempts');
+    expect(result.code).toBe(LoginErrorCode.UserLocked);
+  });
+
+  it('detecta InvalidCredentials a partir de "Invalid user credentials"', () => {
+    const result = classifyLoginError({
+      error: 'invalid_grant',
+      error_description: 'Invalid user credentials',
+    });
+    expect(result.code).toBe(LoginErrorCode.InvalidCredentials);
+    expect(result.message).toContain('Usuário ou senha inválidos');
+  });
+
+  it('detecta KeycloakUnavailable para erros de rede', () => {
+    const result = classifyLoginError(new Error('Failed to fetch'));
+    expect(result.code).toBe(LoginErrorCode.KeycloakUnavailable);
+  });
+
+  it('detecta AccessDenied quando o usuário cancela o fluxo', () => {
+    const result = classifyLoginError('access_denied');
+    expect(result.code).toBe(LoginErrorCode.AccessDenied);
+  });
+
+  it('retorna Unknown com mensagem padrão quando não reconhece o erro', () => {
+    const result = classifyLoginError({ error: 'foo', error_description: 'bar' });
+    expect(result.code).toBe(LoginErrorCode.Unknown);
+    expect(result.message).toContain('Não foi possível concluir o login');
+    expect(result.rawDescription).toBe('bar');
+  });
+
+  it('lida com entradas vazias sem lançar', () => {
+    const result = classifyLoginError(null);
+    expect(result.code).toBe(LoginErrorCode.Unknown);
+    expect(result.rawDescription).toBeUndefined();
+  });
+});

--- a/libs/shared-auth/src/lib/models/login-error.model.ts
+++ b/libs/shared-auth/src/lib/models/login-error.model.ts
@@ -1,0 +1,126 @@
+/**
+ * Códigos de erro do fluxo de login, mapeados a partir das respostas
+ * OIDC do Keycloak. Usado para exibir mensagens contextuais no shell
+ * da app quando o Keycloak redireciona de volta à SPA com erro, e por
+ * fluxos customizados (se/quando existirem) que consumam diretamente
+ * o resource owner password grant.
+ */
+export enum LoginErrorCode {
+  /** Credenciais inválidas (usuário/senha). */
+  InvalidCredentials = 'invalid_credentials',
+  /**
+   * Conta temporariamente bloqueada por brute force protection
+   * (realm com `bruteForceProtected=true` + `failureFactor`).
+   */
+  UserLocked = 'user_locked',
+  /** Provedor de autenticação inacessível. */
+  KeycloakUnavailable = 'keycloak_unavailable',
+  /** Usuário recusou o consentimento ou cancelou o fluxo. */
+  AccessDenied = 'access_denied',
+  /** Qualquer outro erro não reconhecido. */
+  Unknown = 'unknown',
+}
+
+export interface LoginErrorDetails {
+  code: LoginErrorCode;
+  /** Mensagem user-facing em pt-BR. */
+  message: string;
+  /** Descrição original do Keycloak, se disponível (para logs). */
+  rawDescription?: string;
+}
+
+const LOCKED_MARKERS = [
+  'account is disabled',
+  'account disabled',
+  'user is disabled',
+  'temporarily locked',
+  'temporarily disabled',
+  'account is temporarily locked',
+  'user is temporarily locked',
+  'too many',
+];
+
+const INVALID_CREDENTIALS_MARKERS = [
+  'invalid user credentials',
+  'invalid credentials',
+  'invalid grant',
+  'invalid username or password',
+];
+
+const UNAVAILABLE_MARKERS = [
+  'failed to fetch',
+  'network request failed',
+  'unable to connect',
+  'service unavailable',
+];
+
+/**
+ * Classifica um erro OIDC/Keycloak em um `LoginErrorCode` + mensagem
+ * contextual em pt-BR. Aceita entradas variadas (string de description,
+ * objeto com `error_description`, Error genérico).
+ */
+export function classifyLoginError(input: unknown): LoginErrorDetails {
+  const raw = extractDescription(input);
+  const normalized = raw.toLowerCase();
+
+  if (LOCKED_MARKERS.some((m) => normalized.includes(m))) {
+    return {
+      code: LoginErrorCode.UserLocked,
+      message:
+        'Conta temporariamente bloqueada por excesso de tentativas. Aguarde alguns minutos ou use "Esqueci a senha".',
+      rawDescription: raw,
+    };
+  }
+
+  if (INVALID_CREDENTIALS_MARKERS.some((m) => normalized.includes(m))) {
+    return {
+      code: LoginErrorCode.InvalidCredentials,
+      message: 'Usuário ou senha inválidos. Confira os dados e tente novamente.',
+      rawDescription: raw,
+    };
+  }
+
+  if (UNAVAILABLE_MARKERS.some((m) => normalized.includes(m))) {
+    return {
+      code: LoginErrorCode.KeycloakUnavailable,
+      message:
+        'Serviço de autenticação indisponível. Tente novamente em alguns instantes.',
+      rawDescription: raw,
+    };
+  }
+
+  if (normalized.includes('access_denied')) {
+    return {
+      code: LoginErrorCode.AccessDenied,
+      message: 'Acesso recusado. Você cancelou ou não autorizou o login.',
+      rawDescription: raw,
+    };
+  }
+
+  return {
+    code: LoginErrorCode.Unknown,
+    message:
+      'Não foi possível concluir o login. Tente novamente; se persistir, contate o suporte.',
+    rawDescription: raw || undefined,
+  };
+}
+
+function extractDescription(input: unknown): string {
+  if (!input) return '';
+  if (typeof input === 'string') return input;
+  if (input instanceof Error) return input.message ?? '';
+  if (typeof input !== 'object') return '';
+
+  const candidates: unknown[] = [
+    (input as { error_description?: unknown }).error_description,
+    (input as { errorDescription?: unknown }).errorDescription,
+    (input as { description?: unknown }).description,
+    (input as { message?: unknown }).message,
+    (input as { error?: unknown }).error,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.length > 0) return candidate;
+  }
+  return '';
+}


### PR DESCRIPTION
## Objetivo

Task #62 da Story #5 — hardening H2: distinguir \"senha errada\" de \"conta temporariamente bloqueada\" (brute force protection) no fluxo de login.

> Empilhada sobre #73 (#40 → #63 → #39 → #42 → #43 → #41 → #38 → #61 → #37 → #36).

## Escopo e decisão de design

O formulário de login acontece 100% na **UI hospedada do Keycloak** — a SPA não tem um formulário próprio de usuário/senha. A Keycloak theme já distingue estes erros em pt-BR. O que a SPA precisa cobrir é o caminho em que o Keycloak redireciona de volta com \`error\` / \`error_description\` na query string — quando o fluxo OIDC termina em estado de erro propagado.

Esta PR entrega a **infraestrutura classificadora + banner contextual**; não cria um formulário de login customizado (não existe demanda no backlog e seria grande expansão de escopo).

## O que muda

- **\`login-error.model.ts\`** (novo) — \`enum LoginErrorCode\` (\`InvalidCredentials\` | \`UserLocked\` | \`KeycloakUnavailable\` | \`AccessDenied\` | \`Unknown\`), \`LoginErrorDetails\`, \`classifyLoginError(input)\` com pattern matching tolerante sobre marcadores típicos do Keycloak.
- **\`login-error-banner.component.ts\`** (novo) — lê URL do \`Router\` em cada \`NavigationEnd\`, extrai \`error\`/\`error_description\`, aciona \`classifyLoginError\` e mostra banner (\`role=\"alert\"\`, \`aria-live=\"assertive\"\`, tokens Gov.br \`danger\`/\`warning\`, título contextual + mensagem + botão Fechar).
- **\`index.ts\`** — exporta \`LoginErrorCode\`, \`LoginErrorDetails\`, \`classifyLoginError\`, \`LoginErrorBannerComponent\`.
- **\`apps/{selecao,ingresso,portal}/src/app/app.ts\`** — renderiza \`<auth-login-error-banner />\` no shell.
- **\`login-error.model.spec.ts\`** (novo) — 7 cenários: UserLocked (\"temporarily locked\", \"too many\"), InvalidCredentials, KeycloakUnavailable (rede), AccessDenied, Unknown com rawDescription, entrada nula.

## Validação

\`\`\`
npx nx vite:test shared-auth                                                                               # ✓ 40 testes
npx nx run-many --target=build --projects=shared-auth,selecao,ingresso,portal --configuration=development  # ✓
npx nx run-many --target=lint  --projects=shared-auth,selecao,ingresso,portal                              # ✓
\`\`\`

Validação manual (6 tentativas erradas em \`local/hardened-realm\`) fica como checklist da Story #5 — confirma que o banner aparece quando o Keycloak redireciona de volta com erro.

## Definition of Done

- [x] \`authService.login()\` contrato preservado (redirect do Keycloak)
- [x] Enum \`LoginErrorCode\` tipado com descrições pt-BR
- [x] Banner distingue senha errada vs conta bloqueada
- [x] Texto user-facing em pt-BR, WCAG 2.1 AA (role/aria, cores Gov.br)
- [x] Testes unitários para cada cenário

Closes #62
Part of #5