### PR TITLE
test(shared-ui): adiciona casos de teste para o componente de input de cpf

### DIFF
--- a/libs/shared-ui/src/lib/components/cpf-input/cpf-input.spec.ts
+++ b/libs/shared-ui/src/lib/components/cpf-input/cpf-input.spec.ts
@@ -1,0 +1,55 @@
+import { By } from '@angular/platform-browser';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CpfInputComponent } from './cpf-input';
+
+describe('CpfInputComponent (ControlValueAccessor)', () => {
+  let component: CpfInputComponent;
+  let fixture: ComponentFixture<CpfInputComponent>;
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [CpfInputComponent]
+    });
+
+    fixture = TestBed.createComponent(CpfInputComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should update `displayValue` signal when method `writeValue` is called', () => {
+    component.writeValue('52998224725');
+
+    expect(component.displayValue()).toBe('529.982.247-25');
+  });
+
+  it('should call `registeredOnChange` method with argument', () => {
+    const onChangeSpy = vi.fn();
+    onChangeSpy('52998224725');
+
+    component.registerOnChange(onChangeSpy);
+    expect(onChangeSpy).toHaveBeenCalledWith('52998224725');
+  });
+
+  it('should update `disabled` signal when method `setDisabled` is called with `true` argument', () => {
+    component.setDisabledState(true);
+
+    expect(component.disabled()).toBe(true);
+  });
+
+  it('should update `disabled` signal when method `setDisabled` is called with `false` argument', () => {
+    component.setDisabledState(false);
+
+    expect(component.disabled()).toBe(false);
+  });
+
+  it('should call `setDisabledState` with `true` argument and check if `disabled` property input is enabled', () => {
+    const debugElement = fixture.debugElement.query(By.css('input'));
+    const inputElement = debugElement.nativeElement;
+
+    component.setDisabledState(true);
+    fixture.detectChanges();
+
+    expect(inputElement.disabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Resumo

Adiciona casos de testes para o componente de input de cpf.

Closes #48 

## Implementações de teste
- Testa se o novo valor do signal `displayValue` foi atualizado quando o método `writeValue` é chamado.
-  Testa se o novo valor do signal `disabled` foi atualizado quando o método `setDisabled` é chamado enviando o argumento `true`.
-  Testa se o novo valor do signal `disabled` foi atualizado quando o método `setDisabled` é chamado enviando o argumento `false`.
-  Testa se o  método `registeredOnChange` é chamado com argumento específico.
- Testa o valor se a propriedade `disabled` na tag input do html está habilitada quando a propriedade signal `disabled` é atualizada com o valor `true`.
## Mudanças
### Novos arquivos
libs/shared-ui/src/lib/components/cpf-input/cpf-input.spec.ts
## Ressalvas
Alguns testes propostos na task não foram incluídos por limitações de implementação. Eles são:
- Testar o método control disable/enable.
- Clear.