### PR TITLE
feat(shared-ui): implementa o método `setDisabledState` da interface `ControlValueAccessor` e cria a propriedade `signal` `disabled`

### DIFF
--- a/libs/shared-ui/src/lib/components/cpf-input/cpf-input.ts
+++ b/libs/shared-ui/src/lib/components/cpf-input/cpf-input.ts
@@ -20,6 +20,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@a
         [value]="displayValue()"
         (input)="onInput($event)"
         (blur)="onTouched()"
+        [disabled]="disabled()"
         maxlength="14"
         class="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-unifesspa-primary focus:outline-none focus:ring-1 focus:ring-unifesspa-primary"
         [class.border-red-500]="invalid()"
@@ -47,8 +48,8 @@ export class CpfInputComponent implements ControlValueAccessor {
   readonly inputId = input<string>('cpf-input');
   readonly invalid = input<boolean>(false);
   readonly errorMessage = input<string>('');
-
-  displayValue = signal('');
+  readonly disabled = signal(false);
+  readonly displayValue = signal('');
   private rawValue = '';
 
   // noop — substituída por registerOnChange
@@ -67,6 +68,10 @@ export class CpfInputComponent implements ControlValueAccessor {
 
   registerOnTouched(fn: () => void): void {
     this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled.set(isDisabled);
   }
 
   onInput(event: Event): void {


### PR DESCRIPTION
# Resumo

Cria a propriedade `signal` `disabled` com o valor padrão igual a `false`. Implementa o método `setDisabledState` da interface `ControlValueAccessor`. Atribui o binding do `signal` `disabled` no `input` para que o `input` reaja dinamicamente.

# Motivação

Ao implementar o método `setDisabledState` é possível controlar o estado do input programaticamente ao chamar os métodos `control.disable()`/`control.enable()`. Para que o input reaja as alterações do estado faz-se necessário a atribuição do novo estado no `input`.

# O que foi feito

- [x] Cria o `signal` `disabled`
- [x] Implementa o método `setDisabledState` da interface `ControlValueAccessor` e atribui o novo valor a propriedade `signal` `disabled`
- [x] Atualiza o template atribuindo o binding do `signal` `disabled` na propriedade `disabled` na tag do `input`.
