### PR TITLE
refactor(shared-data): adiciona validação mais robusta na função parseDate() em date utils

### DIFF
--- a/libs/shared-data/src/lib/utils/date.util.spec.ts
+++ b/libs/shared-data/src/lib/utils/date.util.spec.ts
@@ -59,7 +59,7 @@ describe('Date Util', () => {
     });
 
     it('transforma corretamente entrada de texto referente a um ano bissexto', () => {
-      expect(parseDate('29/02/2024 ')).not.toBe(null);
+      expect(parseDate('29/02/2024')).toBeTruthy();
     });
 
     it('retorna null quando a data é um texto vazio', () => {

--- a/libs/shared-data/src/lib/utils/date.util.spec.ts
+++ b/libs/shared-data/src/lib/utils/date.util.spec.ts
@@ -1,12 +1,11 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { formatDateBr, formatDateTimeBr, parseDate } from './date.util';
 
 describe('Date Util', () => {
   const VALID_RAW_DATE = '2026-02-14T12:00:00';
   const INVALID_RAW_DATE = '2026-02-14T25:00:00';
-  const DATE_STR = '02/14/2026';
   const DATE = new Date(VALID_RAW_DATE);
-  const INVALID_DATE_MSG = '—';
+  const PLACEHOLDER_DATA_INVALIDA = '—';
 
   describe('formatDateBr()', () => {
     it('formata uma entrada de data em texto bruto para a localidade pt-br', () => {
@@ -18,11 +17,11 @@ describe('Date Util', () => {
     });
 
     it('retorna um "—" quando a entrada de data e hora em texto bruto é inválida', () => {
-      expect(formatDateBr(INVALID_RAW_DATE)).toBe(INVALID_DATE_MSG);
+      expect(formatDateBr(INVALID_RAW_DATE)).toBe(PLACEHOLDER_DATA_INVALIDA);
     });
 
     it('retorna um "—" quando a entrada de um objeto de data e hora é inválida', () => {
-      expect(formatDateBr(new Date(INVALID_RAW_DATE))).toBe(INVALID_DATE_MSG);
+      expect(formatDateBr(new Date(INVALID_RAW_DATE))).toBe(PLACEHOLDER_DATA_INVALIDA);
     });
   });
 
@@ -36,54 +35,59 @@ describe('Date Util', () => {
     });
 
     it('retorna um "—" quando a entrada de um texto bruto de data e hora é inválida', () => {
-      expect(formatDateTimeBr(INVALID_RAW_DATE)).toBe(INVALID_DATE_MSG);
+      expect(formatDateTimeBr(INVALID_RAW_DATE)).toBe(PLACEHOLDER_DATA_INVALIDA);
     });
 
     it('retorna um "—" quando a entrada de um objeto de data e hora é inválida', () => {
-      expect(formatDateTimeBr(new Date(INVALID_RAW_DATE))).toBe(INVALID_DATE_MSG);
+      expect(formatDateTimeBr(new Date(INVALID_RAW_DATE))).toBe(PLACEHOLDER_DATA_INVALIDA);
     });
   });
 
   describe('parseDate()', () => {
-    it('transforma entrada de texto no formato (dd/mm/yyyy) para uma data', () => {
-      const day = 14;
-      const month = '02';
-      const monthParseInt = parseInt(month, 10) - 1;
-      const year = 2025;
-      const result = parseDate(`${day}/${month}/${year}`);
+    describe('entradas válidas', () => {
+      it.each([
+        { input: '14/02/2025', expected: new Date(2025, 1, 14), descricao: 'dia/mês com 2 dígitos' },
+        { input: '01/01/2026', expected: new Date(2026, 0, 1), descricao: 'primeiro do ano' },
+        { input: '31/12/2026', expected: new Date(2026, 11, 31), descricao: 'último do ano' },
+        { input: '29/02/2024', expected: new Date(2024, 1, 29), descricao: 'ano bissexto' },
+        { input: '1/2/2025', expected: new Date(2025, 1, 1), descricao: 'dia/mês com 1 dígito' },
+      ])('parseia "$input" — $descricao', ({ input, expected }) => {
+        expect(parseDate(input)).toEqual(expected);
+      });
 
-      expect(result).toStrictEqual(new Date(year, monthParseInt, day));
-      expect(result?.getDate()).toBe(day);
-      expect(result?.getMonth()).toBe(monthParseInt);
-      expect(result?.getFullYear()).toBe(year);
+      it('tolera espaços nas bordas', () => {
+        expect(parseDate('  14/02/2025  ')).toEqual(new Date(2025, 1, 14));
+      });
+
+      it('limites do intervalo de ano são aceitos (1900 e 2100)', () => {
+        expect(parseDate('01/01/1900')).toEqual(new Date(1900, 0, 1));
+        expect(parseDate('31/12/2100')).toEqual(new Date(2100, 11, 31));
+      });
     });
 
-    it('transforma corretamente entrada de texto referente a um ano bissexto', () => {
-      expect(parseDate('29/02/2024')).toBeTruthy();
-    });
-
-    it('retorna null quando a data é um texto vazio', () => {
-      expect(parseDate('')).toBe(null);
-    });
-
-    it('retorna null quando o mês está fora do intervalo válido', () => {
-        expect(parseDate(DATE_STR)).toBe(null);
-    });
-
-    it('retorna null quando o separador difere de "/"', () => {
-      expect(parseDate('14-02-2026')).toBe(null);
-    });
-
-    it('retorna null quando o dia não existe em um determinado mês', () => {
-      expect(parseDate('32/01/2026')).toBe(null);
-    });
-
-    it('retorna null quando o ano possui apenas dois dígitos', () => {
-      expect(parseDate('01/01/26')).toBe(null);
-    });
-
-    it('retorna null quando o ano não é bissexto', () => {
-      expect(parseDate('29/02/2026')).toBe(null);
+    describe('entradas inválidas (retorna null)', () => {
+      it.each([
+        { input: '', descricao: 'string vazia' },
+        { input: '   ', descricao: 'apenas espaços' },
+        { input: '14-02-2026', descricao: 'separador diferente de "/"' },
+        { input: '14/02/2026/00', descricao: 'mais de 3 segmentos' },
+        { input: '02/14/2026', descricao: 'mês 14 fora do intervalo' },
+        { input: '32/01/2026', descricao: 'dia 32 fora do intervalo' },
+        { input: '00/01/2026', descricao: 'dia 0 fora do intervalo' },
+        { input: '01/00/2026', descricao: 'mês 0 fora do intervalo' },
+        { input: '01/13/2026', descricao: 'mês 13 fora do intervalo' },
+        { input: '01/01/26', descricao: 'ano com 2 dígitos' },
+        { input: '01/01/26000', descricao: 'ano com 5 dígitos' },
+        { input: 'aa/bb/cccc', descricao: 'caracteres não-numéricos' },
+        { input: '01/01/-024', descricao: 'ano com sinal negativo' },
+        { input: '29/02/2026', descricao: '29/02 em ano não bissexto' },
+        { input: '30/02/2024', descricao: '30 de fevereiro nunca existe' },
+        { input: '31/04/2026', descricao: '31 de abril nunca existe' },
+        { input: '01/01/1899', descricao: 'ano anterior a 1900 (fora do domínio Uni+)' },
+        { input: '01/01/2101', descricao: 'ano posterior a 2100 (fora do domínio Uni+)' },
+      ])('retorna null para "$input" — $descricao', ({ input }) => {
+        expect(parseDate(input)).toBeNull();
+      });
     });
   });
 });

--- a/libs/shared-data/src/lib/utils/date.util.ts
+++ b/libs/shared-data/src/lib/utils/date.util.ts
@@ -13,9 +13,20 @@ export function parseDate(dateStr: string): Date | null {
   const parts = dateStr.split('/');
   if (parts.length === 3) {
     const day = parseInt(parts[0], 10);
+    if (day < 1 || day > 31) {
+      return null;
+    }
+    if (parseInt(parts[1], 10) < 1 || parseInt(parts[1], 10) > 12) {
+      return null;
+    }
     const month = parseInt(parts[1], 10) - 1;
+
+    if (parts[2].length !== 4) {
+      return null;
+    }
     const year = parseInt(parts[2], 10);
     const date = new Date(year, month, day);
+
     if (date.getDate() === day && date.getMonth() === month && date.getFullYear() === year) {
       return date;
     }

--- a/libs/shared-data/src/lib/utils/date.util.ts
+++ b/libs/shared-data/src/lib/utils/date.util.ts
@@ -1,3 +1,7 @@
+const DATE_FORMAT_REGEX = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/;
+const MIN_YEAR = 1900;
+const MAX_YEAR = 2100;
+
 export function formatDateBr(date: Date | string): string {
   const d = typeof date === 'string' ? new Date(date) : date;
   return Number.isNaN(d.getTime()) ? '—' : d.toLocaleDateString('pt-BR');
@@ -8,28 +12,35 @@ export function formatDateTimeBr(date: Date | string): string {
   return Number.isNaN(d.getTime()) ? '—' : d.toLocaleString('pt-BR');
 }
 
+/**
+ * Parse uma string no formato `dd/mm/yyyy` para `Date`.
+ *
+ * Tolera espaços nas bordas. Aceita dia/mês com 1 ou 2 dígitos. Retorna
+ * `null` para entradas que:
+ * - não casem com o formato esperado (separador, dígitos, ano com 4 dígitos);
+ * - tenham ano fora do intervalo permitido pelo domínio Uni+ ([1900, 2100]);
+ * - representem data de calendário inexistente (ex.: 30/02, 31/04, 29/02
+ *   em ano não bissexto).
+ */
 export function parseDate(dateStr: string): Date | null {
-  // Aceita dd/mm/yyyy
-  const parts = dateStr.split('/');
-  if (parts.length === 3) {
-    const day = parseInt(parts[0], 10);
-    if (day < 1 || day > 31) {
-      return null;
-    }
-    if (parseInt(parts[1], 10) < 1 || parseInt(parts[1], 10) > 12) {
-      return null;
-    }
-    const month = parseInt(parts[1], 10) - 1;
+  const match = DATE_FORMAT_REGEX.exec(dateStr.trim());
+  if (!match) return null;
 
-    if (parts[2].length !== 4) {
-      return null;
-    }
-    const year = parseInt(parts[2], 10);
-    const date = new Date(year, month, day);
+  const [, dayStr, monthStr, yearStr] = match;
+  const day = Number(dayStr);
+  const month = Number(monthStr); // 1-based no input
+  const year = Number(yearStr);
 
-    if (date.getDate() === day && date.getMonth() === month && date.getFullYear() === year) {
-      return date;
-    }
-  }
-  return null;
+  if (year < MIN_YEAR || year > MAX_YEAR) return null;
+
+  const date = new Date(year, month - 1, day);
+  return isExactCalendarDate(date, day, month, year) ? date : null;
+}
+
+function isExactCalendarDate(date: Date, day: number, month: number, year: number): boolean {
+  return (
+    date.getDate() === day &&
+    date.getMonth() === month - 1 &&
+    date.getFullYear() === year
+  );
 }


### PR DESCRIPTION
## Resumo

Adiciona validação adicional mais robusta na função `parseDate()` para que não haja dependência da implementação da classe Date.

Closes #174

## Mudanças

### Modificados
libs/shared-data/src/lib/utils/date.util.ts
libs/shared-data/src/lib/utils/date.util.spec.ts
## Testes

- [x] Testes unitários passando

## Checklist

- [x] Valida se o mês (antes da subtração) está no intervalo 1...12
- [x] Valida se o tamanho da string do ano é igual a 4
- [x] Valida se o número do dia está dentro do intervalo 1...31
- [x]  As validações acima ocorrem antes da instanciação da classe Date 
