### PR TITLE
ci: cacheia Playwright e pula gates frontend em PRs sem código

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,36 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
+      # Em pull_request, detecta se houve mudança em código frontend.
+      # Em push para main, sempre rodamos os gates (passo abaixo decide).
+      - id: changes
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            frontend:
+              - 'apps/**'
+              - 'libs/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'nx.json'
+              - 'tsconfig*.json'
+              - 'tools/e2e-docker/**'
+              - '.github/workflows/ci.yml'
+
+      - id: gate
+        name: Decidir se gates frontend rodam
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]] || [[ "${{ steps.changes.outputs.frontend }}" == "true" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "Gates frontend habilitados"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "PR sem mudancas em codigo frontend - pulando gates"
+          fi
+
       - name: Iniciar Keycloak
+        if: steps.gate.outputs.run == 'true'
         run: |
           docker run -d \
             --name keycloak \
@@ -32,6 +61,7 @@ jobs:
             quay.io/keycloak/keycloak:26.5 start-dev --import-realm
 
       - name: Aguardar Keycloak ficar saudável
+        if: steps.gate.outputs.run == 'true'
         run: |
           timeout 120 bash -c \
             'until curl -sf http://localhost:9000/health/ready | grep -q "\"UP\""; do sleep 5; done'
@@ -40,20 +70,44 @@ jobs:
       # Keep --stop-agents-after aligned with every target executed below so the
       # distributed run cannot finish before all blocking gates are reconciled.
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
-      - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="lint,test,build,typecheck,e2e"
+      - if: steps.gate.outputs.run == 'true'
+        run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="lint,test,build,typecheck,e2e"
 
-      - uses: actions/setup-node@v4
+      - if: steps.gate.outputs.run == 'true'
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
-      - run: npm ci
-      - run: npx playwright install --with-deps
+      - if: steps.gate.outputs.run == 'true'
+        run: npm ci
 
-      - run: npx nx record -- echo Hello World
-      - run: npx nx run-many -t lint test build typecheck e2e --nxBail --outputStyle=static
+      - name: Extrair versão do Playwright
+        id: pw-version
+        if: steps.gate.outputs.run == 'true'
+        run: |
+          VERSION=$(node -e "const l=require('./package-lock.json'); console.log(l.packages['node_modules/@playwright/test'].version)")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Cache de browsers do Playwright
+        if: steps.gate.outputs.run == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.pw-version.outputs.version }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - if: steps.gate.outputs.run == 'true'
+        run: npx playwright install --with-deps
+
+      - if: steps.gate.outputs.run == 'true'
+        run: npx nx record -- echo Hello World
+
+      - if: steps.gate.outputs.run == 'true'
+        run: npx nx run-many -t lint test build typecheck e2e --nxBail --outputStyle=static
         env:
           KEYCLOAK_ADMIN_PASSWORD: ${{ secrets.KEYCLOAK_ADMIN_PASSWORD || 'admin' }}
 
-      - run: npx nx fix-ci
-        if: always()
+      - if: always() && steps.gate.outputs.run == 'true'
+        run: npx nx fix-ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   actions: read
   contents: read
+  pull-requests: read
 
 jobs:
   main:
@@ -33,6 +34,9 @@ jobs:
               - 'package-lock.json'
               - 'nx.json'
               - 'tsconfig*.json'
+              - 'eslint.config.mjs'
+              - 'vitest.workspace.ts'
+              - 'playwright.config.ts'
               - 'tools/e2e-docker/**'
               - '.github/workflows/ci.yml'
 


### PR DESCRIPTION
Closes #149
Refs #148

## Por que

Hoje qualquer PR — inclusive os que só mexem em `docs/` — paga o ciclo completo de CI: sobe Keycloak, roda `npm ci`, baixa browsers do Playwright e roda `nx run-many` em todos os targets. Para o PR #147 (apenas ADRs), isso resultou em ~5min30s de runner e 41s só no `playwright install --with-deps`.

Este PR é o **alívio imediato** descrito na issue #149. A refatoração arquitetural (mover o e2e para dentro do container `ghcr.io/unifesspa-edu-br/uniplus-e2e-runner` e splitar o job em dois) fica registrada em #148 para tratamento dedicado.

## O que muda em `.github/workflows/ci.yml`

1. **`dorny/paths-filter@v3`** — detecta se o PR mudou caminhos relevantes para frontend (`apps/**`, `libs/**`, `package.json`, `package-lock.json`, `nx.json`, `tsconfig*.json`, `tools/e2e-docker/**`, `.github/workflows/ci.yml`). Em `push` para `main`, o filtro é ignorado e tudo roda sempre.

2. **`actions/cache@v4` em `~/.cache/ms-playwright`** — chave baseada em `runner.os` + versão do `@playwright/test` extraída do `package-lock.json` (mesma técnica que o `e2e-runner-image.yml` já usa). Em cache hit, `npx playwright install --with-deps` ainda roda — apenas reinstala system deps via `apt` (rápido) em vez de baixar browsers (~600 MB).

3. **Steps gated por `if: steps.gate.outputs.run == 'true'`** — Keycloak (sobe + healthcheck), `nx start-ci-run`, `setup-node`, `npm ci`, extração da versão Playwright, cache, `playwright install`, `nx record`, `nx run-many` e `nx fix-ci`. Quando todos os steps gated estão skipped, o job termina success (status check do GitHub trata "all skipped" como success).

## Validação

- ✅ Próprio PR toca `.github/workflows/ci.yml`, então roda todos os gates — confirma que o caminho feliz não regrediu.
- ⏳ Validação do skip em PR docs-only só será observada em PRs futuros que mexam exclusivamente em `docs/`. Critério em #149.
- ⏳ Cache hit aparece a partir da segunda execução com mesma versão do Playwright (atualmente `1.58.2`).

## Não está neste PR

- Refatoração para `container:` ou split em `build-and-test` + `e2e` (issue #148).
- Mudanças em `e2e-runner-image.yml`, specs ou config do Playwright.