### PR TITLE
test(e2e): substitui not.toBeVisible() por toBeHidden() em E2E

### DIFF
--- a/apps/poc-primeng-e2e/src/inscricao-flow.spec.ts
+++ b/apps/poc-primeng-e2e/src/inscricao-flow.spec.ts
@@ -200,7 +200,7 @@ test.describe('Fluxo de inscrição — PoC PrimeNG + Gov.br DS', () => {
     await expect(page.locator('[role="dialog"]')).toBeVisible({ timeout: 3000 });
     await page.locator('[data-testid="btn-cancelar"]').click();
 
-    await expect(page.locator('[role="dialog"]')).not.toBeVisible();
+    await expect(page.locator('[role="dialog"]')).toBeHidden();
 
     await screenshot(page, '12-dialog-fechado');
   });

--- a/apps/poc-primeng-e2e/src/keyboard-a11y.spec.ts
+++ b/apps/poc-primeng-e2e/src/keyboard-a11y.spec.ts
@@ -146,7 +146,7 @@ test.describe('Acessibilidade de teclado — PoC PrimeNG + Gov.br DS', () => {
       await page.keyboard.press('Enter');
       await page.waitForTimeout(300);
 
-      await expect(page.locator('[role="listbox"]')).not.toBeVisible();
+      await expect(page.locator('[role="listbox"]')).toBeHidden();
 
       // PrimeNG select should show selected value
       const selectText = await page.locator('p-select#curso').textContent();
@@ -163,7 +163,7 @@ test.describe('Acessibilidade de teclado — PoC PrimeNG + Gov.br DS', () => {
       await page.keyboard.press('Escape');
       await page.waitForTimeout(300);
 
-      await expect(page.locator('[role="listbox"]')).not.toBeVisible();
+      await expect(page.locator('[role="listbox"]')).toBeHidden();
 
       await screenshot(page, 'k06-select-escape');
     });
@@ -183,7 +183,7 @@ test.describe('Acessibilidade de teclado — PoC PrimeNG + Gov.br DS', () => {
       await page.waitForTimeout(300);
 
       // Dropdown should close after selection
-      await expect(page.locator('[role="listbox"]')).not.toBeVisible();
+      await expect(page.locator('[role="listbox"]')).toBeHidden();
 
       // Select should show a value (not placeholder)
       const selectText = await page.locator('p-select#curso').textContent();
@@ -335,7 +335,7 @@ test.describe('Acessibilidade de teclado — PoC PrimeNG + Gov.br DS', () => {
       await page.keyboard.press('Escape');
       await page.waitForTimeout(300);
 
-      await expect(page.locator('[role="dialog"]')).not.toBeVisible();
+      await expect(page.locator('[role="dialog"]')).toBeHidden();
 
       await screenshot(page, 'k14-escape-dialog');
     });

--- a/apps/portal-e2e/src/specs/auth-oidc.spec.ts
+++ b/apps/portal-e2e/src/specs/auth-oidc.spec.ts
@@ -29,7 +29,7 @@ test.describe('Autenticação OIDC — Portal do Candidato', () => {
       await page.goto('/processos');
 
       const logoutBtn = page.locator('button[aria-label="Sair da aplicação"]');
-      await expect(logoutBtn).not.toBeVisible();
+      await expect(logoutBtn).toBeHidden();
     });
   });
 
@@ -60,7 +60,7 @@ test.describe('Autenticação OIDC — Portal do Candidato', () => {
 
       const header = page.locator('header');
       // Verifica que NÃO exibe o nome civil quando há nome social
-      await expect(header.getByText('Usuário Candidato')).not.toBeVisible();
+      await expect(header.getByText('Usuário Candidato')).toBeHidden();
     });
 
     test('candidato acessa /acompanhamento (authGuard sem roleGuard)', async ({ page }) => {


### PR DESCRIPTION
## Resumo

Aplica a regra `playwright/no-useless-not` via `eslint --fix` em 7 ocorrências espalhadas pelos apps E2E. `toBeHidden()` é semanticamente equivalente a `not.toBeVisible()` no Playwright e expressa a intenção de forma mais clara — recomendação do ESLint plugin.

Closes #112

## Mudanças

| Arquivo | Linhas afetadas | Contexto |
|---|---|---|
| `apps/portal-e2e/src/specs/auth-oidc.spec.ts` | 32, 63 | Asserções pós-logout (botão Sair, nome do usuário) |
| `apps/poc-primeng-e2e/src/inscricao-flow.spec.ts` | 203 | Dialog fechado após submit |
| `apps/poc-primeng-e2e/src/keyboard-a11y.spec.ts` | 149, 166, 186, 338 | Listbox/dialog fechados após Enter/Escape |

## Notas

- A issue #112 mencionava **6 ocorrências** com base em snapshot inicial — o inventário real era **7**. Diferença documentada na mensagem de commit.
- Substituição mecânica via `eslint --fix`. Sem edição manual.
- Total de warnings em `poc-primeng-e2e` + `portal-e2e` reduzido de **67 → 60** (esperado).
- Lint completo (`nx run-many --target=lint --all`) continua exit 0.

## Riscos

- **Mínimo.** Playwright [recomenda explicitamente](https://playwright.dev/docs/api/class-locatorassertions#locator-assertions-to-be-hidden) usar `toBeHidden()` em vez de `not.toBeVisible()` — ambas têm a mesma lógica de retry/timeout e cobrem os mesmos casos (elemento hidden ou não anexado ao DOM).
- E2E afetados não foram executados localmente (POC E2E não é coberto pelo `tools/e2e-docker/run.sh` hoje — débito separado).

## Checklist

- [x] Lint completo passa
- [x] Pre-commit hook ativo e validado durante o commit
- [x] Conventional commits em pt-BR, sem `Co-Authored-By`
- [x] Issue vinculada (`Closes #112`)
- [ ] Suítes E2E rodadas localmente (recomendado, não bloqueante)