### PR TITLE
ci: endurece gate do nx run-many

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,11 @@ jobs:
           timeout 120 bash -c \
             'until curl -sf http://localhost:9000/health/ready | grep -q "\"UP\""; do sleep 5; done'
 
-      # This enables task distribution via Nx Cloud
-      # Run this command as early as possible, before dependencies are installed
+      # This enables task distribution via Nx Cloud.
+      # Keep --stop-agents-after aligned with every target executed below so the
+      # distributed run cannot finish before all blocking gates are reconciled.
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-      - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e"
+      - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="lint,test,build,typecheck,e2e"
 
       - uses: actions/setup-node@v4
         with:
@@ -50,7 +51,7 @@ jobs:
       - run: npx playwright install --with-deps
 
       - run: npx nx record -- echo Hello World
-      - run: npx nx run-many -t lint test build typecheck e2e
+      - run: npx nx run-many -t lint test build typecheck e2e --nxBail --outputStyle=static
         env:
           KEYCLOAK_ADMIN_PASSWORD: ${{ secrets.KEYCLOAK_ADMIN_PASSWORD || 'admin' }}
 

--- a/libs/shared-auth/src/lib/components/user-header-info.component.spec.ts
+++ b/libs/shared-auth/src/lib/components/user-header-info.component.spec.ts
@@ -44,7 +44,8 @@ describe('UserHeaderInfoComponent', () => {
       ],
     });
 
-    const fixture: ComponentFixture<UserHeaderInfoComponent> = TestBed.createComponent(UserHeaderInfoComponent);
+    const fixture: ComponentFixture<UserHeaderInfoComponent> =
+      TestBed.createComponent(UserHeaderInfoComponent);
     fixture.detectChanges();
     return { fixture, logout };
   }
@@ -155,14 +156,16 @@ describe('UserHeaderInfoComponent', () => {
     expect(el.querySelector('button')).toBeTruthy();
   });
 
-  it('exibe roles com underscore ou caractere especial sem quebrar', () => {
-    const rolesEspeciais: UserProfile = {
+  it('filtra roles internas do Keycloak sem quebrar', () => {
+    const rolesInternas: UserProfile = {
       ...profileData,
-      roles: ['offline_access', 'uma-role-composta'],
+      roles: ['candidato', 'offline_access', 'uma_authorization'],
     };
-    const { fixture } = setup(rolesEspeciais);
+    const { fixture } = setup(rolesInternas);
     const el: HTMLElement = fixture.nativeElement;
-    expect(el.textContent).toContain('offline_access, uma-role-composta');
+    expect(el.textContent).toContain('candidato');
+    expect(el.textContent).not.toContain('offline_access');
+    expect(el.textContent).not.toContain('uma_authorization');
   });
 
   it('dispara logout() a cada clique (sem debounce)', () => {

--- a/libs/shared-core/vite.config.mts
+++ b/libs/shared-core/vite.config.mts
@@ -14,6 +14,7 @@ export default defineConfig(() => ({
     globals: true,
     environment: 'jsdom',
     include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    passWithNoTests: true,
     setupFiles: ['src/test-setup.ts'],
     reporters: ['default'],
     coverage: {


### PR DESCRIPTION
## Resumo

- Alinha `--stop-agents-after` com todos os targets executados no CI principal: `lint,test,build,typecheck,e2e`.
- Adiciona `--nxBail` ao `nx run-many` para o comando principal falhar ao primeiro target vermelho.
- Usa `--outputStyle=static` para logs estáveis em CI.
- Corrige as falhas que o gate passou a expor: `shared-auth:test` tinha spec desatualizada para filtro de roles internas do Keycloak; `shared-core:test` não tinha specs e agora usa `passWithNoTests`.

## Validação

- Baseline de `main`: runs mais recentes `CI` e `Lint completo (workspace)` no SHA `3a6ddfb5` passaram antes deste PR.
- `npx prettier --check .github/workflows/ci.yml libs/shared-auth/src/lib/components/user-header-info.component.spec.ts libs/shared-core/vite.config.mts`
- `git diff --check -- .github/workflows/ci.yml libs/shared-auth/src/lib/components/user-header-info.component.spec.ts libs/shared-core/vite.config.mts`
- `cd libs/shared-auth && npx vitest run` com Node 22: 56 testes passaram.
- `cd libs/shared-core && npx vitest run --passWithNoTests` com Node 22: sem specs, exit 0.
- `NX_DAEMON=false npx nx run-many --help | rg -- --nxBail` com Node 22 confirmou suporte ao flag.

Não rodei o `run-many` completo localmente: o sandbox bloqueou workers/daemon do Nx com `EPERM` em socket local. A validação real do gate fica no GitHub Actions deste PR.

Closes #133