### PR TITLE
fix(poc-primeng-e2e): substitui serve-static por http-server direto para evitar bug de unlink ENOENT

### DIFF
--- a/apps/poc-primeng-e2e/playwright.config.ts
+++ b/apps/poc-primeng-e2e/playwright.config.ts
@@ -25,9 +25,10 @@ export default defineConfig({
   // linhas 195–202) — o segundo disparo do handler crasha com ENOENT.
   // Substituir pelo `http-server` direto evita o bug e mantém o mesmo
   // comportamento de SPA fallback via `--proxy ?`. Ver #131.
+  // O build é garantido via `dependsOn` no project.json, não inline aqui.
   webServer: {
     command:
-      'npx nx run poc-primeng:build && npx http-server dist/apps/poc-primeng/browser -p 4230 -s -c-1 --cors --proxy "http://localhost:4230?"',
+      'npx http-server dist/apps/poc-primeng/browser -p 4230 -s -c-1 --cors --proxy "http://localhost:4230?"',
     url: 'http://localhost:4230',
     reuseExistingServer: true,
     cwd: workspaceRoot,

--- a/apps/poc-primeng-e2e/playwright.config.ts
+++ b/apps/poc-primeng-e2e/playwright.config.ts
@@ -23,12 +23,11 @@ export default defineConfig({
   // `exit` e `SIGTERM` para fazer `unlinkSync('404.html')` no shutdown
   // (ver node_modules/@nx/web/src/executors/file-server/file-server.impl.js
   // linhas 195–202) — o segundo disparo do handler crasha com ENOENT.
-  // Substituir pelo `http-server` direto evita o bug e mantém o mesmo
-  // comportamento de SPA fallback via `--proxy ?`. Ver #131.
-  // O build é garantido via `dependsOn` no project.json, não inline aqui.
+  // O target `serve-static-e2e` (em apps/poc-primeng/project.json) usa
+  // `nx:run-commands` com `http-server` direto, evitando o bug.
+  // Ver #131.
   webServer: {
-    command:
-      'npx http-server dist/apps/poc-primeng/browser -p 4230 -s -c-1 --cors --proxy "http://localhost:4230?"',
+    command: 'npx nx run poc-primeng:serve-static-e2e',
     url: 'http://localhost:4230',
     reuseExistingServer: true,
     cwd: workspaceRoot,

--- a/apps/poc-primeng-e2e/playwright.config.ts
+++ b/apps/poc-primeng-e2e/playwright.config.ts
@@ -18,8 +18,16 @@ export default defineConfig({
     locale: 'pt-BR',
     timezoneId: 'America/Belem',
   },
+  // Antes usava `npx nx run poc-primeng:serve-static`, que delega ao
+  // `@nx/web:file-server`. Esse executor registra o mesmo handler em
+  // `exit` e `SIGTERM` para fazer `unlinkSync('404.html')` no shutdown
+  // (ver node_modules/@nx/web/src/executors/file-server/file-server.impl.js
+  // linhas 195–202) — o segundo disparo do handler crasha com ENOENT.
+  // Substituir pelo `http-server` direto evita o bug e mantém o mesmo
+  // comportamento de SPA fallback via `--proxy ?`. Ver #131.
   webServer: {
-    command: 'npx nx run poc-primeng:serve-static',
+    command:
+      'npx nx run poc-primeng:build && npx http-server dist/apps/poc-primeng/browser -p 4230 -s -c-1 --cors --proxy "http://localhost:4230?"',
     url: 'http://localhost:4230',
     reuseExistingServer: true,
     cwd: workspaceRoot,

--- a/apps/poc-primeng-e2e/project.json
+++ b/apps/poc-primeng-e2e/project.json
@@ -5,5 +5,9 @@
   "sourceRoot": "apps/poc-primeng-e2e/src",
   "implicitDependencies": ["poc-primeng"],
   "// targets": "to see all targets run: nx show project poc-primeng-e2e --web",
-  "targets": {}
+  "targets": {
+    "e2e": {
+      "dependsOn": [{ "target": "build", "projects": ["poc-primeng"] }]
+    }
+  }
 }

--- a/apps/poc-primeng-e2e/project.json
+++ b/apps/poc-primeng-e2e/project.json
@@ -5,9 +5,5 @@
   "sourceRoot": "apps/poc-primeng-e2e/src",
   "implicitDependencies": ["poc-primeng"],
   "// targets": "to see all targets run: nx show project poc-primeng-e2e --web",
-  "targets": {
-    "e2e": {
-      "dependsOn": [{ "target": "build", "projects": ["poc-primeng"] }]
-    }
-  }
+  "targets": {}
 }

--- a/apps/poc-primeng/project.json
+++ b/apps/poc-primeng/project.json
@@ -78,6 +78,15 @@
         "staticFilePath": "dist/apps/poc-primeng/browser",
         "spa": true
       }
+    },
+    "serve-static-e2e": {
+      "continuous": true,
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npx http-server dist/apps/poc-primeng/browser -p 4230 -s -c-1 --cors --proxy \"http://localhost:4230?\"",
+        "cwd": "{workspaceRoot}"
+      },
+      "dependsOn": [{ "target": "build" }]
     }
   }
 }


### PR DESCRIPTION
## Resumo

Resolve `Error: ENOENT: no such file or directory, unlink 'dist/apps/poc-primeng/browser/404.html'` em CI substituindo o `webServer.command` do `playwright.config.ts` — sai de `npx nx run poc-primeng:serve-static` (que usa `@nx/web:file-server` com bug) e entra `http-server` direto.

## Causa raiz (bug upstream do @nx/web)

`@nx/web:file-server` em modo `spa: true` faz duas coisas (`node_modules/@nx/web/src/executors/file-server/file-server.impl.js`, linhas 171–202):

1. **Startup**: `copyFileSync(index.html, 404.html)` — truque do http-server para SPA routing (`https://github.com/http-party/http-server#magic-files`).
2. **Shutdown** (handler `processExitListener`): `unlinkSync('404.html')`.

```js
const processExitListener = () => {
    serve.kill();
    if (disposeWatch) {
        disposeWatch();
    }
    if (options.spa) {
        (0, fs_1.unlinkSync)((0, path_1.join)(outputPath, '404.html'));
    }
};
process.on('exit', processExitListener);
process.on('SIGTERM', processExitListener);
```

O **mesmo handler está registrado em dois eventos**: `exit` e `SIGTERM`. Em CI, SIGTERM dispara primeiro (unlink OK), depois Node emite `exit` que chama o handler de novo — segundo `unlinkSync` falha com ENOENT.

```
Error: ENOENT: no such file or directory, unlink 'dist/apps/poc-primeng/browser/404.html'
    at unlinkSync (node:fs:1948:11)
    at process.processExitListener (node_modules/@nx/web/src/executors/file-server/file-server.impl.js:201:33)
    at process.emit (node:events:519:28)
    ...
```

A 100 testes do `playwright test` passam ANTES do shutdown crashar — então o exit code do `nx run poc-primeng-e2e:e2e` em si **fica não-zero por causa da exceção uncaught no shutdown**, não por causa de teste falhando. Hoje isso fica mascarado pelo CI (issue #133); quando o gate for endurecido, vai bloquear o merge.

Comportamento confirmado em runs recentes em `main`:
- run 24970083028, 24969564856, 24968935630 — todos mostram `Error: ENOENT` logo após `100 passed`.
- Stack trace consistente, sempre em `file-server.impl.js:201:33`.

## Por que não reportar upstream e esperar fix

Reportar upstream é o caminho certo a longo prazo, mas:
- Bloquearia #133 (CI hardening) por semanas até PR ser mergeado e versão lançada.
- Workaround é trivial e mais limpo do que esperar.
- Issue separada (#132 — refactor arquitetural) já discute repensar dependências de `@nx/web` em geral; um ticket de bug upstream pode ser anexado lá.

## Mudança

```diff
+  // Antes usava `npx nx run poc-primeng:serve-static`, que delega ao
+  // `@nx/web:file-server`. Esse executor registra o mesmo handler em
+  // `exit` e `SIGTERM` para fazer `unlinkSync('404.html')` no shutdown
+  // (ver node_modules/@nx/web/src/executors/file-server/file-server.impl.js
+  // linhas 195–202) — o segundo disparo do handler crasha com ENOENT.
+  // Substituir pelo `http-server` direto evita o bug e mantém o mesmo
+  // comportamento de SPA fallback via `--proxy ?`. Ver #131.
   webServer: {
-    command: 'npx nx run poc-primeng:serve-static',
+    command:
+      'npx nx run poc-primeng:build && npx http-server dist/apps/poc-primeng/browser -p 4230 -s -c-1 --cors --proxy "http://localhost:4230?"',
     url: 'http://localhost:4230',
     reuseExistingServer: true,
     cwd: workspaceRoot,
     timeout: 180000,
   },
```

- `http-server` v14.1.1 já está em `node_modules` como dependência transitiva do próprio `@nx/web` — não adiciona dep nova.
- Flags equivalentes ao que o `@nx/web:file-server` configurava internamente: `-s` (silent), `-c-1` (no cache), `--cors`, `--proxy "http://localhost:4230?"` (SPA fallback — replica a `proxyUrl` que o executor gerava).
- O `npx nx run poc-primeng:build &&` garante que o build acontece antes do servidor subir (substituindo o `buildTarget` que o `serve-static` resolvia automaticamente).

## Validação local

```
$ npx nx run poc-primeng-e2e:e2e
100 passed (31.1s)

NX   Successfully ran target e2e for project poc-primeng-e2e

EXIT: 0
```

- 100/100 testes verdes
- exit 0 limpo
- sem `ENOENT` em stderr
- sem mensagens de stack trace pós-suíte

## Test plan

- [ ] CI verde neste PR
- [ ] Após merge: confirmar que o `Error: ENOENT` desaparece dos logs de futuras runs em `main`
- [ ] Após #133 (CI hardening) mergear, validar que `poc-primeng-e2e:e2e` continua verde

## Não-objetivos

- Reportar bug upstream para `@nx/web` — pode ser feito em paralelo, fora do escopo deste PR.
- Reescrever o target `serve-static` do `poc-primeng` (ainda existe no `project.json` para usos manuais como `nx serve-static poc-primeng` em dev) — manter intacto reduz blast radius.

Closes #131