### PR TITLE
docs(adrs): cria base canônica de decisões arquiteturais (MADR 4.0)

### DIFF
--- a/docs/adrs/.markdownlint-cli2.jsonc
+++ b/docs/adrs/.markdownlint-cli2.jsonc
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "default": true,
+    "MD013": false,
+    "MD024": { "siblings_only": true },
+    "MD033": false,
+    "MD041": false,
+    "MD060": false
+  },
+  "globs": ["*.md"],
+  "ignores": ["_template.md"]
+}

--- a/docs/adrs/0001-separacao-em-tres-aplicacoes-frontend.md
+++ b/docs/adrs/0001-separacao-em-tres-aplicacoes-frontend.md
@@ -1,0 +1,70 @@
+---
+status: "accepted"
+date: "2026-05-01"
+decision-makers:
+  - "Tech Lead (CTIC)"
+  - "P.O. CEPS"
+  - "P.O. CRCA"
+---
+
+# ADR-0001: Separação em três aplicações frontend (Seleção, Ingresso, Portal)
+
+## Contexto e enunciado do problema
+
+O `uniplus-web` atende dois públicos com perfis de acesso completamente distintos: usuários internos (gestores, avaliadores, operadores) e candidatos externos. Além disso, o ciclo de vida do processo seletivo cobre duas fases operacionais conduzidas por setores diferentes da Unifesspa — Seleção (CEPS) e Ingresso (CRCA) — com cadências de release próprias.
+
+Unificar todas as funcionalidades em um único bundle Angular implicaria entregar código administrativo a candidatos no browser, acoplar deploys entre setores e crescer continuamente o initial chunk conforme novas features fossem adicionadas a cada lado.
+
+## Drivers da decisão
+
+- Públicos com superfícies de funcionalidade disjuntas (gestores vs. candidatos).
+- Setores donos diferentes (CEPS, CRCA) com prazos e janelas de release próprias.
+- Necessidade de bundle inicial pequeno para o portal público (mobile-first, redes lentas).
+- Princípio de mínimo privilégio: candidatos não devem receber código administrativo no browser.
+
+## Opções consideradas
+
+- Três aplicações Angular distintas em monorepo Nx, com bibliotecas compartilhadas.
+- Aplicação única Angular com lazy loading e route guards por perfil.
+- Duas aplicações (administrativa unificada + portal do candidato).
+
+## Resultado da decisão
+
+**Escolhida:** três aplicações Angular distintas no monorepo Nx — `selecao`, `ingresso` e `portal` — cada uma com seu próprio `app.config.ts`, layout, rotas e ciclo de deploy.
+
+| Aplicação | Público                          | Setor responsável |
+|-----------|----------------------------------|-------------------|
+| selecao   | Gestores e avaliadores do CEPS   | CEPS              |
+| ingresso  | Gestores do CRCA                 | CRCA              |
+| portal    | Candidatos (acesso público)      | Plataforma        |
+
+As três compartilham bibliotecas via path aliases (`@uniplus/shared-ui`, `@uniplus/shared-auth`, `@uniplus/shared-data`) mas são buildadas e deployadas independentemente. A separação física entre `apps/selecao`, `apps/ingresso` e `apps/portal` reflete os bounded contexts e isola as superfícies de exposição.
+
+## Consequências
+
+### Positivas
+
+- Bundle inicial do portal público mantém-se enxuto — candidatos não recebem código administrativo.
+- Deploys independentes — uma correção no portal não exige redeploy das aplicações administrativas.
+- Ownership claro por setor (CEPS, CRCA, plataforma).
+- Module boundaries do Nx impedem que apps administrativas vazem código sensível para o portal por importação acidental.
+
+### Negativas
+
+- Três Dockerfiles, três pipelines de build e três rotas de deploy.
+- Configurações de bootstrap (interceptors, layout, providers) duplicadas em alguns pontos, mitigado pelas bibliotecas compartilhadas.
+- Navegação entre apps requer redirecionamento entre origens distintas (não é SPA única).
+
+### Neutras
+
+- A separação é ortogonal à decisão de monorepo único versus repositórios separados (ver ADR-0003).
+
+## Confirmação
+
+- Module boundaries do Nx (regras de `@nx/enforce-module-boundaries` no ESLint) impedem dependências cruzadas indevidas entre `apps/`.
+- Pipeline de CI usa `nx affected` para garantir que cada app compila e testa isoladamente.
+
+## Mais informações
+
+- ADR-0003 detalha a escolha do Nx como build system.
+- **Origem:** revisão da ADR interna Uni+ ADR-003 (não publicada).

--- a/docs/adrs/0002-angular-21-como-framework-spa.md
+++ b/docs/adrs/0002-angular-21-como-framework-spa.md
@@ -1,0 +1,74 @@
+---
+status: "accepted"
+date: "2026-05-01"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0002: Angular 21 como framework SPA
+
+## Contexto e enunciado do problema
+
+O `uniplus-web` precisa de um framework SPA que sustente formulários complexos com validação tipada (inscrições com dezenas de campos, dependências condicionais e regras de cota), tabelas de dados administrativas, upload de documentos e acessibilidade obrigatória. A equipe é pequena e mantida por servidores da Unifesspa, exigindo uma stack opinada com documentação ampla, ciclo LTS e baixa rotatividade arquitetural.
+
+A escolha do framework precisa também ser compatível com a estratégia de UI baseada em PrimeNG unstyled + tokens Gov.br (ADR-0006/0007/0008) e com a obrigatoriedade de manter Zone.js (ADR-0005).
+
+## Drivers da decisão
+
+- Formulários complexos com tipagem forte (Reactive Forms tipados).
+- Equipe pequena, com benefício em frameworks opinados.
+- Ciclo LTS estável e suporte a longo prazo (vida útil ≥ 5 anos do sistema).
+- TypeScript em strict mode como padrão de qualidade.
+- Compatibilidade com bibliotecas de componentes maduras voltadas a Angular.
+
+## Opções consideradas
+
+- Angular 21 com TypeScript 5.9 strict.
+- React + biblioteca de componentes (ex.: Material UI ou Ant Design).
+- Vue 3 com Composition API.
+
+## Resultado da decisão
+
+**Escolhida:** Angular 21 (standalone components, signals, OnPush change detection) com TypeScript 5.9 em strict mode.
+
+Padrões obrigatórios derivados desta escolha:
+
+- **Sempre** standalone components (sem NgModules).
+- **Sempre** `ChangeDetectionStrategy.OnPush`.
+- **Sempre** signals para estado reativo.
+- Reactive Forms tipados para todos os formulários.
+- Lazy loading em todas as feature routes.
+- Strict mode do TypeScript ligado em todos os projetos do workspace.
+
+Angular oferece um framework opinado com router, forms e DI integrados, reduzindo decisões arbitrárias e divergência de estilo entre os apps. Signals e standalone components, estabilizados nas versões 17–21, modernizam a API reativa e simplificam o bootstrap das aplicações.
+
+## Consequências
+
+### Positivas
+
+- Reactive Forms tipados eliminam classes inteiras de bugs de formulário em compile time.
+- Standalone + signals reduzem boilerplate e tornam o grafo de dependências por feature explícito.
+- Ciclo LTS de 18 meses por major, com `nx migrate` cobrindo grande parte das atualizações automaticamente.
+- Ecossistema maduro com PrimeNG, Keycloak Angular e ferramentas de teste integradas (Vitest, Playwright).
+
+### Negativas
+
+- Curva de aprendizado mais íngreme que React/Vue para desenvolvedores iniciantes.
+- Bundle inicial maior que frameworks minimalistas; mitigado por lazy loading e tree-shaking.
+- Atualizações entre majors podem exigir ajustes em bibliotecas de terceiros.
+
+### Neutras
+
+- A escolha de Angular fixa a integração de UI em torno do PrimeNG (ADR-0007), não em bibliotecas voltadas a React/Vue.
+
+## Confirmação
+
+- ESLint com `@angular-eslint` aplicado em todos os apps e libs do workspace.
+- `tsconfig.base.json` exige `strict: true` e `strictTemplates: true`.
+- `nx migrate` é a ferramenta canônica para promover atualizações entre majors.
+
+## Mais informações
+
+- ADR-0003 detalha o uso do Nx como build system.
+- ADR-0005 explica a permanência de Zone.js no Angular 21.
+- **Origem:** revisão da ADR interna Uni+ ADR-006 (não publicada).

