### PR TITLE
feat(shared-ui): adiciona validação de segurança e testes unitários para o componente file upload

### DIFF
--- a/libs/shared-ui/src/lib/components/file-upload/file-upload.spec.ts
+++ b/libs/shared-ui/src/lib/components/file-upload/file-upload.spec.ts
@@ -1,0 +1,218 @@
+import { By } from '@angular/platform-browser';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, expect, it, beforeEach } from 'vitest';
+import { FileUploadComponent } from './file-upload';
+
+describe('FileUploadComponent', () => {
+  const MAX_SIZE_IN_MB = 10;
+  const MAX_SIZE_IN_BYTES = MAX_SIZE_IN_MB * 1024 * 1024;
+  const MAX_SIZE_MB_MSG = `Arquivo excede o tamanho máximo de ${MAX_SIZE_IN_MB}MB.`
+  const VALID_FILE_MOCK = new File([new ArrayBuffer(MAX_SIZE_IN_BYTES)], "file-mock.pdf", { type: "application/pdf" });
+  const OVERSIZED_FILE_MOCK = new File([new ArrayBuffer(MAX_SIZE_IN_BYTES + 1)], "oversized-file-mock.pdf", { type: "application/pdf" });
+  const TYPE_NOT_ALLOWED_FILE_MOCK = new File([new ArrayBuffer(MAX_SIZE_IN_BYTES)], "not-allowed-file-mock.gif", { type: "image/gif" });
+  const EXTENSION_NOT_ALLOWED_FILE_MOCK = new File([new ArrayBuffer(MAX_SIZE_IN_BYTES)], "not-allowed-file-mock.gif", { type: "image/png" });
+  const TYPE_NOT_ALLOWED_MSG = 'Tipo de arquivo não permitido. Envie arquivos nos formatos: .pdf,.jpg,.jpeg,.png';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [FileUploadComponent] });
+  });
+
+  function setup() {
+    const fixture: ComponentFixture<FileUploadComponent> =
+      TestBed.createComponent(FileUploadComponent);
+    const component = fixture.componentInstance;
+    fixture.detectChanges();
+    const fileSelectOutputSpy = vi.spyOn(component.fileSelected, 'emit');
+    const removeFileSpy = vi.spyOn(component, 'removeFile');
+    const onDragLeaveSpy = vi.spyOn(component, "onDragLeave");
+    const onDragOverSpy = vi.spyOn(component, "onDragOver");
+    const onFileSelectedSpy = vi.spyOn(component, "onFileSelected");
+    const onDropSpy = vi.spyOn(component, "onDrop");
+    const fileInputClickSpy = vi.spyOn(component.fileInput()?.nativeElement, 'click');
+    const getDivButton = () =>
+        fixture.debugElement.query(By.css('[role="button"]'));
+    const getFileInput = () =>
+        fixture.debugElement.query(By.css('#file-upload-input'));
+    const getFileInputEl = () => getFileInput().nativeElement as HTMLInputElement;
+    const getButtons = () => fixture.debugElement.queryAll(By.css('button'));
+    const getSelectButtonEl = () =>
+      getButtons().find(button => button.nativeElement.textContent.trim() === 'selecione do computador')?.nativeElement as HTMLButtonElement;
+    const getRemoveButtonEl = () =>
+        getButtons().find(button => button.nativeElement.textContent.trim() === 'Remover')?.nativeElement as HTMLButtonElement;
+    return {
+      fixture,
+      component,
+      getDivButton,
+      getFileInputEl,
+      getFileInput,
+      getSelectButtonEl,
+      getRemoveButtonEl,
+      fileSelectOutputSpy,
+      removeFileSpy,
+      onDragLeaveSpy,
+      onDragOverSpy,
+      onFileSelectedSpy,
+      fileInputClickSpy,
+      onDropSpy
+    }
+  }
+
+  it('inicializa o componente corretamente', () => {
+    const { component } = setup();
+    expect(component).toBeTruthy();
+  });
+
+  it('seleciona arquivo no input', () => {
+    const { fixture, component, getFileInput, fileSelectOutputSpy } = setup();
+    const fileInput = getFileInput();
+    const eventWithFileMock = {
+      target: {
+        files: [VALID_FILE_MOCK]
+      }
+    } as unknown as Event;
+    fileInput.triggerEventHandler('change', eventWithFileMock);
+
+    fixture.detectChanges();
+    const file = (eventWithFileMock.target as HTMLInputElement).files?.[0];
+
+    expect(component.error()).toBe('');
+    expect(component.selectedFile()).toBe(file);
+    expect(fileSelectOutputSpy).toHaveBeenCalledWith(file);
+    expect(fileInput.nativeElement.value).toBe('');
+  });
+
+  it('dispara o evento de dragover no container do input', () => {
+    const { fixture, component, getDivButton, onDragOverSpy } = setup();
+    const uploadButtonDiv = getDivButton();
+    const dragEventEmptyMock = {
+      preventDefault: vi.fn(),
+    } as unknown as DragEvent;
+    uploadButtonDiv.triggerEventHandler('dragover', dragEventEmptyMock);
+    fixture.detectChanges();
+
+    expect(onDragOverSpy).toHaveBeenCalled();
+    expect(dragEventEmptyMock.preventDefault).toHaveBeenCalled();
+    expect(component.isDragging()).toBe(true);
+  });
+
+  it('dispara o evento de dragleave no container do input', () => {
+    const { fixture, component, getDivButton, onDragLeaveSpy } = setup();
+    const uploadButtonDiv = getDivButton();
+    component.isDragging.set(true);
+    fixture.detectChanges();
+
+    uploadButtonDiv.triggerEventHandler('dragleave');
+    fixture.detectChanges();
+
+    expect(onDragLeaveSpy).toHaveBeenCalled();
+    expect(component.isDragging()).toBe(false);
+  });
+
+  it('dispara evento drop no container do input quando um arquivo está selecionado', () => {
+    const { fixture, component, getDivButton, fileSelectOutputSpy, getFileInput, onDropSpy } = setup();
+    const uploadButtonDiv = getDivButton();
+    const fileInput = getFileInput();
+    const dragEventWithFileMock = {
+      preventDefault: vi.fn(),
+      dataTransfer: {
+        files: [VALID_FILE_MOCK]
+      }
+    } as unknown as DragEvent;
+    uploadButtonDiv.triggerEventHandler('drop', dragEventWithFileMock);
+    fixture.detectChanges();
+
+    expect(dragEventWithFileMock.preventDefault).toHaveBeenCalled();
+    expect(onDropSpy).toHaveBeenCalled();
+    expect(component.isDragging()).toBe(false);
+    expect(fileSelectOutputSpy).toHaveBeenCalled();
+    expect(fileInput.nativeElement.value).toBe('');
+  });
+
+  it(`rejeita arquivos maiores que ${MAX_SIZE_IN_MB.toString()}MB`, () => {
+    const { fixture, component, getFileInput, fileSelectOutputSpy } = setup();
+    const fileInput = getFileInput();
+    const eventWithOversizedFileMock = {
+      target: {
+        files: [OVERSIZED_FILE_MOCK]
+      }
+    } as unknown as Event;
+    fileInput.triggerEventHandler('change', eventWithOversizedFileMock);
+    fixture.detectChanges();
+
+    expect(fileSelectOutputSpy).not.toHaveBeenCalled();
+    expect(component.error()).toBe(MAX_SIZE_MB_MSG);
+    expect(component.selectedFile()).toBe(null);
+  });
+
+  it('emite evento de clique no input quando clica no botão de selecionar arquivo do computador', () => {
+    const { fixture, getSelectButtonEl, fileInputClickSpy } = setup();
+    const selectButtonEl = getSelectButtonEl();
+
+    selectButtonEl.dispatchEvent(new Event('click'));
+    fixture.detectChanges();
+
+    expect(fileInputClickSpy).toHaveBeenCalled();
+  });
+
+  it('remove um arquivo previamente selecionado', () => {
+    const { fixture, component, getRemoveButtonEl, removeFileSpy } = setup();
+    component.selectedFile.set(VALID_FILE_MOCK);
+    fixture.detectChanges();
+
+    const removeButtonEl = getRemoveButtonEl();
+    removeButtonEl.dispatchEvent(new Event('click'));
+    fixture.detectChanges();
+
+    expect(removeFileSpy).toHaveBeenCalled();
+    expect(component.selectedFile()).toBe(null);
+    expect(component.error()).toBe('');
+  });
+
+  it('emite um evento keydown.enter no container do input', () => {
+    const { fixture, getFileInput, fileInputClickSpy } = setup();
+    const fileInputEl = getFileInput();
+
+    fileInputEl.triggerEventHandler('keydown.enter', { target: fileInputEl.nativeElement.click() });
+    fixture.detectChanges();
+
+    expect(fileInputClickSpy).toHaveBeenCalled();
+  });
+
+  it('rejeita arquivo quando o tipo do arquivo não faz parte dos tipos aceitos', () => {
+    const { fixture, component, getFileInput, onFileSelectedSpy, fileSelectOutputSpy } = setup();
+    const fileInput = getFileInput();
+    const eventWithFileNotAllowedTypeMock = {
+      target: { files: [TYPE_NOT_ALLOWED_FILE_MOCK] }
+    } as unknown as Event;
+
+    fileInput.triggerEventHandler('change', eventWithFileNotAllowedTypeMock);
+    fixture.detectChanges();
+    const file = (eventWithFileNotAllowedTypeMock.target as HTMLInputElement).files?.[0];
+
+    expect(component.error()).toBe(TYPE_NOT_ALLOWED_MSG);
+    expect(file?.size).toBe(MAX_SIZE_IN_BYTES);
+    expect(onFileSelectedSpy).toHaveBeenCalledWith(eventWithFileNotAllowedTypeMock);
+    expect(fileInput.nativeElement.value).toBe('');
+    expect(fileSelectOutputSpy).not.toHaveBeenCalled();
+    expect(component.selectedFile()).toBe(null);
+    expect(fileInput.nativeElement.value).toBe('');
+  });
+
+  it('rejeita arquivo quando a extensão do arquivo não faz parte das extensões aceitas', () => {
+    const { fixture, component, getFileInput, onFileSelectedSpy, fileSelectOutputSpy } = setup();
+    const fileInput = getFileInput();
+    const eventWithFileNotAllowedExtensionMock = {
+      target: {
+        files: [EXTENSION_NOT_ALLOWED_FILE_MOCK]
+      }
+    } as unknown as Event;
+
+    fileInput.triggerEventHandler('change', eventWithFileNotAllowedExtensionMock);
+    fixture.detectChanges();
+
+    expect(onFileSelectedSpy).toHaveBeenCalledWith(eventWithFileNotAllowedExtensionMock);
+    expect(fileSelectOutputSpy).not.toHaveBeenCalled();
+    expect(component.error()).toBe(TYPE_NOT_ALLOWED_MSG);
+    expect(fileInput.nativeElement.value).toBe('');
+  });
+});

