### PR TITLE
docs(adr-0012): remover prescrição especulativa de promoção (achado P2 do Codex no #163)

### DIFF
--- a/docs/adrs/0012-placement-api-result-em-shared-core.md
+++ b/docs/adrs/0012-placement-api-result-em-shared-core.md
@@ -87,16 +87,7 @@ Esta ADR explicitamente **não fecha a porta** para criar `libs/shared-http` mai
 - Cliente Angular codegen (`libs/api-selecao-client`) ou outras libs ficam acopladas pesadamente ao subdiretório, justificando export estável separado.
 - Mudança de equipe ou ownership exige isolamento técnico.
 
-…então promove via:
-
-```bash
-nx generate @nx/angular:move \
-  --project=shared-core \
-  --destination=shared-http \
-  --paths=src/lib/http
-```
-
-Promoção é um comando Nx + ajuste de imports cross-lib via codemod. Sem lock-in arquitetural na decisão de hoje.
+…então a subpasta vira lib própria. **Não há lock-in arquitetural** na decisão de hoje: o design do adapter (tipos, interceptor, i18n service) é independente do local físico, e a promoção é refactor mecânico — gerar a nova lib via `nx g lib`, deslocar os arquivos, atualizar imports dos consumidores via codemod. Os passos exatos serão definidos no PR de promoção, quando o contexto real existir; descrever procedimento agora seria especulação sobre código que ainda não foi escrito.
 
 ### Esta ADR não decide
 
@@ -140,6 +131,6 @@ Promoção é um comando Nx + ajuste de imports cross-lib via codemod. Sem lock-
 
 - [ADR-0011](0011-consumer-adapter-api-result.md) — superseded em parte por esta ADR (apenas placement; design e migração permanecem válidos).
 - ADR-0002 do `uniplus-api` (Clean Architecture) — base da analogia de simetria entre backend e frontend para cross-cutting infra.
-- [Nx — Move generator](https://nx.dev/nx-api/angular/generators/move) — caminho de promoção futura sem lock-in.
+- [Nx — Library generation](https://nx.dev/recipes/angular/library) — referência para `nx g lib` quando a promoção for feita.
 - [Nx — Library generation](https://nx.dev/recipes/angular/library) — critério para nova lib.
 - Princípio YAGNI ("You Aren't Gonna Need It") — base da rejeição de criar lib justificada por código especulativo.


### PR DESCRIPTION
Closes #164
Refs #163

## Resumo

Codex flagou no review da PR #163 (mergeada) que o comando \`nx generate @nx/angular:move --project=... --paths=...\` documentado na seção \"Caminho de promoção futura\" da ADR-0012 usa flags inválidas.

A correção certa **não é prescrever um procedimento mais correto** — é reconhecer que descrever passo a passo um refactor entre dois lugares que **ainda não existem** (\`shared-core/http/\` ainda não foi implementado; \`shared-http\` nunca existiu) é exatamente o tipo de especulação que a ADR-0012 deveria evitar (foi a crítica original que justificou ela existir).

## O que muda

Substitui a prescrição especulativa (lista de 7 passos com comandos Nx, paths, codemods) por **uma frase honesta**: não há lock-in arquitetural; design do adapter é independente do local físico; promoção é refactor mecânico cujos passos exatos serão definidos no PR de promoção quando o contexto real existir.

Atualiza referência \"Mais informações\" para apontar a doc de \`nx g lib\` (operação que será de fato executada no dia, se justificar).

## O que NÃO muda

A essência da decisão permanece válida e binding:

- Adapter vive em \`libs/shared-core/src/lib/http/\`
- Critérios para eventual promoção (>20 arquivos, ownership específico, codegen acoplado pesado) inalterados
- Não há lock-in arquitetural

## Verificações locais

- \`bash tools/adr-lint/validate.sh\` → 12 ADR(s) validados sem erros
- \`npx markdownlint-cli2 'docs/adrs/0012-*.md'\` → 0 errors

## Cross-review

Cross-review por \`jf2s\` após CI verde. Após merge, vou postar reply ao thread do Codex no #163 referenciando este PR e marcar o thread como resolvido.