### PR TITLE
chore(api-codegen): sincroniza baseline OpenAPI selecao com cursor pagination (#187)

### DIFF
--- a/libs/shared-data/openapi/selecao.openapi.json
+++ b/libs/shared-data/openapi/selecao.openapi.json
@@ -191,22 +191,19 @@
         ],
         "parameters": [
           {
-            "name": "AfterId",
+            "name": "cursor",
             "in": "query",
+            "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "type": "string"
             }
           },
           {
-            "name": "Limit",
+            "name": "limit",
             "in": "query",
+            "description": "Tamanho m\u00E1ximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026).",
             "schema": {
-              "pattern": "^-?(?:0|[1-9]\\d*)$",
-              "type": [
-                "integer",
-                "string"
-              ],
+              "type": "integer",
               "format": "int32"
             }
           }
@@ -214,6 +211,21 @@
         "responses": {
           "200": {
             "description": "OK",
+            "headers": {
+              "Link": {
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022next\u0022 s\u00F3 quando h\u00E1 pr\u00F3xima p\u00E1gina. Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 (ADR-0026).",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Quantidade de itens retornados na p\u00E1gina atual (sempre menor ou igual ao limit efetivo).",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
             "content": {
               "text/plain": {
                 "schema": {
@@ -281,7 +293,8 @@
               }
             }
           }
-        }
+        },
+        "x-uniplus-paginated": true
       }
     },
     "/api/editais/{id}": {

--- a/libs/shared-data/src/lib/api/selecao/schema.ts
+++ b/libs/shared-data/src/lib/api/selecao/schema.ts
@@ -54,8 +54,10 @@ export interface paths {
         readonly get: {
             readonly parameters: {
                 readonly query?: {
-                    readonly AfterId?: string;
-                    readonly Limit?: number | string;
+                    /** @description Cursor opaco AES-GCM emitido pelo servidor no header Link da página anterior. Ausente na primeira página. Cliente trata como string opaca — não decodificar (ADR-0026, ADR-0031). */
+                    readonly cursor?: string;
+                    /** @description Tamanho máximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026). */
+                    readonly limit?: number;
                 };
                 readonly header?: never;
                 readonly path?: never;
@@ -66,6 +68,10 @@ export interface paths {
                 /** @description OK */
                 readonly 200: {
                     headers: {
+                        /** @description Links de navegação da paginação (RFC 5988/8288). rel="self" sempre presente; rel="next" só quando há próxima página. Cada link carrega o cursor opaco no parâmetro `cursor` (ADR-0026). */
+                        readonly Link?: string;
+                        /** @description Quantidade de itens retornados na página atual (sempre menor ou igual ao limit efetivo). */
+                        readonly "X-Page-Size"?: number;
                         readonly [name: string]: unknown;
                     };
                     content: {


### PR DESCRIPTION
## Resumo

Pull do baseline corrigido em \`uniplus-api/contracts/openapi.selecao.json\` após merge do [PR uniplus-api#333](https://github.com/unifesspa-edu-br/uniplus-api/pull/333) (commit `1836962`). \`GET /api/editais\` agora declara o contrato wire fixado pela ADR-0026:

- query params \`cursor\` (string opaca AES-GCM) + \`limit\` (int) — antes vazavam \`AfterId\`/\`Limit\` do PageRequest interno do backend
- response 200 headers \`Link\` (RFC 5988/8288) + \`X-Page-Size\` — antes ausentes
- extension \`x-uniplus-paginated: true\` para detecção client-side

\`schema.ts\` regenerado via \`openapi-typescript\` ([ADR-0013](docs/adrs/0013-codegen-openapi-typescript-node-only.md), codegen Node-only). Descrições em pt-BR preservadas; \`AfterId\` removido; \`cursor\` passa a ser opt-in.

## Foundation para Frente 4

Esta sync destrava a Frente 4 do Frontend Milestone B (helpers \`parseLink\` / \`extractNextCursor\` + tipo \`Cursor\` opaco em \`shared-core/http/\`) que vai consumir o contrato wire correto. Sem o sync, o codegen produziria tipos errados (\`AfterId\`/\`Limit\`) divergentes do runtime real.

## Aderência aos critérios de aceite (#187)

- ✅ **CA-01:** Baseline em \`libs/shared-data/openapi/selecao.openapi.json\` bate com \`uniplus-api/contracts/openapi.selecao.json\` em commit \`1836962\`.
- ✅ **CA-02:** \`generate-api-clients.sh\` rodado; \`schema.ts\` regenerado.
- ✅ **CA-03:** Schema gerado tem \`cursor\`/\`limit\`; \`AfterId\` ausente (\`grep -c AfterId schema.ts → 0\`).
- ✅ **CA-04:** Schema declara \`Link\` e \`X-Page-Size\` no response 200 com descrições.
- ✅ **CA-05:** \`npx nx affected --target=lint,test,typecheck,build --base=origin/main\` verde (8 projetos + 2 deps, 0 erros).
- ✅ **CA-06:** Drift check em CI deve passar (codegen idempotente).

## Test plan

- [x] Codegen rodado (\`bash libs/shared-data/scripts/generate-api-clients.sh\`).
- [x] \`grep -c AfterId\` em \`schema.ts\` = 0 (vazado eliminado).
- [x] Snippet do schema bate com expected:
  - linhas 57-60: \`cursor\` + \`limit\` query params com descrições ADR-0026.
  - linhas 71-74: \`Link\` + \`X-Page-Size\` response headers RFC 5988/8288.
- [x] \`npx nx affected --target=lint,test,typecheck,build\` — 8 projetos verdes.
- [ ] CI verde no PR.
- [ ] Codex review absorvido.

## Não-escopo

- Implementação dos helpers F4 (\`parseLink\`, \`extractNextCursor\`, \`Cursor\` branded type) — issues separadas.
- Atualização do \`EditaisApi\` ou outros services — quando consumer real surgir (Frente 6 do plano).
- \`ingresso.openapi.json\` — não tem endpoints com \`[FromCursor]\` ainda; baseline preservada.

## Referências

- Issue: #187
- [PR uniplus-api#333](https://github.com/unifesspa-edu-br/uniplus-api/pull/333) — fix root cause (mergeado).
- [Issue uniplus-api#332](https://github.com/unifesspa-edu-br/uniplus-api/issues/332) — bug original.
- ADRs: [ADR-0013](docs/adrs/0013-codegen-openapi-typescript-node-only.md) (codegen Node-only), [ADR-0026 (uniplus-api)](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0026-paginacao-cursor-opaco-cifrado.md) (cursor opaco), [ADR-0031 (uniplus-api)](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0031-decoding-de-cursor-opaco-no-boundary-http.md) (decode no boundary).

Closes #187