--- a/libs/shared-ui/src/lib/components/file-upload/file-upload.spec.ts
+++ b/libs/shared-ui/src/lib/components/file-upload/file-upload.spec.ts
@@ -273,4 +273,44 @@ describe('FileUploadComponent', () => {
     expect(component.selectedFile()).toBe(valid);
     expect(component.error()).toContain('Tipo de arquivo não permitido');
   });
+
+  it('gera IDs únicos por instância para isolar `for`/`aria-describedby` em multi-upload', () => {
+    const first = TestBed.createComponent(FileUploadComponent);
+    const second = TestBed.createComponent(FileUploadComponent);
+    first.detectChanges();
+    second.detectChanges();
+
+    expect(first.componentInstance.inputId).not.toBe(second.componentInstance.inputId);
+    expect(first.componentInstance.errorId).not.toBe(second.componentInstance.errorId);
+
+    const firstInput = first.debugElement.query(By.css('input[type="file"]')).nativeElement as HTMLInputElement;
+    const secondInput = second.debugElement.query(By.css('input[type="file"]')).nativeElement as HTMLInputElement;
+
+    expect(firstInput.id).toBe(first.componentInstance.inputId);
+    expect(secondInput.id).toBe(second.componentInstance.inputId);
+    expect(firstInput.id).not.toBe(secondInput.id);
+  });
+
+  it('aria-describedby aponta para o errorId da própria instância quando há erro', () => {
+    const { fixture, dropZone, errorMessage } = setup();
+    pickFile(fixture, OVERSIZED_PDF());
+
+    const dropZoneEl = dropZone().nativeElement as HTMLButtonElement;
+    const errorEl = errorMessage().nativeElement as HTMLElement;
+
+    expect(dropZoneEl.getAttribute('aria-describedby')).toBe(errorEl.id);
+    expect(errorEl.id).toMatch(/^ui-file-upload-\d+-error$/);
+  });
+
+  it('label[for] aponta para o inputId da própria instância', () => {
+    const { fixture } = setup();
+    fixture.componentRef.setInput('label', 'Documento de identificação');
+    fixture.detectChanges();
+
+    const labelEl = fixture.debugElement.query(By.css('label')).nativeElement as HTMLLabelElement;
+    const inputEl = fixture.debugElement.query(By.css('input[type="file"]')).nativeElement as HTMLInputElement;
+
+    expect(labelEl.htmlFor).toBe(inputEl.id);
+    expect(labelEl.htmlFor).toMatch(/^ui-file-upload-\d+-input$/);
+  });
 });