--- a/docs/adrs/0003-nx-como-build-system-do-monorepo-frontend.md
+++ b/docs/adrs/0003-nx-como-build-system-do-monorepo-frontend.md
@@ -1,0 +1,82 @@
+---
+status: "accepted"
+date: "2026-05-01"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0003: Nx como build system do monorepo frontend
+
+## Contexto e enunciado do problema
+
+O `uniplus-web` mantém três aplicações Angular (Seleção, Ingresso, Portal — ver ADR-0001) que compartilham lógica de autenticação, componentes de UI e modelos de dados. Sem uma ferramenta de monorepo, o código compartilhado teria de ser publicado como pacotes npm internos ou duplicado entre repositórios, com overhead de versionamento e divergência inevitável de configuração (ESLint, Tailwind, Docker).
+
+A escolha precisa cobrir cache de builds/testes, execução afetada por diff (`affected`), generators padronizados e module boundaries enforçáveis via lint.
+
+## Drivers da decisão
+
+- Três apps + bibliotecas compartilhadas em um único repositório.
+- Necessidade de cache de builds/testes para reduzir tempo de CI.
+- Module boundaries explícitos para impedir dependências indevidas (ex.: `portal` consumir código de `selecao`).
+- Generators padronizados para criar libs e features sem reinventar layout de pastas.
+
+## Opções consideradas
+
+- Nx como orquestrador do monorepo Angular.
+- Multi-repo (um repositório por aplicação), com libs compartilhadas publicadas como pacotes npm internos.
+- Monorepo com apenas npm workspaces, sem orquestrador.
+- Turborepo como orquestrador de monorepo.
+
+## Resultado da decisão
+
+**Escolhida:** Nx como build system e orquestrador do monorepo. Estrutura adotada:
+
+```text
+apps/
+  selecao/  selecao-e2e/
+  ingresso/ ingresso-e2e/
+  portal/   portal-e2e/
+  poc-primeng/ poc-primeng-e2e/
+libs/
+  shared-ui/
+  shared-auth/
+  shared-data/
+```
+
+Path aliases:
+
+- `@uniplus/shared-ui` → `libs/shared-ui/src/index.ts`
+- `@uniplus/shared-auth` → `libs/shared-auth/src/index.ts`
+- `@uniplus/shared-data` → `libs/shared-data/src/index.ts`
+
+Module boundaries são enforçados via `@nx/enforce-module-boundaries` no ESLint, impedindo, por exemplo, que `apps/portal` importe diretamente de `apps/selecao`.
+
+## Consequências
+
+### Positivas
+
+- Código compartilhado versionado junto com as apps, sem publicação de pacotes internos.
+- Cache local e remoto de builds/testes reduz tempo de CI em PRs que tocam poucas libs.
+- `nx affected` executa apenas targets impactados por um diff.
+- Grafo de dependências explícito (`nx graph`) facilita a visualização da arquitetura.
+- Refatorações cross-cutting (ex.: renomear DTO em `shared-data`) ficam atômicas em um único commit.
+
+### Negativas
+
+- Curva de aprendizado para quem nunca usou Nx.
+- Repositório único cresce em tamanho; clones iniciais são mais lentos.
+- Atualizações de versão do Nx podem exigir migrações coordenadas.
+
+### Neutras
+
+- A escolha de Nx é independente da escolha de Angular como framework — é possível remover o Nx no futuro sem reescrever código de negócio, apenas reorganizando configs de build.
+
+## Confirmação
+
+- Pipeline de CI executa `nx affected --target=build`, `vite:test` e `lint`.
+- ESLint roda `@nx/enforce-module-boundaries` em todos os projetos.
+
+## Mais informações
+
+- ADR-0001 detalha a separação em três aplicações.
+- **Origem:** revisão da ADR interna Uni+ ADR-007 (não publicada).

