### PR TITLE
docs(contributing): documenta regras de integração da branch main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,6 +210,26 @@ gh pr create --base main
 
 ---
 
+## Regras de integração
+
+Este repositório adota políticas de proteção da branch `main` para garantir histórico linear, previsível e auditável. As regras são aplicadas automaticamente pelo GitHub aos colaboradores sem permissão administrativa.
+
+- Apenas **Rebase merge** é permitido — merge commits e squash estão desabilitados
+- Histórico linear obrigatório
+- Force-push e deleção da `main` bloqueados
+- PRs exigem:
+  - 1 aprovação de colaborador com permissão de escrita
+  - Status checks de CI passando:
+    - `main` (workflow `CI` — `.github/workflows/ci.yml`, job `main`)
+    - `nx run-many --target=lint --all` (workflow `Lint completo (workspace)` — `.github/workflows/lint-full.yml`)
+  - Branch atualizada com a `main` antes do merge
+  - Todas as conversas do review resolvidas
+  - Aprovações anteriores são descartadas quando novos commits são enviados (*dismiss stale reviews* + *require last push approval*)
+
+Casos excepcionais podem ser tratados por admins do repositório. A política operacional completa — incluindo procedimento de rebase, regras de ouro e troubleshooting — vive no **[Guia de Commits e Integração § 5](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/guia-commits-e-integracao.md)**, fonte de verdade para todos os repositórios do projeto.
+
+---
+
 ## Padrões de código
 
 ### Organização de features (por app)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,12 +219,13 @@ Este repositório adota políticas de proteção da branch `main` para garantir 
 - Force-push e deleção da `main` bloqueados
 - PRs exigem:
   - 1 aprovação de colaborador com permissão de escrita
-  - Status checks de CI passando:
+  - Status checks de CI passando — detalhes do que cada check verifica em [Quality gates](#quality-gates):
     - `main` (workflow `CI` — `.github/workflows/ci.yml`, job `main`)
     - `nx run-many --target=lint --all` (workflow `Lint completo (workspace)` — `.github/workflows/lint-full.yml`)
   - Branch atualizada com a `main` antes do merge
   - Todas as conversas do review resolvidas
-  - Aprovações anteriores são descartadas quando novos commits são enviados (*dismiss stale reviews* + *require last push approval*)
+  - Aprovações anteriores são descartadas a cada novo commit (*dismiss stale reviews*)
+  - O último push da branch deve ser feito por usuário diferente do aprovador (*require last push approval*)
 
 Casos excepcionais podem ser tratados por admins do repositório. A política operacional completa — incluindo procedimento de rebase, regras de ouro e troubleshooting — vive no **[Guia de Commits e Integração § 5](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/guia-commits-e-integracao.md)**, fonte de verdade para todos os repositórios do projeto.
 


### PR DESCRIPTION
## Resumo

Adiciona seção `## Regras de integração` ao `CONTRIBUTING.md`, documentando as políticas de proteção da branch `main` aplicadas ao repositório. Trabalho-irmão do PR unifesspa-edu-br/uniplus-api#130 — documentação local descreve **o que está aplicado**; a [Guia § 5](https://github.com/unifesspa-edu-br/uniplus-docs/blob/main/docs/guia-commits-e-integracao.md) permanece como fonte de verdade operacional.

## Configuração efetiva refletida no documento

A configuração foi aplicada simultaneamente a este PR (Tech Lead) e o documento descreve fielmente o estado atual:

**Repo settings (`gh api repos/unifesspa-edu-br/uniplus-web`):**
- `allow_merge_commit=false`, `allow_squash_merge=false`, `allow_rebase_merge=true`
- `allow_update_branch=true`, `delete_branch_on_merge=true`

**Branch protection `main` (`gh api repos/unifesspa-edu-br/uniplus-web/branches/main/protection`):**
- `required_linear_history=true`
- `required_pull_request_reviews.required_approving_review_count=1`
- `dismiss_stale_reviews=true`, `require_last_push_approval=true`
- `required_conversation_resolution=true`
- `required_status_checks.strict=true`, contexts:
  - `main` (workflow `CI` — `.github/workflows/ci.yml`)
  - `nx run-many --target=lint --all` (workflow `Lint completo (workspace)` — `.github/workflows/lint-full.yml`)
- `allow_force_pushes=false`, `allow_deletions=false`

## Notas

- Lint completo está marcado como required check porque o workspace está higienizado (PR #115) e o pipeline está verde no `main`. Issue #111 trata apenas de **warnings** remanescentes em `*-e2e` — warnings são tolerados pelo gate (errors bloqueiam).
- Esta config alinha o `uniplus-web` com a já vigente em `uniplus-api`.

Closes #90