### PR TITLE
fix(lgpd) atualiza função maskCpf para o padrão da lgpd

### DIFF
--- a/libs/shared-data/src/lib/utils/cpf.util.spec.ts
+++ b/libs/shared-data/src/lib/utils/cpf.util.spec.ts
@@ -23,7 +23,7 @@ describe('cpf.util', () => {
 
   describe('maskCpf', () => {
     it('should mask CPF for LGPD', () => {
-      expect(maskCpf('52998224725')).toBe('***.982.***-25');
+      expect(maskCpf('52998224725')).toBe('***.***.***-25');
     });
   });
 });

--- a/libs/shared-data/src/lib/utils/cpf.util.ts
+++ b/libs/shared-data/src/lib/utils/cpf.util.ts
@@ -21,6 +21,6 @@ export function formatCpf(cpf: string): string {
 }
 
 export function maskCpf(cpf: string): string {
-  const digits = cpf.replace(/\D/g, '').padStart(11, '0');
-  return `***.${digits.slice(3, 6)}.***-${digits.slice(9)}`;
+  const digits = cpf.replace(/\D/g, '');
+  return `***.***.***-${digits.slice(-2)}`;
 }

--- a/libs/shared-ui/src/lib/pipes/cpf.pipe.spec.ts
+++ b/libs/shared-ui/src/lib/pipes/cpf.pipe.spec.ts
@@ -4,11 +4,11 @@ describe('CpfPipe', () => {
   const pipe = new CpfPipe();
 
   it('should format CPF correctly', () => {
-    expect(pipe.transform('12345678901')).toBe('123.456.789-01');
+    expect(pipe.transform('52998224725')).toBe('529.982.247-25');
   });
 
   it('should mask CPF correctly', () => {
-    expect(pipe.transform('12345678901', true)).toBe('***.456.***-01');
+    expect(pipe.transform('52998224725', true)).toBe('***.***.***-25');
   });
 
   it('should handle empty value', () => {

--- a/libs/shared-ui/src/lib/pipes/cpf.pipe.ts
+++ b/libs/shared-ui/src/lib/pipes/cpf.pipe.ts
@@ -9,7 +9,7 @@ export class CpfPipe implements PipeTransform {
     if (!value) return '';
     const digits = value.replace(/\D/g, '').padStart(11, '0');
     if (masked) {
-      return `***.${digits.slice(3, 6)}.***-${digits.slice(9, 11)}`;
+      return `***.***.***-${digits.slice(-2)}`;
     }
     return `${digits.slice(0, 3)}.${digits.slice(3, 6)}.${digits.slice(6, 9)}-${digits.slice(9, 11)}`;
   }


### PR DESCRIPTION
## Resumo

Atualiza a função maskCpf do arquivo cpf.util.ts para o padrão da lgpd, bem como também corrige o pipe de formatador de cpf para o padrão lgpd. Os testes de ambos os arquivos também foram atualizados.

## Mudanças

### Arquivos Modificados

libs/shared-data/src/lib/utils/cpf.util.ts
libs/shared-data/src/lib/utils/cpf.util.spec.ts

libs/shared-ui/src/lib/pipes/cpf.pipe.ts
libs/shared-ui/src/lib/pipes/cpf.pipe.spec.ts

## Testes

- [x] Testes unitários passando

Closes #11