--- a/docs/adrs/0004-vitest-como-framework-de-testes-unitarios.md
+++ b/docs/adrs/0004-vitest-como-framework-de-testes-unitarios.md
@@ -1,0 +1,74 @@
+---
+status: "accepted"
+date: "2026-05-01"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0004: Vitest como framework de testes unitários
+
+## Contexto e enunciado do problema
+
+O `uniplus-web` precisa de um framework de testes unitários para componentes Angular, services, pipes e utilidades de bibliotecas compartilhadas. A escolha precisa integrar bem com o build system Nx (ADR-0003), com o pipeline Vite já adotado pelo Angular CLI moderno e com a estratégia de affected tests no CI.
+
+Durante o scaffolding do workspace, a opção padrão do Nx 22 para projetos Angular passou a ser Vitest via `@analogjs/vitest-angular`, em substituição ao Jest tradicional.
+
+## Drivers da decisão
+
+- Reaproveitar o pipeline Vite já configurado para build, evitando uma segunda pipeline de transformação.
+- Configuração unificada (um único `vite.config.mts` por projeto) versus arquivos separados (`jest.config.ts`).
+- Alinhamento com o padrão atual do Nx 22 para projetos Angular.
+- API de assertions familiar (`expect`, `describe`, `it`) para reduzir atrito na migração de exemplos.
+
+## Opções consideradas
+
+- Vitest via `@analogjs/vitest-angular`.
+- Jest via `jest-preset-angular`.
+- Web Test Runner (`@web/test-runner`) com navegador real.
+
+## Resultado da decisão
+
+**Escolhida:** Vitest 4.x como framework de testes unitários, integrado ao Angular via `@analogjs/vitest-angular` 2.x.
+
+Stack de testes unitários:
+
+| Componente              | Tecnologia                  |
+|-------------------------|-----------------------------|
+| Test runner             | Vitest 4.x                  |
+| Integração Angular      | @analogjs/vitest-angular 2.x|
+| Cobertura               | @vitest/coverage-v8 4.x     |
+| Ambiente DOM            | jsdom                       |
+| Setup                   | `src/test-setup.ts`         |
+
+Configuração centralizada em `vite.config.mts` por projeto. Major versions de Vitest e do plugin Angular ficam pinned no `package.json` para evitar surpresas em atualizações.
+
+## Consequências
+
+### Positivas
+
+- Execução de testes mais rápida por reutilizar o pipeline Vite.
+- Configuração simplificada em um único arquivo por projeto.
+- Hot module replacement em modo watch (`vitest --watch`).
+- UI de debugging via `@vitest/ui` quando necessário.
+- Menos atrito com atualizações futuras do Nx, que padronizou Vitest para Angular.
+
+### Negativas
+
+- Ecossistema de plugins menor que o do Jest.
+- Documentação Angular específica para Vitest ainda menos abundante que para Jest.
+- Equipe pode ter familiaridade prévia com Jest e precisar de ramp-up curto.
+
+### Neutras
+
+- A API de assertions é largamente compatível com Jest, então exemplos da comunidade podem ser portados com baixa fricção.
+
+## Confirmação
+
+- `npx nx vite:test <projeto>` é o comando canônico de execução local.
+- Pipeline de CI executa `nx affected --target=vite:test` em PRs.
+
+## Mais informações
+
+- ADR-0003 detalha o uso do Nx.
+- Documentação: [Analog Vitest Angular](https://analogjs.org/docs/features/testing/vitest), [Nx Vitest Plugin](https://nx.dev/nx-api/vitest).
+- **Origem:** revisão da ADR interna Uni+ ADR-016 (não publicada).

--- a/docs/adrs/0004-vitest-como-framework-de-testes-unitarios.md
+++ b/docs/adrs/0004-vitest-como-framework-de-testes-unitarios.md
@@ -64,8 +64,8 @@ Configuração centralizada em `vite.config.mts` por projeto. Major versions de 
 
 ## Confirmação
 
-- `npx nx vite:test <projeto>` é o comando canônico de execução local.
-- Pipeline de CI executa `nx affected --target=vite:test` em PRs.
+- `npx nx test <projeto>` é o comando canônico de execução local (o target `test` resolve para o executor Vitest configurado no projeto, exposto pelo plugin Nx como `vite:test`).
+- Pipeline de CI (`.github/workflows/ci.yml`) executa `npx nx run-many -t lint test build typecheck e2e --nxBail`, com o target `test` cobrindo todos os projetos do workspace.
 
 ## Mais informações
 

--- a/docs/adrs/0005-manter-zonejs-no-angular-21.md
+++ b/docs/adrs/0005-manter-zonejs-no-angular-21.md
@@ -1,0 +1,74 @@
+---
+status: "accepted"
+date: "2026-05-01"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0005: Manter Zone.js no Angular 21
+
+## Contexto e enunciado do problema
+
+O Angular 21 promoveu o modo zoneless a stable, permitindo remover Zone.js da aplicação e delegar toda a detecção de mudanças a signals e `provideZonelessChangeDetection()`. Como o `uniplus-web` é um workspace novo, é razoável questionar se vale adotar zoneless desde o início para reduzir bundle e simplificar o modelo mental de change detection.
+
+Por outro lado, a estratégia de UI do projeto (ver ADR-0006/0007/0008) depende fortemente de PrimeNG 21, e nenhuma versão do PrimeNG declara compatibilidade oficial com modo zoneless. Bugs ativos foram identificados em DynamicDialog, Tooltip e Select com virtualScroll quando rodando sem Zone.js — todos componentes centrais para os fluxos de inscrição, homologação e classificação.
+
+## Drivers da decisão
+
+- Compatibilidade total com PrimeNG 21 (Dialog, Tooltip, Select com virtualScroll são componentes críticos).
+- Confiabilidade durante janelas de inscrição com milhares de candidatos simultâneos.
+- Risco de bugs difíceis de diagnosticar em overlays e formulários complexos.
+- Custo de manter workarounds manuais por componente é alto e frágil.
+
+## Opções consideradas
+
+- Manter Zone.js com `provideZoneChangeDetection({ eventCoalescing: true })`.
+- Adotar modo zoneless com `provideZonelessChangeDetection()`.
+- Híbrido: zoneless com patches manuais nos componentes PrimeNG afetados.
+- Trocar PrimeNG por uma biblioteca zoneless-compatible (ex.: Angular Material).
+
+## Resultado da decisão
+
+**Escolhida:** manter Zone.js em todas as aplicações do workspace, com `provideZoneChangeDetection({ eventCoalescing: true })` e `"polyfills": ["zone.js"]` declarado nos `project.json`.
+
+Justificativa central:
+
+1. PrimeNG 21 não suporta oficialmente o modo zoneless e há issues abertas afetando Dialog, Tooltip e Select.
+2. `eventCoalescing: true` agrupa eventos DOM em um único ciclo de change detection e captura parte do ganho de performance que motivaria o zoneless.
+3. Os componentes do projeto seguem `OnPush` + signals, o que torna uma migração futura para zoneless straightforward, caso o PrimeNG declare suporte oficial.
+
+Reavaliação obrigatória a cada major release do PrimeNG e do Angular.
+
+## Consequências
+
+### Positivas
+
+- Compatibilidade total com PrimeNG 21 em todos os fluxos.
+- Sem workarounds frágeis ou patches manuais de change detection.
+- `eventCoalescing` entrega parte do ganho de performance do zoneless sem o risco.
+- Migração futura para zoneless permanece viável, dado que componentes já são `OnPush` + signals.
+
+### Negativas
+
+- Zone.js adiciona aproximadamente 30–40 KB ao bundle inicial (~13 KB gzip).
+- Monkey-patching de APIs nativas (setTimeout, Promise, addEventListener) permanece ativo.
+- Não se beneficia da simplificação de debugging que o modo zoneless oferece.
+
+### Neutras
+
+- A decisão é reversível assim que o PrimeNG declarar suporte oficial a zoneless — não há trabalho descartável.
+
+## Confirmação
+
+- Lint/CI pode verificar que `provideZonelessChangeDetection` não é usado em `app.config.ts`.
+- `project.json` de cada app deve declarar `polyfills: ["zone.js"]`.
+
+## Mais informações
+
+- ADR-0006/0007/0008 detalham a estratégia de UI baseada em PrimeNG unstyled + Tailwind + Gov.br.
+- Referências externas:
+  - [Angular PR #62699 — Promote zoneless to stable](https://github.com/angular/angular/pull/62699)
+  - [PrimeNG #19497 — DynamicDialog em zoneless](https://github.com/primefaces/primeng/issues/19497)
+  - [PrimeNG #18358 — Tooltip requer Zone.js](https://github.com/primefaces/primeng/issues/18358)
+  - [Angular `provideZoneChangeDetection`](https://angular.dev/api/core/provideZoneChangeDetection)
+- **Origem:** revisão da ADR interna Uni+ ADR-017 (não publicada).

--- a/docs/adrs/0006-govbr-design-system-como-contrato-visual.md
+++ b/docs/adrs/0006-govbr-design-system-como-contrato-visual.md
@@ -1,0 +1,76 @@
+---
+status: "accepted"
+date: "2026-05-01"
+decision-makers:
+  - "Tech Lead (CTIC)"
+  - "Diretora do CTIC"
+---
+
+# ADR-0006: Adoção do Gov.br Design System como contrato visual
+
+## Contexto e enunciado do problema
+
+O Uni+ é uma plataforma digital de processos institucionais mantida pela Unifesspa — autarquia federal integrante do SISP — e dirigida ao cidadão (candidatos, estudantes, servidores). Essa combinação enquadra o sistema no escopo obrigatório do **Padrão Digital de Governo** (Gov.br Design System), mantido pelo SERPRO.
+
+Os instrumentos legais aplicáveis incluem o Decreto 9.756/2019 (portal gov.br obrigatório para autarquias federais), a Portaria SEI-MCOM 540/2020 (Padrão Digital obrigatório para administração direta, autárquica e fundacional), a IN SGD/ME 94/2022 (DS como padrão obrigatório em contratações TIC do SISP), a Lei 14.129/2021 (Governo Digital) e o e-MAG 3.1 (acessibilidade).
+
+Não adotar o Gov.br DS implica risco formal de apontamento em auditorias TCU/CGU e descumprimento da Portaria 540.
+
+## Drivers da decisão
+
+- Obrigatoriedade legal para órgãos do SISP voltados ao cidadão.
+- Identidade visual reconhecível pelos candidatos, alinhada ao portal gov.br.
+- Acessibilidade WCAG 2.1 AA / e-MAG 3.1 incorporada por design.
+- Independência em relação ao wrapper Angular oficial, que está em pre-release há 4+ anos com bugs documentados.
+
+## Opções consideradas
+
+- Adotar o Gov.br DS via tokens CSS oficiais (`@govbr-ds/core`) como contrato visual canônico.
+- Adotar o wrapper oficial `@govbr-ds/webcomponents-angular` (Web Components via Stencil).
+- Não adotar o Gov.br DS, usando paleta institucional própria.
+
+## Resultado da decisão
+
+**Escolhida:** adotar o Gov.br Design System como contrato visual canônico do `uniplus-web` por meio dos tokens CSS oficiais do pacote `@govbr-ds/core` 3.7.
+
+Diretrizes derivadas da decisão:
+
+1. Importar `@govbr-ds/core/dist/core-tokens.min.css` no `styles.css` global de cada app.
+2. Não importar o runtime JS do `@govbr-ds/core` — apenas os tokens CSS.
+3. **Não** consumir `@govbr-ds/webcomponents-angular`. O wrapper permanece em pre-release há mais de quatro anos, possui bugs documentados em roteamento SPA, não integra-se nativamente com Signals/Reactive Forms (são Web Components via Stencil) e tem catálogo limitado.
+4. Permanecer na linha v3 dos tokens enquanto a v4 estiver em pre-release; reavaliar a migração quando a v4 atingir GA com janela de estabilidade ≥ 3 meses, migration guide oficial publicado e compatibilidade comprovada com a stack em uso.
+5. Cumprir e-MAG 3.1 / WCAG 2.1 AA via componentes que herdem o focus ring oficial (dourado tracejado, 4 px, `#c2850c`) e contraste mínimo derivado dos próprios tokens.
+
+A forma operacional de aplicar este contrato visual aos componentes UI é definida nas ADRs 0007 (PrimeNG unstyled) e 0008 (mapeamento Tailwind).
+
+## Consequências
+
+### Positivas
+
+- Cumprimento da Portaria SEI-MCOM 540/2020, da IN SGD/ME 94/2022 e da Lei 14.129/2021.
+- Identidade visual gov.br reconhecível, alinhada ao portal único do governo federal.
+- Conformidade com WCAG 2.1 AA / e-MAG 3.1 herdada dos tokens, sem trabalho adicional por componente.
+- Independência do wrapper Angular oficial, eliminando risco de bug em produção causado por pacote pre-release.
+
+### Negativas
+
+- Divergência declarada do wrapper oficial; em caso de auditoria que exija o pacote específico, será necessário apresentar a justificativa documentada (bugs, pre-release crônico) e os tokens como evidência primária.
+- Necessidade de monitoramento ativo do roadmap v3 → v4 do `@govbr-ds/core`.
+
+### Neutras
+
+- A escolha pelos tokens CSS é compatível com qualquer biblioteca de componentes que aceite estilização via classes externas — não amarra o projeto a uma biblioteca específica.
+
+## Confirmação
+
+- `package.json` declara `@govbr-ds/core` em versão 3.7.x pinned.
+- `styles.css` global de cada app importa `core-tokens.min.css`.
+- Suíte de testes E2E inclui asserções visuais e de tokens (cores, tipografia, focus ring) para detectar regressões.
+
+## Mais informações
+
+- ADR-0007 define a biblioteca de componentes (PrimeNG unstyled).
+- ADR-0008 define o mapeamento dos tokens via Tailwind `@theme`.
+- Base legal: [Portaria SEI-MCOM 540/2020](https://www.gov.br/governodigital/pt-br/estrategias-e-governanca-digital/sisp/guia-do-gestor/guia-orientativo-de-padroes-e-fluxos-das-tecnologias-de-transformacao-digital/padrao-de-governo-digital-design-system), [IN SGD/ME 94/2022](https://www.gov.br/governodigital/pt-br/contratacoes-de-tic/instrucao-normativa-sgd-me-no-94-de-23-de-dezembro-de-2022), [Lei 14.129/2021](https://www.planalto.gov.br/ccivil_03/_ato2019-2022/2021/lei/l14129.htm), [Decreto 9.756/2019](https://www.planalto.gov.br/ccivil_03/_ato2019-2022/2019/decreto/d9756.htm).
+- Documentação: [Gov.br DS](https://www.gov.br/ds/home), [`@govbr-ds/core`](https://gitlab.com/govbr-ds).
+- **Origem:** revisão da ADR interna Uni+ ADR-018 (não publicada), seção de adoção do DS.

--- a/docs/adrs/0007-primeng-em-modo-unstyled.md
+++ b/docs/adrs/0007-primeng-em-modo-unstyled.md
@@ -64,9 +64,10 @@ A POC validou esta estratégia em `apps/poc-primeng/` com 8 componentes funciona
 
 ## Confirmação
 
-- `app.config.ts` de cada app deve conter `providePrimeNG({ unstyled: true, pt: govbrPassThrough })`.
-- Lint/CI pode verificar ausência de imports de temas do PrimeNG (`primeng/themes/aura`, `primeng/themes/lara`).
-- Suíte E2E da POC em `apps/poc-primeng-e2e/` é o gate de regressão visual e de acessibilidade.
+- **Validação atual.** A decisão está validada em `apps/poc-primeng/` (`providePrimeNG({ unstyled: true, pt: govbrPassThrough })` + `govbrPassThrough` central) e exercitada pela suíte E2E `apps/poc-primeng-e2e/` como gate de regressão visual e de acessibilidade.
+- **Estado em produção.** Os apps `selecao`, `ingresso` e `portal` ainda não aplicam `providePrimeNG({ unstyled: true, pt: govbrPassThrough })`; a configuração canônica está pendente de migração.
+- **Plano de adoção.** `selecao`, `ingresso` e `portal` devem adotar essa configuração quando a base UX/Gov.br for consolidada, em Stories de migração de UI dedicadas, fora do escopo deste ADR.
+- **Gate adicional quando a migração ocorrer.** Lint/CI deve verificar a ausência de imports de temas do PrimeNG (`primeng/themes/aura`, `primeng/themes/lara`, etc.) nos apps em produção.
 
 ## Mais informações
 

--- a/docs/adrs/0007-primeng-em-modo-unstyled.md
+++ b/docs/adrs/0007-primeng-em-modo-unstyled.md
@@ -34,7 +34,7 @@ O wrapper oficial `@govbr-ds/webcomponents-angular` foi descartado por pre-relea
 
 Diretrizes derivadas da decisão:
 
-1. Habilitar o modo unstyled via `providePrimeNG({ theme: 'none' })` no `app.config.ts` de cada app.
+1. Habilitar o modo unstyled no `app.config.ts` de cada app via `providePrimeNG({ unstyled: true, pt: govbrPassThrough })` — `unstyled: true` é o flag canônico do PrimeNG 21 para suprimir os estilos de componente; `pt` injeta o objeto PassThrough Gov.br.
 2. **Não** importar temas do PrimeNG (Aura, Lara, Saga, etc.) — qualquer tema entraria em conflito com os tokens Gov.br.
 3. Manter um objeto `govbrPassThrough` central (ex.: `apps/*/src/app/primeng-govbr-pt.ts`) que define, slot a slot, as classes Tailwind aplicadas a cada componente PrimeNG utilizado.
 4. Para componentes que o PrimeNG não cobre adequadamente (ex.: header/footer institucional Gov.br, componentes específicos do contrato visual), implementar em Angular nativo aplicando classes Tailwind derivadas dos tokens.
@@ -64,7 +64,7 @@ A POC validou esta estratégia em `apps/poc-primeng/` com 8 componentes funciona
 
 ## Confirmação
 
-- `app.config.ts` de cada app deve conter `providePrimeNG({ theme: 'none' })`.
+- `app.config.ts` de cada app deve conter `providePrimeNG({ unstyled: true, pt: govbrPassThrough })`.
 - Lint/CI pode verificar ausência de imports de temas do PrimeNG (`primeng/themes/aura`, `primeng/themes/lara`).
 - Suíte E2E da POC em `apps/poc-primeng-e2e/` é o gate de regressão visual e de acessibilidade.
 

--- a/docs/adrs/0007-primeng-em-modo-unstyled.md
+++ b/docs/adrs/0007-primeng-em-modo-unstyled.md
@@ -1,0 +1,76 @@
+---
+status: "accepted"
+date: "2026-05-01"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0007: PrimeNG em modo unstyled como component library
+
+## Contexto e enunciado do problema
+
+Adotado o Gov.br Design System como contrato visual canônico (ADR-0006), o `uniplus-web` precisa de uma biblioteca de componentes Angular que cubra o catálogo necessário (formulários complexos, tabelas com paginação e filtros, calendar, dialog, file upload, select com virtualScroll, tabs, multi-step wizard) sem impor um tema próprio que conflite com os tokens Gov.br.
+
+O wrapper oficial `@govbr-ds/webcomponents-angular` foi descartado por pre-release crônico, bugs em roteamento SPA e catálogo limitado (~36 componentes). Bibliotecas com tema próprio (PrimeNG default, Angular Material com Material Design) implicariam em sobrescrever estilos via especificidade — abordagem frágil e cara em manutenção.
+
+## Drivers da decisão
+
+- Catálogo amplo de componentes prontos (≥ 80 componentes maduros).
+- Possibilidade de aplicar identidade visual externa sem sobrescrever CSS por especificidade.
+- Acessibilidade ARIA nativa (roles, atributos, navegação por teclado).
+- Integração nativa com Reactive Forms tipados e signals.
+- Compatibilidade com Zone.js (ADR-0005) — bibliotecas que exigem zoneless ficam fora.
+
+## Opções consideradas
+
+- PrimeNG 21 em modo unstyled, com PassThrough API aplicando classes Tailwind por slot.
+- PrimeNG 21 com tema próprio (Aura/Lara) e overrides via CSS.
+- Angular Material com tema customizado.
+- Construir componentes próprios em Angular nativo a partir do CDK + Tailwind.
+
+## Resultado da decisão
+
+**Escolhida:** PrimeNG 21 em **modo unstyled** com PassThrough API.
+
+Diretrizes derivadas da decisão:
+
+1. Habilitar o modo unstyled via `providePrimeNG({ theme: 'none' })` no `app.config.ts` de cada app.
+2. **Não** importar temas do PrimeNG (Aura, Lara, Saga, etc.) — qualquer tema entraria em conflito com os tokens Gov.br.
+3. Manter um objeto `govbrPassThrough` central (ex.: `apps/*/src/app/primeng-govbr-pt.ts`) que define, slot a slot, as classes Tailwind aplicadas a cada componente PrimeNG utilizado.
+4. Para componentes que o PrimeNG não cobre adequadamente (ex.: header/footer institucional Gov.br, componentes específicos do contrato visual), implementar em Angular nativo aplicando classes Tailwind derivadas dos tokens.
+5. Acessibilidade: confiar em ARIA nativo do PrimeNG (`role="tab"`, `role="dialog"`, `aria-modal`, `aria-selected`, `aria-expanded`) e manter focus ring overlay Gov.br via `<span>` `position: fixed` ajustado dinamicamente.
+
+A POC validou esta estratégia em `apps/poc-primeng/` com 8 componentes funcionais, 13/13 testes Vitest e 88/88 testes Playwright (15 fluxo + 56 tokens + 17 acessibilidade), produzindo apenas 1 `!important` no código (supressão do outline nativo). A POC permanece como referência de implementação obrigatória.
+
+## Consequências
+
+### Positivas
+
+- PassThrough injeta classes Tailwind diretamente nos slots internos dos componentes, eliminando a batalha de especificidade típica de overrides CSS.
+- Catálogo amplo (80+ componentes) cobre o escopo presente e futuro do Uni+.
+- ARIA + navegação por teclado built-in nos componentes PrimeNG, reduzindo trabalho de acessibilidade.
+- Manutenção centralizada — todos os mapeamentos slot → classes vivem em 1–2 arquivos por app, sem editar código de bibliotecas instaladas.
+- Estratégia permite substituir um componente PrimeNG por implementação Angular nativa sem reescrever a estratégia.
+
+### Negativas
+
+- Bundle inicial maior do que alternativas sem PrimeNG (~119 KB gzip com Zone.js, ainda dentro do aceitável).
+- Dois componentes têm limitação em unstyled mode: `p-confirmdialog` (não renderiza conteúdo) e `p-table` (PassThrough não aplica em `ng-template #header/#body`). Workarounds documentados na POC (~10 minutos por ocorrência).
+- Equipe precisa familiarizar-se com a PassThrough API e com o catálogo do PrimeNG.
+
+### Neutras
+
+- A decisão é independente da escolha de tokens Gov.br: trocar para outro DS exigiria apenas reescrever o `govbrPassThrough` e o `@theme` do Tailwind.
+
+## Confirmação
+
+- `app.config.ts` de cada app deve conter `providePrimeNG({ theme: 'none' })`.
+- Lint/CI pode verificar ausência de imports de temas do PrimeNG (`primeng/themes/aura`, `primeng/themes/lara`).
+- Suíte E2E da POC em `apps/poc-primeng-e2e/` é o gate de regressão visual e de acessibilidade.
+
+## Mais informações
+
+- ADR-0006 define o Gov.br DS como contrato visual.
+- ADR-0008 define o mapeamento dos tokens via Tailwind.
+- Documentação: [PrimeNG — Unstyled + PassThrough](https://primeng.org/theming).
+- **Origem:** revisão da ADR interna Uni+ ADR-018 (não publicada), seção de PrimeNG unstyled + PassThrough.

--- a/docs/adrs/0008-tailwind-css-4-com-tokens-govbr.md
+++ b/docs/adrs/0008-tailwind-css-4-com-tokens-govbr.md
@@ -74,9 +74,10 @@ Diretrizes derivadas da decisão:
 
 ## Confirmação
 
-- Lint pode banir cores hardcoded (`#xxx`, `rgb(...)`) no código-fonte de apps e libs.
-- Suíte E2E em `apps/poc-primeng-e2e/src/govbr-design-tokens.spec.ts` (46 testes) executa em CI como gate de regressão visual.
-- O guia de tokens (em documentação interna do projeto) explicita o catálogo de utilitários disponíveis.
+- **Validação atual.** Os tokens Gov.br e o mapeamento Tailwind 4 via `@theme` foram validados em `apps/poc-primeng/src/styles.css`, exercitados pela suíte E2E `apps/poc-primeng-e2e/src/govbr-design-tokens.spec.ts` (46 testes) como gate de regressão visual.
+- **Estado em produção.** Os apps `selecao`, `ingresso` e `portal` ainda usam `src/styles.scss` com apenas `@tailwind base/components/utilities`; não importam `@govbr-ds/core` nem expõem o `@theme` com tokens Gov.br.
+- **Plano de adoção.** A adoção produtiva depende da conclusão da fundação UX/design system; será conduzida em Stories de migração dedicadas (incluindo a transição de `styles.scss` para `styles.css` e o import dos tokens antes do Tailwind), fora do escopo deste ADR.
+- **Gates adicionais quando a migração ocorrer.** Lint/CI deve banir cores hardcoded (`#xxx`, `rgb(...)`) no código-fonte de apps e libs em produção; o guia interno de tokens documenta o catálogo de utilitários disponíveis.
 
 ## Mais informações
 

--- a/docs/adrs/0008-tailwind-css-4-com-tokens-govbr.md
+++ b/docs/adrs/0008-tailwind-css-4-com-tokens-govbr.md
@@ -1,0 +1,85 @@
+---
+status: "accepted"
+date: "2026-05-01"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0008: Tailwind CSS 4 com tokens Gov.br via `@theme`
+
+## Contexto e enunciado do problema
+
+Adotados o Gov.br Design System como contrato visual (ADR-0006) e PrimeNG em modo unstyled (ADR-0007), o `uniplus-web` precisa de um mecanismo concreto para aplicar os tokens CSS do `@govbr-ds/core` aos componentes — tanto aos PrimeNG (via PassThrough) quanto aos componentes Angular nativos. Reescrever CSS por componente seria caro e fragmentaria a identidade visual; usar variáveis CSS soltas espalha o conhecimento dos nomes de tokens em arquivos diversos.
+
+A POC mostrou que mapear os 46 tokens principais (cores, tipografia, espaçamento, bordas, sombras, focus ring) como utilitários Tailwind centraliza o vocabulário visual e elimina ambiguidade no código de feature.
+
+## Drivers da decisão
+
+- Vocabulário visual centralizado em um único lugar.
+- Utilitários expressivos (`bg-govbr-primary`, `text-govbr-danger`, `rounded-govbr-input`) consumíveis por PassThrough do PrimeNG e por componentes Angular nativos.
+- Compatibilidade com a major 4 do Tailwind, que introduziu a diretiva `@theme` para mapear tokens a partir de variáveis CSS.
+- Migração simplificada quando o `@govbr-ds/core` evoluir para v4 — o mapeamento fica em um único arquivo.
+
+## Opções consideradas
+
+- Tailwind CSS 4 com mapeamento dos tokens Gov.br via `@theme`.
+- Tailwind CSS 4 sem `@theme`, consumindo variáveis CSS diretamente em `class="text-[var(--color-...)]"`.
+- CSS Modules com variáveis CSS, sem framework utility-first.
+- SCSS com mixins.
+
+## Resultado da decisão
+
+**Escolhida:** Tailwind CSS 4 com mapeamento dos 46 tokens Gov.br via diretiva `@theme`.
+
+Diretrizes derivadas da decisão:
+
+1. Importar os tokens em `styles.css` global de cada app, antes do Tailwind:
+
+   ```css
+   @import "@govbr-ds/core/dist/core-tokens.min.css";
+   @import "tailwindcss";
+   ```
+
+2. Mapear os tokens como extensões do Tailwind via `@theme` em um único arquivo central por app:
+
+   ```css
+   @theme {
+     --color-govbr-primary: var(--blue-warm-vivid-70);
+     --color-govbr-danger: var(--red-vivid-50);
+     --rounded-govbr-input: var(--surface-rounder-sm);
+     /* … 46 tokens cobrindo cores, tipografia, espaçamento, bordas, sombras */
+   }
+   ```
+
+3. Consumir os tokens **sempre** via utilitários Tailwind (`bg-govbr-primary`, `text-govbr-danger`, `rounded-govbr-input`) — nunca hardcoded.
+4. Manter a POC (`apps/poc-primeng/src/styles.css`) como fonte-verdade do mapeamento; replicar mudanças para os apps em produção.
+
+## Consequências
+
+### Positivas
+
+- Vocabulário visual canônico centralizado em um único arquivo por app.
+- Utilitários expressivos cobrem PassThrough do PrimeNG e componentes Angular nativos uniformemente.
+- Migração v3 → v4 do `@govbr-ds/core` concentra-se em atualizar o `@theme`, sem varrer arquivos de feature.
+- Suíte E2E pode asserter contra os utilitários (regressão de tokens visíveis na DOM como classes Tailwind).
+
+### Negativas
+
+- Tailwind 4 ainda é relativamente novo; algumas integrações de IDE e plugins podem exigir ajuste de configuração.
+- Conhecimento dos nomes dos tokens precisa ser difundido na equipe (mitigado por documentação interna em `docs/`).
+
+### Neutras
+
+- A escolha por Tailwind 4 é independente do framework SPA — trocar Angular não invalidaria o mapeamento.
+
+## Confirmação
+
+- Lint pode banir cores hardcoded (`#xxx`, `rgb(...)`) no código-fonte de apps e libs.
+- Suíte E2E em `apps/poc-primeng-e2e/src/govbr-design-tokens.spec.ts` (46 testes) executa em CI como gate de regressão visual.
+- O guia de tokens (em documentação interna do projeto) explicita o catálogo de utilitários disponíveis.
+
+## Mais informações
+
+- ADR-0006 define o Gov.br DS como contrato visual.
+- ADR-0007 define o uso do PrimeNG em modo unstyled.
+- **Origem:** revisão da ADR interna Uni+ ADR-018 (não publicada), seção de mapeamento Tailwind `@theme`.

--- a/docs/adrs/0009-keycloak-como-identity-provider-oidc.md
+++ b/docs/adrs/0009-keycloak-como-identity-provider-oidc.md
@@ -1,0 +1,74 @@
+---
+status: "accepted"
+date: "2026-05-01"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0009: Keycloak como identity provider OIDC do `uniplus-web`
+
+## Contexto e enunciado do problema
+
+O `uniplus-web` é composto por três aplicações Angular (Seleção, Ingresso, Portal — ver ADR-0001) cujos usuários precisam autenticar-se com diferentes perfis (administrador, gestor, avaliador, candidato). Os candidatos chegam preferencialmente pelo Login Único do gov.br, e os usuários internos pelo IdP institucional. O frontend precisa de SSO entre as três apps e de tokens JWT carregados automaticamente nas requisições aos backends.
+
+A escolha do identity provider e do contrato de tokens é cross-cutting com o backend (`uniplus-api`), mas, do ponto de vista do `uniplus-web`, o que importa é o protocolo (OIDC) e a integração no bootstrap das aplicações Angular.
+
+## Drivers da decisão
+
+- SSO nativo entre as três apps frontend.
+- Federação com gov.br (Login Único) via OIDC, sem código customizado.
+- Tokens JWT injetados automaticamente em requisições HTTP do Angular.
+- Roles e atributos customizados (nome social, CPF) gerenciáveis no IdP.
+- Compatibilidade com Angular 21, Reactive Forms, signals e Zone.js.
+
+## Opções consideradas
+
+- Keycloak via `keycloak-angular` + `keycloak-js`.
+- Auth0 (SaaS).
+- Implementação OIDC própria com `oidc-client-ts`.
+- ASP.NET Identity + Duende IdentityServer (IdP gerido pelo backend).
+
+## Resultado da decisão
+
+**Escolhida:** consumir um Keycloak externo como identity provider OIDC, integrado ao Angular via `keycloak-angular` e `keycloak-js`.
+
+Diretrizes derivadas da decisão para o `uniplus-web`:
+
+1. Inicializar Keycloak via `APP_INITIALIZER` (`provideAuth()`) no bootstrap de cada app.
+2. Configurar `tokenInterceptor` em `libs/shared-auth` para injetar `Authorization: Bearer <jwt>` em todas as requisições HTTP que tenham o backend Uni+ como destino.
+3. Implementar `authGuard` e `roleGuard` em `libs/shared-auth` para proteger rotas por perfil.
+4. Persistência de sessão usando o storage padrão do `keycloak-js` (sessionStorage) com silent SSO check via iframe — **nunca** armazenar tokens em `localStorage`.
+5. Logout iniciado no Keycloak (`keycloak.logout({ redirectUri })`) para garantir invalidação da sessão SSO entre as três apps.
+6. Atributos como `nome_social` e `cpf` consumidos via claims do token; LGPD obriga masking em logs (CPF como `***.***.***-XX`).
+
+A configuração específica de realm, clients, flows e mappers do Keycloak é responsabilidade da plataforma e está fora do escopo deste ADR — o `uniplus-web` apenas consome um endpoint OIDC.
+
+## Consequências
+
+### Positivas
+
+- SSO entre as três aplicações frontend sem código adicional.
+- Federação com gov.br via protocolo padrão (OIDC), sem implementação customizada.
+- Tokens JWT stateless, cacheados pelo `keycloak-js` durante a sessão do usuário.
+- Reuso da biblioteca de autenticação (`@uniplus/shared-auth`) entre as três apps elimina divergência.
+
+### Negativas
+
+- Dependência de um serviço Keycloak disponível para que o frontend bootstrape em produção.
+- `keycloak-js` historicamente usa iframe para silent SSO check; políticas restritivas de cookies (SameSite) podem exigir ajustes específicos.
+- Atualizações de major do `keycloak-angular` precisam ser coordenadas com a versão do servidor Keycloak.
+
+### Neutras
+
+- A decisão é independente do framework SPA: trocar Angular obrigaria adotar a SDK Keycloak da nova plataforma, sem alterar o protocolo.
+
+## Confirmação
+
+- `libs/shared-auth` é a única origem de imports de `keycloak-js`/`keycloak-angular` no workspace (verificável por lint).
+- Suíte E2E inclui cenários de login, refresh, expiração de token e logout para regressão.
+- Tokens **nunca** são logados; sinks aplicam masking de claims sensíveis (CPF).
+
+## Mais informações
+
+- ADR-0001 detalha a separação em três aplicações (todas consumindo o mesmo realm Keycloak para SSO).
+- **Origem:** revisão da ADR interna Uni+ ADR-008 (não publicada), versão sanitizada para o frontend.

--- a/docs/adrs/0010-opentelemetry-para-instrumentacao-frontend.md
+++ b/docs/adrs/0010-opentelemetry-para-instrumentacao-frontend.md
@@ -1,0 +1,74 @@
+---
+status: "accepted"
+date: "2026-05-01"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0010: OpenTelemetry para instrumentação do `uniplus-web` (RUM)
+
+## Contexto e enunciado do problema
+
+Durante janelas de inscrição, o `uniplus-web` recebe milhares de candidatos simultâneos em redes heterogêneas (mobile, residencial, institucional). Sem instrumentação client-side, problemas como latência percebida alta, erros silenciosos em rotas raras, falhas de upload de documentos ou bugs específicos de browser passam despercebidos até serem reportados pelos próprios candidatos — quando o impacto já ocorreu.
+
+A correlação entre a sessão do candidato no browser e a requisição correspondente no backend depende de propagação de `traceId` entre as duas pontas. Sem isso, investigar uma falha exige cruzar logs manualmente.
+
+## Drivers da decisão
+
+- Necessidade de traces end-to-end correlacionando frontend ↔ backend ↔ consumers.
+- Métricas de Real User Monitoring (Web Vitals: LCP, FID, CLS, INP).
+- Detecção proativa de erros JavaScript não tratados em produção.
+- Padrão aberto, sem vendor lock-in, alinhado ao backend (que também adota OpenTelemetry).
+- Conformidade LGPD: instrumentação **não** pode coletar PII (CPF, nome, endereço, claims do token).
+
+## Opções consideradas
+
+- OpenTelemetry JavaScript SDK (`@opentelemetry/sdk-trace-web` + auto-instrumentações para fetch/XHR/document load).
+- Sentry (ou similar) como SaaS de error tracking + RUM.
+- Application Insights JavaScript SDK.
+- Sem instrumentação cliente (apenas server-side).
+
+## Resultado da decisão
+
+**Escolhida:** OpenTelemetry JavaScript SDK como instrumentação canônica do `uniplus-web`, exportando traces via OTLP/HTTP para o OpenTelemetry Collector da plataforma.
+
+Diretrizes derivadas da decisão:
+
+1. Inicializar o SDK no `main.ts` (ou em provider dedicado) **antes** do bootstrap do Angular, para capturar o `document load`.
+2. Habilitar auto-instrumentações para `fetch`, `XMLHttpRequest`, `document-load` e `user-interaction`.
+3. Propagar `traceparent` (W3C Trace Context) em todas as requisições para o backend Uni+ — o `tokenInterceptor` (ADR-0009) e o trace exporter convivem no mesmo pipeline HTTP.
+4. Coletar Web Vitals (LCP, FID, CLS, INP, TTFB) como métricas separadas, exportadas via OTLP/HTTP.
+5. **Nunca** anexar PII a spans, eventos ou atributos. Atributos permitidos: `app.name` (selecao/ingresso/portal), `app.version`, `route`, `http.status_code`, `error.type`. Atributos proibidos: CPF, nome, e-mail, claims do token, valores de input.
+6. Aplicar sampling adaptativo: head-based 10% para tráfego normal, 100% para sessões com erro detectado.
+7. Configurar URL do Collector e sample rates por ambiente (dev/staging/prod) via variáveis injetadas em build (`environment.ts` por configuração Nx).
+
+## Consequências
+
+### Positivas
+
+- Traces end-to-end correlacionando sessão do candidato à requisição backend e ao consumer Kafka.
+- Web Vitals em painel único, com alertas proativos antes que candidatos reportem lentidão.
+- Padrão aberto sem vendor lock-in — o backend de armazenamento (Tempo, outro qualquer) pode mudar sem reescrever instrumentação.
+- Erros JS em produção capturados como spans com `error.type` e stack trace, sem expor PII.
+
+### Negativas
+
+- SDK adiciona ~30–50 KB ao bundle inicial (gzip), parcialmente mitigado por tree-shaking das auto-instrumentações não usadas.
+- Configuração inicial exige cuidado com sampling, propagators e exporters.
+- Política de privacidade do app deve refletir a coleta de telemetria sem PII.
+
+### Neutras
+
+- A decisão é independente do backend escolhido para armazenamento de traces (Tempo, Jaeger, etc.).
+
+## Confirmação
+
+- Lint/CI pode verificar que atributos sensíveis (CPF, nome, e-mail) não aparecem em chamadas a `span.setAttribute`.
+- Painéis de Web Vitals e error rate em Grafana cobrem cada uma das três apps separadamente.
+- Suíte E2E pode validar a presença do header `traceparent` em requisições ao backend.
+
+## Mais informações
+
+- ADR-0009 detalha o token interceptor que coexiste com o trace exporter.
+- Documentação: [OpenTelemetry JS](https://opentelemetry.io/docs/instrumentation/js/), [W3C Trace Context](https://www.w3.org/TR/trace-context/).
+- **Origem:** revisão da ADR interna Uni+ ADR-014 (não publicada), recorte de instrumentação frontend (RUM).

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,51 @@
+# Architecture Decision Records — `uniplus-web`
+
+Base canônica de decisões arquiteturais do `uniplus-web`, formato [MADR 4.0](https://adr.github.io/madr/).
+
+Cada ADR registra **uma única decisão**. Histórico de decisões institucionais que originaram parte deste acervo permanece em documentação interna não publicada — quando relevante, a seção `Mais informações` de cada ADR cita a origem como `Origem: revisão da ADR interna Uni+ ADR-NNN (não publicada)`.
+
+## Estrutura
+
+- Cada ADR em arquivo `NNNN-titulo-em-slug.md` (4 dígitos, slug ASCII).
+- Frontmatter YAML obrigatório com `status`, `date`, `decision-makers`.
+- Seções fixas: Contexto, Drivers, Opções, Resultado da decisão (única), Consequências, Confirmação opcional, Mais informações.
+- Conteúdo em pt-BR; chaves do frontmatter em inglês para compatibilidade com ferramentas MADR.
+
+## Linter
+
+Validador local em [`tools/adr-lint/`](../../tools/adr-lint/README.md):
+
+```bash
+bash tools/adr-lint/validate.sh
+```
+
+Adicionalmente:
+
+```bash
+npx markdownlint-cli2 'docs/adrs/**/*.md'
+```
+
+## Índice
+
+| ADR | Título | Status | Data |
+|-----|--------|--------|------|
+| [0001](0001-separacao-em-tres-aplicacoes-frontend.md) | Separação em três aplicações frontend (Seleção, Ingresso, Portal) | accepted | 2026-05-01 |
+| [0002](0002-angular-21-como-framework-spa.md) | Angular 21 como framework SPA | accepted | 2026-05-01 |
+| [0003](0003-nx-como-build-system-do-monorepo-frontend.md) | Nx como build system do monorepo frontend | accepted | 2026-05-01 |
+| [0004](0004-vitest-como-framework-de-testes-unitarios.md) | Vitest como framework de testes unitários | accepted | 2026-05-01 |
+| [0005](0005-manter-zonejs-no-angular-21.md) | Manter Zone.js no Angular 21 | accepted | 2026-05-01 |
+| [0006](0006-govbr-design-system-como-contrato-visual.md) | Adoção do Gov.br Design System como contrato visual | accepted | 2026-05-01 |
+| [0007](0007-primeng-em-modo-unstyled.md) | PrimeNG em modo unstyled como component library | accepted | 2026-05-01 |
+| [0008](0008-tailwind-css-4-com-tokens-govbr.md) | Tailwind CSS 4 com tokens Gov.br via `@theme` | accepted | 2026-05-01 |
+| [0009](0009-keycloak-como-identity-provider-oidc.md) | Keycloak como identity provider OIDC do `uniplus-web` | accepted | 2026-05-01 |
+| [0010](0010-opentelemetry-para-instrumentacao-frontend.md) | OpenTelemetry para instrumentação do `uniplus-web` (RUM) | accepted | 2026-05-01 |
+
+## Como adicionar um novo ADR
+
+1. Identifique o próximo número sequencial (`ls docs/adrs/[0-9]*.md | wc -l`).
+2. Copie [`_template.md`](_template.md).
+3. Renomeie para `NNNN-titulo-em-slug.md` (slug ASCII em minúsculas, hífens como separador).
+4. Preencha frontmatter, contexto, drivers, opções, resultado da decisão (única), consequências.
+5. Rode o linter (`bash tools/adr-lint/validate.sh`).
+6. Adicione linha ao índice acima.
+7. Abra PR.

--- a/docs/adrs/_template.md
+++ b/docs/adrs/_template.md
@@ -1,0 +1,73 @@
+---
+status: "proposed"
+date: "YYYY-MM-DD"
+decision-makers:
+  - "Tech Lead"
+consulted: []
+informed: []
+---
+
+# ADR-NNNN: {Título curto da decisão}
+
+## Contexto e enunciado do problema
+
+{Descrição do problema, necessidade ou oportunidade que motiva a decisão.
+Pode citar requisitos funcionais, regras de negócio, ADRs anteriores ou
+restrições externas. Mantenha enxuto: 2 a 5 parágrafos.}
+
+## Drivers da decisão
+
+- {força, concern ou restrição relevante}
+- {…}
+
+## Opções consideradas
+
+- {Opção 1}
+- {Opção 2}
+- {Opção 3}
+
+## Resultado da decisão
+
+**Escolhida:** "{Opção X}", porque {justificativa central}.
+
+{Detalhamento da decisão em 1–3 parágrafos. Esta seção é única por ADR
+— uma decisão por documento (regra "1 ADR = 1 decisão").}
+
+## Consequências
+
+### Positivas
+
+- {benefício}
+- {…}
+
+### Negativas
+
+- {trade-off}
+- {…}
+
+### Neutras
+
+- {efeito sem polaridade clara, se houver}
+
+## Confirmação
+
+{Como verificar que a decisão está sendo seguida — ex.: lint rule, fitness test,
+métrica observada. Opcional, mas recomendado para decisões enforçáveis.}
+
+## Prós e contras das opções
+
+### {Opção 1}
+
+- Bom, porque …
+- Ruim, porque …
+
+### {Opção 2}
+
+- Bom, porque …
+- Ruim, porque …
+
+## Mais informações
+
+- {links para guias operacionais, ADRs relacionadas, RFCs externas}
+- {emendas posteriores, notas de revisão}
+- {se aplicável: **Origem:** revisão da ADR interna Uni+ ADR-NNN (não publicada)}

--- a/tools/adr-lint/README.md
+++ b/tools/adr-lint/README.md
@@ -1,0 +1,40 @@
+# adr-lint
+
+Validador MADR 4.0 para ADRs do projeto Uni+. Script bash sem dependências externas.
+
+## Uso
+
+```bash
+bash tools/adr-lint/validate.sh                 # valida docs/adrs
+bash tools/adr-lint/validate.sh docs/adrs       # explícito
+```
+
+Saída:
+
+- `ok   NNNN-titulo.md` — ADR válido.
+- `FAIL NNNN-titulo.md` — ADR com erros (listados abaixo).
+
+Exit code != 0 quando houver pelo menos um erro.
+
+## Regras enforçadas
+
+1. Nome de arquivo no padrão `NNNN-slug.md` (4 dígitos, slug ASCII em minúsculas).
+2. Frontmatter YAML presente entre dois `---` no topo.
+3. Campos obrigatórios: `status`, `date`, `decision-makers`.
+4. `status` ∈ `{proposed, accepted, rejected, deprecated}` ou `superseded by ADR-NNNN`.
+5. `date` em formato ISO `YYYY-MM-DD`.
+6. H1 do arquivo coincide com o número do nome (`# ADR-NNNN: ...`).
+7. Exatamente UMA seção `## Resultado da decisão` por arquivo (regra "1 ADR = 1 decisão").
+8. Seções obrigatórias presentes: `Contexto e enunciado do problema`, `Opções consideradas`, `Resultado da decisão`, `Consequências`.
+
+Mais detalhes em [`docs/adrs/_template.md`](../../docs/adrs/_template.md).
+
+## Hygiene de markdown
+
+Adicionalmente, rode `markdownlint-cli2` para verificações gerais:
+
+```bash
+npx markdownlint-cli2 'docs/adrs/**/*.md'
+```
+
+Configuração em `docs/adrs/.markdownlint-cli2.jsonc`.

--- a/tools/adr-lint/validate.sh
+++ b/tools/adr-lint/validate.sh
@@ -40,7 +40,10 @@ for FILE in "$DIR"/*.md; do
 
   if ! head -1 "$FILE" | grep -q '^---$'; then
     ERR+=("frontmatter YAML ausente (esperado --- na linha 1)")
-  elif ! tail -n +2 "$FILE" | head -n 50 | grep -q '^---$'; then
+  # awk standalone evita falso positivo por SIGPIPE: a versão antiga
+  # `tail | head -n 50 | grep -q` falhava sob `pipefail` em ADRs grandes
+  # porque o `tail` recebia SIGPIPE quando o `grep -q` saía cedo após o match.
+  elif ! awk 'NR==1 && /^---$/{c=1; next} c==1 && /^---$/{found=1; exit} END{exit found ? 0 : 1}' "$FILE"; then
     ERR+=("frontmatter YAML sem delimitador de fechamento (esperado --- após bloco YAML)")
   fi
 

--- a/tools/adr-lint/validate.sh
+++ b/tools/adr-lint/validate.sh
@@ -52,7 +52,10 @@ for FILE in "$DIR"/*.md; do
     fi
   done
 
-  STATUS=$(printf '%s\n' "$FM" | grep '^status:' | head -1 | sed -E 's/^status:[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/')
+  # `|| true` evita que o pipeline aborte sob `set -euo pipefail` quando o
+  # campo está ausente — o erro já foi registrado no loop anterior e o script
+  # precisa seguir até o relatório final.
+  STATUS=$(printf '%s\n' "$FM" | { grep '^status:' || true; } | head -1 | sed -E 's/^status:[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/')
   if [[ -n "$STATUS" ]]; then
     if [[ ! "$STATUS" =~ ^(proposed|accepted|rejected|deprecated)$ ]] && \
        [[ ! "$STATUS" =~ ^superseded\ by\ ADR-[0-9]{4}$ ]]; then
@@ -60,7 +63,7 @@ for FILE in "$DIR"/*.md; do
     fi
   fi
 
-  DATE=$(printf '%s\n' "$FM" | grep '^date:' | head -1 | sed -E 's/^date:[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/')
+  DATE=$(printf '%s\n' "$FM" | { grep '^date:' || true; } | head -1 | sed -E 's/^date:[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/')
   if [[ -n "$DATE" ]] && [[ ! "$DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
     ERR+=("date inválida: '$DATE' (esperado YYYY-MM-DD)")
   fi

--- a/tools/adr-lint/validate.sh
+++ b/tools/adr-lint/validate.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# tools/adr-lint/validate.sh — validador MADR 4.0 para ADRs do projeto Uni+.
+#
+# Uso:
+#   bash tools/adr-lint/validate.sh           # valida ./docs/adrs
+#   bash tools/adr-lint/validate.sh DIR       # valida DIR
+#
+# Sai com código != 0 se houver violações.
+
+set -euo pipefail
+
+DIR="${1:-docs/adrs}"
+ERRORS=0
+COUNT=0
+
+if [[ ! -d "$DIR" ]]; then
+  echo "ERRO: diretório $DIR não encontrado" >&2
+  exit 2
+fi
+
+shopt -s nullglob
+
+# Itera todo arquivo .md do diretório e exclui apenas README.md e arquivos
+# começando com "_" (ex.: _template.md). Isso garante que ADRs com nomes
+# fora do padrão NNNN-slug.md (ex.: foo.md, adr-001.md) sejam reportados
+# como falha em vez de silenciosamente ignorados.
+for FILE in "$DIR"/*.md; do
+  BASE=$(basename "$FILE")
+  case "$BASE" in
+    README.md|_*.md) continue ;;
+  esac
+
+  COUNT=$((COUNT + 1))
+  NUM_FILE="${BASE%%-*}"
+  ERR=()
+
+  if [[ ! "$BASE" =~ ^[0-9]{4}-[a-z0-9-]+\.md$ ]]; then
+    ERR+=("nome de arquivo fora do padrão NNNN-titulo-em-slug.md")
+  fi
+
+  if ! head -1 "$FILE" | grep -q '^---$'; then
+    ERR+=("frontmatter YAML ausente (esperado --- na linha 1)")
+  elif ! tail -n +2 "$FILE" | head -n 50 | grep -q '^---$'; then
+    ERR+=("frontmatter YAML sem delimitador de fechamento (esperado --- após bloco YAML)")
+  fi
+
+  FM=$(awk 'BEGIN{c=0} /^---$/{c++; if (c==2) exit; next} c==1' "$FILE" 2>/dev/null || echo "")
+
+  for REQUIRED in "status" "date" "decision-makers"; do
+    if ! printf '%s\n' "$FM" | grep -q "^${REQUIRED}:"; then
+      ERR+=("frontmatter sem campo obrigatório: $REQUIRED")
+    fi
+  done
+
+  STATUS=$(printf '%s\n' "$FM" | grep '^status:' | head -1 | sed -E 's/^status:[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/')
+  if [[ -n "$STATUS" ]]; then
+    if [[ ! "$STATUS" =~ ^(proposed|accepted|rejected|deprecated)$ ]] && \
+       [[ ! "$STATUS" =~ ^superseded\ by\ ADR-[0-9]{4}$ ]]; then
+      ERR+=("status inválido: '$STATUS' (esperado proposed|accepted|rejected|deprecated|superseded by ADR-NNNN)")
+    fi
+  fi
+
+  DATE=$(printf '%s\n' "$FM" | grep '^date:' | head -1 | sed -E 's/^date:[[:space:]]*"?([^"]*)"?[[:space:]]*$/\1/')
+  if [[ -n "$DATE" ]] && [[ ! "$DATE" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    ERR+=("date inválida: '$DATE' (esperado YYYY-MM-DD)")
+  fi
+
+  H1=$(grep -m1 '^# ' "$FILE" || true)
+  if [[ ! "$H1" =~ ^\#\ ADR-${NUM_FILE}:\  ]]; then
+    ERR+=("H1 não bate: esperado '# ADR-${NUM_FILE}: ...', encontrado '$H1'")
+  fi
+
+  COUNT_DECISION=$(grep -c '^## Resultado da decisão' "$FILE" || true)
+  COUNT_DECISION=${COUNT_DECISION:-0}
+  if [[ "$COUNT_DECISION" -ne 1 ]]; then
+    ERR+=("'## Resultado da decisão' deve aparecer exatamente 1 vez (encontrado: $COUNT_DECISION)")
+  fi
+
+  for SECTION in "## Contexto e enunciado do problema" "## Opções consideradas" "## Resultado da decisão" "## Consequências"; do
+    if ! grep -q "^${SECTION}\$" "$FILE"; then
+      ERR+=("seção obrigatória ausente: '$SECTION'")
+    fi
+  done
+
+  if [[ "${#ERR[@]}" -gt 0 ]]; then
+    ERRORS=$((ERRORS + ${#ERR[@]}))
+    echo "FAIL $BASE"
+    for E in "${ERR[@]}"; do
+      echo "  - $E"
+    done
+  else
+    echo "ok   $BASE"
+  fi
+done
+
+if [[ "$COUNT" -eq 0 ]]; then
+  echo "AVISO: nenhum arquivo NNNN-*.md encontrado em $DIR" >&2
+  exit 0
+fi
+
+echo
+if [[ "$ERRORS" -gt 0 ]]; then
+  echo "Total de erros: $ERRORS em $COUNT arquivo(s)."
+  exit 1
+fi
+
+echo "$COUNT ADR(s) validados sem erros."


### PR DESCRIPTION
## Resumo

Cria a base canônica de decisões arquiteturais do `uniplus-web` em `docs/adrs/`, separando-a do repositório privado `uniplus-docs/docs/adrs/`. Espelha o trabalho concluído em [`uniplus-api#214`](https://github.com/unifesspa-edu-br/uniplus-api/pull/214).

10 ADRs canônicas em **MADR 4.0**, renumeradas desde `0001`, com regra estrita "1 ADR = 1 decisão" e sem referenciar paths/URLs do `uniplus-docs`.

## Conteúdo

- `docs/adrs/README.md` — índice + estratégia + tabela das 10 ADRs.
- `docs/adrs/_template.md` — template MADR 4.0 em pt-BR.
- `docs/adrs/.markdownlint-cli2.jsonc` — config markdownlint.
- `docs/adrs/0001-...md` a `0010-...md` — 10 ADRs:

| # | Decisão única |
|---|---------------|
| 0001 | Separação em três aplicações frontend (Seleção, Ingresso, Portal) |
| 0002 | Angular 21 como framework SPA |
| 0003 | Nx como build system do monorepo frontend |
| 0004 | Vitest como framework de testes unitários |
| 0005 | Manter Zone.js no Angular 21 |
| 0006 | Adoção do Gov.br Design System como contrato visual |
| 0007 | PrimeNG em modo unstyled como component library |
| 0008 | Tailwind CSS 4 com tokens Gov.br via `@theme` |
| 0009 | Keycloak como identity provider OIDC |
| 0010 | OpenTelemetry para instrumentação frontend (RUM) |

- `tools/adr-lint/validate.sh` — validador bash sem deps externas.
- `tools/adr-lint/README.md` — uso local.

ADRs antigas equivalentes (Uni+ ADR-003/006/007/008/014/016/017/018) permanecem em `uniplus-docs` como histórico. Splits aplicados: ADR-006 antiga → 0002 (só Angular); ADR-018 antiga → 0006/0007/0008 (Gov.br DS, PrimeNG unstyled, Tailwind tokens); ADR-008 antiga → 0009 (versão sanitizada para frontend); ADR-014 antiga → 0010 (recorte RUM).

## Validações locais

- [x] `find docs/adrs -name "[0-9]*.md" | wc -l` → `10`
- [x] `grep -r "uniplus-docs" docs/adrs/` → zero hits
- [x] `bash tools/adr-lint/validate.sh` → exit 0 (10 ADRs validados)
- [x] `npx markdownlint-cli2 'docs/adrs/**/*.md'` → exit 0

Closes #146