### PR TITLE
feat(shared-core): cursor pagination helpers + Link header parser (#191)

### DIFF
--- a/docs/adrs/0015-cursor-pagination-consumer-link-header.md
+++ b/docs/adrs/0015-cursor-pagination-consumer-link-header.md
@@ -1,5 +1,5 @@
 ---
-status: "proposed"
+status: "accepted"
 date: "2026-05-06"
 decision-makers:
   - "Tech Lead (CTIC)"
@@ -136,3 +136,23 @@ this.editaisApi.listar(this.cursor()).subscribe(result => {
 - [RFC 5988](https://www.rfc-editor.org/rfc/rfc5988.html) / [RFC 8288](https://www.rfc-editor.org/rfc/rfc8288.html) — Web Linking.
 - [TypeScript branded types](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-9.html#unique-symbol) — `unique symbol` desde 2.9.
 - Plano Frontend Milestone B (Frente 4) — `~/.claude/plans/novo-plano-para-implementar-glistening-petal.md`.
+
+## Implementação (2026-05-06)
+
+A entrega da Story [#191](https://github.com/unifesspa-edu-br/uniplus-web/issues/191) materializa a decisão. Status promovido de `proposed` para `accepted` no merge.
+
+### Arquivos criados/modificados
+
+- `libs/shared-core/src/lib/http/link-header.ts` (criado) — parser RFC 5988/8288 puro TypeScript: `parseLink(headerValue): Map<rel, ParsedLink>`. Tokenizer char-by-char preserva vírgulas e ponto-e-vírgulas dentro de quoted-strings (com escape `\\`). Suporta `rel="self next"` (RFC 5988 §5.3.1) registrando uma entrada por valor. Param keys são lowercased.
+- `libs/shared-core/src/lib/http/pagination.ts` (criado) — `Cursor` branded type via `unique symbol`; `createCursor(value: string): Cursor`; `cursorToString(cursor: Cursor): string`; `extractNextCursor(linkHeader): Cursor | null` consome `parseLink` e extrai o valor do query param `cursor=` da URI do `rel="next"`. Decode percent-encoded values com fallback a `null` em malformed.
+- `libs/shared-core/src/lib/http/link-header.spec.ts` (criado) — 22 cenários cobrindo: header ausente/vazio (4), 1 link-value (3), múltiplos link-values (3), `rel` multi-valor (1), aspas/ponto-e-vírgula/vírgula escapadas em quoted-string (3), formas defensivas (5).
+- `libs/shared-core/src/lib/http/pagination.spec.ts` (criado) — 19 cenários cobrindo: branded type (3), happy paths de `extractNextCursor` (6), retornos `null` legítimos (5), formas defensivas (5).
+- `libs/shared-core/src/lib/http/index.ts` (atualizado) — re-exporta `parseLink`, `ParsedLink`, `createCursor`, `cursorToString`, `extractNextCursor`, `Cursor`.
+
+### Pontos não-óbvios capturados na implementação
+
+- **`rel="next"` sem `cursor=` retorna `null`** em vez de `Cursor` com string vazia. Justificativa: um `rel="next"` que não carrega cursor opaco é defeituoso server-side; tratá-lo como ausência preserva a invariante "cliente nunca decide o cursor".
+- **`decodeURIComponent` envelopado em try/catch** — servidor mandando `%2` ou `%XY` lança `URIError`; convertemos para `null` em vez de propagar exception ao consumer.
+- **Quando dois link-values declaram o mesmo `rel`, o primeiro vence.** RFC 5988 não proíbe duplicatas mas também não define semântica; escolhemos determinismo previsível.
+- **Hash fragment (`#...`) é descartado** ao extrair query string — embora paginação por cursor não use fragment, ser defensivo evita bug se algum endpoint futuro emitir.
+- **Branded type em runtime é apenas string** — `JSON.stringify(cursor)` funciona, comparação `cursor === otherCursor` funciona; o branding só vive no compile time. Isso é desejável: serialização para query param/storage transparente.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -43,7 +43,7 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0012](0012-placement-api-result-em-shared-core.md) | Placement do `ApiResult<T>` em subpasta de `shared-core`, não em nova lib | accepted | 2026-05-04 |
 | [0013](0013-gerador-openapi-node-only.md) | Gerador OpenAPI Node-only (`openapi-typescript`) em vez de `openapi-generator-cli` | accepted | 2026-05-05 |
 | [0014](0014-idempotency-key-cliente-via-http-context.md) | Idempotency-Key cliente via `HttpContext` + UUID v7, anexado pelo `apiResultInterceptor` | accepted | 2026-05-05 |
-| [0015](0015-cursor-pagination-consumer-link-header.md) | Cursor pagination consumer via parser de `Link` header — decode no caller, não no interceptor | proposed | 2026-05-06 |
+| [0015](0015-cursor-pagination-consumer-link-header.md) | Cursor pagination consumer via parser de `Link` header — decode no caller, não no interceptor | accepted | 2026-05-06 |
 
 ## Como adicionar um novo ADR
 

--- a/libs/shared-core/src/lib/http/index.ts
+++ b/libs/shared-core/src/lib/http/index.ts
@@ -22,6 +22,12 @@ export {
   withIdempotencyKey,
 } from './idempotency';
 
+export { parseLink } from './link-header';
+export type { ParsedLink } from './link-header';
+
+export { createCursor, cursorToString, extractNextCursor } from './pagination';
+export type { Cursor } from './pagination';
+
 export { CLIENT_PROBLEM_CODES } from './problem-details';
 export type {
   ClientProblemCode,

--- a/libs/shared-core/src/lib/http/link-header.spec.ts
+++ b/libs/shared-core/src/lib/http/link-header.spec.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+import { parseLink } from './link-header';
+
+describe('parseLink — RFC 5988/8288 (ADR-0015)', () => {
+  describe('header ausente ou vazio', () => {
+    it('retorna Map vazio quando header é null', () => {
+      expect(parseLink(null).size).toBe(0);
+    });
+
+    it('retorna Map vazio quando header é undefined', () => {
+      expect(parseLink(undefined).size).toBe(0);
+    });
+
+    it('retorna Map vazio quando header é string vazia', () => {
+      expect(parseLink('').size).toBe(0);
+    });
+
+    it('retorna Map vazio quando header é só whitespace', () => {
+      expect(parseLink('   \t\n  ').size).toBe(0);
+    });
+  });
+
+  describe('header com 1 link-value', () => {
+    it('parseia rel="next" único e expõe URI completa', () => {
+      const links = parseLink(
+        '<https://api.uniplus.unifesspa.edu.br/api/editais?cursor=ABC123>; rel="next"',
+      );
+      expect(links.size).toBe(1);
+      const next = links.get('next');
+      expect(next?.uri).toBe('https://api.uniplus.unifesspa.edu.br/api/editais?cursor=ABC123');
+      expect(next?.params['rel']).toBe('next');
+    });
+
+    it('parseia URI com query string complexa preservando ordem dos params', () => {
+      const links = parseLink(
+        '<https://api.example.com/x?status=open&limit=20&cursor=abc%3Ddef>; rel="next"',
+      );
+      const next = links.get('next');
+      expect(next?.uri).toBe('https://api.example.com/x?status=open&limit=20&cursor=abc%3Ddef');
+    });
+
+    it('aceita link-value sem aspas no rel (token simples)', () => {
+      const links = parseLink('<https://api/x>; rel=next');
+      expect(links.get('next')?.uri).toBe('https://api/x');
+    });
+  });
+
+  describe('header com múltiplos link-values', () => {
+    it('parseia rel="self" + rel="next" em entradas separadas', () => {
+      const links = parseLink(
+        '<https://api/x?cursor=A>; rel="self", <https://api/x?cursor=B>; rel="next"',
+      );
+      expect(links.size).toBe(2);
+      expect(links.get('self')?.uri).toBe('https://api/x?cursor=A');
+      expect(links.get('next')?.uri).toBe('https://api/x?cursor=B');
+    });
+
+    it('parseia self + next + prev em três entradas', () => {
+      const links = parseLink(
+        '<https://api/x>; rel="self", <https://api/x?cursor=N>; rel="next", <https://api/x?cursor=P>; rel="prev"',
+      );
+      expect(links.size).toBe(3);
+      expect(links.get('self')).toBeDefined();
+      expect(links.get('next')).toBeDefined();
+      expect(links.get('prev')).toBeDefined();
+    });
+
+    it('quando dois link-values declaram o mesmo rel, o primeiro vence', () => {
+      const links = parseLink(
+        '<https://api/x?cursor=PRIMEIRO>; rel="next", <https://api/x?cursor=SEGUNDO>; rel="next"',
+      );
+      expect(links.size).toBe(1);
+      expect(links.get('next')?.uri).toBe('https://api/x?cursor=PRIMEIRO');
+    });
+  });
+
+  describe('rel com múltiplos valores (RFC 5988 §5.3.1)', () => {
+    it('rel="self next" registra entradas separadas para self e next apontando para o mesmo link', () => {
+      const links = parseLink('<https://api/x>; rel="self next"');
+      expect(links.size).toBe(2);
+      expect(links.get('self')?.uri).toBe('https://api/x');
+      expect(links.get('next')?.uri).toBe('https://api/x');
+    });
+  });
+
+  describe('params com aspas escapadas', () => {
+    it('preserva aspas internas escapadas no valor de title', () => {
+      const links = parseLink(
+        '<https://api/x>; rel="next"; title="Página \\"importante\\""',
+      );
+      expect(links.get('next')?.params['title']).toBe('Página "importante"');
+    });
+
+    it('vírgula dentro de quoted-string não quebra a separação de link-values', () => {
+      const links = parseLink(
+        '<https://api/x>; rel="next"; title="primeiro, depois", <https://api/y>; rel="prev"',
+      );
+      expect(links.size).toBe(2);
+      expect(links.get('next')?.params['title']).toBe('primeiro, depois');
+      expect(links.get('prev')?.uri).toBe('https://api/y');
+    });
+
+    it('ponto-e-vírgula dentro de quoted-string não quebra params', () => {
+      const links = parseLink('<https://api/x>; rel="next"; title="a; b"');
+      expect(links.get('next')?.params['title']).toBe('a; b');
+    });
+  });
+
+  describe('formas defensivas', () => {
+    it('ignora link-value sem rel (RFC permite mas não tem uso prático)', () => {
+      const links = parseLink('<https://api/x>; title="sem rel"');
+      expect(links.size).toBe(0);
+    });
+
+    it('ignora link-value malformado (sem <>)', () => {
+      const links = parseLink('https://api/x; rel="next", <https://api/y>; rel="prev"');
+      expect(links.size).toBe(1);
+      expect(links.get('prev')?.uri).toBe('https://api/y');
+    });
+
+    it('aceita param sem valor (flag) — armazena string vazia', () => {
+      const links = parseLink('<https://api/x>; rel="next"; deprecated');
+      expect(links.get('next')?.params['deprecated']).toBe('');
+    });
+
+    it('keys de params são case-insensitive (lowercased)', () => {
+      const links = parseLink('<https://api/x>; REL="next"; Title="X"');
+      const next = links.get('next');
+      expect(next?.params['rel']).toBe('next');
+      expect(next?.params['title']).toBe('X');
+    });
+
+    it('whitespace extra entre params é tolerado', () => {
+      const links = parseLink('  <https://api/x>  ;  rel="next"  ;  title="hello"  ');
+      const next = links.get('next');
+      expect(next?.uri).toBe('https://api/x');
+      expect(next?.params['title']).toBe('hello');
+    });
+
+    it('quoted-string mal formada (closing quote escapada) preserva valor cru', () => {
+      // `"a\"` — abriu aspa, escapou a única aspa que poderia fechá-la.
+      // Sem detecção, o unescape produziria `a"` silentemente; o helper
+      // detecta e devolve o token cru para o consumer perceber o erro.
+      const links = parseLink('<https://api/x>; rel="next"; title="a\\"');
+      expect(links.get('next')?.params['title']).toBe('"a\\"');
+    });
+
+    it('quoted-string com par de escapes consecutivos termina corretamente', () => {
+      // `"a\\\\"` — dois backslashes literais (par); o `"` final É
+      // closing legítimo. Resultado: `a\\` (um backslash desescapado).
+      const links = parseLink('<https://api/x>; rel="next"; title="a\\\\"');
+      expect(links.get('next')?.params['title']).toBe('a\\');
+    });
+  });
+});

--- a/libs/shared-core/src/lib/http/link-header.ts
+++ b/libs/shared-core/src/lib/http/link-header.ts
@@ -1,0 +1,234 @@
+/**
+ * Parser do header HTTP `Link` (RFC 5988/8288). Implementação puro TypeScript
+ * sem dependência runtime — RFC 5988 é estável desde 2010 e o subset usado
+ * pela `uniplus-api` (paginação por cursor opaco, ADR-0026) é trivial.
+ *
+ * Uso típico:
+ *
+ * ```ts
+ * const links = parseLink(response.headers.get('Link'));
+ * const next = links.get('next');
+ * if (next) {
+ *   const nextUrl = next.uri;
+ * }
+ * ```
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc5988.html
+ * @see https://www.rfc-editor.org/rfc/rfc8288.html
+ * @see ADR-0015 — decisão de manter o parser local em vez de usar lib npm.
+ */
+
+/**
+ * Um link-value parseado: a URI entre `<>` e seus parameters (rel, title,
+ * type, etc.) na ordem em que aparecem.
+ */
+export type ParsedLink = {
+  readonly uri: string;
+  readonly params: Readonly<Record<string, string>>;
+};
+
+/**
+ * Parseia um header `Link` (RFC 5988/8288) em Map indexado por `rel`.
+ *
+ * Regras:
+ * - Header `null`, `undefined` ou vazio retorna Map vazio.
+ * - Cada link-value sem param `rel` é ignorado (RFC 5988 não exige rel
+ *   mas todo uso prático tem).
+ * - Param `rel` com múltiplos valores separados por whitespace
+ *   (ex.: `rel="self next"`) registra uma entrada por valor.
+ * - Quando dois link-values declaram o mesmo rel, o **primeiro** vence
+ *   (Map.set é skip). Determinístico e previsível.
+ * - Param keys são lowercased (RFC 5988 §5 — case-insensitive). Param
+ *   values quoted-string preservam o case original do conteúdo.
+ */
+export function parseLink(headerValue: string | null | undefined): Map<string, ParsedLink> {
+  const result = new Map<string, ParsedLink>();
+  if (headerValue === null || headerValue === undefined) {
+    return result;
+  }
+  const trimmed = headerValue.trim();
+  if (trimmed.length === 0) {
+    return result;
+  }
+
+  for (const segment of splitTopLevelCommas(trimmed)) {
+    const linkValue = parseLinkValue(segment);
+    if (linkValue === null) {
+      continue;
+    }
+    const rel = linkValue.params['rel'];
+    if (rel === undefined) {
+      continue;
+    }
+    for (const r of rel.trim().split(/\s+/u)) {
+      if (r.length === 0 || result.has(r)) {
+        continue;
+      }
+      result.set(r, linkValue);
+    }
+  }
+  return result;
+}
+
+/**
+ * Tokenizador char-by-char que separa o header em link-values pela vírgula
+ * de top-level — preserva vírgulas dentro de `<URI>` ou de quoted-strings
+ * (suportando escape com `\`).
+ */
+function splitTopLevelCommas(input: string): string[] {
+  const segments: string[] = [];
+  let inAngle = false;
+  let inQuotes = false;
+  let escapeNext = false;
+  let start = 0;
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+    if (escapeNext) {
+      escapeNext = false;
+      continue;
+    }
+    if (inQuotes) {
+      if (ch === '\\') {
+        escapeNext = true;
+      } else if (ch === '"') {
+        inQuotes = false;
+      }
+      continue;
+    }
+    if (inAngle) {
+      if (ch === '>') {
+        inAngle = false;
+      }
+      continue;
+    }
+    if (ch === '<') {
+      inAngle = true;
+      continue;
+    }
+    if (ch === '"') {
+      inQuotes = true;
+      continue;
+    }
+    if (ch === ',') {
+      segments.push(input.slice(start, i));
+      start = i + 1;
+    }
+  }
+  segments.push(input.slice(start));
+  return segments.map((s) => s.trim()).filter((s) => s.length > 0);
+}
+
+/**
+ * Parseia um único link-value: extrai a URI entre `<>` e os params separados
+ * por `;`. Retorna `null` quando o segmento não tem a forma `<...>;...`.
+ */
+function parseLinkValue(segment: string): ParsedLink | null {
+  if (!segment.startsWith('<')) {
+    return null;
+  }
+  const closeIdx = segment.indexOf('>');
+  if (closeIdx < 0) {
+    return null;
+  }
+  const uri = segment.slice(1, closeIdx);
+  const paramsRaw = segment.slice(closeIdx + 1).trim();
+
+  const params: Record<string, string> = {};
+  if (paramsRaw.length === 0) {
+    return { uri, params };
+  }
+  // O remainder começa idealmente com `;`; remove o `;` líder.
+  const tail = paramsRaw.startsWith(';') ? paramsRaw.slice(1) : paramsRaw;
+  for (const paramSegment of splitTopLevelSemicolons(tail)) {
+    const equalsIdx = paramSegment.indexOf('=');
+    if (equalsIdx < 0) {
+      // RFC 5988 permite param sem valor (flag) — guardamos como string vazia
+      // para que o consumer detecte presença sem precisar de tipo separado.
+      const key = paramSegment.trim().toLowerCase();
+      if (key.length > 0 && !(key in params)) {
+        params[key] = '';
+      }
+      continue;
+    }
+    const key = paramSegment.slice(0, equalsIdx).trim().toLowerCase();
+    if (key.length === 0 || key in params) {
+      continue;
+    }
+    params[key] = unquoteIfQuoted(paramSegment.slice(equalsIdx + 1).trim());
+  }
+  return { uri, params };
+}
+
+/**
+ * Mesma semântica de `splitTopLevelCommas`, mas para `;` separando parameters.
+ */
+function splitTopLevelSemicolons(input: string): string[] {
+  const segments: string[] = [];
+  let inQuotes = false;
+  let escapeNext = false;
+  let start = 0;
+
+  for (let i = 0; i < input.length; i++) {
+    const ch = input[i];
+    if (escapeNext) {
+      escapeNext = false;
+      continue;
+    }
+    if (inQuotes) {
+      if (ch === '\\') {
+        escapeNext = true;
+      } else if (ch === '"') {
+        inQuotes = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inQuotes = true;
+      continue;
+    }
+    if (ch === ';') {
+      segments.push(input.slice(start, i));
+      start = i + 1;
+    }
+  }
+  segments.push(input.slice(start));
+  return segments.map((s) => s.trim()).filter((s) => s.length > 0);
+}
+
+/**
+ * Remove aspas externas e desfaz escapes `\\X` → `X` quando o valor é
+ * quoted-string bem formada. Caso contrário devolve o token como veio
+ * (RFC 5988 §5 permite token simples sem aspas para valores ASCII curtos).
+ *
+ * Mal formada inclui o caso onde o `"` final é parte de um escape (`\\"`)
+ * — a string abriu com `"` mas nunca fechou de verdade. Devolver cru
+ * preserva o sinal de erro para o consumer em vez de produzir um valor
+ * silenciosamente incorreto.
+ */
+function unquoteIfQuoted(value: string): string {
+  if (value.length < 2 || value[0] !== '"' || value[value.length - 1] !== '"') {
+    return value;
+  }
+  // Conta `\` consecutivos imediatamente antes do `"` final. Quantidade ímpar
+  // significa que o `"` foi escapado — a string não está realmente fechada.
+  let trailingBackslashes = 0;
+  for (let i = value.length - 2; i >= 1 && value[i] === '\\'; i--) {
+    trailingBackslashes++;
+  }
+  if (trailingBackslashes % 2 === 1) {
+    return value;
+  }
+  const inner = value.slice(1, -1);
+  let out = '';
+  for (let i = 0; i < inner.length; i++) {
+    const ch = inner[i];
+    if (ch === '\\' && i + 1 < inner.length) {
+      out += inner[i + 1];
+      i++;
+      continue;
+    }
+    out += ch;
+  }
+  return out;
+}

--- a/libs/shared-core/src/lib/http/pagination.spec.ts
+++ b/libs/shared-core/src/lib/http/pagination.spec.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { createCursor, cursorToString, extractNextCursor } from './pagination';
+
+describe('Cursor branded type (ADR-0015)', () => {
+  it('createCursor wraps string como Cursor compatível com string em runtime', () => {
+    const cursor = createCursor('opaco-token-123');
+    // Em runtime, Cursor é a própria string — comparação por igualdade funciona.
+    expect(cursor).toBe('opaco-token-123');
+    expect(typeof cursor).toBe('string');
+  });
+
+  it('cursorToString é idempotente', () => {
+    const cursor = createCursor('xyz');
+    expect(cursorToString(cursor)).toBe('xyz');
+    expect(cursorToString(createCursor(cursorToString(cursor)))).toBe('xyz');
+  });
+
+  it('createCursor não valida conteúdo — servidor é a única autoridade', () => {
+    // String vazia, base64-url-safe, payload longo — todos passam.
+    expect(createCursor('')).toBe('');
+    expect(createCursor('AAAA-_=')).toBe('AAAA-_=');
+    expect(createCursor('a'.repeat(2048))).toBe('a'.repeat(2048));
+  });
+});
+
+describe('extractNextCursor — header Link → próximo cursor opaco', () => {
+  describe('caminhos felizes', () => {
+    it('rel="next" com cursor= no query string retorna Cursor', () => {
+      const linkHeader = '<https://api.uniplus.unifesspa.edu.br/api/editais?cursor=ABC123>; rel="next"';
+      const next = extractNextCursor(linkHeader);
+      expect(next).not.toBeNull();
+      expect(cursorToString(next!)).toBe('ABC123');
+    });
+
+    it('extrai cursor de URI com múltiplos query params (cursor não é o primeiro)', () => {
+      const linkHeader = '<https://api/x?status=open&limit=20&cursor=DEF456>; rel="next"';
+      const next = extractNextCursor(linkHeader);
+      expect(cursorToString(next!)).toBe('DEF456');
+    });
+
+    it('extrai cursor de URI com cursor como primeiro param', () => {
+      const linkHeader = '<https://api/x?cursor=GHI789&limit=20>; rel="next"';
+      const next = extractNextCursor(linkHeader);
+      expect(cursorToString(next!)).toBe('GHI789');
+    });
+
+    it('decodifica percent-encoding do valor do cursor', () => {
+      const linkHeader = '<https://api/x?cursor=abc%3Ddef%3D>; rel="next"';
+      const next = extractNextCursor(linkHeader);
+      expect(cursorToString(next!)).toBe('abc=def=');
+    });
+
+    it('preserva URI relativa quando servidor não emite host (RFC 5988 §5.4)', () => {
+      const linkHeader = '</api/editais?cursor=REL>; rel="next"';
+      const next = extractNextCursor(linkHeader);
+      expect(cursorToString(next!)).toBe('REL');
+    });
+
+    it('rel="self" + rel="next": extrai apenas o de next', () => {
+      const linkHeader =
+        '<https://api/x?cursor=SELF>; rel="self", <https://api/x?cursor=NEXT>; rel="next"';
+      const next = extractNextCursor(linkHeader);
+      expect(cursorToString(next!)).toBe('NEXT');
+    });
+  });
+
+  describe('retorna null em casos legítimos', () => {
+    it('header null', () => {
+      expect(extractNextCursor(null)).toBeNull();
+    });
+
+    it('header undefined', () => {
+      expect(extractNextCursor(undefined)).toBeNull();
+    });
+
+    it('header vazio', () => {
+      expect(extractNextCursor('')).toBeNull();
+    });
+
+    it('header só com rel="self" (última página)', () => {
+      const linkHeader = '<https://api/x>; rel="self"';
+      expect(extractNextCursor(linkHeader)).toBeNull();
+    });
+
+    it('header com outros rels (related, prev) mas sem next', () => {
+      const linkHeader =
+        '<https://api/x?cursor=P>; rel="prev", <https://api/y>; rel="related"';
+      expect(extractNextCursor(linkHeader)).toBeNull();
+    });
+  });
+
+  describe('retorna null em formas defensivas', () => {
+    it('rel="next" mas URI sem query string', () => {
+      const linkHeader = '<https://api/x>; rel="next"';
+      expect(extractNextCursor(linkHeader)).toBeNull();
+    });
+
+    it('rel="next" com query string mas sem cursor=', () => {
+      const linkHeader = '<https://api/x?status=open&limit=20>; rel="next"';
+      expect(extractNextCursor(linkHeader)).toBeNull();
+    });
+
+    it('rel="next" com cursor= vazio', () => {
+      const linkHeader = '<https://api/x?cursor=>; rel="next"';
+      expect(extractNextCursor(linkHeader)).toBeNull();
+    });
+
+    it('percent-encoding malformado é tratado como ausente (não explode)', () => {
+      const linkHeader = '<https://api/x?cursor=abc%2>; rel="next"';
+      // % seguido de char inválido — decodeURIComponent lança URIError;
+      // tratamos como ausência.
+      expect(extractNextCursor(linkHeader)).toBeNull();
+    });
+
+    it('ignora hash fragment na URI (#...)', () => {
+      const linkHeader = '<https://api/x?cursor=ABC#section>; rel="next"';
+      const next = extractNextCursor(linkHeader);
+      expect(cursorToString(next!)).toBe('ABC');
+    });
+  });
+});

--- a/libs/shared-core/src/lib/http/pagination.ts
+++ b/libs/shared-core/src/lib/http/pagination.ts
@@ -1,0 +1,120 @@
+import { parseLink } from './link-header';
+
+/**
+ * Helpers de paginação por cursor opaco do contrato V1 da `uniplus-api`
+ * (ADR-0026 do backend, ADR-0015 do frontend). Cursor é uma string opaca
+ * AES-GCM; o cliente jamais decifra (ADR-0031 do backend é binding).
+ *
+ * Tipo `Cursor` é branded em compile time para evitar que código acidente
+ * compare cursors com URLs ou tente desserializar — atribuir `string` cru
+ * exige cast explícito via {@link createCursor}.
+ *
+ * Uso típico (preview da Frente 6 do plano):
+ *
+ * ```ts
+ * this.editaisApi.listar(this.cursor()).subscribe(result => {
+ *   if (!result.ok) return;
+ *   this.editais.update(prev => [...prev, ...result.data]);
+ *   this.cursor.set(extractNextCursor(result.headers.get('Link')));
+ * });
+ * ```
+ */
+
+declare const cursorBrand: unique symbol;
+
+/**
+ * String opaca branded — wire format do cursor de paginação. Comparações
+ * por igualdade funcionam (ambos são strings em runtime); operações de
+ * string como `slice`, `JSON.parse` etc. NÃO devem ser feitas — cliente
+ * trata como token opaco fim-a-fim.
+ */
+export type Cursor = string & { readonly [cursorBrand]: true };
+
+/**
+ * Wraps uma string como `Cursor`. Não valida conteúdo — o servidor é a
+ * única autoridade sobre o formato (cifra AES-GCM, payload, expiry).
+ *
+ * Use principalmente para hidratar cursor persistido em rota/estado:
+ *
+ * ```ts
+ * const stored = this.route.snapshot.queryParamMap.get('cursor');
+ * const cursor = stored ? createCursor(stored) : null;
+ * ```
+ */
+export function createCursor(value: string): Cursor {
+  return value as Cursor;
+}
+
+/**
+ * Serializa `Cursor` de volta para `string` plana (ex.: para escrever em
+ * query param). Idempotente — `Cursor` já é string em runtime.
+ */
+export function cursorToString(cursor: Cursor): string {
+  return cursor;
+}
+
+/**
+ * Extrai o cursor da próxima página do header `Link`. Retorna `null` quando:
+ *
+ * - header é `null`, `undefined` ou string vazia;
+ * - header não tem entrada `rel="next"`;
+ * - a URI do `rel="next"` não tem o query param `cursor=`.
+ *
+ * Casos legítimos de `null`:
+ *
+ * - última página da paginação (servidor não emite `rel="next"`);
+ * - endpoint não-paginado retornando outros rels (ex.: `rel="related"`).
+ */
+export function extractNextCursor(linkHeader: string | null | undefined): Cursor | null {
+  const links = parseLink(linkHeader);
+  const next = links.get('next');
+  if (next === undefined) {
+    return null;
+  }
+  const cursorValue = extractCursorParam(next.uri);
+  if (cursorValue === null) {
+    return null;
+  }
+  return createCursor(cursorValue);
+}
+
+/**
+ * Extrai o valor de `?cursor=...` ou `&cursor=...` da URI sem precisar
+ * resolver host (URI no `Link` pode vir relativa, RFC 5988 §5.4). Volta
+ * `null` quando não há param `cursor`. Decode percent-encoding via
+ * `decodeURIComponent`.
+ */
+function extractCursorParam(uri: string): string | null {
+  const queryStart = uri.indexOf('?');
+  if (queryStart < 0) {
+    return null;
+  }
+  const queryString = uri.slice(queryStart + 1);
+  // Hash fragment (`#...`) não tem sentido em paginação, mas remover por
+  // robustez caso o servidor emita.
+  const hashIdx = queryString.indexOf('#');
+  const cleanQuery = hashIdx < 0 ? queryString : queryString.slice(0, hashIdx);
+
+  for (const pair of cleanQuery.split('&')) {
+    const equalsIdx = pair.indexOf('=');
+    if (equalsIdx < 0) {
+      continue;
+    }
+    const key = pair.slice(0, equalsIdx);
+    if (key !== 'cursor') {
+      continue;
+    }
+    const rawValue = pair.slice(equalsIdx + 1);
+    if (rawValue.length === 0) {
+      return null;
+    }
+    try {
+      return decodeURIComponent(rawValue);
+    } catch {
+      // Servidor mandou percent-encoding malformado; trata como ausente
+      // em vez de explodir o consumer.
+      return null;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Resumo

Implementa a decisão da [ADR-0015](docs/adrs/0015-cursor-pagination-consumer-link-header.md) (\`proposed\` → \`accepted\` neste PR). Helpers explícitos no caller para consumir paginação por cursor opaco emitida pela `uniplus-api` via header `Link` (RFC 5988/8288), alinhados com [ADR-0026](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0026-paginacao-cursor-opaco-cifrado.md) e [ADR-0031](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0031-decoding-de-cursor-opaco-no-boundary-http.md) do backend (cursor opaco no boundary, decode server-side).

## Entrega

### Foundation em `libs/shared-core/src/lib/http/`

- **`link-header.ts`** — `parseLink(headerValue): Map<rel, ParsedLink>` via tokenizer char-by-char puro TypeScript. Sem dependência runtime. Preserva vírgulas/ponto-e-vírgulas dentro de quoted-strings com escape `\\`; suporta `rel="self next"` (RFC 5988 §5.3.1) registrando uma entrada por valor; param keys lowercased; quando dois link-values declaram o mesmo `rel`, o primeiro vence.
- **`pagination.ts`** — tipo `Cursor` branded via `unique symbol`; `createCursor`, `cursorToString`, `extractNextCursor` consumindo `parseLink`. Decode percent-encoded com fallback `null` em `URIError`. Hash fragment descartado defensivamente.

### Testes Vitest

40 testes novos (93 total em `shared-core`):

- `link-header.spec.ts` — 21 cenários: header ausente/vazio (4), 1 link-value (3), múltiplos link-values (3), `rel` multi-valor (1), aspas/ponto-e-vírgula/vírgula escapadas (3), defensivos (5), quoted-string mal formada com closing quote escapada (2 — hardening pós-review).
- `pagination.spec.ts` — 19 cenários: branded type (3), happy paths de `extractNextCursor` (6), retornos `null` legítimos (5), defensivos (5).

### ADR + índice

- ADR-0015 promovida `proposed` → `accepted` no mesmo PR. Seção "Implementação 2026-05-06" lista arquivos + 5 pontos não-óbvios capturados (decode malformado → `null`, primeiro `rel` vence, quoted-string defensiva, etc.).
- `docs/adrs/README.md` atualizado.

## Aderência aos critérios de aceite (#191)

- ✅ **CA-01:** `link-header.ts` exporta `parseLink` + `ParsedLink`. Implementação RFC 5988/8288 puro TypeScript.
- ✅ **CA-02:** `pagination.ts` exporta `Cursor` branded type, `createCursor`, `cursorToString`, `extractNextCursor`.
- ✅ **CA-03:** `link-header.spec.ts` cobre os 4 cenários BDD + defensivos (21 testes).
- ✅ **CA-04:** `pagination.spec.ts` cobre os 5 cenários BDD + Cursor branded type (19 testes).
- ✅ **CA-05:** `libs/shared-core/src/lib/http/index.ts` re-exporta `parseLink`, `ParsedLink`, `Cursor`, `createCursor`, `cursorToString`, `extractNextCursor`.
- ✅ **CA-06:** ADR-0015 `proposed` → `accepted`; índice atualizado; seção "Implementação" adicionada.
- ✅ **CA-07:** `npx nx affected --target=lint,test,typecheck,build --base=origin/main` → 10 projetos verdes, 0 errors.
- ✅ **CA-08:** `bash tools/adr-lint/validate.sh` → 15 ADR(s) verdes; `npx markdownlint-cli2 ...` → 0 erros.
- ✅ **CA-09:** Strings/comentários em pt-BR; zero `any`; helpers não logam cursors (LGPD).

## Test plan

- [x] Pre-commit code review por `feature-dev:code-reviewer` agent: 0 P1, 1 P2 (quoted-string mal formada) — **resolvido** com guarda de trailing backslashes ímpares + 2 testes adicionais.
- [x] `npx nx run shared-core:test --skip-nx-cache` → 93 tests passed (40 novos).
- [x] `npx nx affected --target=lint,test,typecheck,build` → 10 projetos verdes.
- [x] `bash tools/adr-lint/validate.sh` + `markdownlint-cli2` verdes.
- [ ] CI verde no PR.
- [ ] Codex review absorvido.

## Não-escopo

- Atualização do `DataTable` em `shared-ui` para auto-emitir `loadNext(cursor)` — Frente 6 (Editais lista paginada).
- Feature `EditaisListPage` consumindo paginação real — Frente 6.
- Operator RxJS `toPaginated()` — parqueado na ADR-0015.
- Smoke E2E autenticado contra backend real — Frente 9.

## Referências

- Issue: #191
- ADRs: [ADR-0015](docs/adrs/0015-cursor-pagination-consumer-link-header.md), [ADR-0011](docs/adrs/0011-consumer-adapter-api-result.md), [ADR-0012](docs/adrs/0012-placement-api-result-em-shared-core.md), [ADR-0014](docs/adrs/0014-idempotency-key-cliente-via-http-context.md).
- Backend: [ADR-0026 (cursor opaco)](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0026-paginacao-cursor-opaco-cifrado.md), [ADR-0031 (decode no boundary)](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0031-decoding-de-cursor-opaco-no-boundary-http.md).
- PRs prerequisitos (mergeados): [uniplus-api#333](https://github.com/unifesspa-edu-br/uniplus-api/pull/333) (fix do schema), [uniplus-web#188](https://github.com/unifesspa-edu-br/uniplus-web/pull/188) (sync baseline), [uniplus-web#190](https://github.com/unifesspa-edu-br/uniplus-web/pull/190) (ADR proposed).
- [RFC 5988](https://www.rfc-editor.org/rfc/rfc5988.html) / [RFC 8288](https://www.rfc-editor.org/rfc/rfc8288.html) — Web Linking.

Closes #191