--- a/libs/shared-ui/src/lib/components/file-upload/file-upload.spec.ts
+++ b/libs/shared-ui/src/lib/components/file-upload/file-upload.spec.ts
@@ -1,18 +1,9 @@
 import { By } from '@angular/platform-browser';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { describe, expect, it, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { FileUploadComponent } from './file-upload';
 
 describe('FileUploadComponent', () => {
-  const MAX_SIZE_IN_MB = 10;
-  const MAX_SIZE_IN_BYTES = MAX_SIZE_IN_MB * 1024 * 1024;
-  const MAX_SIZE_MB_MSG = `Arquivo excede o tamanho máximo de ${MAX_SIZE_IN_MB}MB.`
-  const VALID_FILE_MOCK = new File([new ArrayBuffer(MAX_SIZE_IN_BYTES)], "file-mock.pdf", { type: "application/pdf" });
-  const OVERSIZED_FILE_MOCK = new File([new ArrayBuffer(MAX_SIZE_IN_BYTES + 1)], "oversized-file-mock.pdf", { type: "application/pdf" });
-  const TYPE_NOT_ALLOWED_FILE_MOCK = new File([new ArrayBuffer(MAX_SIZE_IN_BYTES)], "not-allowed-file-mock.gif", { type: "image/gif" });
-  const EXTENSION_NOT_ALLOWED_FILE_MOCK = new File([new ArrayBuffer(MAX_SIZE_IN_BYTES)], "not-allowed-file-mock.gif", { type: "image/png" });
-  const TYPE_NOT_ALLOWED_MSG = 'Tipo de arquivo não permitido. Envie arquivos nos formatos: .pdf,.jpg,.jpeg,.png';
-
   beforeEach(() => {
     TestBed.configureTestingModule({ imports: [FileUploadComponent] });
   });
@@ -22,197 +13,264 @@ describe('FileUploadComponent', () => {
       TestBed.createComponent(FileUploadComponent);
     const component = fixture.componentInstance;
     fixture.detectChanges();
-    const fileSelectOutputSpy = vi.spyOn(component.fileSelected, 'emit');
-    const removeFileSpy = vi.spyOn(component, 'removeFile');
-    const onDragLeaveSpy = vi.spyOn(component, "onDragLeave");
-    const onDragOverSpy = vi.spyOn(component, "onDragOver");
-    const onFileSelectedSpy = vi.spyOn(component, "onFileSelected");
-    const onDropSpy = vi.spyOn(component, "onDrop");
-    const fileInputClickSpy = vi.spyOn(component.fileInput()?.nativeElement, 'click');
-    const getDivButton = () =>
-        fixture.debugElement.query(By.css('[role="button"]'));
-    const getFileInput = () =>
-        fixture.debugElement.query(By.css('#file-upload-input'));
-    const getFileInputEl = () => getFileInput().nativeElement as HTMLInputElement;
-    const getButtons = () => fixture.debugElement.queryAll(By.css('button'));
-    const getSelectButtonEl = () =>
-      getButtons().find(button => button.nativeElement.textContent.trim() === 'selecione do computador')?.nativeElement as HTMLButtonElement;
-    const getRemoveButtonEl = () =>
-        getButtons().find(button => button.nativeElement.textContent.trim() === 'Remover')?.nativeElement as HTMLButtonElement;
-    return {
-      fixture,
-      component,
-      getDivButton,
-      getFileInputEl,
-      getFileInput,
-      getSelectButtonEl,
-      getRemoveButtonEl,
-      fileSelectOutputSpy,
-      removeFileSpy,
-      onDragLeaveSpy,
-      onDragOverSpy,
-      onFileSelectedSpy,
-      fileInputClickSpy,
-      onDropSpy
-    }
+
+    const dropZone = () => fixture.debugElement.query(By.css('button[aria-label^="Área de upload"]'));
+    const hiddenInput = () => fixture.debugElement.query(By.css('input[type="file"]'));
+    const errorMessage = () => fixture.debugElement.query(By.css('[role="alert"]'));
+    const removeButton = () => fixture.debugElement.query(By.css('button[aria-label="Remover arquivo"]'));
+
+    return { fixture, component, dropZone, hiddenInput, errorMessage, removeButton };
   }
 
-  it('inicializa o componente corretamente', () => {
+  function makeFile(options: { name: string; type: string; sizeBytes: number }): File {
+    return new File([new ArrayBuffer(options.sizeBytes)], options.name, { type: options.type });
+  }
+
+  function setInputFiles(input: HTMLInputElement, files: File[]): void {
+    Object.defineProperty(input, 'files', {
+      configurable: true,
+      get: () => Object.assign(files, { item: (i: number) => files[i] ?? null }),
+    });
+  }
+
+  function pickFile(fixture: ComponentFixture<FileUploadComponent>, file: File): void {
+    const input = fixture.debugElement.query(By.css('input[type="file"]')).nativeElement as HTMLInputElement;
+    setInputFiles(input, [file]);
+    input.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+  }
+
+  function dropFile(fixture: ComponentFixture<FileUploadComponent>, file: File | null): void {
+    const dropZone = fixture.debugElement.query(By.css('button[aria-label^="Área de upload"]'));
+    const dataTransfer = file ? { files: [file] } : { files: [] };
+    dropZone.triggerEventHandler('drop', { preventDefault: () => undefined, dataTransfer });
+    fixture.detectChanges();
+  }
+
+  const VALID_PDF = () => makeFile({ name: 'documento.pdf', type: 'application/pdf', sizeBytes: 1024 });
+  const OVERSIZED_PDF = () =>
+    makeFile({ name: 'grande.pdf', type: 'application/pdf', sizeBytes: 10 * 1024 * 1024 + 1 });
+  const GIF_FILE = () => makeFile({ name: 'foto.gif', type: 'image/gif', sizeBytes: 1024 });
+  const PNG_WITH_GIF_EXTENSION = () =>
+    makeFile({ name: 'foto.gif', type: 'image/png', sizeBytes: 1024 });
+  const UPPERCASE_PDF = () => makeFile({ name: 'RELATORIO.PDF', type: 'application/pdf', sizeBytes: 1024 });
+  const NO_EXTENSION = () => makeFile({ name: 'arquivo', type: 'application/pdf', sizeBytes: 1024 });
+  const MIME_SPOOFED = () => makeFile({ name: 'malicioso.pdf', type: 'text/html', sizeBytes: 1024 });
+
+  it('inicializa com estado vazio', () => {
     const { component } = setup();
-    expect(component).toBeTruthy();
+    expect(component.selectedFile()).toBeNull();
+    expect(component.error()).toBeNull();
+    expect(component.isDragging()).toBe(false);
   });
 
-  it('seleciona arquivo no input', () => {
-    const { fixture, component, getFileInput, fileSelectOutputSpy } = setup();
-    const fileInput = getFileInput();
-    const eventWithFileMock = {
-      target: {
-        files: [VALID_FILE_MOCK]
-      }
-    } as unknown as Event;
-    fileInput.triggerEventHandler('change', eventWithFileMock);
+  it('aceita um arquivo válido via input[type=file]', () => {
+    const { fixture, component } = setup();
+    const file = VALID_PDF();
 
-    fixture.detectChanges();
-    const file = (eventWithFileMock.target as HTMLInputElement).files?.[0];
+    pickFile(fixture, file);
 
-    expect(component.error()).toBe('');
     expect(component.selectedFile()).toBe(file);
-    expect(fileSelectOutputSpy).toHaveBeenCalledWith(file);
-    expect(fileInput.nativeElement.value).toBe('');
+    expect(component.error()).toBeNull();
   });
 
-  it('dispara o evento de dragover no container do input', () => {
-    const { fixture, component, getDivButton, onDragOverSpy } = setup();
-    const uploadButtonDiv = getDivButton();
-    const dragEventEmptyMock = {
-      preventDefault: vi.fn(),
-    } as unknown as DragEvent;
-    uploadButtonDiv.triggerEventHandler('dragover', dragEventEmptyMock);
-    fixture.detectChanges();
+  it('limpa o valor do input após cada seleção para permitir re-selecionar o mesmo arquivo', () => {
+    const { fixture, hiddenInput } = setup();
 
-    expect(onDragOverSpy).toHaveBeenCalled();
-    expect(dragEventEmptyMock.preventDefault).toHaveBeenCalled();
+    pickFile(fixture, VALID_PDF());
+
+    expect((hiddenInput().nativeElement as HTMLInputElement).value).toBe('');
+  });
+
+  it('marca isDragging como true durante dragover e false em dragleave', () => {
+    const { fixture, component, dropZone } = setup();
+
+    dropZone().triggerEventHandler('dragover', { preventDefault: () => undefined });
+    fixture.detectChanges();
     expect(component.isDragging()).toBe(true);
-  });
 
-  it('dispara o evento de dragleave no container do input', () => {
-    const { fixture, component, getDivButton, onDragLeaveSpy } = setup();
-    const uploadButtonDiv = getDivButton();
-    component.isDragging.set(true);
+    dropZone().triggerEventHandler('dragleave', undefined);
     fixture.detectChanges();
-
-    uploadButtonDiv.triggerEventHandler('dragleave');
-    fixture.detectChanges();
-
-    expect(onDragLeaveSpy).toHaveBeenCalled();
     expect(component.isDragging()).toBe(false);
   });
 
-  it('dispara evento drop no container do input quando um arquivo está selecionado', () => {
-    const { fixture, component, getDivButton, fileSelectOutputSpy, getFileInput, onDropSpy } = setup();
-    const uploadButtonDiv = getDivButton();
-    const fileInput = getFileInput();
-    const dragEventWithFileMock = {
-      preventDefault: vi.fn(),
-      dataTransfer: {
-        files: [VALID_FILE_MOCK]
-      }
-    } as unknown as DragEvent;
-    uploadButtonDiv.triggerEventHandler('drop', dragEventWithFileMock);
-    fixture.detectChanges();
+  it('aceita um arquivo válido via drag & drop', () => {
+    const { fixture, component } = setup();
+    const file = VALID_PDF();
 
-    expect(dragEventWithFileMock.preventDefault).toHaveBeenCalled();
-    expect(onDropSpy).toHaveBeenCalled();
+    dropFile(fixture, file);
+
+    expect(component.selectedFile()).toBe(file);
     expect(component.isDragging()).toBe(false);
-    expect(fileSelectOutputSpy).toHaveBeenCalled();
-    expect(fileInput.nativeElement.value).toBe('');
   });
 
-  it(`rejeita arquivos maiores que ${MAX_SIZE_IN_MB.toString()}MB`, () => {
-    const { fixture, component, getFileInput, fileSelectOutputSpy } = setup();
-    const fileInput = getFileInput();
-    const eventWithOversizedFileMock = {
-      target: {
-        files: [OVERSIZED_FILE_MOCK]
-      }
-    } as unknown as Event;
-    fileInput.triggerEventHandler('change', eventWithOversizedFileMock);
-    fixture.detectChanges();
+  it('rejeita drop sem arquivo sem alterar estado', () => {
+    const { fixture, component } = setup();
 
-    expect(fileSelectOutputSpy).not.toHaveBeenCalled();
-    expect(component.error()).toBe(MAX_SIZE_MB_MSG);
-    expect(component.selectedFile()).toBe(null);
+    dropFile(fixture, null);
+
+    expect(component.selectedFile()).toBeNull();
+    expect(component.error()).toBeNull();
   });
 
-  it('emite evento de clique no input quando clica no botão de selecionar arquivo do computador', () => {
-    const { fixture, getSelectButtonEl, fileInputClickSpy } = setup();
-    const selectButtonEl = getSelectButtonEl();
+  it('rejeita arquivo maior que o tamanho máximo configurado', () => {
+    const { fixture, component, errorMessage } = setup();
 
-    selectButtonEl.dispatchEvent(new Event('click'));
-    fixture.detectChanges();
+    pickFile(fixture, OVERSIZED_PDF());
 
-    expect(fileInputClickSpy).toHaveBeenCalled();
+    expect(component.selectedFile()).toBeNull();
+    expect(component.error()).toBe('Arquivo excede o tamanho máximo de 10MB.');
+    expect(errorMessage().nativeElement.textContent).toContain('10MB');
   });
 
-  it('remove um arquivo previamente selecionado', () => {
-    const { fixture, component, getRemoveButtonEl, removeFileSpy } = setup();
-    component.selectedFile.set(VALID_FILE_MOCK);
-    fixture.detectChanges();
+  it('rejeita arquivo cujo MIME não está na whitelist (mesmo com extensão válida)', () => {
+    const { fixture, component } = setup();
 
-    const removeButtonEl = getRemoveButtonEl();
-    removeButtonEl.dispatchEvent(new Event('click'));
-    fixture.detectChanges();
+    pickFile(fixture, MIME_SPOOFED());
 
-    expect(removeFileSpy).toHaveBeenCalled();
-    expect(component.selectedFile()).toBe(null);
-    expect(component.error()).toBe('');
+    expect(component.selectedFile()).toBeNull();
+    expect(component.error()).toContain('Tipo de arquivo não permitido');
   });
 
-  it('emite um evento keydown.enter no container do input', () => {
-    const { fixture, getFileInput, fileInputClickSpy } = setup();
-    const fileInputEl = getFileInput();
+  it('rejeita arquivo cuja extensão não está em accept (mesmo com MIME válido)', () => {
+    const { fixture, component } = setup();
 
-    fileInputEl.triggerEventHandler('keydown.enter', { target: fileInputEl.nativeElement.click() });
-    fixture.detectChanges();
+    pickFile(fixture, PNG_WITH_GIF_EXTENSION());
 
-    expect(fileInputClickSpy).toHaveBeenCalled();
+    expect(component.selectedFile()).toBeNull();
+    expect(component.error()).toContain('Tipo de arquivo não permitido');
   });
 
-  it('rejeita arquivo quando o tipo do arquivo não faz parte dos tipos aceitos', () => {
-    const { fixture, component, getFileInput, onFileSelectedSpy, fileSelectOutputSpy } = setup();
-    const fileInput = getFileInput();
-    const eventWithFileNotAllowedTypeMock = {
-      target: { files: [TYPE_NOT_ALLOWED_FILE_MOCK] }
-    } as unknown as Event;
+  it('rejeita arquivo sem nenhuma extensão', () => {
+    const { fixture, component } = setup();
 
-    fileInput.triggerEventHandler('change', eventWithFileNotAllowedTypeMock);
-    fixture.detectChanges();
-    const file = (eventWithFileNotAllowedTypeMock.target as HTMLInputElement).files?.[0];
+    pickFile(fixture, NO_EXTENSION());
 
-    expect(component.error()).toBe(TYPE_NOT_ALLOWED_MSG);
-    expect(file?.size).toBe(MAX_SIZE_IN_BYTES);
-    expect(onFileSelectedSpy).toHaveBeenCalledWith(eventWithFileNotAllowedTypeMock);
-    expect(fileInput.nativeElement.value).toBe('');
-    expect(fileSelectOutputSpy).not.toHaveBeenCalled();
-    expect(component.selectedFile()).toBe(null);
-    expect(fileInput.nativeElement.value).toBe('');
+    expect(component.selectedFile()).toBeNull();
+    expect(component.error()).toContain('Tipo de arquivo não permitido');
   });
 
-  it('rejeita arquivo quando a extensão do arquivo não faz parte das extensões aceitas', () => {
-    const { fixture, component, getFileInput, onFileSelectedSpy, fileSelectOutputSpy } = setup();
-    const fileInput = getFileInput();
-    const eventWithFileNotAllowedExtensionMock = {
-      target: {
-        files: [EXTENSION_NOT_ALLOWED_FILE_MOCK]
-      }
-    } as unknown as Event;
+  it('aceita arquivo com extensão em maiúsculas (case-insensitive)', () => {
+    const { fixture, component } = setup();
+    const file = UPPERCASE_PDF();
 
-    fileInput.triggerEventHandler('change', eventWithFileNotAllowedExtensionMock);
+    pickFile(fixture, file);
+
+    expect(component.selectedFile()).toBe(file);
+    expect(component.error()).toBeNull();
+  });
+
+  it('rejeita GIF independentemente de extensão e MIME', () => {
+    const { fixture, component } = setup();
+
+    pickFile(fixture, GIF_FILE());
+
+    expect(component.selectedFile()).toBeNull();
+    expect(component.error()).toContain('Tipo de arquivo não permitido');
+  });
+
+  it('respeita o accept configurado pelo consumidor (.pdf apenas)', () => {
+    const { fixture, component } = setup();
+    fixture.componentRef.setInput('accept', '.pdf');
+    fixture.componentRef.setInput('allowedMimeTypes', ['application/pdf']);
     fixture.detectChanges();
 
-    expect(onFileSelectedSpy).toHaveBeenCalledWith(eventWithFileNotAllowedExtensionMock);
-    expect(fileSelectOutputSpy).not.toHaveBeenCalled();
-    expect(component.error()).toBe(TYPE_NOT_ALLOWED_MSG);
-    expect(fileInput.nativeElement.value).toBe('');
+    pickFile(fixture, makeFile({ name: 'foto.png', type: 'image/png', sizeBytes: 1024 }));
+
+    expect(component.selectedFile()).toBeNull();
+    expect(component.error()).toBe('Tipo de arquivo não permitido. Envie arquivos nos formatos: .pdf');
+  });
+
+  it('respeita o maxSizeMb configurado pelo consumidor', () => {
+    const { fixture, component } = setup();
+    fixture.componentRef.setInput('maxSizeMb', 1);
+    fixture.detectChanges();
+
+    pickFile(fixture, makeFile({ name: 'doc.pdf', type: 'application/pdf', sizeBytes: 1024 * 1024 + 1 }));
+
+    expect(component.selectedFile()).toBeNull();
+    expect(component.error()).toBe('Arquivo excede o tamanho máximo de 1MB.');
+  });
+
+  it('atualiza a mensagem de tipo não permitido quando accept muda em runtime', () => {
+    const { fixture, component } = setup();
+
+    pickFile(fixture, GIF_FILE());
+    expect(component.error()).toContain('.pdf,.jpg,.jpeg,.png');
+
+    fixture.componentRef.setInput('accept', '.pdf');
+    fixture.componentRef.setInput('allowedMimeTypes', ['application/pdf']);
+    fixture.detectChanges();
+    pickFile(fixture, GIF_FILE());
+
+    expect(component.error()).toBe('Tipo de arquivo não permitido. Envie arquivos nos formatos: .pdf');
+  });
+
+  it('limpa estado quando o usuário clica em Remover', () => {
+    const { fixture, component, removeButton } = setup();
+    pickFile(fixture, VALID_PDF());
+
+    removeButton().triggerEventHandler('click', new MouseEvent('click'));
+    fixture.detectChanges();
+
+    expect(component.selectedFile()).toBeNull();
+    expect(component.error()).toBeNull();
+  });
+
+  it('abre o seletor de arquivo nativo ao clicar na área de drop', () => {
+    const { fixture, component, dropZone } = setup();
+    const inputElement = component.fileInput().nativeElement;
+    const clicks: number[] = [];
+    inputElement.click = () => clicks.push(1);
+
+    dropZone().triggerEventHandler('click', new MouseEvent('click'));
+    fixture.detectChanges();
+
+    expect(clicks.length).toBe(1);
+  });
+
+  it('é renderizado como <button> nativo (acessível por teclado Enter e Space sem handler manual)', () => {
+    const { dropZone } = setup();
+    expect(dropZone().nativeElement.tagName).toBe('BUTTON');
+    expect(dropZone().nativeElement.getAttribute('type')).toBe('button');
+  });
+
+  it('expõe a mensagem de erro com role=alert para leitores de tela', () => {
+    const { fixture, errorMessage } = setup();
+    pickFile(fixture, OVERSIZED_PDF());
+
+    expect(errorMessage().nativeElement.getAttribute('role')).toBe('alert');
+  });
+
+  it('substitui um arquivo previamente selecionado quando outro é escolhido', () => {
+    const { fixture, component } = setup();
+    const first = VALID_PDF();
+    const second = makeFile({ name: 'outro.pdf', type: 'application/pdf', sizeBytes: 2048 });
+
+    pickFile(fixture, first);
+    pickFile(fixture, second);
+
+    expect(component.selectedFile()).toBe(second);
+  });
+
+  it('limpa o erro anterior quando uma nova seleção válida é feita', () => {
+    const { fixture, component } = setup();
+
+    pickFile(fixture, OVERSIZED_PDF());
+    expect(component.error()).not.toBeNull();
+
+    pickFile(fixture, VALID_PDF());
+    expect(component.error()).toBeNull();
+  });
+
+  it('rejeita drop com arquivo inválido sem alterar selectedFile prévio', () => {
+    const { fixture, component } = setup();
+    const valid = VALID_PDF();
+    pickFile(fixture, valid);
+
+    dropFile(fixture, GIF_FILE());
+
+    expect(component.selectedFile()).toBe(valid);
+    expect(component.error()).toContain('Tipo de arquivo não permitido');
   });
 });

--- a/libs/shared-ui/src/lib/components/file-upload/file-upload.ts
+++ b/libs/shared-ui/src/lib/components/file-upload/file-upload.ts
@@ -18,7 +18,7 @@ type ValidationResult = { ok: true } | { ok: false; reason: string };
   template: `
     <div class="flex flex-col gap-2">
       @if (label()) {
-        <label for="file-upload-input" class="text-sm font-medium text-gray-700">{{ label() }}</label>
+        <label [attr.for]="inputId" class="text-sm font-medium text-gray-700">{{ label() }}</label>
       }
       <button
         #dropZone
@@ -27,7 +27,7 @@ type ValidationResult = { ok: true } | { ok: false; reason: string };
         [class.border-unifesspa-primary]="isDragging()"
         [class.bg-blue-50]="isDragging()"
         [attr.aria-label]="ariaLabel()"
-        [attr.aria-describedby]="error() ? 'file-upload-error' : null"
+        [attr.aria-describedby]="error() ? errorId : null"
         (click)="openFilePicker()"
         (dragover)="$event.preventDefault(); onDragOver()"
         (dragleave)="onDragLeave()"
@@ -45,7 +45,7 @@ type ValidationResult = { ok: true } | { ok: false; reason: string };
       </button>
       <input
         #fileInput
-        id="file-upload-input"
+        [id]="inputId"
         type="file"
         class="hidden"
         [accept]="accept()"
@@ -66,12 +66,20 @@ type ValidationResult = { ok: true } | { ok: false; reason: string };
         </div>
       }
       @if (error(); as message) {
-        <small id="file-upload-error" class="text-xs text-red-600" role="alert">{{ message }}</small>
+        <small [id]="errorId" class="text-xs text-red-600" role="alert">{{ message }}</small>
       }
     </div>
   `,
 })
 export class FileUploadComponent {
+  // Garante IDs únicos por instância para isolar `for`/`aria-describedby`
+  // quando há múltiplos `<ui-file-upload>` na mesma página.
+  private static instanceCount = 0;
+  private readonly instanceId = `ui-file-upload-${++FileUploadComponent.instanceCount}`;
+
+  readonly inputId = `${this.instanceId}-input`;
+  readonly errorId = `${this.instanceId}-error`;
+
   readonly label = input<string>('');
   readonly accept = input<string>('.pdf,.jpg,.jpeg,.png');
   readonly allowedMimeTypes = input<readonly string[]>([

--- a/libs/shared-ui/src/lib/components/file-upload/file-upload.ts
+++ b/libs/shared-ui/src/lib/components/file-upload/file-upload.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, input, output, signal } from '@angular/core';
+import { Component, ChangeDetectionStrategy, input, output, signal, viewChild, ElementRef } from '@angular/core';
 
 @Component({
   selector: 'ui-file-upload',
@@ -59,14 +59,16 @@ import { Component, ChangeDetectionStrategy, input, output, signal } from '@angu
 export class FileUploadComponent {
   readonly label = input<string>('');
   readonly accept = input<string>('.pdf,.jpg,.jpeg,.png');
+  readonly allowedMimeType = input<string[]>(['application/pdf' ,'image/jpg', 'image/jpeg', 'image/png']);
   readonly acceptLabel = input<string>('PDF, JPG ou PNG');
   readonly maxSizeMb = input<number>(10);
-
+  readonly typeNotAllowedMsg = signal(`Tipo de arquivo não permitido. Envie arquivos nos formatos: ${this.accept()}`);
   readonly fileSelected = output<File>();
 
   readonly selectedFile = signal<File | null>(null);
   readonly isDragging = signal(false);
   readonly error = signal<string>('');
+  readonly fileInput = viewChild<ElementRef>('fileInput');
 
   onDragOver(event: DragEvent): void {
     event.preventDefault();
@@ -104,6 +106,12 @@ export class FileUploadComponent {
     const maxBytes = this.maxSizeMb() * 1024 * 1024;
     if (file.size > maxBytes) {
       this.error.set(`Arquivo excede o tamanho máximo de ${this.maxSizeMb()}MB.`);
+      return;
+    }
+
+    const extension = file.name.slice(file.name.lastIndexOf("."));
+    if (!this.allowedMimeType().includes(file.type) || !this.accept().split(',').includes(extension)) {
+      this.error.set(this.typeNotAllowedMsg());
       return;
     }
     this.error.set('');

--- a/libs/shared-ui/src/lib/components/file-upload/file-upload.ts
+++ b/libs/shared-ui/src/lib/components/file-upload/file-upload.ts
@@ -1,57 +1,72 @@
-import { Component, ChangeDetectionStrategy, input, output, signal, viewChild, ElementRef } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  computed,
+  input,
+  model,
+  signal,
+  viewChild,
+} from '@angular/core';
+
+type ValidationResult = { ok: true } | { ok: false; reason: string };
 
 @Component({
   selector: 'ui-file-upload',
   standalone: true,
-  imports: [],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="flex flex-col gap-2">
       @if (label()) {
         <label for="file-upload-input" class="text-sm font-medium text-gray-700">{{ label() }}</label>
       }
-      <div
-        class="flex items-center justify-center rounded-lg border-2 border-dashed border-gray-300 px-6 py-8 transition-colors"
+      <button
+        #dropZone
+        type="button"
+        class="flex w-full items-center justify-center rounded-lg border-2 border-dashed border-gray-300 px-6 py-8 text-left transition-colors hover:border-unifesspa-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-unifesspa-primary"
         [class.border-unifesspa-primary]="isDragging()"
         [class.bg-blue-50]="isDragging()"
-        (dragover)="onDragOver($event)"
+        [attr.aria-label]="ariaLabel()"
+        [attr.aria-describedby]="error() ? 'file-upload-error' : null"
+        (click)="openFilePicker()"
+        (dragover)="$event.preventDefault(); onDragOver()"
         (dragleave)="onDragLeave()"
-        (drop)="onDrop($event)"
-        role="button"
-        tabindex="0"
-        [attr.aria-label]="'Área de upload de arquivo'"
-        (keydown.enter)="fileInput.click()"
+        (drop)="$event.preventDefault(); onDrop($event.dataTransfer?.files)"
       >
         <div class="text-center">
           <p class="text-sm text-gray-600">
             Arraste um arquivo aqui ou
-            <button type="button" class="font-medium text-unifesspa-primary hover:underline" (click)="fileInput.click()">
-              selecione do computador
-            </button>
+            <span class="font-medium text-unifesspa-primary underline">selecione do computador</span>
           </p>
           <p class="mt-1 text-xs text-gray-500">
             {{ acceptLabel() }} &mdash; Tamanho máximo: {{ maxSizeMb() }}MB
           </p>
         </div>
-      </div>
+      </button>
       <input
         #fileInput
         id="file-upload-input"
         type="file"
         class="hidden"
         [accept]="accept()"
-        (change)="onFileSelected($event)"
+        (change)="onFilesPicked(fileInput)"
       />
-      @if (selectedFile()) {
-      <div class="flex items-center justify-between rounded-md bg-gray-100 px-3 py-2">
-        <span class="text-sm text-gray-700">{{ selectedFile()?.name }}</span>
-        <button type="button" class="text-sm text-red-600 hover:underline" (click)="removeFile()" aria-label="Remover arquivo">
-          Remover
-        </button>
-      </div>
+      @let file = selectedFile();
+      @if (file) {
+        <div class="flex items-center justify-between rounded-md bg-gray-100 px-3 py-2">
+          <span class="text-sm text-gray-700">{{ file.name }}</span>
+          <button
+            type="button"
+            class="text-sm text-red-600 hover:underline"
+            (click)="removeFile()"
+            aria-label="Remover arquivo"
+          >
+            Remover
+          </button>
+        </div>
       }
-      @if (error()) {
-        <small class="text-xs text-red-600">{{ error() }}</small>
+      @if (error(); as message) {
+        <small id="file-upload-error" class="text-xs text-red-600" role="alert">{{ message }}</small>
       }
     </div>
   `,
@@ -59,19 +74,43 @@ import { Component, ChangeDetectionStrategy, input, output, signal, viewChild, E
 export class FileUploadComponent {
   readonly label = input<string>('');
   readonly accept = input<string>('.pdf,.jpg,.jpeg,.png');
-  readonly allowedMimeType = input<string[]>(['application/pdf' ,'image/jpg', 'image/jpeg', 'image/png']);
+  readonly allowedMimeTypes = input<readonly string[]>([
+    'application/pdf',
+    'image/jpg',
+    'image/jpeg',
+    'image/png',
+  ]);
   readonly acceptLabel = input<string>('PDF, JPG ou PNG');
   readonly maxSizeMb = input<number>(10);
-  readonly typeNotAllowedMsg = signal(`Tipo de arquivo não permitido. Envie arquivos nos formatos: ${this.accept()}`);
-  readonly fileSelected = output<File>();
 
-  readonly selectedFile = signal<File | null>(null);
+  readonly selectedFile = model<File | null>(null);
   readonly isDragging = signal(false);
-  readonly error = signal<string>('');
-  readonly fileInput = viewChild<ElementRef>('fileInput');
+  readonly error = signal<string | null>(null);
 
-  onDragOver(event: DragEvent): void {
-    event.preventDefault();
+  readonly fileInput = viewChild.required<ElementRef<HTMLInputElement>>('fileInput');
+
+  readonly ariaLabel = computed(
+    () => `Área de upload de arquivo. ${this.acceptLabel()}. Tamanho máximo ${this.maxSizeMb()}MB.`,
+  );
+
+  private readonly maxBytes = computed(() => this.maxSizeMb() * 1024 * 1024);
+  private readonly acceptedExtensions = computed(() =>
+    this.accept()
+      .split(',')
+      .map((extension) => extension.trim().toLowerCase())
+      .filter((extension) => extension.length > 0),
+  );
+  private readonly normalizedMimeTypes = computed(() =>
+    this.allowedMimeTypes().map((type) => type.toLowerCase()),
+  );
+  private readonly maxSizeError = computed(
+    () => `Arquivo excede o tamanho máximo de ${this.maxSizeMb()}MB.`,
+  );
+  private readonly typeNotAllowedError = computed(
+    () => `Tipo de arquivo não permitido. Envie arquivos nos formatos: ${this.accept()}`,
+  );
+
+  onDragOver(): void {
     this.isDragging.set(true);
   }
 
@@ -79,43 +118,58 @@ export class FileUploadComponent {
     this.isDragging.set(false);
   }
 
-  onDrop(event: DragEvent): void {
-    event.preventDefault();
+  onDrop(files: FileList | null | undefined): void {
     this.isDragging.set(false);
-    const file = event.dataTransfer?.files[0];
-    if (file) {
-      this.validateAndSelect(file);
-    }
+    const file = files?.[0];
+    if (file) this.handleFile(file);
   }
 
-  onFileSelected(event: Event): void {
-    const input = event.target as HTMLInputElement;
+  onFilesPicked(input: HTMLInputElement): void {
     const file = input.files?.[0];
-    if (file) {
-      this.validateAndSelect(file);
-    }
+    if (file) this.handleFile(file);
     input.value = '';
   }
 
   removeFile(): void {
     this.selectedFile.set(null);
-    this.error.set('');
+    this.error.set(null);
   }
 
-  private validateAndSelect(file: File): void {
-    const maxBytes = this.maxSizeMb() * 1024 * 1024;
-    if (file.size > maxBytes) {
-      this.error.set(`Arquivo excede o tamanho máximo de ${this.maxSizeMb()}MB.`);
-      return;
-    }
+  openFilePicker(): void {
+    this.fileInput().nativeElement.click();
+  }
 
-    const extension = file.name.slice(file.name.lastIndexOf("."));
-    if (!this.allowedMimeType().includes(file.type) || !this.accept().split(',').includes(extension)) {
-      this.error.set(this.typeNotAllowedMsg());
+  // Validação client-side é UX/anti-engano. A fronteira real de segurança
+  // (magic bytes, antivírus) é responsabilidade do servidor — ver ADR-012
+  // (quarentena → ClamAV → bucket definitivo).
+  private handleFile(file: File): void {
+    const result = this.validate(file);
+    if (!result.ok) {
+      this.error.set(result.reason);
       return;
     }
-    this.error.set('');
+    this.error.set(null);
     this.selectedFile.set(file);
-    this.fileSelected.emit(file);
+  }
+
+  private validate(file: File): ValidationResult {
+    if (file.size > this.maxBytes()) {
+      return { ok: false, reason: this.maxSizeError() };
+    }
+    if (!this.isMimeAllowed(file) || !this.isExtensionAllowed(file)) {
+      return { ok: false, reason: this.typeNotAllowedError() };
+    }
+    return { ok: true };
+  }
+
+  private isMimeAllowed(file: File): boolean {
+    return this.normalizedMimeTypes().includes(file.type.toLowerCase());
+  }
+
+  private isExtensionAllowed(file: File): boolean {
+    const dotIndex = file.name.lastIndexOf('.');
+    if (dotIndex < 0) return false;
+    const extension = file.name.slice(dotIndex).toLowerCase();
+    return this.acceptedExtensions().includes(extension);
   }
 }


### PR DESCRIPTION
## Resumo
A seguir será apresentado as atividades de forma resumida:
- Adição de validação de tipo
- Adição de validação por extensão
- Testes unitários 
 
Closes #6 

## Motivação
Atualmente o componente `FileUploadComponent` da lib shared-ui valida apenas tamanho do arquivo. Ao mesmo tempo o componente não possui testes unitários. Logo faz-se necessário criar os testes unitários para alcançar a meta de no mínimo de 80% de cobertura.
## Mudanças

### Novos arquivos
libs/shared-ui/src/lib/components/file-upload/file-upload.spec.ts

### Modificados
libs/shared-ui/src/lib/components/file-upload/file-upload.ts

## Checklist

- [x] Validação por tipo de arquivo
- [x] Validação por extensão
- [x] Validação no momento da seleção do arquivo e no drag & drop
- [x] Testes unitários
- [x] Exibe mensagem de erro em pt-BR quando o tipo não é permitido 