### PR TITLE
fix(shared-ui): move formatCpfProgressive de shared-data para eliminar import cross-lib

### DIFF
--- a/libs/shared-data/src/lib/index.ts
+++ b/libs/shared-data/src/lib/index.ts
@@ -10,7 +10,7 @@ export { ApiErrorHandlerService } from './services/api-error-handler.service';
 export type { ProblemDetails } from './services/api-error-handler.service';
 
 // Utils
-export { isValidCpf, formatCpf, formatCpfProgressive, maskCpf } from './utils/cpf.util';
+export { isValidCpf, formatCpf, maskCpf } from './utils/cpf.util';
 export { formatDateBr, formatDateTimeBr, parseDate } from './utils/date.util';
 
 // Validators

--- a/libs/shared-data/src/lib/utils/cpf.util.spec.ts
+++ b/libs/shared-data/src/lib/utils/cpf.util.spec.ts
@@ -1,4 +1,4 @@
-import { isValidCpf, formatCpf, formatCpfProgressive, maskCpf } from './cpf.util';
+import { isValidCpf, formatCpf, maskCpf } from './cpf.util';
 
 describe('cpf.util', () => {
   describe('isValidCpf', () => {
@@ -24,35 +24,6 @@ describe('cpf.util', () => {
   describe('maskCpf', () => {
     it('should mask CPF for LGPD', () => {
       expect(maskCpf('52998224725')).toBe('***.***.***-25');
-    });
-  });
-
-  describe('formatCpfProgressive', () => {
-    it.each([
-      ['', ''],
-      ['1', '1'],
-      ['123', '123'],
-      ['1234', '123.4'],
-      ['123456', '123.456'],
-      ['1234567', '123.456.7'],
-      ['123456789', '123.456.789'],
-      ['1234567890', '123.456.789-0'],
-      ['12345678901', '123.456.789-01'],
-      ['1234567890199', '123.456.789-01'],
-    ])('formata progressivamente "%s" como "%s"', (input, expected) => {
-      expect(formatCpfProgressive(input)).toBe(expected);
-    });
-
-    it('retorna string vazia para null', () => {
-      expect(formatCpfProgressive(null)).toBe('');
-    });
-
-    it('retorna string vazia para undefined', () => {
-      expect(formatCpfProgressive(undefined)).toBe('');
-    });
-
-    it('remove caracteres não numéricos antes de formatar', () => {
-      expect(formatCpfProgressive('abc529.982.247-25xyz')).toBe('529.982.247-25');
     });
   });
 });

--- a/libs/shared-data/src/lib/utils/cpf.util.ts
+++ b/libs/shared-data/src/lib/utils/cpf.util.ts
@@ -20,28 +20,6 @@ export function formatCpf(cpf: string): string {
   return `${digits.slice(0, 3)}.${digits.slice(3, 6)}.${digits.slice(6, 9)}-${digits.slice(9)}`;
 }
 
-/**
- * Formata um valor parcial ou completo como máscara progressiva de CPF para
- * exibição durante a digitação. Diferente de `formatCpf`, NÃO aplica padding
- * — mostra apenas a parte da máscara correspondente aos dígitos disponíveis.
- *
- * Ignora caracteres não-numéricos e limita a entrada a 11 dígitos.
- *
- * @example
- * formatCpfProgressive('123')         // '123'
- * formatCpfProgressive('1234')        // '123.4'
- * formatCpfProgressive('12345678901') // '123.456.789-01'
- * formatCpfProgressive('abc529xyz')   // '529'
- * formatCpfProgressive(null)          // ''
- */
-export function formatCpfProgressive(value: string | null | undefined): string {
-  const digits = (value ?? '').replace(/\D/g, '').slice(0, 11);
-  if (digits.length <= 3) return digits;
-  if (digits.length <= 6) return `${digits.slice(0, 3)}.${digits.slice(3)}`;
-  if (digits.length <= 9) return `${digits.slice(0, 3)}.${digits.slice(3, 6)}.${digits.slice(6)}`;
-  return `${digits.slice(0, 3)}.${digits.slice(3, 6)}.${digits.slice(6, 9)}-${digits.slice(9)}`;
-}
-
 export function maskCpf(cpf: string): string {
   const digits = cpf.replace(/\D/g, '');
   return `***.***.***-${digits.slice(-2)}`;

--- a/libs/shared-ui/package.json
+++ b/libs/shared-ui/package.json
@@ -7,8 +7,7 @@
     "@angular/forms": "^21.2.0",
     "vite": "^7.0.0",
     "@analogjs/vite-plugin-angular": "^2.2.0",
-    "@nx/vite": "^22.6.0",
-    "@org/shared-data": "0.0.1"
+    "@nx/vite": "^22.6.0"
   },
   "sideEffects": false
 }

--- a/libs/shared-ui/src/lib/components/cpf-input/cpf-input.ts
+++ b/libs/shared-ui/src/lib/components/cpf-input/cpf-input.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy, input, forwardRef, signal } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { formatCpfProgressive } from '@uniplus/shared-data';
+import { formatCpfProgressive } from '../../utils/cpf-format.util';
 
 /**
  * Input mascarado de CPF integrado a Reactive Forms via ControlValueAccessor.

--- a/libs/shared-ui/src/lib/utils/cpf-format.util.spec.ts
+++ b/libs/shared-ui/src/lib/utils/cpf-format.util.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { formatCpfProgressive } from './cpf-format.util';
+
+describe('formatCpfProgressive', () => {
+  it.each([
+    ['', ''],
+    ['1', '1'],
+    ['123', '123'],
+    ['1234', '123.4'],
+    ['123456', '123.456'],
+    ['1234567', '123.456.7'],
+    ['123456789', '123.456.789'],
+    ['1234567890', '123.456.789-0'],
+    ['12345678901', '123.456.789-01'],
+    ['1234567890199', '123.456.789-01'],
+  ])('formata progressivamente "%s" como "%s"', (input, expected) => {
+    expect(formatCpfProgressive(input)).toBe(expected);
+  });
+
+  it('retorna string vazia para null', () => {
+    expect(formatCpfProgressive(null)).toBe('');
+  });
+
+  it('retorna string vazia para undefined', () => {
+    expect(formatCpfProgressive(undefined)).toBe('');
+  });
+
+  it('remove caracteres não numéricos antes de formatar', () => {
+    expect(formatCpfProgressive('abc529.982.247-25xyz')).toBe('529.982.247-25');
+  });
+});

--- a/libs/shared-ui/src/lib/utils/cpf-format.util.ts
+++ b/libs/shared-ui/src/lib/utils/cpf-format.util.ts
@@ -1,0 +1,22 @@
+/**
+ * Formata um valor parcial ou completo como máscara progressiva de CPF para
+ * exibição durante a digitação. Diferente de `formatCpf` (em `@uniplus/shared-data`),
+ * NÃO aplica padding — mostra apenas a parte da máscara correspondente aos dígitos
+ * disponíveis.
+ *
+ * Ignora caracteres não-numéricos e limita a entrada a 11 dígitos.
+ *
+ * @example
+ * formatCpfProgressive('123')         // '123'
+ * formatCpfProgressive('1234')        // '123.4'
+ * formatCpfProgressive('12345678901') // '123.456.789-01'
+ * formatCpfProgressive('abc529xyz')   // '529'
+ * formatCpfProgressive(null)          // ''
+ */
+export function formatCpfProgressive(value: string | null | undefined): string {
+  const digits = (value ?? '').replace(/\D/g, '').slice(0, 11);
+  if (digits.length <= 3) return digits;
+  if (digits.length <= 6) return `${digits.slice(0, 3)}.${digits.slice(3)}`;
+  if (digits.length <= 9) return `${digits.slice(0, 3)}.${digits.slice(3, 6)}.${digits.slice(6)}`;
+  return `${digits.slice(0, 3)}.${digits.slice(3, 6)}.${digits.slice(6, 9)}-${digits.slice(9)}`;
+}


### PR DESCRIPTION
## Resumo

Resolve a falha de `nx run shared-ui:build:production` movendo a função `formatCpfProgressive` de `@uniplus/shared-data` para dentro de `shared-ui`. A causa raiz é um limite arquitetural: ng-packagr não lida bem com import cross-lib via TS path mapping (que resolve para o source-tree de outra lib).

**Escopo deste PR:** apenas o fix do build (`shared-ui:build:production`). O CI hardening previsto na #124 ficou deferido — explicação em "Por quê" abaixo.

## Mudanças

| Arquivo | Mudança |
|---|---|
| `libs/shared-ui/src/lib/utils/cpf-format.util.ts` (novo) | Função movida de `shared-data` |
| `libs/shared-ui/src/lib/utils/cpf-format.util.spec.ts` (novo) | Spec dedicada migrada |
| `libs/shared-ui/src/lib/components/cpf-input/cpf-input.ts` | Import alterado para path relativo `../../utils/cpf-format.util` |
| `libs/shared-data/src/lib/utils/cpf.util.ts` | Função `formatCpfProgressive` removida |
| `libs/shared-data/src/lib/utils/cpf.util.spec.ts` | Bloco de testes correspondente removido |
| `libs/shared-data/src/lib/index.ts` | Função removida do barrel export |

Diff: +56 / -54 (6 arquivos).

## Por quê

### Causa raiz

`shared-ui:build:production` falhava com:

```
TypeError: Cannot destructure property 'pos' of 'file.referencedFiles[index]' as it is undefined.
    at getReferencedFileLocation (typescript.js:126740:10)
    at fileIncludeReasonToDiagnostics (typescript.js:133580:31)
```

A mensagem é o sistema de diagnóstico do TypeScript falhando ao tentar gerar uma mensagem sobre por que um arquivo foi incluído no programa — o erro REAL fica mascarado.

**Triagem:**

| Hipótese | Resultado |
|---|---|
| `tsc --noEmit -p libs/shared-ui/tsconfig.lib.prod.json` | ✅ passa limpo (vanilla TS resolve OK) |
| Inline da função em `cpf-input.ts` | ✅ build passa em 510ms |
| Import original `@uniplus/shared-data` (path mapping para source) | ❌ ng-packagr crasha |

ng-packagr usa o Angular Compiler, que tem regras próprias de resolução de módulos para libs. Quando `shared-ui` importa `@uniplus/shared-data` via path mapping para o source de `shared-data/src`, o compilador puxa os arquivos TS de outra lib para dentro do programa de `shared-ui`, e o sistema de diagnóstico crasha.

### Decisão técnica

`formatCpfProgressive` é formatador progressivo de máscara de CPF — UI puro, sem semântica de domínio (diferente de `cpfValidator` em `shared-data`, que tem regra de validação algorítmica). Único consumidor no workspace era o componente `CpfInputComponent` em `shared-ui`. Mover é o caminho mais limpo para esta função.

Alternativas consideradas e descartadas:
- **Override de `paths` em `tsconfig.lib.prod.json`** apontando para `dist/libs/shared-data/index.d.ts` — funciona, mas é tapa-buraco arquitetural sobre um problema real de fronteira entre libs.
- **Inline em `cpf-input.ts`** — também funciona, mas perde a unit spec dedicada e mistura formatação com componente.
- **Extrair para uma lib base buildada antes de `shared-ui` e `shared-data`** — caminho certo se a UI compartilhada crescer e mais utilities precisarem ser compartilhadas. Acompanhamento na #132.

### CI hardening — por que não está aqui

A #124 também pede endurecer o CI para que regressões de build/test/e2e bloqueiem merge. Isso ficou deferido neste PR porque:

1. O CI atual mascara silenciosamente OUTROS bugs além do `shared-ui:build`:
   - `ingresso-e2e`: 6 testes falhando em `example.spec.ts` (#134)
   - `poc-primeng-e2e`: `ENOENT: dist/apps/poc-primeng/browser/404.html` (#131)
2. Se eu apertasse o gate agora, `main` ficaria vermelha por causa desses dois — o que bloquearia aprovações de todos os PRs subsequentes da sprint.
3. Bundlear shared-ui + ingresso-e2e + poc-primeng-e2e + CI hardening em um único PR criaria algo massivo e difícil de revisar.

Caminho proposto: mergear o CI hardening (#133) por último, depois que #134 e #131 estiverem mergeadas.

## Validação

| Validação | Resultado |
|---|---|
| `npx nx run shared-ui:build:production --skip-nx-cache` | ✅ 511ms |
| `npx nx run-many --target=build --all --parallel=2 --skip-nx-cache` | ✅ 8 projetos |
| `npx nx run-many --target=lint --all --parallel=4 --skip-nx-cache` | ✅ 13 projetos |
| `npx nx run shared-data:test --watch=false --skip-nx-cache` | ✅ 14 testes (cpf.util 5 + cpf.validator 9) |
| `npx nx run shared-ui:test --watch=false --skip-nx-cache` | ✅ 39 testes (cpf-format.util 13 + cpf.pipe 3 + cpf-input 23) |

Falhas pré-existentes em `shared-core:test` e `shared-auth:test` (`No test files found`) são baseline de `main` — libs sem testes ainda. Sem regressão.

## Test plan

- [ ] CI verde neste PR
- [ ] Após merge: `npm ci && npx nx run shared-ui:build:production` reproduz exit 0 em qualquer máquina com Node 22
- [ ] Após merge: nenhum app/lib reporta `Cannot resolve '@uniplus/shared-data'` para `formatCpfProgressive` (verificado via grep — único consumidor era `cpf-input.ts`)

## Follow-ups (já abertos)

- **#134** — fix(ingresso-e2e): `example.spec.ts` falha com 6 testes (scaffold default)
- **#131** — fix(poc-primeng-e2e): `ENOENT` em `dist/apps/poc-primeng/browser/404.html`
- **#133** — ci: endurecer `nx run-many` para propagar exit codes não-zero (depende de #130, #134, #131)
- **#132** — refactor(arch): extrair lib base buildada para UI utilities compartilhados

Refs #124