### PR TITLE
fix(ingresso-e2e): substitui scaffold default por smoke test de redirect Keycloak

### DIFF
--- a/apps/ingresso-e2e/playwright.config.ts
+++ b/apps/ingresso-e2e/playwright.config.ts
@@ -5,6 +5,10 @@ import { workspaceRoot } from '@nx/devkit';
 // For CI, you may want to set BASE_URL to the deployed application.
 const baseURL = process.env['BASE_URL'] || 'http://localhost:4201';
 
+// webkit requer libs Ubuntu (libicudata.so.74, libxml2.so.2 etc.) — só executa em CI.
+// Localmente em distros não-Debian, defina CI=true para incluir webkit.
+const isCI = !!process.env['CI'];
+
 /**
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
@@ -40,10 +44,10 @@ export default defineConfig({
       use: { ...devices['Desktop Firefox'] },
     },
 
-    {
+    ...(isCI ? [{
       name: 'webkit',
       use: { ...devices['Desktop Safari'] },
-    },
+    }] : []),
 
     // Uncomment for mobile browsers support
     /* {

--- a/apps/ingresso-e2e/src/example.spec.ts
+++ b/apps/ingresso-e2e/src/example.spec.ts
@@ -1,11 +1,15 @@
 import { test, expect } from '@playwright/test';
 
-test('deve carregar a página inicial', async ({ page }) => {
+test('deve redirecionar para o Keycloak ao acessar a raiz sem sessão', async ({ page }) => {
   await page.goto('/');
-  await expect(page.locator('h1')).toContainText('Ingresso');
+  await page.waitForURL(/realms\/unifesspa\/protocol\/openid-connect/, { timeout: 10_000 });
+  await expect(page.locator('#kc-login')).toBeVisible();
 });
 
-test('deve navegar para chamadas', async ({ page }) => {
-  await page.goto('/chamadas');
-  await expect(page.locator('h2')).toContainText('Chamadas');
+test.skip('deve exibir dashboard após login (requer fixture Keycloak + API Ingresso)', async ({ page }) => {
+  // Teste de integração completo — requer Keycloak rodando com usuário
+  // de role admin/gestor + API Ingresso. Coberto futuramente em
+  // auth-oidc.spec.ts + chamadas-flow.spec.ts (a implementar).
+  await page.goto('/dashboard');
+  await expect(page.locator('h1')).toContainText('Ingresso');
 });


### PR DESCRIPTION
## Resumo

Substitui o `example.spec.ts` (scaffold default do Nx Playwright) por smoke test que reflete a realidade da app Ingresso: backoffice protegido por `authGuard + roleGuard('admin', 'gestor')`. Adota o mesmo padrão já validado em `selecao-e2e`.

## Mudanças

### `apps/ingresso-e2e/src/example.spec.ts`

**Antes** — assumia app pública:
```ts
test('deve carregar a página inicial', async ({ page }) => {
  await page.goto('/');
  await expect(page.locator('h1')).toContainText('Ingresso');
});
test('deve navegar para chamadas', async ({ page }) => {
  await page.goto('/chamadas');
  await expect(page.locator('h2')).toContainText('Chamadas');
});
```

Ambos batiam no `authGuard`, eram redirecionados ao Keycloak e nunca encontravam o `h1`/`h2` esperado. 2 testes × 3 browsers (chromium, firefox, webkit) = **6 falhas mascaradas**.

**Depois** — paridade com `selecao-e2e`:
```ts
test('deve redirecionar para o Keycloak ao acessar a raiz sem sessão', async ({ page }) => {
  await page.goto('/');
  await page.waitForURL(/realms\/unifesspa\/protocol\/openid-connect/, { timeout: 10_000 });
  await expect(page.locator('#kc-login')).toBeVisible();
});

test.skip('deve exibir dashboard após login (requer fixture Keycloak + API Ingresso)', ...);
```

### `apps/ingresso-e2e/playwright.config.ts`

Webkit condicional em CI (paridade com `selecao-e2e`). Localmente em distros não-Debian, libs nativas do webkit (`libicudata.so.74` etc.) podem faltar — pular evita ruído de execução local sem afetar cobertura em CI.

## Por quê

Esse PR é parte do unblock para o CI hardening (#133). A #124 documentou que `ingresso-e2e` falhava silenciosamente em CI por causa do mascaramento de exit codes. PR #130 resolveu o `shared-ui:build` mas adiou o hardening exatamente porque os e2e (ingresso e poc-primeng) ainda falhariam. Este PR resolve o ingresso; #131 ataca poc-primeng; #133 endurece o gate depois.

A escolha por reescrever em vez de adicionar fixture Keycloak completa é pragmática: fixture de auth real ainda não existe no projeto (ver test skipado, que documenta o débito). Smoke test de redirect já garante que a app está minimamente funcional + o auth está cabeado, sem exigir infraestrutura adicional.

## Validação

Keycloak local subido via:
```bash
KEYCLOAK_ADMIN_PASSWORD=admin docker compose -f tools/e2e-docker/docker-compose.e2e.yml up -d keycloak
```

Aguardado healthcheck (`http://localhost:9000/health/ready`), realm `unifesspa` importado com sucesso.

```
$ npx nx run ingresso-e2e:e2e
Running 4 tests using 4 workers
[chromium+firefox] redirect Keycloak — passed
[chromium+firefox] dashboard (skipped)

2 skipped
2 passed (3.0s)
```

Em CI rodará também webkit (6 total: 3 passed + 3 skipped).

## Test plan

- [ ] CI verde neste PR (incluindo webkit)
- [ ] Após merge: confirmar que o run de `nx run ingresso-e2e:e2e` em CI reporta 0 falhas
- [ ] Após #131 e este PR mergeados, #133 (CI hardening) pode prosseguir sem deixar `main` vermelha

## Não-objetivos

- Implementar fixture Keycloak completa para testes autenticados — escopo separado, planejado conforme a app Ingresso ganha conteúdo testável.
- Adicionar `ingresso-e2e` ao `tools/e2e-docker/run.sh` — runner Docker pode ser estendido em PR separado se houver demanda.

Closes #134