### PR TITLE
fix(poc-primeng-e2e): mitiga Chromium Protocol error sob carga

### DIFF
--- a/apps/poc-primeng-e2e/playwright.config.ts
+++ b/apps/poc-primeng-e2e/playwright.config.ts
@@ -6,6 +6,12 @@ const baseURL = process.env['BASE_URL'] || 'http://localhost:4230';
 
 export default defineConfig({
   ...nxE2EPreset(__filename, { testDir: './src' }),
+  // Limita paralelismo e adiciona retries para mitigar
+  // `page.screenshot: Protocol error (Page.captureScreenshot)` sob carga
+  // (Chromium crashando em dev machine com workers paralelos + screenshots
+  // fullPage). Ver #123 para detalhes.
+  workers: process.env['CI'] ? 1 : 2,
+  retries: process.env['CI'] ? 2 : 1,
   use: {
     baseURL,
     trace: 'on-first-retry',

--- a/apps/poc-primeng-e2e/src/govbr-design-tokens.spec.ts
+++ b/apps/poc-primeng-e2e/src/govbr-design-tokens.spec.ts
@@ -5,10 +5,26 @@ import { join } from 'path';
 const screenshotsDir = join(__dirname, '..', 'screenshots');
 
 async function screenshot(page: Page, name: string) {
-  await page.screenshot({
-    path: `${screenshotsDir}/${name}.png`,
-    fullPage: true,
-  });
+  // Retry interno para `Page.captureScreenshot Protocol error` (Chromium
+  // crashando sob carga em dev machine). Defesa em profundidade — o
+  // playwright.config também tem retries de teste, mas isso evita
+  // re-rodar todo o teste por causa de um único screenshot transitório.
+  // Ver #123.
+  const maxAttempts = 3;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await page.screenshot({
+        path: `${screenshotsDir}/${name}.png`,
+        fullPage: true,
+      });
+      return;
+    } catch (err) {
+      const isProtocolError =
+        err instanceof Error && /Protocol error.*captureScreenshot/i.test(err.message);
+      if (!isProtocolError || attempt === maxAttempts) throw err;
+      await page.waitForTimeout(500);
+    }
+  }
 }
 
 async function getStyles(


### PR DESCRIPTION
## Resumo

Mitiga o flake `page.screenshot: Protocol error (Page.captureScreenshot)` reportado em #123 (originado da review do PR #122). Combina três camadas de defesa: limita paralelismo, adiciona retries de teste, e adiciona retry interno na captura específica.

## Mudanças

### `apps/poc-primeng-e2e/playwright.config.ts` (+6 linhas)

```ts
workers: process.env['CI'] ? 1 : 2,
retries: process.env['CI'] ? 2 : 1,
```

- **Workers** — antes era default (`os.cpus().length`, geralmente 8+ em dev machine). Reduz pressão paralela no Chromium browser process.
- **Retries** — antes era 0. 1 retry local + 2 em CI tolera falha transitória sem mascarar bug determinístico.

### `apps/poc-primeng-e2e/src/govbr-design-tokens.spec.ts` (+24/-4 no helper `screenshot()`)

Wrapper interno com retry específico para `Protocol error.*captureScreenshot`. Defesa em profundidade — evita re-rodar todo o teste por causa de uma única captura transitória, e o regex restrito ao Protocol error evita mascarar erros legítimos (timeout, page crash, etc.).

```ts
const isProtocolError =
  err instanceof Error && /Protocol error.*captureScreenshot/i.test(err.message);
if (!isProtocolError || attempt === maxAttempts) throw err;
await page.waitForTimeout(500);
```

## Por quê

A causa raiz é Chromium browser process crashando sob carga (instâncias paralelas + screenshots `fullPage` em todos os 56 testes geram memory pressure). A issue propôs três opções (A: workers; B: retries; D: wrapper); este PR aplica as três combinadas para máxima cobertura sem precisar investigar o memory leak (Opção C, alto esforço).

A Opção D (wrapper interno) é especialmente valiosa porque o ponto exato de falha é a chamada CDP `Page.captureScreenshot` — retry interno é mais barato que retry de teste inteiro e tem menor blast radius.

## Validação

12 runs consecutivos da suíte `govbr-design-tokens.spec.ts` em ambiente local (Node 22.22.2, Chromium do Playwright):

| run | resultado | Protocol errors |
|---|---|---|
| 1–12 | ✅ 56/56 testes em ~9s | 0 |

**12/12 verdes, 0 Protocol errors.** Baseline reportado na issue era 2–4 falhas em 12 runs.

> **Limitação honesta:** o critério de aceite ideal da issue é 50 runs sem falha. Validei 12 runs (mesmo número que reproduziu o bug no diagnóstico original — se zerar nesse N, evidência é estatisticamente clara). Validação completa de 50 runs deve acontecer naturalmente em CI ao longo do tempo, ou pode ser feita pós-merge em ambiente menos saturado (rodei este PR depois de #129 e #130 na mesma máquina).

## Test plan

- [ ] CI verde neste PR
- [ ] Após merge: rodar 50 runs consecutivos da suíte em ambiente menos carregado (idealmente em workflow dedicado, ou validação manual em janela ociosa) → 0 Protocol errors esperados
- [ ] Monitorar próximos PRs que tocam `poc-primeng-e2e` — se Protocol error reaparecer, considerar Opção C da #123 (investigar memory leak)

## Não-objetivos

- Aplicar wrapper de retry nos outros 3 specs (`govbr-referencia.spec.ts`, `keyboard-a11y.spec.ts`, `inscricao-flow.spec.ts`) — a config `workers/retries` global já cobre. Se algum deles flakear no futuro, vale extrair util compartilhada.
- Investigar memory leak (Opção C) — ROI baixo enquanto mitigação funciona.
- Refatorar a suíte para reduzir uso de `fullPage: true` — escopo separado.

Closes #123