### PR TITLE
chore: aplica polish da review do PR #125 (S2 + S3)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ nvm use   # lê a versão do .nvmrc (Node 22 LTS)
 npm install
 ```
 
-> Sem `nvm`? Garanta Node 22.x manualmente — o `npm install` falha com `EBADENGINE` em outras versões (`engine-strict=true` em `.npmrc`).
+> Sem gerenciador compatível com `.nvmrc` (`nvm`, `fnm`, `volta`)? Garanta Node 22.x manualmente — o `npm install` falha com `EBADENGINE` em outras versões (`engine-strict=true` em `.npmrc`).
 
 O `npm install` ativa o hook de pre-commit do `husky`, que roda `lint-staged` em cada `git commit` e formata/valida apenas os arquivos staged. Veja [Estratégia de lint em três camadas](#estratégia-de-lint-em-três-camadas).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,11 @@ Este documento descreve como contribuir com o frontend da plataforma Uni+. Leia-
 ```bash
 git clone git@github.com:unifesspa-edu-br/uniplus-web.git
 cd uniplus-web
+nvm use   # lê a versão do .nvmrc (Node 22 LTS)
 npm install
 ```
+
+> Sem `nvm`? Garanta Node 22.x manualmente — o `npm install` falha com `EBADENGINE` em outras versões (`engine-strict=true` em `.npmrc`).
 
 O `npm install` ativa o hook de pre-commit do `husky`, que roda `lint-staged` em cada `git commit` e formata/valida apenas os arquivos staged. Veja [Estratégia de lint em três camadas](#estratégia-de-lint-em-três-camadas).
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Frontend do Uni+ (S2U) da Unifesspa, construido como monorepo Nx com Angular 21.
 ## Inicio rapido
 
 ```bash
-# Instalar dependencias
-npm install
+# Instalar dependencias (requer Node 22.x — veja CONTRIBUTING.md para setup com nvm)
+nvm use && npm install
 
 # Servir a aplicacao selecao
 npx nx serve selecao

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "uniplus-web",
   "version": "0.0.0",
   "license": "UNLICENSED",
+  "engines": {
+    "node": ">=22.0.0 <23.0.0"
+  },
   "scripts": {
     "start:selecao": "nx serve selecao",
     "start:ingresso": "nx serve ingresso",
@@ -21,9 +24,6 @@
     "affected:build": "nx affected --target=build",
     "affected:lint": "nx affected --target=lint",
     "prepare": "husky"
-  },
-  "engines": {
-    "node": ">=22.0.0 <23.0.0"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,mjs,cjs}": "eslint --fix"


### PR DESCRIPTION
## Resumo

Follow-up do PR #125 — aplica os dois refinements opcionais ([S2] e [S3]) que ficaram fora do escopo cirúrgico do merge anterior.

## Mudanças

| Arquivo | Mudança |
|---|---|
| `CONTRIBUTING.md` | Adiciona `nvm use` no bloco de **Setup inicial** (lê `.nvmrc`) + nota de fallback para quem não usa nvm |
| `package.json` | Move bloco `engines` para **antes** de `scripts`, seguindo convenção npm |

Diff total: **+6 / -3** em 2 arquivos. Nenhuma mudança funcional — apenas documentação e reordenação de chaves.

## Por quê

- **[S2]** Com `engine-strict=true` ativo (PR #125), `npm install` falha em Node ≠ 22.x. A linha `nvm use` faz o setup ser auto-corretivo para quem usa nvm; a nota de fallback orienta os demais.
- **[S3]** Estética/convenção npm — `engines` antes de `scripts` é o ordenamento canônico (npm docs, `npm init`, repos de referência).

## Validação

- `nvm use` lê `.nvmrc` corretamente → Node 22.22.2
- `npm install` em Node 22.x: ✅ OK (sem regressão, lockfile inalterado)
- `npm install` em Node 24.15.0: ❌ falha com `EBADENGINE` (comportamento esperado de `engine-strict=true`)
- JSON do `package.json`: válido (`python3 -c "import json; json.load(open('package.json'))"`)

## Test plan

- [ ] CI principal verde (paridade com `main`)
- [ ] Lint completo verde
- [ ] Revisão do diff: confirmar que apenas ordenação de chaves muda em `package.json`

Closes #126
Refs #125