### PR TITLE
refactor(shared-ui): converte displayValue para signal no CpfInputComponent

### DIFF
--- a/libs/shared-ui/src/lib/components/cpf-input/cpf-input.ts
+++ b/libs/shared-ui/src/lib/components/cpf-input/cpf-input.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, input, forwardRef } from '@angular/core';
+import { Component, ChangeDetectionStrategy, input, forwardRef, signal } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@angular/forms';
 
 @Component({
@@ -17,7 +17,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@a
         [id]="inputId()"
         type="text"
         [placeholder]="placeholder()"
-        [value]="displayValue"
+        [value]="displayValue()"
         (input)="onInput($event)"
         (blur)="onTouched()"
         maxlength="14"
@@ -48,7 +48,7 @@ export class CpfInputComponent implements ControlValueAccessor {
   readonly invalid = input<boolean>(false);
   readonly errorMessage = input<string>('');
 
-  displayValue = '';
+  displayValue = signal('');
   private rawValue = '';
 
   // noop — substituída por registerOnChange
@@ -58,7 +58,7 @@ export class CpfInputComponent implements ControlValueAccessor {
 
   writeValue(value: string): void {
     this.rawValue = (value || '').replace(/\D/g, '');
-    this.displayValue = this.formatCpf(this.rawValue);
+    this.displayValue.set(this.formatCpf(this.rawValue));
   }
 
   registerOnChange(fn: (value: string) => void): void {
@@ -72,8 +72,8 @@ export class CpfInputComponent implements ControlValueAccessor {
   onInput(event: Event): void {
     const input = event.target as HTMLInputElement;
     this.rawValue = input.value.replace(/\D/g, '').substring(0, 11);
-    this.displayValue = this.formatCpf(this.rawValue);
-    input.value = this.displayValue;
+    this.displayValue.set(this.formatCpf(this.rawValue));
+    input.value = this.displayValue();
     this.onChange(this.rawValue);
   }
 


### PR DESCRIPTION
## Resumo

Converte `displayValue` de propriedade simples (`string`) para `signal('')` no `CpfInputComponent`, alinhando ao padrão OnPush + signals do Angular 21.

Closes #46

## Motivação

Com `ChangeDetectionStrategy.OnPush`, uma propriedade não-reativa (`displayValue = ''`) não dispara atualização do template ao ser alterada via `writeValue()` ou `onInput()`. O signal resolve isso de forma idiomática sem necessidade de `markForCheck()`.

## O que muda

| Antes | Depois |
|---|---|
| `displayValue = ''` | `displayValue = signal('')` |
| `[value]="displayValue"` | `[value]="displayValue()"` |
| `this.displayValue = x` | `this.displayValue.set(x)` |
| `this.displayValue` (leitura) | `this.displayValue()` |

## O que falta para fechar a issue #7

Este PR cobre a task de reatividade do `displayValue`. Ainda pendente (próximo PR):

- [ ] Implementar `setDisabledState(isDisabled: boolean)` com signal `disabled`
- [ ] Template com `[disabled]="disabled()"`
- [ ] Testes unitários do `ControlValueAccessor` (writeValue, disable/enable, formatação)

