### PR TITLE
ci: usa nx affected em pull_request e mantém run-many em push para main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,17 @@ jobs:
       - if: steps.gate.outputs.run == 'true'
         run: npx nx record -- echo Hello World
 
-      - if: steps.gate.outputs.run == 'true'
+      # Em pull_request, usamos `nx affected` para rodar apenas os projects
+      # impactados pelo diff contra a branch base. Em push para main, fazemos
+      # sweep completo via `nx run-many` como rede de segurança.
+      - name: Rodar gates (nx affected — pull_request)
+        if: steps.gate.outputs.run == 'true' && github.event_name == 'pull_request'
+        run: npx nx affected -t lint test build typecheck e2e --base=origin/${{ github.base_ref }} --head=HEAD --nxBail --outputStyle=static
+        env:
+          KEYCLOAK_ADMIN_PASSWORD: ${{ secrets.KEYCLOAK_ADMIN_PASSWORD || 'admin' }}
+
+      - name: Rodar gates (nx run-many — push em main)
+        if: steps.gate.outputs.run == 'true' && github.event_name == 'push'
         run: npx nx run-many -t lint test build typecheck e2e --nxBail --outputStyle=static
         env:
           KEYCLOAK_ADMIN_PASSWORD: ${{ secrets.KEYCLOAK_ADMIN_PASSWORD || 'admin' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,9 +111,14 @@ jobs:
       # Em pull_request, usamos `nx affected` para rodar apenas os projects
       # impactados pelo diff contra a branch base. Em push para main, fazemos
       # sweep completo via `nx run-many` como rede de segurança.
+      # --exclude=uniplus-web: o root project tem um target `e2e` inferido
+      # pelo @nx/playwright a partir do `playwright.config.ts` da raiz que
+      # está mal configurado (testMatch pega specs de Vitest). `nx run-many`
+      # historicamente ignorava esse target, mas `nx affected` o invoca.
+      # Excluir é cirúrgico; a correção do config raiz fica em issue própria.
       - name: Rodar gates (nx affected — pull_request)
         if: steps.gate.outputs.run == 'true' && github.event_name == 'pull_request'
-        run: npx nx affected -t lint test build typecheck e2e --base=origin/${{ github.base_ref }} --head=HEAD --nxBail --outputStyle=static
+        run: npx nx affected -t lint test build typecheck e2e --base=origin/${{ github.base_ref }} --head=HEAD --exclude=uniplus-web --nxBail --outputStyle=static
         env:
           KEYCLOAK_ADMIN_PASSWORD: ${{ secrets.KEYCLOAK_ADMIN_PASSWORD || 'admin' }}
 


### PR DESCRIPTION
Closes #151
Refs #148

## Por que

O job \`main\` em \`.github/workflows/ci.yml\` gasta ~3min em \`npx nx run-many -t lint test build typecheck e2e\` mesmo em PRs pequenos que tocam apenas uma lib ou app. Esse trabalho é desperdício no PR: o Nx sabe quais projects foram afetados pelo diff e poderia rodar só esses.

Os scripts em \`package.json\` já distinguem os dois modos (\`affected:lint\`, \`affected:test\`, \`affected:build\`) — falta apenas o CI usar a variante \`affected\` em pull_request.

## O que muda

Substitui o step único de \`nx run-many\` por dois steps mutuamente exclusivos:

- **pull_request** → \`npx nx affected -t lint test build typecheck e2e --base=origin/\${{ github.base_ref }} --head=HEAD --nxBail --outputStyle=static\`
- **push em main** → \`npx nx run-many -t lint test build typecheck e2e --nxBail --outputStyle=static\` (sweep completo no branch protegido continua sendo a rede de segurança).

\`fetch-depth: 0\` já está no \`actions/checkout\` desde o PR original — o \`affected\` consegue resolver a base.

## Validação

- ✅ Próprio PR toca \`.github/workflows/ci.yml\` — pelo grafo do Nx, esse arquivo não impacta diretamente nenhum project, então \`affected\` deve sair com \`No projects to run\` em segundos. Se passar verde, prova que o caminho funciona.
- ⏳ PR seguinte que mexer em \`libs/shared-ui\` (por exemplo) deve rodar lint/test/build/typecheck para \`shared-ui\` + apps consumidoras, e e2e somente se houver impacto.
- ⏳ Próximo \`push\` em \`main\` confirma que o sweep completo continua funcionando.

## Riscos

- **Falsos negativos do grafo do Nx:** se um arquivo fora do dependency graph (ex.: tema CSS importado por path absoluto) for alterado, \`affected\` pode não pegar. Mitigação: o sweep completo em push para main captura.
- **\`origin/\${{ github.base_ref }}\` em PR de fork:** PRs internos da org não têm esse problema.

## Fora de escopo

- Refatoração para job em \`container:\` (#148).