### PR TITLE
fix(e2e): troca imagem Keycloak vanilla por imagem composta uniplus-keycloak

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,11 @@ jobs:
 
       - name: Iniciar Keycloak
         if: steps.gate.outputs.run == 'true'
+        # Imagem composta uniplus-keycloak: base quay.io/keycloak/keycloak:26.5.7
+        # + JAR cpf-matcher embutido. Mesma imagem do uniplus-api e do compose
+        # E2E local (tools/e2e-docker/docker-compose.e2e.yml). Patch fixo para
+        # reprodutibilidade — bump é PR explícito. Política em
+        # uniplus-api/docker/keycloak/README.md#imagem-do-keycloak.
         run: |
           docker run -d \
             --name keycloak \
@@ -62,7 +67,7 @@ jobs:
             -e KC_BOOTSTRAP_ADMIN_USERNAME=admin \
             -e KC_BOOTSTRAP_ADMIN_PASSWORD=${{ secrets.KEYCLOAK_ADMIN_PASSWORD || 'admin' }} \
             -v $PWD/tools/e2e-docker/keycloak/realm-export.json:/opt/keycloak/data/import/realm-export.json:ro \
-            quay.io/keycloak/keycloak:26.5 start-dev --import-realm
+            ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.2 start-dev --import-realm
 
       - name: Aguardar Keycloak ficar saudável
         if: steps.gate.outputs.run == 'true'

--- a/tools/e2e-docker/docker-compose.e2e.yml
+++ b/tools/e2e-docker/docker-compose.e2e.yml
@@ -6,7 +6,13 @@
 
 services:
   keycloak:
-    image: quay.io/keycloak/keycloak:26.5
+    # Imagem composta uniplus-keycloak: base quay.io/keycloak/keycloak:26.5.7
+    # + JAR cpf-matcher embutido em /opt/keycloak/providers/ (Authenticator Java
+    # SPI custom para Identity Brokering gov.br). Mesma imagem consumida pelo
+    # uniplus-api/docker/docker-compose.yml. Patch fixo para reprodutibilidade
+    # entre devs do time — atualização é PR explícito. Política e ciclo de
+    # release em uniplus-api/docker/keycloak/README.md#imagem-do-keycloak.
+    image: ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.2
     command: start-dev --import-realm
     environment:
       KC_HEALTH_ENABLED: "true"


### PR DESCRIPTION
## Resumo

Substitui a imagem Keycloak vanilla (`quay.io/keycloak/keycloak:26.5`) pela imagem composta canônica do projeto Uni+ (`ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.2`) no E2E e no CI do frontend, alinhando com a entrega da Story `uniplus-api#218` (Identity Brokering gov.br via SPI `cpf-matcher`).

A imagem composta contém:

- Base: `quay.io/keycloak/keycloak:26.5.7`
- JAR `cpf-matcher-1.0.2.jar` embutido em `/opt/keycloak/providers/` (Authenticator Java SPI custom para auto-link por CPF no first-broker-login do gov.br)

Documentação canônica: [`uniplus-api/docker/keycloak/README.md#imagem-do-keycloak`](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docker/keycloak/README.md#imagem-do-keycloak).

## Mudanças

- **`tools/e2e-docker/docker-compose.e2e.yml`** — troca da imagem + comentário explicando origem e política de pinning.
- **`.github/workflows/ci.yml`** — troca da imagem no `docker run` inline do job E2E + comentário equivalente.

Mantido `start-dev --import-realm` (a imagem composta tem `CMD ["start"]` por padrão e precisa do override em DEV).

## Política de pinning

Patch fixo (`1.0.2`) em ambos os pontos, alinhando com o `docker-compose.yml` do `uniplus-api` e com a política descrita em [`uniplus-api/docker/keycloak/README.md`](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docker/keycloak/README.md#imagem-do-keycloak):

| Cenário | Tag |
|---|---|
| Compose dev / E2E reproduzível | Patch fixo (`1.0.2`) ✅ |
| CI ad-hoc | Float `1.x` (não adotado aqui — CI do `uniplus-web` ganha estabilidade com patch fixo enquanto a infra de CI ainda está em ajuste) |
| HML / PROD | Patch fixo |

Bump futuro é PR explícito.

## Validação local

```bash
docker pull ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.2
# Image is up to date

docker run --rm --entrypoint sh ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.2 \
  -c "ls /opt/keycloak/providers/"
# cpf-matcher-1.0.2.jar  README.md

docker run -d -p 18080:8080 -p 19000:9000 \
  -e KC_HEALTH_ENABLED=true -e KC_HOSTNAME_STRICT=false \
  -e KC_BOOTSTRAP_ADMIN_USERNAME=admin -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
  -v $PWD/tools/e2e-docker/keycloak/realm-export.json:/opt/keycloak/data/import/realm-export.json:ro \
  ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.0.2 start-dev --import-realm

# health=UP em ~10s
# log: "uniplus-cpf-matcher (...) is implementing the internal SPI authenticator"
# log: "Realm 'unifesspa' imported"
```

## Referências

- Imagem composta: [`unifesspa-edu-br/uniplus-keycloak-providers`](https://github.com/unifesspa-edu-br/uniplus-keycloak-providers)
- ADR upstream: [`uniplus-api/docs/adrs/0020-identity-brokering-govbr.md`](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0020-identity-brokering-govbr.md)
- PR de docs upstream: `unifesspa-edu-br/uniplus-api#243` (mergeado em 02/05/2026)

Closes #154
