### PR TITLE
test(e2e): estabiliza testes flaky de tabs e fontes em govbr-design-tokens

### DIFF
--- a/apps/poc-primeng-e2e/src/govbr-design-tokens.spec.ts
+++ b/apps/poc-primeng-e2e/src/govbr-design-tokens.spec.ts
@@ -252,8 +252,6 @@ test.describe('Design tokens Gov.br DS — PoC PrimeNG', () => {
 
     test('T3.7: tab ativa — primary', async ({ page }) => {
       const tab = page.locator('[role="tablist"] [role="tab"][aria-selected="true"]');
-      // toHaveCSS faz polling — necessário porque PrimeNG aplica os estilos de
-      // estado ativo após o ChangeDetection do Angular pós-navegação.
       await expect(tab).toHaveCSS('color', 'rgb(19, 81, 180)');
       await screenshot(page, 't3-07-tab-ativa-cor');
     });
@@ -329,9 +327,10 @@ test.describe('Design tokens Gov.br DS — PoC PrimeNG', () => {
 
     test('T4.7: tab inativa — border-bottom transparente', async ({ page }) => {
       const tab = page.locator('[role="tablist"] [role="tab"][aria-selected="false"]').first();
-      // Aceita tanto rgba(0,0,0,0) quanto 'transparent' — browsers podem
-      // serializar a cor transparente de qualquer das duas formas.
-      await expect(tab).toHaveCSS('border-bottom-color', /rgba\(0, 0, 0, 0\)|transparent/);
+      // Aceita tanto rgba(0, 0, 0, 0) quanto 'transparent' — browsers podem
+      // serializar a cor transparente de qualquer das duas formas. Regex
+      // ancorado para evitar match em strings que apenas contenham o pattern.
+      await expect(tab).toHaveCSS('border-bottom-color', /^(rgba\(0, 0, 0, 0\)|transparent)$/);
       await screenshot(page, 't4-07-tab-inativa-borda');
     });
 

--- a/apps/poc-primeng-e2e/src/govbr-design-tokens.spec.ts
+++ b/apps/poc-primeng-e2e/src/govbr-design-tokens.spec.ts
@@ -47,6 +47,9 @@ test.describe('Design tokens Gov.br DS — PoC PrimeNG', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/inscricao');
     await expect(page.locator('poc-govbr-header')).toBeVisible({ timeout: 10_000 });
+    // Aguarda fontes institucionais (Rawline/Raleway) terminarem de carregar
+    // — sem isso, font-family fica como fallback genérico e quebra T1.2/T1.5.
+    await page.evaluate(() => document.fonts.ready);
   });
 
   // ─── T1: Tipografia ─────────────────────────────────────────
@@ -249,15 +252,15 @@ test.describe('Design tokens Gov.br DS — PoC PrimeNG', () => {
 
     test('T3.7: tab ativa — primary', async ({ page }) => {
       const tab = page.locator('[role="tablist"] [role="tab"][aria-selected="true"]');
-      const styles = await getStyles(tab, ['color']);
-      expect(styles['color']).toBe('rgb(19, 81, 180)');
+      // toHaveCSS faz polling — necessário porque PrimeNG aplica os estilos de
+      // estado ativo após o ChangeDetection do Angular pós-navegação.
+      await expect(tab).toHaveCSS('color', 'rgb(19, 81, 180)');
       await screenshot(page, 't3-07-tab-ativa-cor');
     });
 
     test('T3.8: tab inativa — gray escuro', async ({ page }) => {
       const tab = page.locator('[role="tablist"] [role="tab"][aria-selected="false"]').first();
-      const styles = await getStyles(tab, ['color']);
-      expect(styles['color']).toBe('rgb(99, 99, 99)');
+      await expect(tab).toHaveCSS('color', 'rgb(99, 99, 99)');
       await screenshot(page, 't3-08-tab-inativa-cor');
     });
 
@@ -319,19 +322,16 @@ test.describe('Design tokens Gov.br DS — PoC PrimeNG', () => {
 
     test('T4.6: tab ativa — border-bottom 4px primary (Gov.br DS)', async ({ page }) => {
       const tab = page.locator('[role="tablist"] [role="tab"][aria-selected="true"]');
-      const styles = await getStyles(tab, ['border-bottom-color', 'border-bottom-width']);
-      expect(styles['border-bottom-color']).toBe('rgb(19, 81, 180)');
-      expect(styles['border-bottom-width']).toBe('4px');
+      await expect(tab).toHaveCSS('border-bottom-color', 'rgb(19, 81, 180)');
+      await expect(tab).toHaveCSS('border-bottom-width', '4px');
       await screenshot(page, 't4-06-tab-ativa-borda');
     });
 
     test('T4.7: tab inativa — border-bottom transparente', async ({ page }) => {
       const tab = page.locator('[role="tablist"] [role="tab"][aria-selected="false"]').first();
-      const styles = await getStyles(tab, ['border-bottom-color']);
-      expect(
-        styles['border-bottom-color'] === 'rgba(0, 0, 0, 0)' ||
-          styles['border-bottom-color'] === 'transparent',
-      ).toBeTruthy();
+      // Aceita tanto rgba(0,0,0,0) quanto 'transparent' — browsers podem
+      // serializar a cor transparente de qualquer das duas formas.
+      await expect(tab).toHaveCSS('border-bottom-color', /rgba\(0, 0, 0, 0\)|transparent/);
       await screenshot(page, 't4-07-tab-inativa-borda');
     });
 


### PR DESCRIPTION
## Resumo

Resolve a sub-issue **#120** da Story #111: elimina os flakes consistentes em `govbr-design-tokens.spec.ts` documentados no PR #119 e rastreados desde a #109.

## Estratégia aplicada

### Fontes (T1.2, T1.5)

`document.fonts.ready` no `beforeEach` após o goto. Sem isso, `font-family` fica como fallback genérico durante 100-300ms iniciais e quebra a assertion `toMatch(/Rawline|Raleway/i)`.

```ts
test.beforeEach(async ({ page }) => {
  await page.goto('/inscricao');
  await expect(page.locator('poc-govbr-header')).toBeVisible({ timeout: 10_000 });
  await page.evaluate(() => document.fonts.ready);  // ← novo
});
```

### Estilos de tab (T3.7, T3.8, T4.6, T4.7)

Troca `getStyles + expect.toBe` por `await expect(locator).toHaveCSS(...)`. O `toHaveCSS` faz polling com timeout default de 5s — cobre o intervalo entre o ChangeDetection do Angular pós-navegação e a aplicação dos estilos dinâmicos pelo PrimeNG.

```ts
// Antes
const styles = await getStyles(tab, ['color']);
expect(styles['color']).toBe('rgb(19, 81, 180)');

// Depois
await expect(tab).toHaveCSS('color', 'rgb(19, 81, 180)');
```

T4.7 aceita tanto `rgba(0, 0, 0, 0)` quanto `transparent` via regex — browsers podem serializar a cor transparente de qualquer das duas formas, e o pattern original (boolean OR) era hostil a retry.

## Validação

**50 runs consecutivos** de `nx run poc-primeng-e2e:e2e-ci--src/govbr-design-tokens.spec.ts`:

| Teste | Falhas em 50 runs | Status |
|---|---:|:---:|
| T1.2 (h1 fonte) | **0** | ✅ |
| T1.5 (input fonte) | **0** | ✅ |
| T3.7 (cor tab ativa) | **0** | ✅ |
| T3.8 (cor tab inativa) | **0** | ✅ |
| T4.6 (border tab ativa) | **0** | ✅ |
| T4.7 (border tab inativa) | **0** | ✅ |

**Critério de aceite atingido** (\"0 falhas em T3.7/T3.8/T4.6/T4.7/T1.2/T1.5 em 50 runs\").

## Observação fora de escopo

Sob carga muito alta (12+ runs em sequência rápida no dev machine), 3 testes aleatórios (T1.4, T2.4, T2.5) falharam com:

```
Error: page.screenshot: Protocol error (Page.captureScreenshot): Unable to capture screenshot
```

Esse é um Chromium crash sob load (recurso/timeout do browser process), **não** relacionado às alterações deste PR nem aos testes alvo do #120. Não esperado em CI (cada spec roda com Chromium fresco em isolation). Se reproduzir em CI, abre-se issue separada — hipótese: limitar `workers` no Playwright config ou adicionar retry-on-protocol-error.

## Test plan

- [ ] CI passa lint e E2E
- [ ] Após este merge, **Story #111 fecha 100%** dos critérios — todas as 4 sub-issues completas

Closes #120
Refs #111