### PR TITLE
test(shared): adiciona testes de média prioridade — CpfInput, ConfirmDialog, DataTable, date utils

### DIFF
--- a/libs/shared-data/src/lib/utils/date.util.spec.ts
+++ b/libs/shared-data/src/lib/utils/date.util.spec.ts
@@ -36,7 +36,7 @@ describe('Date Util', () => {
     });
 
     it('retorna um "—" quando a entrada de um texto bruto de data e hora é inválida', () => {
-      expect(formatDateTimeBr(new Date(INVALID_RAW_DATE))).toBe(INVALID_DATE_MSG);
+      expect(formatDateTimeBr(INVALID_RAW_DATE)).toBe(INVALID_DATE_MSG);
     });
 
     it('retorna um "—" quando a entrada de um objeto de data e hora é inválida', () => {
@@ -59,7 +59,7 @@ describe('Date Util', () => {
     });
 
     it('transforma corretamente entrada de texto referente a um ano bissexto', () => {
-      expect(parseDate('24/02/2026')).not.toBe(null);
+      expect(parseDate('29/02/2024 ')).not.toBe(null);
     });
 
     it('retorna null quando a data é um texto vazio', () => {

--- a/libs/shared-data/src/lib/utils/date.util.spec.ts
+++ b/libs/shared-data/src/lib/utils/date.util.spec.ts
@@ -51,7 +51,7 @@ describe('Date Util', () => {
     });
 
     it('retorna null quando a data é um texto vazio', () => {
-      expect(parseDate).toBe(null);
+      expect(parseDate('')).toBe(null);
     });
 
     it('retorna null quando a entrada de texto difere da localidade pt-br e do formato (dd/mm/yyyy)', () => {

--- a/libs/shared-data/src/lib/utils/date.util.spec.ts
+++ b/libs/shared-data/src/lib/utils/date.util.spec.ts
@@ -2,11 +2,11 @@ import { describe, it, expect } from 'vitest';
 import { formatDateBr, formatDateTimeBr, parseDate } from './date.util';
 
 describe('Date Util', () => {
-  const VALID_RAW_DATE = '02/14/2026 12:00:00';
-  const INVALID_RAW_DATE = '02/14/2026 25:00:00';
+  const VALID_RAW_DATE = '2026-02-14T12:00:00';
+  const INVALID_RAW_DATE = '2026-02-14T25:00:00';
   const DATE_STR = '02/14/2026';
   const DATE = new Date(VALID_RAW_DATE);
-  const INVALID_DATE_MSG = 'Invalid Date';
+  const INVALID_DATE_MSG = '—';
 
   describe('formatDateBr()', () => {
     it('formata uma entrada de data em texto bruto para a localidade pt-br', () => {
@@ -17,11 +17,11 @@ describe('Date Util', () => {
       expect(formatDateBr(DATE)).toBe('14/02/2026');
     });
 
-    it('retorna uma mensagem de data inválida quando a entrada de data e hora em texto bruto é inválida', () => {    
+    it('retorna um "—" quando a entrada de data e hora em texto bruto é inválida', () => {
       expect(formatDateBr(INVALID_RAW_DATE)).toBe(INVALID_DATE_MSG);
     });
 
-    it('retorna uma mensagem de data inválida quando a entrada de um objeto de data e hora é inválida', () => {            
+    it('retorna um "—" quando a entrada de um objeto de data e hora é inválida', () => {
       expect(formatDateBr(new Date(INVALID_RAW_DATE))).toBe(INVALID_DATE_MSG);
     });
   });
@@ -31,8 +31,16 @@ describe('Date Util', () => {
       expect(formatDateTimeBr(VALID_RAW_DATE)).toBe('14/02/2026, 12:00:00');
     });
 
-    it('formata uma entrada de data e hora para o formato de data e hora na localidade pt-br', () => {    
+    it('formata uma entrada de data e hora para o formato de data e hora na localidade pt-br', () => {
       expect(formatDateTimeBr(DATE)).toBe('14/02/2026, 12:00:00');
+    });
+
+    it('retorna um "—" quando a entrada de um texto bruto de data e hora é inválida', () => {
+      expect(formatDateTimeBr(new Date(INVALID_RAW_DATE))).toBe(INVALID_DATE_MSG);
+    });
+
+    it('retorna um "—" quando a entrada de um objeto de data e hora é inválida', () => {
+      expect(formatDateTimeBr(new Date(INVALID_RAW_DATE))).toBe(INVALID_DATE_MSG);
     });
   });
 
@@ -50,12 +58,32 @@ describe('Date Util', () => {
       expect(result?.getFullYear()).toBe(year);
     });
 
+    it('transforma corretamente entrada de texto referente a um ano bissexto', () => {
+      expect(parseDate('24/02/2026')).not.toBe(null);
+    });
+
     it('retorna null quando a data é um texto vazio', () => {
       expect(parseDate('')).toBe(null);
     });
 
-    it('retorna null quando a entrada de texto difere da localidade pt-br e do formato (dd/mm/yyyy)', () => {
+    it('retorna null quando o mês está fora do intervalo válido', () => {
         expect(parseDate(DATE_STR)).toBe(null);
+    });
+
+    it('retorna null quando o separador difere de "/"', () => {
+      expect(parseDate('14-02-2026')).toBe(null);
+    });
+
+    it('retorna null quando o dia não existe em um determinado mês', () => {
+      expect(parseDate('32/01/2026')).toBe(null);
+    });
+
+    it('retorna null quando o ano possui apenas dois dígitos', () => {
+      expect(parseDate('01/01/26')).toBe(null);
+    });
+
+    it('retorna null quando o ano não é bissexto', () => {
+      expect(parseDate('29/02/2026')).toBe(null);
     });
   });
 });

--- a/libs/shared-data/src/lib/utils/date.util.spec.ts
+++ b/libs/shared-data/src/lib/utils/date.util.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { formatDateBr, formatDateTimeBr, parseDate } from './date.util';
+
+describe('Date Util', () => {
+  const VALID_RAW_DATE = '02/14/2026 12:00:00';
+  const INVALID_RAW_DATE = '02/14/2026 25:00:00';
+  const DATE_STR = '02/14/2026';
+  const DATE = new Date(VALID_RAW_DATE);
+  const INVALID_DATE_MSG = 'Invalid Date';
+
+  describe('formatDateBr()', () => {
+    it('formata uma entrada de data em texto bruto para a localidade pt-br', () => {
+      expect(formatDateBr(VALID_RAW_DATE)).toBe('14/02/2026');
+    });
+
+    it('formata uma entrada de data para a localidade pt-br', () => {
+      expect(formatDateBr(DATE)).toBe('14/02/2026');
+    });
+
+    it('retorna uma mensagem de data inválida quando a entrada de data e hora em texto bruto é inválida', () => {    
+      expect(formatDateBr(INVALID_RAW_DATE)).toBe(INVALID_DATE_MSG);
+    });
+
+    it('retorna uma mensagem de data inválida quando a entrada de um objeto de data e hora é inválida', () => {            
+      expect(formatDateBr(new Date(INVALID_RAW_DATE))).toBe(INVALID_DATE_MSG);
+    });
+  });
+
+  describe('formatDateTimeBr()', () => {
+    it('formata uma entrada de texto bruto de data e hora para o formato de data e hora na localidade pt-br', () => {
+      expect(formatDateTimeBr(VALID_RAW_DATE)).toBe('14/02/2026, 12:00:00');
+    });
+
+    it('formata uma entrada de data e hora para o formato de data e hora na localidade pt-br', () => {    
+      expect(formatDateTimeBr(DATE)).toBe('14/02/2026, 12:00:00');
+    });
+  });
+
+  describe('parseDate()', () => {
+    it('transforma entrada de texto no formato (dd/mm/yyyy) para uma data', () => {
+      const day = 14;
+      const month = '02';
+      const monthParseInt = parseInt(month, 10) - 1;
+      const year = 2025;
+      const result = parseDate(`${day}/${month}/${year}`);
+
+      expect(result).toStrictEqual(new Date(year, monthParseInt, day));
+      expect(result?.getDate()).toBe(day);
+      expect(result?.getMonth()).toBe(monthParseInt);
+      expect(result?.getFullYear()).toBe(year);
+    });
+
+    it('retorna null quando a data é um texto vazio', () => {
+      expect(parseDate).toBe(null);
+    });
+
+    it('retorna null quando a entrada de texto difere da localidade pt-br e do formato (dd/mm/yyyy)', () => {
+        expect(parseDate(DATE_STR)).toBe(null);
+    });
+  });
+});

--- a/libs/shared-data/src/lib/utils/date.util.ts
+++ b/libs/shared-data/src/lib/utils/date.util.ts
@@ -1,11 +1,11 @@
 export function formatDateBr(date: Date | string): string {
   const d = typeof date === 'string' ? new Date(date) : date;
-  return d.toLocaleDateString('pt-BR');
+  return Number.isNaN(d.getTime()) ? '—' : d.toLocaleDateString('pt-BR');
 }
 
 export function formatDateTimeBr(date: Date | string): string {
   const d = typeof date === 'string' ? new Date(date) : date;
-  return d.toLocaleString('pt-BR');
+  return Number.isNaN(d.getTime()) ? '—' : d.toLocaleString('pt-BR');
 }
 
 export function parseDate(dateStr: string): Date | null {

--- a/libs/shared-ui/src/lib/components/confirm-dialog/confirm-dialog.spec.ts
+++ b/libs/shared-ui/src/lib/components/confirm-dialog/confirm-dialog.spec.ts
@@ -1,0 +1,87 @@
+import { By } from '@angular/platform-browser';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, expect, it } from 'vitest';
+import { ConfirmDialogComponent } from './confirm-dialog';
+
+describe('ConfirmDialogComponent', () => {
+  function setup() {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+    imports: [ConfirmDialogComponent],
+    });
+    const fixture: ComponentFixture<ConfirmDialogComponent> =
+          TestBed.createComponent(ConfirmDialogComponent);
+    fixture.detectChanges();
+    const component = fixture.componentInstance;
+    const getDialogEl = () =>
+        fixture.debugElement.query(By.css('[role="dialog"]')).nativeElement as HTMLDivElement;
+    const getCancelButtonEl = () => fixture.debugElement.queryAll(By.css('button'))[0].nativeElement as HTMLButtonElement;
+    const getConfirmButtonEl = () => fixture.debugElement.queryAll(By.css('button'))[1].nativeElement as HTMLButtonElement;
+    const confirmedOutputSpy = vi.spyOn(component.confirmed, 'emit');
+    const cancelledOutputSpy = vi.spyOn(component.cancelled, 'emit');
+    return {
+        fixture,
+        component,
+        getDialogEl,
+        getCancelButtonEl,
+        getConfirmButtonEl,
+        confirmedOutputSpy,
+        cancelledOutputSpy
+    };
+  }
+
+  it('inicializa o componente corretamente', () => {
+    const { component } = setup();
+    expect(component).toBeTruthy();
+  });
+
+  it('renderiza o componente sem nós filhos no DOM quando visible() é false (default)', () => {
+    const { fixture } = setup();
+    expect(fixture.debugElement.children.length).toBe(0);
+  });
+
+  it('renderiza o dialog quando o input visible() é inicializado com o valor true', () => {
+    const { fixture, getDialogEl, getCancelButtonEl, getConfirmButtonEl } = setup();
+    fixture.componentRef.setInput('visible', true);
+    fixture.detectChanges();
+
+    const headingEl = fixture.debugElement.query(By.css('h3')).nativeElement as HTMLHeadingElement;
+    const paragraphEl = fixture.debugElement.query(By.css('p')).nativeElement as HTMLParagraphElement;
+    const cancelButtonEl = getCancelButtonEl();
+    const confirmButtonEl = getConfirmButtonEl();
+    const dialogEl = getDialogEl();
+
+    expect(dialogEl).toBeTruthy();
+    expect(headingEl).toBeTruthy();
+    expect(headingEl.textContent).toBe('Confirmação');
+    expect(paragraphEl.textContent).toBe('Deseja realmente prosseguir?');
+    expect(confirmButtonEl.textContent).toBe(' Confirmar ');
+    expect(cancelButtonEl.textContent).toBe(' Cancelar ');
+  });
+
+  it('emite um evento de output cancelled() quando clicar no botão cancelar', () => {
+    const { fixture, component, getCancelButtonEl, cancelledOutputSpy } = setup();
+    fixture.componentRef.setInput('visible', true);
+    fixture.detectChanges();
+
+    const cancelButtonEl = getCancelButtonEl();
+    cancelButtonEl.click();
+    fixture.detectChanges();
+
+    expect(component.visible()).toBe(false);
+    expect(cancelledOutputSpy).toHaveBeenCalled();
+  });
+
+  it('emite um evento de output confirmed() quando clicar no botão confirmar', () => {
+    const { fixture, component, getConfirmButtonEl, confirmedOutputSpy } = setup();
+    fixture.componentRef.setInput('visible', true);
+    fixture.detectChanges();
+
+    const confirmButtonEl = getConfirmButtonEl();
+    confirmButtonEl.click();
+    fixture.detectChanges();
+
+    expect(component.visible()).toBe(false);
+    expect(confirmedOutputSpy).toHaveBeenCalled();
+  });
+});

--- a/libs/shared-ui/src/lib/components/confirm-dialog/confirm-dialog.spec.ts
+++ b/libs/shared-ui/src/lib/components/confirm-dialog/confirm-dialog.spec.ts
@@ -1,6 +1,6 @@
 import { By } from '@angular/platform-browser';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { ConfirmDialogComponent } from './confirm-dialog';
 
 describe('ConfirmDialogComponent', () => {
@@ -15,8 +15,9 @@ describe('ConfirmDialogComponent', () => {
     const component = fixture.componentInstance;
     const getDialogEl = () =>
         fixture.debugElement.query(By.css('[role="dialog"]')).nativeElement as HTMLDivElement;
-    const getCancelButtonEl = () => fixture.debugElement.queryAll(By.css('button'))[0].nativeElement as HTMLButtonElement;
-    const getConfirmButtonEl = () => fixture.debugElement.queryAll(By.css('button'))[1].nativeElement as HTMLButtonElement;
+    const getButtons = () => fixture.debugElement.queryAll(By.css('button'));
+    const getCancelButtonEl = () => getButtons().find(b => b.nativeElement.textContent.trim() === 'Cancelar')?.nativeElement as HTMLButtonElement;
+    const getConfirmButtonEl = () => getButtons().find(b => b.nativeElement.textContent.trim() === 'Confirmar')?.nativeElement as HTMLButtonElement;
     const confirmedOutputSpy = vi.spyOn(component.confirmed, 'emit');
     const cancelledOutputSpy = vi.spyOn(component.cancelled, 'emit');
     return {
@@ -55,8 +56,8 @@ describe('ConfirmDialogComponent', () => {
     expect(headingEl).toBeTruthy();
     expect(headingEl.textContent).toBe('Confirmação');
     expect(paragraphEl.textContent).toBe('Deseja realmente prosseguir?');
-    expect(confirmButtonEl.textContent).toBe(' Confirmar ');
-    expect(cancelButtonEl.textContent).toBe(' Cancelar ');
+    expect(confirmButtonEl.textContent?.trim()).toBe('Confirmar');
+    expect(cancelButtonEl.textContent?.trim()).toBe('Cancelar');
   });
 
   it('emite um evento de output cancelled() quando clicar no botão cancelar', () => {

--- a/libs/shared-ui/src/lib/components/confirm-dialog/confirm-dialog.spec.ts
+++ b/libs/shared-ui/src/lib/components/confirm-dialog/confirm-dialog.spec.ts
@@ -1,33 +1,33 @@
 import { By } from '@angular/platform-browser';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { ConfirmDialogComponent } from './confirm-dialog';
 
 describe('ConfirmDialogComponent', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [ConfirmDialogComponent] });
+  });
+
   function setup() {
-    TestBed.resetTestingModule();
-    TestBed.configureTestingModule({
-    imports: [ConfirmDialogComponent],
-    });
     const fixture: ComponentFixture<ConfirmDialogComponent> =
-          TestBed.createComponent(ConfirmDialogComponent);
+      TestBed.createComponent(ConfirmDialogComponent);
     fixture.detectChanges();
     const component = fixture.componentInstance;
     const getDialogEl = () =>
-        fixture.debugElement.query(By.css('[role="dialog"]')).nativeElement as HTMLDivElement;
+      fixture.debugElement.query(By.css('[role="dialog"]')).nativeElement as HTMLDivElement;
     const getButtons = () => fixture.debugElement.queryAll(By.css('button'));
     const getCancelButtonEl = () => getButtons().find(b => b.nativeElement.textContent.trim() === 'Cancelar')?.nativeElement as HTMLButtonElement;
     const getConfirmButtonEl = () => getButtons().find(b => b.nativeElement.textContent.trim() === 'Confirmar')?.nativeElement as HTMLButtonElement;
     const confirmedOutputSpy = vi.spyOn(component.confirmed, 'emit');
     const cancelledOutputSpy = vi.spyOn(component.cancelled, 'emit');
     return {
-        fixture,
-        component,
-        getDialogEl,
-        getCancelButtonEl,
-        getConfirmButtonEl,
-        confirmedOutputSpy,
-        cancelledOutputSpy
+      fixture,
+      component,
+      getDialogEl,
+      getCancelButtonEl,
+      getConfirmButtonEl,
+      confirmedOutputSpy,
+      cancelledOutputSpy
     };
   }
 

--- a/libs/shared-ui/src/lib/components/data-table/data-table.spec.ts
+++ b/libs/shared-ui/src/lib/components/data-table/data-table.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { describe, it } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { DataTableComponent,DataTableColumn } from './data-table';
 
 describe('DataTableComponent', () => {
@@ -40,7 +40,7 @@ describe('DataTableComponent', () => {
     const { fixture, component } = setup();
     fixture.componentRef.setInput('columns', COLUMNS);
     fixture.detectChanges();
-    
+
     expect(component.columns()).toBeTruthy();
     expect(component.columns().length).toBe(COLUMNS.length);
   });
@@ -63,6 +63,17 @@ describe('DataTableComponent', () => {
     expect(tbodyQuery.children.length).toBe(DATA.length);
   });
 
+  it('renderiza o valor de cada célula conforme o field da coluna', () => {
+    const { fixture } = setup();
+    fixture.componentRef.setInput('columns', COLUMNS);
+    fixture.componentRef.setInput('data', DATA);
+    fixture.detectChanges();
+
+    const cells = fixture.debugElement.queryAll(By.css('tbody td'));
+    expect(cells[0].nativeElement.textContent.trim()).toBe('1');
+    expect(cells[1].nativeElement.textContent.trim()).toBe('Joe Doe');
+  });
+
   it('renderiza a tabela com mensagem de vazio quando o input columns() é um array vazio e data é um array vazio (default)', () => {
     const { fixture, component } = setup();
     fixture.detectChanges();
@@ -71,6 +82,6 @@ describe('DataTableComponent', () => {
     expect(component.columns()).toBeTruthy();
     expect(component.columns().length).toBe(0);
     expect(component.emptyMessage()).toBe('Nenhum registro encontrado.');
-    expect(tableCellEl.textContent).toBe(' Nenhum registro encontrado. ');
+    expect(tableCellEl.textContent.trim()).toBe(component.emptyMessage());
   });
 });

--- a/libs/shared-ui/src/lib/components/data-table/data-table.spec.ts
+++ b/libs/shared-ui/src/lib/components/data-table/data-table.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { DataTableComponent, DataTableColumn } from './data-table';
 
 describe('DataTableComponent', () => {
@@ -14,15 +14,17 @@ describe('DataTableComponent', () => {
     header: 'Name',
     sortable: true
   }];
+
   const DATA: Record<string, unknown>[] = [
     { id: '1', name: 'Joe Doe' },
     { id: '2', name: 'Joana Doe' }
   ];
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [DataTableComponent] });
+  });
+
   function setup() {
-    TestBed.resetTestingModule();
-    TestBed.configureTestingModule({
-        imports: [DataTableComponent],
-    });
     const fixture: ComponentFixture<DataTableComponent> =
       TestBed.createComponent(DataTableComponent);
     fixture.componentRef.setInput('columns', []);

--- a/libs/shared-ui/src/lib/components/data-table/data-table.spec.ts
+++ b/libs/shared-ui/src/lib/components/data-table/data-table.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { describe, it, expect } from 'vitest';
-import { DataTableComponent,DataTableColumn } from './data-table';
+import { DataTableComponent, DataTableColumn } from './data-table';
 
 describe('DataTableComponent', () => {
   const COLUMNS: DataTableColumn[] = [{
@@ -54,15 +54,6 @@ describe('DataTableComponent', () => {
     expect(tbodyQuery.children.length).toBe(DATA.length);
   });
 
-  it('renderiza a tabela com linhas quando o input data() está preenchido', () => {
-    const { fixture } = setup();
-    fixture.componentRef.setInput('data', DATA);
-    fixture.detectChanges();
-    const tbodyQuery = fixture.debugElement.query(By.css('tbody'));
-
-    expect(tbodyQuery.children.length).toBe(DATA.length);
-  });
-
   it('renderiza o valor de cada célula conforme o field da coluna', () => {
     const { fixture } = setup();
     fixture.componentRef.setInput('columns', COLUMNS);
@@ -72,6 +63,8 @@ describe('DataTableComponent', () => {
     const cells = fixture.debugElement.queryAll(By.css('tbody td'));
     expect(cells[0].nativeElement.textContent.trim()).toBe('1');
     expect(cells[1].nativeElement.textContent.trim()).toBe('Joe Doe');
+    expect(cells[2].nativeElement.textContent.trim()).toBe('2');
+    expect(cells[3].nativeElement.textContent.trim()).toBe('Joana Doe');
   });
 
   it('renderiza a tabela com mensagem de vazio quando o input columns() é um array vazio e data é um array vazio (default)', () => {

--- a/libs/shared-ui/src/lib/components/data-table/data-table.spec.ts
+++ b/libs/shared-ui/src/lib/components/data-table/data-table.spec.ts
@@ -1,0 +1,76 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { describe, it } from 'vitest';
+import { DataTableComponent,DataTableColumn } from './data-table';
+
+describe('DataTableComponent', () => {
+  const COLUMNS: DataTableColumn[] = [{
+    field: 'id',
+    header: 'ID',
+    sortable: false
+  },
+  {
+    field: 'name',
+    header: 'Name',
+    sortable: true
+  }];
+  const DATA: Record<string, unknown>[] = [
+    { id: '1', name: 'Joe Doe' },
+    { id: '2', name: 'Joana Doe' }
+  ];
+  function setup() {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+        imports: [DataTableComponent],
+    });
+    const fixture: ComponentFixture<DataTableComponent> =
+      TestBed.createComponent(DataTableComponent);
+    fixture.componentRef.setInput('columns', []);
+    fixture.detectChanges();
+    const component = fixture.componentInstance;
+    return { fixture, component };
+  }
+
+  it('inicializa o componente corretamente', () => {
+    const { component } = setup();
+    expect(component).toBeTruthy();
+  });
+
+  it('renderiza a tabela com colunas quando o input columns() está preenchido', () => {
+    const { fixture, component } = setup();
+    fixture.componentRef.setInput('columns', COLUMNS);
+    fixture.detectChanges();
+    
+    expect(component.columns()).toBeTruthy();
+    expect(component.columns().length).toBe(COLUMNS.length);
+  });
+
+  it('renderiza a tabela com linhas quando o input data() está preenchido', () => {
+    const { fixture } = setup();
+    fixture.componentRef.setInput('data', DATA);
+    fixture.detectChanges();
+    const tbodyQuery = fixture.debugElement.query(By.css('tbody'));
+
+    expect(tbodyQuery.children.length).toBe(DATA.length);
+  });
+
+  it('renderiza a tabela com linhas quando o input data() está preenchido', () => {
+    const { fixture } = setup();
+    fixture.componentRef.setInput('data', DATA);
+    fixture.detectChanges();
+    const tbodyQuery = fixture.debugElement.query(By.css('tbody'));
+
+    expect(tbodyQuery.children.length).toBe(DATA.length);
+  });
+
+  it('renderiza a tabela com mensagem de vazio quando o input columns() é um array vazio e data é um array vazio (default)', () => {
+    const { fixture, component } = setup();
+    fixture.detectChanges();
+    const tableCellEl = fixture.debugElement.query(By.css('td')).nativeElement as HTMLTableCellElement;
+
+    expect(component.columns()).toBeTruthy();
+    expect(component.columns().length).toBe(0);
+    expect(component.emptyMessage()).toBe('Nenhum registro encontrado.');
+    expect(tableCellEl.textContent).toBe(' Nenhum registro encontrado. ');
+  });
+});


### PR DESCRIPTION
# Resumo
Criação de testes unitários para o componentes de CPFInput, DataTable, Date Utils e Dialog Component. 

Closes #50 
# Motivação
Atualmente a cobertura de testes nos componentes existentes não existe ou está muito baixa. A criação dos testes garante maior confiabilidade e segurança. Gradualmente a cobertura deve aumentar e é planeja-se que seja de pelo menos 80%.

# Mudanças

<!-- Lista detalhada das mudanças por categoria -->

## Novos arquivos
libs/shared-ui/src/lib/components/confirm-dialog/confirm-dialog.spec.ts
libs/shared-ui/src/lib/components/data-table/data-table.spec.ts
libs/shared-data/src/lib/utils/date.util.spec.ts

## Arquivos modificados

libs/shared-data/src/lib/utils/date.util.ts


# Testes
- [x] testes unitários para o componente CPFInput já estão cobertos por outro PR
- [x] Atualização da implementação em Date Utils e adição de testes unitários
- [x] Testes unitários para o componente dialog-confirm
- [x] Testes unitários para o componente data-table

# Impedimentos

Alguns problemas foram encontrados no momento de criação dos testes propostos.
- Falta de atributo `data-testid` atrelados aos elementos html. Esse atributo HTML personalizado é usado para identificar elementos de forma estável e única em testes automatizados, evitando a fragilidade de seletores CSS ou XPath. Sugere-se um debate sobre o uso desse atributo.
- Problemas com quebra de linha no template html. O Angular entende que a quebra de linha é um espaço (white-space), logo quando utilizamos uma interpolação dentro em um elemento ele adiciona o espaço no lugar da quebra de linha. Esse tipo de comportamento atrapalha a comparação do atributos com o o valor renderizado no html nos testes unitários. No commit [9652e94](https://github.com/unifesspa-edu-br/uniplus-web/commit/9652e942ccf40ca4ad71210901ecb4b636ccb207) há testes que possuem esse problema. Segue o exemplo abaixo: https://github.com/unifesspa-edu-br/uniplus-web/blob/9652e942ccf40ca4ad71210901ecb4b636ccb207/libs/shared-ui/src/lib/components/confirm-dialog/confirm-dialog.spec.ts#L58-L59. Uma possível solução para esse problema está neste [https://github.com/angular/angular/issues/37635#issuecomment-1172527514](link). Contudo não parece ser muito elegante.

# Considerações Finais
Todos os testes obrigatórios estão prontos. Os itens presentes na seção de "Impedimentos" foram sanados ou planejados para serem resolvidos em um outro momento.