### PR TITLE
test+feat(shared-ui): cobertura completa, a11y, DRY e validação do CpfInputComponent (stacked sobre #89)

### DIFF
--- a/libs/shared-data/package.json
+++ b/libs/shared-data/package.json
@@ -4,6 +4,7 @@
   "peerDependencies": {
     "@angular/common": "^21.2.0",
     "@angular/core": "^21.2.0",
+    "@angular/forms": "^21.2.0",
     "vite": "^7.0.0",
     "@analogjs/vite-plugin-angular": ">=2.0.0",
     "@nx/vite": ">=22.0.0"

--- a/libs/shared-data/src/lib/index.ts
+++ b/libs/shared-data/src/lib/index.ts
@@ -12,3 +12,6 @@ export type { ProblemDetails } from './services/api-error-handler.service';
 // Utils
 export { isValidCpf, formatCpf, formatCpfProgressive, maskCpf } from './utils/cpf.util';
 export { formatDateBr, formatDateTimeBr, parseDate } from './utils/date.util';
+
+// Validators
+export { cpfValidator } from './validators/cpf.validator';

--- a/libs/shared-data/src/lib/index.ts
+++ b/libs/shared-data/src/lib/index.ts
@@ -10,5 +10,5 @@ export { ApiErrorHandlerService } from './services/api-error-handler.service';
 export type { ProblemDetails } from './services/api-error-handler.service';
 
 // Utils
-export { isValidCpf, formatCpf, maskCpf } from './utils/cpf.util';
+export { isValidCpf, formatCpf, formatCpfProgressive, maskCpf } from './utils/cpf.util';
 export { formatDateBr, formatDateTimeBr, parseDate } from './utils/date.util';

--- a/libs/shared-data/src/lib/utils/cpf.util.spec.ts
+++ b/libs/shared-data/src/lib/utils/cpf.util.spec.ts
@@ -1,4 +1,4 @@
-import { isValidCpf, formatCpf, maskCpf } from './cpf.util';
+import { isValidCpf, formatCpf, formatCpfProgressive, maskCpf } from './cpf.util';
 
 describe('cpf.util', () => {
   describe('isValidCpf', () => {
@@ -24,6 +24,35 @@ describe('cpf.util', () => {
   describe('maskCpf', () => {
     it('should mask CPF for LGPD', () => {
       expect(maskCpf('52998224725')).toBe('***.***.***-25');
+    });
+  });
+
+  describe('formatCpfProgressive', () => {
+    it.each([
+      ['', ''],
+      ['1', '1'],
+      ['123', '123'],
+      ['1234', '123.4'],
+      ['123456', '123.456'],
+      ['1234567', '123.456.7'],
+      ['123456789', '123.456.789'],
+      ['1234567890', '123.456.789-0'],
+      ['12345678901', '123.456.789-01'],
+      ['1234567890199', '123.456.789-01'],
+    ])('formata progressivamente "%s" como "%s"', (input, expected) => {
+      expect(formatCpfProgressive(input)).toBe(expected);
+    });
+
+    it('retorna string vazia para null', () => {
+      expect(formatCpfProgressive(null)).toBe('');
+    });
+
+    it('retorna string vazia para undefined', () => {
+      expect(formatCpfProgressive(undefined)).toBe('');
+    });
+
+    it('remove caracteres não numéricos antes de formatar', () => {
+      expect(formatCpfProgressive('abc529.982.247-25xyz')).toBe('529.982.247-25');
     });
   });
 });

--- a/libs/shared-data/src/lib/utils/cpf.util.ts
+++ b/libs/shared-data/src/lib/utils/cpf.util.ts
@@ -20,6 +20,28 @@ export function formatCpf(cpf: string): string {
   return `${digits.slice(0, 3)}.${digits.slice(3, 6)}.${digits.slice(6, 9)}-${digits.slice(9)}`;
 }
 
+/**
+ * Formata um valor parcial ou completo como máscara progressiva de CPF para
+ * exibição durante a digitação. Diferente de `formatCpf`, NÃO aplica padding
+ * — mostra apenas a parte da máscara correspondente aos dígitos disponíveis.
+ *
+ * Ignora caracteres não-numéricos e limita a entrada a 11 dígitos.
+ *
+ * @example
+ * formatCpfProgressive('123')         // '123'
+ * formatCpfProgressive('1234')        // '123.4'
+ * formatCpfProgressive('12345678901') // '123.456.789-01'
+ * formatCpfProgressive('abc529xyz')   // '529'
+ * formatCpfProgressive(null)          // ''
+ */
+export function formatCpfProgressive(value: string | null | undefined): string {
+  const digits = (value ?? '').replace(/\D/g, '').slice(0, 11);
+  if (digits.length <= 3) return digits;
+  if (digits.length <= 6) return `${digits.slice(0, 3)}.${digits.slice(3)}`;
+  if (digits.length <= 9) return `${digits.slice(0, 3)}.${digits.slice(3, 6)}.${digits.slice(6)}`;
+  return `${digits.slice(0, 3)}.${digits.slice(3, 6)}.${digits.slice(6, 9)}-${digits.slice(9)}`;
+}
+
 export function maskCpf(cpf: string): string {
   const digits = cpf.replace(/\D/g, '');
   return `***.***.***-${digits.slice(-2)}`;

--- a/libs/shared-data/src/lib/validators/cpf.validator.spec.ts
+++ b/libs/shared-data/src/lib/validators/cpf.validator.spec.ts
@@ -1,0 +1,49 @@
+import { FormControl, Validators } from '@angular/forms';
+import { cpfValidator } from './cpf.validator';
+
+describe('cpfValidator', () => {
+  it('aceita CPF válido formatado', () => {
+    const control = new FormControl('529.982.247-25', [cpfValidator]);
+    expect(control.errors).toBeNull();
+  });
+
+  it('aceita CPF válido sem máscara', () => {
+    const control = new FormControl('52998224725', [cpfValidator]);
+    expect(control.errors).toBeNull();
+  });
+
+  it('rejeita CPF com dígitos verificadores incorretos', () => {
+    const control = new FormControl('123.456.789-00', [cpfValidator]);
+    expect(control.errors).toEqual({ cpfInvalido: true });
+  });
+
+  it('rejeita CPF com todos os dígitos iguais', () => {
+    const control = new FormControl('111.111.111-11', [cpfValidator]);
+    expect(control.errors).toEqual({ cpfInvalido: true });
+  });
+
+  it('rejeita CPF com menos de 11 dígitos', () => {
+    const control = new FormControl('123456', [cpfValidator]);
+    expect(control.errors).toEqual({ cpfInvalido: true });
+  });
+
+  it('aceita valor vazio (obrigatoriedade fica para Validators.required)', () => {
+    const control = new FormControl('', [cpfValidator]);
+    expect(control.errors).toBeNull();
+  });
+
+  it('aceita null (obrigatoriedade fica para Validators.required)', () => {
+    const control = new FormControl(null, [cpfValidator]);
+    expect(control.errors).toBeNull();
+  });
+
+  it('compõe com Validators.required: vazio rejeitado por required, não por cpfValidator', () => {
+    const control = new FormControl('', [Validators.required, cpfValidator]);
+    expect(control.errors).toEqual({ required: true });
+  });
+
+  it('compõe com Validators.required: CPF inválido reportado por cpfValidator', () => {
+    const control = new FormControl('123.456.789-00', [Validators.required, cpfValidator]);
+    expect(control.errors).toEqual({ cpfInvalido: true });
+  });
+});

--- a/libs/shared-data/src/lib/validators/cpf.validator.ts
+++ b/libs/shared-data/src/lib/validators/cpf.validator.ts
@@ -1,0 +1,21 @@
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+import { isValidCpf } from '../utils/cpf.util';
+
+/**
+ * Validator de CPF para Reactive Forms baseado em `isValidCpf`.
+ *
+ * Valida o algoritmo dos dígitos verificadores (Lei do Cadastro de Pessoas
+ * Físicas, Receita Federal). Retorna `null` quando o valor é válido ou vazio
+ * (a obrigatoriedade deve ser composta com `Validators.required`).
+ *
+ * @example
+ * new FormControl('', [Validators.required, cpfValidator]);
+ * // se inválido: { cpfInvalido: true }
+ */
+export const cpfValidator: ValidatorFn = (
+  control: AbstractControl,
+): ValidationErrors | null => {
+  const value = control.value as string | null | undefined;
+  if (value == null || value === '') return null;
+  return isValidCpf(value) ? null : { cpfInvalido: true };
+};

--- a/libs/shared-ui/package.json
+++ b/libs/shared-ui/package.json
@@ -7,7 +7,8 @@
     "@angular/forms": "^21.2.0",
     "vite": "^7.0.0",
     "@analogjs/vite-plugin-angular": "^2.2.0",
-    "@nx/vite": "^22.6.0"
+    "@nx/vite": "^22.6.0",
+    "@org/shared-data": "0.0.1"
   },
   "sideEffects": false
 }

--- a/libs/shared-ui/src/lib/components/cpf-input/cpf-input.spec.ts
+++ b/libs/shared-ui/src/lib/components/cpf-input/cpf-input.spec.ts
@@ -110,6 +110,49 @@ describe('CpfInputComponent (ControlValueAccessor)', () => {
     expect(input.getAttribute('aria-describedby')).toBe('cpf-error');
   });
 
+  it('aplica inputmode=numeric e autocomplete=off para UX mobile e LGPD', () => {
+    const { getInputEl } = setup();
+    const input = getInputEl();
+    expect(input.getAttribute('inputmode')).toBe('numeric');
+    expect(input.getAttribute('autocomplete')).toBe('off');
+  });
+
+  it('usa ariaLabel como fallback quando label() é vazio', () => {
+    const { fixture, getInputEl } = setup();
+    fixture.detectChanges();
+    expect(getInputEl().getAttribute('aria-label')).toBe('CPF');
+  });
+
+  it('omite aria-label quando label() está presente (para evitar duplicação)', () => {
+    const { fixture, getInputEl } = setup();
+    fixture.componentRef.setInput('label', 'Informe seu CPF');
+    fixture.detectChanges();
+    expect(getInputEl().getAttribute('aria-label')).toBeNull();
+  });
+
+  it('aceita ariaLabel customizado quando label() é vazio', () => {
+    const { fixture, getInputEl } = setup();
+    fixture.componentRef.setInput('ariaLabel', 'CPF do candidato');
+    fixture.detectChanges();
+    expect(getInputEl().getAttribute('aria-label')).toBe('CPF do candidato');
+  });
+
+  it('marca aria-required e required nativo quando required=true', () => {
+    const { fixture, getInputEl } = setup();
+    fixture.componentRef.setInput('required', true);
+    fixture.detectChanges();
+    const input = getInputEl();
+    expect(input.getAttribute('aria-required')).toBe('true');
+    expect(input.required).toBe(true);
+  });
+
+  it('omite aria-required quando required=false (default)', () => {
+    const { getInputEl } = setup();
+    const input = getInputEl();
+    expect(input.getAttribute('aria-required')).toBeNull();
+    expect(input.required).toBe(false);
+  });
+
   it('dispara o callback registrado em registerOnTouched no blur do input', () => {
     const { component, onTouchedSpy, getInputEl } = setup();
 

--- a/libs/shared-ui/src/lib/components/cpf-input/cpf-input.spec.ts
+++ b/libs/shared-ui/src/lib/components/cpf-input/cpf-input.spec.ts
@@ -10,13 +10,14 @@ describe('CpfInputComponent (ControlValueAccessor)', () => {
   function setup() {
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
-      imports: [CpfInputComponent]
+      imports: [CpfInputComponent],
     });
 
     const onTouchedSpy = vi.fn();
     const onChangeSpy = vi.fn();
 
-    const fixture: ComponentFixture<CpfInputComponent> = TestBed.createComponent(CpfInputComponent);
+    const fixture: ComponentFixture<CpfInputComponent> =
+      TestBed.createComponent(CpfInputComponent);
     fixture.detectChanges();
     const getInputEl = () =>
       fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
@@ -28,8 +29,23 @@ describe('CpfInputComponent (ControlValueAccessor)', () => {
     const { fixture, component, getInputEl } = setup();
     component.writeValue(CPF_RAW);
     fixture.detectChanges();
-    const input = getInputEl();
-    expect(input.value).toBe(CPF_FORMATTED);
+    expect(getInputEl().value).toBe(CPF_FORMATTED);
+  });
+
+  it('limpa o input quando writeValue recebe null (form.reset)', () => {
+    const { fixture, component, getInputEl } = setup();
+    component.writeValue(CPF_RAW);
+    fixture.detectChanges();
+    component.writeValue(null as unknown as string);
+    fixture.detectChanges();
+    expect(getInputEl().value).toBe('');
+  });
+
+  it('remove caracteres não numéricos do valor recebido em writeValue', () => {
+    const { fixture, component, getInputEl } = setup();
+    component.writeValue('abc529.982.247-25xyz');
+    fixture.detectChanges();
+    expect(getInputEl().value).toBe(CPF_FORMATTED);
   });
 
   it('propaga o CPF sem máscara pelo callback registrado em registerOnChange', () => {
@@ -50,63 +66,65 @@ describe('CpfInputComponent (ControlValueAccessor)', () => {
     expect(component.disabled()).toBe(true);
   });
 
-  it('atualiza a propriedade disabled', () => {
+  it('restaura disabled para false após setDisabledState(false)', () => {
     const { component } = setup();
     component.setDisabledState(true);
     component.setDisabledState(false);
     expect(component.disabled()).toBe(false);
   });
 
-  it('checa se a propriedade disable no input existe quando o signal disabled é atualizado com valor true', () => {
+  it('checa se a propriedade disabled no input existe quando o signal disabled é atualizado com valor true', () => {
     const { fixture, component, getInputEl } = setup();
     const inputEl = getInputEl();
-  
+
     component.setDisabledState(true);
     fixture.detectChanges();
 
-    expect(inputEl.disabled).toBeTruthy();
     expect(inputEl.disabled).toBe(true);
   });
 
   it.each([
     ['123', '123'],
     ['1234', '123.4'],
+    ['123456', '123.456'],
     ['1234567', '123.456.7'],
+    ['123456789', '123.456.789'],
     ['12345678901', '123.456.789-01'],
-    ['1234567890199', '123.456.789-01']
+    ['1234567890199', '123.456.789-01'],
   ])('formata progressivamente "%s" como "%s"', (raw, expected) => {
-    const { component } = setup();
+    const { fixture, component, getInputEl } = setup();
     component.writeValue(raw);
-    expect(component.displayValue()).toBe(expected);
+    fixture.detectChanges();
+    expect(getInputEl().value).toBe(expected);
   });
 
   it('marca aria-invalid e vincula aria-describedby quando invalid=true', () => {
     const { fixture, getInputEl } = setup();
-      fixture.componentRef.setInput('invalid', true);
-      fixture.componentRef.setInput('errorMessage', 'CPF inválido');
-      fixture.componentRef.setInput('inputId', 'cpf');
-      fixture.detectChanges();
-      const input = getInputEl();
+    fixture.componentRef.setInput('invalid', true);
+    fixture.componentRef.setInput('errorMessage', 'CPF inválido');
+    fixture.componentRef.setInput('inputId', 'cpf');
+    fixture.detectChanges();
+    const input = getInputEl();
 
-      expect(input.getAttribute('aria-invalid')).toBe('true');
-      expect(input.getAttribute('aria-describedby')).toBe('cpf-error');
-    });
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+    expect(input.getAttribute('aria-describedby')).toBe('cpf-error');
+  });
 
-    it('dispara o callback registrado em registerOnTouched no blur do input', () => {
-      const { component, onTouchedSpy, getInputEl } = setup();
-    
-      component.registerOnTouched(onTouchedSpy);
-      const input = getInputEl();
-      input.dispatchEvent(new Event('blur'));
-      expect(onTouchedSpy).toHaveBeenCalledOnce();
-    });
+  it('dispara o callback registrado em registerOnTouched no blur do input', () => {
+    const { component, onTouchedSpy, getInputEl } = setup();
 
-    it('trunca entrada em 11 dígitos e remove caracteres não numéricos no onInput', () => {
-      const { onChangeSpy, component, getInputEl } = setup();
-      component.registerOnChange(onChangeSpy);
-      const input = getInputEl();
-      input.value = 'abc529982247250000xyz';
-      input.dispatchEvent(new Event('input'));
-      expect(onChangeSpy).toHaveBeenLastCalledWith('52998224725');
-    });
+    component.registerOnTouched(onTouchedSpy);
+    getInputEl().dispatchEvent(new Event('blur'));
+
+    expect(onTouchedSpy).toHaveBeenCalledOnce();
+  });
+
+  it('trunca entrada em 11 dígitos e remove caracteres não numéricos no onInput', () => {
+    const { onChangeSpy, component, getInputEl } = setup();
+    component.registerOnChange(onChangeSpy);
+    const input = getInputEl();
+    input.value = 'abc529982247250000xyz';
+    input.dispatchEvent(new Event('input'));
+    expect(onChangeSpy).toHaveBeenLastCalledWith('52998224725');
+  });
 });

--- a/libs/shared-ui/src/lib/components/cpf-input/cpf-input.ts
+++ b/libs/shared-ui/src/lib/components/cpf-input/cpf-input.ts
@@ -1,10 +1,10 @@
 import { Component, ChangeDetectionStrategy, input, forwardRef, signal } from '@angular/core';
-import { ControlValueAccessor, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@angular/forms';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { formatCpfProgressive } from '@uniplus/shared-data';
 
 @Component({
   selector: 'ui-cpf-input',
   standalone: true,
-  imports: [ReactiveFormsModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="flex flex-col gap-1">
@@ -49,7 +49,6 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@a
 })
 export class CpfInputComponent implements ControlValueAccessor {
   protected readonly MASKED_LENGTH = 14;
-  private static readonly DIGIT_LENGTH = 11;
 
   readonly label = input<string>('');
   readonly ariaLabel = input<string>('CPF');
@@ -66,8 +65,9 @@ export class CpfInputComponent implements ControlValueAccessor {
   private onTouched: () => void = () => undefined;
 
   writeValue(value: string | null | undefined): void {
-    this.rawValue = this.toRawDigits(value);
-    this.displayValue.set(this.formatCpf(this.rawValue));
+    const formatted = formatCpfProgressive(value);
+    this.displayValue.set(formatted);
+    this.rawValue = formatted.replace(/\D/g, '');
   }
 
   registerOnChange(fn: (value: string) => void): void {
@@ -88,20 +88,10 @@ export class CpfInputComponent implements ControlValueAccessor {
 
   onInput(event: Event): void {
     const input = event.target as HTMLInputElement;
-    this.rawValue = this.toRawDigits(input.value);
-    this.displayValue.set(this.formatCpf(this.rawValue));
-    input.value = this.displayValue();
+    const formatted = formatCpfProgressive(input.value);
+    this.displayValue.set(formatted);
+    this.rawValue = formatted.replace(/\D/g, '');
+    input.value = formatted;
     this.onChange(this.rawValue);
-  }
-
-  private toRawDigits(value: string | null | undefined): string {
-    return (value ?? '').replace(/\D/g, '').slice(0, CpfInputComponent.DIGIT_LENGTH);
-  }
-
-  private formatCpf(value: string): string {
-    if (value.length <= 3) return value;
-    if (value.length <= 6) return `${value.slice(0, 3)}.${value.slice(3)}`;
-    if (value.length <= 9) return `${value.slice(0, 3)}.${value.slice(3, 6)}.${value.slice(6)}`;
-    return `${value.slice(0, 3)}.${value.slice(3, 6)}.${value.slice(6, 9)}-${value.slice(9)}`;
   }
 }

--- a/libs/shared-ui/src/lib/components/cpf-input/cpf-input.ts
+++ b/libs/shared-ui/src/lib/components/cpf-input/cpf-input.ts
@@ -16,12 +16,17 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@a
       <input
         [id]="inputId()"
         type="text"
+        inputmode="numeric"
+        autocomplete="off"
         [placeholder]="placeholder()"
         [value]="displayValue()"
         (input)="onInput($event)"
-        (blur)="onTouched()"
+        (blur)="handleBlur()"
         [disabled]="disabled()"
-        maxlength="14"
+        [attr.maxlength]="MASKED_LENGTH"
+        [attr.aria-label]="label() ? null : ariaLabel()"
+        [attr.aria-required]="required() ? 'true' : null"
+        [attr.required]="required() ? '' : null"
         class="rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-unifesspa-primary focus:outline-none focus:ring-1 focus:ring-unifesspa-primary"
         [class.border-red-500]="invalid()"
         [attr.aria-invalid]="invalid()"
@@ -43,22 +48,25 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@a
   ],
 })
 export class CpfInputComponent implements ControlValueAccessor {
+  protected readonly MASKED_LENGTH = 14;
+  private static readonly DIGIT_LENGTH = 11;
+
   readonly label = input<string>('');
+  readonly ariaLabel = input<string>('CPF');
   readonly placeholder = input<string>('000.000.000-00');
   readonly inputId = input<string>('cpf-input');
   readonly invalid = input<boolean>(false);
+  readonly required = input<boolean>(false);
   readonly errorMessage = input<string>('');
   readonly disabled = signal(false);
   readonly displayValue = signal('');
   private rawValue = '';
 
-  // noop — substituída por registerOnChange
   private onChange: (value: string) => void = () => undefined;
-  // noop — substituída por registerOnTouched
-  onTouched: () => void = () => undefined;
+  private onTouched: () => void = () => undefined;
 
-  writeValue(value: string): void {
-    this.rawValue = (value || '').replace(/\D/g, '');
+  writeValue(value: string | null | undefined): void {
+    this.rawValue = this.toRawDigits(value);
     this.displayValue.set(this.formatCpf(this.rawValue));
   }
 
@@ -74,18 +82,26 @@ export class CpfInputComponent implements ControlValueAccessor {
     this.disabled.set(isDisabled);
   }
 
+  protected handleBlur(): void {
+    this.onTouched();
+  }
+
   onInput(event: Event): void {
     const input = event.target as HTMLInputElement;
-    this.rawValue = input.value.replace(/\D/g, '').substring(0, 11);
+    this.rawValue = this.toRawDigits(input.value);
     this.displayValue.set(this.formatCpf(this.rawValue));
     input.value = this.displayValue();
     this.onChange(this.rawValue);
+  }
+
+  private toRawDigits(value: string | null | undefined): string {
+    return (value ?? '').replace(/\D/g, '').slice(0, CpfInputComponent.DIGIT_LENGTH);
   }
 
   private formatCpf(value: string): string {
     if (value.length <= 3) return value;
     if (value.length <= 6) return `${value.slice(0, 3)}.${value.slice(3)}`;
     if (value.length <= 9) return `${value.slice(0, 3)}.${value.slice(3, 6)}.${value.slice(6)}`;
-    return `${value.slice(0, 3)}.${value.slice(3, 6)}.${value.slice(6, 9)}-${value.slice(9, 11)}`;
+    return `${value.slice(0, 3)}.${value.slice(3, 6)}.${value.slice(6, 9)}-${value.slice(9)}`;
   }
 }

--- a/libs/shared-ui/src/lib/components/cpf-input/cpf-input.ts
+++ b/libs/shared-ui/src/lib/components/cpf-input/cpf-input.ts
@@ -47,6 +47,17 @@ import { formatCpfProgressive } from '@uniplus/shared-data';
     },
   ],
 })
+/**
+ * Input mascarado de CPF integrado a Reactive Forms via ControlValueAccessor.
+ *
+ * **Não valida o algoritmo do CPF** — apenas aplica máscara e propaga o valor
+ * raw (11 dígitos) para o FormControl. Para validação semântica, componha com
+ * `cpfValidator` de `@uniplus/shared-data`:
+ *
+ * @example
+ * import { cpfValidator } from '@uniplus/shared-data';
+ * new FormControl('', [Validators.required, cpfValidator]);
+ */
 export class CpfInputComponent implements ControlValueAccessor {
   protected readonly MASKED_LENGTH = 14;
 


### PR DESCRIPTION
## Resumo

PR **stacked** sobre o #89 (target = `feature/48-cpf-input-test`). Adiciona, em cima dos testes originais do @denilson-santos-unifesspa, as correções 🔴 bloqueantes identificadas na análise técnica do componente:

- Cobertura de testes complementar (writeValue null/undefined, edge cases, asserções no DOM)
- A11y/UX/LGPD (`inputmode=numeric`, `aria-label` fallback, `required`/`aria-required`, `autocomplete=off`)
- DRY (consome `formatCpfProgressive` de `@uniplus/shared-data`)
- Validação semântica (`cpfValidator` em `shared-data` baseado em `isValidCpf`)

**Fluxo proposto:** mergear este PR no #89 → revisar #89 com tudo consolidado → aprovar e mergear #89 em `main` → fecha #48.

## Commits (5)

| # | Tipo | Descrição |
|---|---|---|
| 1 | test | Completa cobertura: writeValue(null), edge cases, DOM-asserts (`b083df0`) |
| 2 | feat 🔴 | A11y/UX/LGPD: inputmode=numeric, aria-label fallback, required, autocomplete=off (`2aa94a9`) |
| 3 | refactor 🔴 | DRY: consome formatCpfProgressive de @uniplus/shared-data (`bf032ef`) |
| 4 | feat 🔴 | cpfValidator em shared-data baseado em isValidCpf (`ac21e12`) |
| 5 | chore | Declara @org/shared-data como peerDep (`e6129bd`) |

## Mudanças por arquivo

**Novo:**
- `libs/shared-data/src/lib/validators/cpf.validator.ts` — ValidatorFn para Reactive Forms
- `libs/shared-data/src/lib/validators/cpf.validator.spec.ts` — 9 testes

**Modificado em `shared-data`:**
- `cpf.util.ts` — adiciona `formatCpfProgressive` (formatação durante digitação, sem padding)
- `cpf.util.spec.ts` — 13 testes parametrizados
- `index.ts` — exporta `formatCpfProgressive` e `cpfValidator`
- `package.json` — declara `@angular/forms` como peerDep

**Modificado em `shared-ui`:**
- `cpf-input.ts` — consome `formatCpfProgressive`, adiciona inputs `ariaLabel`/`required`, encapsula `onTouched` via `handleBlur` protected, JSDoc apontando para `cpfValidator`
- `cpf-input.spec.ts` — completa cobertura (23 testes, era 11 no #89 original)
- `package.json` — declara `@org/shared-data` como peerDep

## Validação

- ✅ Lint: `nx lint shared-ui shared-data` ambos verdes
- ✅ Testes: `shared-ui` 26 (cpf-input 23 + cpf-pipe 3), `shared-data` 27

## Test plan

- [x] `npx nx vite:test shared-ui` — 26 passed
- [x] `npx nx vite:test shared-data` — 27 passed
- [x] `npx nx lint shared-ui shared-data` — all pass
- [ ] Smoke test manual: instanciar `<ui-cpf-input [formControl]="ctrl">` em `apps/poc-primeng` validando máscara + `cpfValidator`

## Achados não cobertos por este PR (issues a abrir como follow-up)

🟡 importantes:
- Cursor position bug (digitar no meio reposiciona cursor para o final)
- Migração para tokens Gov.br + PrimeNG unstyled (alinhamento ao ADR-018)
- Testes de integração CpfInputComponent + FormControl/FormGroup real

## Referências

- Stacked sobre #89 (Story #48)
- Issue #109 (lint hygiene workspace — débito identificado em paralelo)