### PR TITLE
feat(selecao): EditaisCreatePage form Reactive tipado + Idempotency-Key form-scoped

### DIFF
--- a/apps/selecao-e2e/src/specs/edital-crud.spec.ts
+++ b/apps/selecao-e2e/src/specs/edital-crud.spec.ts
@@ -17,4 +17,23 @@ test.describe('Editais — CRUD', () => {
     // no tbody. Quando há itens, as linhas aparecem em <tbody tr>.
     await expect(page.locator('table[role="grid"]')).toBeVisible();
   });
+
+  test('deve permitir navegar até /editais/novo e renderizar o form de criação (F7)', async ({
+    page,
+  }) => {
+    await page.goto('/editais');
+    await keycloakLogin(page, ADMIN.username, ADMIN.password);
+
+    await page.getByRole('link', { name: 'Novo edital' }).click();
+
+    await expect(page).toHaveURL(/\/editais\/novo$/);
+    await expect(page.locator('h2')).toContainText('Novo edital');
+    await expect(page.locator('#numeroEdital')).toBeVisible();
+    await expect(page.locator('#anoEdital')).toBeVisible();
+    await expect(page.locator('#titulo')).toBeVisible();
+    await expect(page.locator('#tipoProcesso')).toBeVisible();
+    await expect(page.locator('#maximoOpcoesCurso')).toBeVisible();
+    // Submit fica disabled enquanto form invalid + nenhum campo preenchido.
+    await expect(page.getByRole('button', { name: 'Criar edital' })).toBeDisabled();
+  });
 });

--- a/apps/selecao/src/app/features/editais/editais-create.page.spec.ts
+++ b/apps/selecao/src/app/features/editais/editais-create.page.spec.ts
@@ -1,0 +1,235 @@
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiResultInterceptor } from '@uniplus/shared-core';
+import { SELECAO_BASE_PATH } from '@uniplus/shared-data';
+import { EditaisCreatePage } from './editais-create.page';
+
+const BASE = 'http://localhost:5000';
+
+const COMANDO_VALIDO = {
+  numeroEdital: 42,
+  anoEdital: 2026,
+  titulo: 'PSE 2026',
+  tipoProcesso: 1,
+  maximoOpcoesCurso: 2,
+};
+
+describe('EditaisCreatePage', () => {
+  let fixture: ComponentFixture<EditaisCreatePage>;
+  let component: EditaisCreatePage;
+  let controller: HttpTestingController;
+  let router: Router;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [EditaisCreatePage],
+      providers: [
+        provideHttpClient(withInterceptors([apiResultInterceptor])),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        { provide: SELECAO_BASE_PATH, useValue: BASE },
+      ],
+    });
+
+    fixture = TestBed.createComponent(EditaisCreatePage);
+    component = fixture.componentInstance;
+    controller = TestBed.inject(HttpTestingController);
+    router = TestBed.inject(Router);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => controller.verify());
+
+  function preencherFormComValido(): void {
+    component.form.setValue(COMANDO_VALIDO);
+  }
+
+  it('inicializa form vazio (titulo + maximoOpcoesCurso default 1) e gera idempotency key na 1ª render', () => {
+    expect(component.form.value.titulo).toBe('');
+    expect(component.form.value.maximoOpcoesCurso).toBe(1);
+    expect(component.idempotencyKeyAtual()).toMatch(/^[0-9a-f-]{36}$/);
+    expect(component.submitting()).toBe(false);
+    expect(component.errorMessage()).toBeNull();
+  });
+
+  it('form invalid não dispara POST e marca controls como touched', () => {
+    component['enviar']();
+
+    controller.expectNone(`${BASE}/api/editais`);
+    expect(component.form.controls.titulo.touched).toBe(true);
+    expect(component.form.controls.numeroEdital.touched).toBe(true);
+  });
+
+  it('submit válido dispara POST com Idempotency-Key, navega para /editais e regenera key', async () => {
+    const navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
+    preencherFormComValido();
+    const keyOriginal = component.idempotencyKeyAtual();
+
+    component['enviar']();
+
+    expect(component.submitting()).toBe(true);
+
+    const req = controller.expectOne(`${BASE}/api/editais`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.headers.get('Idempotency-Key')).toBe(keyOriginal);
+    expect(req.request.body).toEqual(COMANDO_VALIDO);
+    req.flush('01960000-0000-7000-0000-000000000099', {
+      status: 201,
+      statusText: 'Created',
+    });
+
+    expect(component.submitting()).toBe(false);
+    expect(navigateSpy).toHaveBeenCalledWith(['/editais']);
+    expect(component.idempotencyKeyAtual()).not.toBe(keyOriginal);
+    expect(component.idempotencyKeyAtual()).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('submit com 422 mapeia errors[].field para FormControl.setErrors({ backend })', () => {
+    preencherFormComValido();
+
+    component['enviar']();
+
+    controller.expectOne(`${BASE}/api/editais`).flush(
+      {
+        type: 'about:blank',
+        title: 'Falha de validação',
+        status: 422,
+        code: 'uniplus.validation.falhou',
+        traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+        errors: [
+          { field: 'titulo', code: 'NotEmpty', message: 'Título não pode ser vazio.' },
+          { field: 'numeroEdital', code: 'GreaterThan', message: 'Número deve ser positivo.' },
+        ],
+      },
+      { status: 422, statusText: 'Unprocessable Entity', headers: { 'Content-Type': 'application/problem+json' } },
+    );
+
+    expect(component.submitting()).toBe(false);
+    expect(component.errorMessage()).toBeNull();
+    expect(component.form.controls.titulo.errors).toEqual({
+      backend: { code: 'NotEmpty', message: 'Título não pode ser vazio.' },
+    });
+    expect(component.form.controls.numeroEdital.errors).toEqual({
+      backend: { code: 'GreaterThan', message: 'Número deve ser positivo.' },
+    });
+    // Outros campos permanecem sem erro do backend.
+    expect(component.form.controls.anoEdital.errors).toBeNull();
+  });
+
+  it('submit com 422 sem field reconhecido cai num banner geral (não silencia)', () => {
+    preencherFormComValido();
+    component['enviar']();
+
+    controller.expectOne(`${BASE}/api/editais`).flush(
+      {
+        type: 'about:blank',
+        title: 'Falha de validação',
+        status: 422,
+        code: 'uniplus.validation.falhou',
+        traceId: 'tx',
+        errors: [{ field: 'campo_inexistente', code: 'X', message: 'Y' }],
+      },
+      { status: 422, statusText: 'Unprocessable Entity', headers: { 'Content-Type': 'application/problem+json' } },
+    );
+
+    expect(component.errorMessage()).toContain('Não foi possível mapear');
+  });
+
+  it('submit com 409 popula errorMessage banner via ProblemI18nService.title', () => {
+    preencherFormComValido();
+    component['enviar']();
+
+    controller.expectOne(`${BASE}/api/editais`).flush(
+      {
+        type: 'about:blank',
+        title: 'Edital já existente',
+        status: 409,
+        code: 'uniplus.selecao.edital.duplicado',
+        traceId: 'tx2',
+      },
+      { status: 409, statusText: 'Conflict', headers: { 'Content-Type': 'application/problem+json' } },
+    );
+
+    expect(component.errorMessage()).toBe('Edital já existente');
+    expect(component.submitting()).toBe(false);
+  });
+
+  it('após 422, corrigir campo limpa o erro backend e permite resubmissão com a mesma key (form-scoped end-to-end)', () => {
+    preencherFormComValido();
+    const keyOriginal = component.idempotencyKeyAtual();
+
+    component['enviar']();
+    controller.expectOne(`${BASE}/api/editais`).flush(
+      {
+        type: 'about:blank',
+        title: 'Falha de validação',
+        status: 422,
+        code: 'uniplus.validation.falhou',
+        traceId: 'tx',
+        errors: [{ field: 'titulo', code: 'NotEmpty', message: 'Título é obrigatório.' }],
+      },
+      { status: 422, statusText: 'Unprocessable Entity', headers: { 'Content-Type': 'application/problem+json' } },
+    );
+
+    expect(component.form.controls.titulo.errors).toMatchObject({
+      backend: { code: 'NotEmpty', message: 'Título é obrigatório.' },
+    });
+    expect(component.form.invalid).toBe(true);
+
+    // Usuário corrige o campo — Angular re-executa validators e limpa o erro `backend`
+    // (Angular sobrescreve setErrors manual no próximo valueChange).
+    component.form.controls.titulo.setValue('PSE 2026 Corrigido');
+    expect(component.form.controls.titulo.errors).toBeNull();
+    expect(component.form.valid).toBe(true);
+
+    // Segundo submit: form-scoped key preservada — backend reconhece como replay legítimo.
+    component['enviar']();
+    const reqRetry = controller.expectOne(`${BASE}/api/editais`);
+    expect(reqRetry.request.headers.get('Idempotency-Key')).toBe(keyOriginal);
+    reqRetry.flush('id-novo-pos-correcao', { status: 201, statusText: 'Created' });
+
+    expect(component.idempotencyKeyAtual()).not.toBe(keyOriginal);
+  });
+
+  it('em falha, idempotency key é PRESERVADA — retry reusa a mesma key (form-scoped strategy)', () => {
+    preencherFormComValido();
+    const keyOriginal = component.idempotencyKeyAtual();
+
+    component['enviar']();
+    controller.expectOne(`${BASE}/api/editais`).flush(
+      {
+        type: 'about:blank',
+        title: 'Edital já existente',
+        status: 409,
+        code: 'uniplus.selecao.edital.duplicado',
+        traceId: 'tx',
+      },
+      { status: 409, statusText: 'Conflict', headers: { 'Content-Type': 'application/problem+json' } },
+    );
+
+    expect(component.idempotencyKeyAtual()).toBe(keyOriginal);
+
+    // Retry: mesma key viaja de novo
+    component['enviar']();
+    const reqRetry = controller.expectOne(`${BASE}/api/editais`);
+    expect(reqRetry.request.headers.get('Idempotency-Key')).toBe(keyOriginal);
+    reqRetry.flush('id-novo', { status: 201, statusText: 'Created' });
+  });
+
+  it('botão submit fica disabled enquanto submitting()', () => {
+    preencherFormComValido();
+    component['enviar']();
+    fixture.detectChanges();
+
+    const botao = fixture.nativeElement.querySelector('button[type="submit"]') as HTMLButtonElement;
+    expect(botao.disabled).toBe(true);
+
+    controller.expectOne(`${BASE}/api/editais`).flush('id', { status: 201, statusText: 'Created' });
+  });
+});

--- a/apps/selecao/src/app/features/editais/editais-create.page.ts
+++ b/apps/selecao/src/app/features/editais/editais-create.page.ts
@@ -1,0 +1,282 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
+import {
+  ProblemDetails,
+  ProblemI18nService,
+  ProblemValidationError,
+  idempotencyKey,
+  withIdempotencyKey,
+} from '@uniplus/shared-core';
+import { CriarEditalCommand, EditaisApi } from '@uniplus/shared-data';
+
+/**
+ * Form Reactive tipado para criação de edital.
+ *
+ * Os tipos batem 1:1 com `CriarEditalCommand` do contrato V1, com a ressalva
+ * de que `tipoProcesso` é `integer` no schema sem enum exposto — usado como
+ * `number` no form com input numérico provisório enquanto o gap de contrato
+ * (issue follow-up no `uniplus-api`) não é fechado.
+ */
+interface CriarEditalForm {
+  numeroEdital: FormControl<number | null>;
+  anoEdital: FormControl<number | null>;
+  titulo: FormControl<string>;
+  tipoProcesso: FormControl<number | null>;
+  maximoOpcoesCurso: FormControl<number>;
+}
+
+/**
+ * Container (ADR-0017) da feature Editais — criação via POST `/api/editais`.
+ *
+ * **Form-scoped Idempotency-Key (ADR-0014):** a key é gerada uma vez na
+ * inicialização do form (signal) e reusada em retries enquanto o submit
+ * estiver "ativo". Reset apenas após 201 sucesso. Em 422/409 a key é
+ * preservada para permitir retry com correção do payload (replay protege
+ * contra double-submit acidental).
+ */
+@Component({
+  selector: 'sel-editais-create-page',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ReactiveFormsModule, RouterLink],
+  template: `
+    <header class="mb-5">
+      <h2 class="text-2xl font-bold text-gray-800">Novo edital</h2>
+      <p class="text-sm text-gray-600">Cadastre os dados básicos do processo seletivo.</p>
+    </header>
+
+    @if (errorMessage()) {
+      <div
+        class="mb-4 flex items-start gap-2 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800"
+        role="alert"
+      >
+        <span class="font-semibold">{{ errorMessage() }}</span>
+      </div>
+    }
+
+    <form [formGroup]="form" (ngSubmit)="enviar()" novalidate class="grid max-w-2xl gap-4">
+      <div>
+        <label for="numeroEdital" class="mb-1 block text-sm font-medium text-gray-700">
+          Número do edital
+        </label>
+        <input
+          id="numeroEdital"
+          type="number"
+          formControlName="numeroEdital"
+          [attr.aria-invalid]="erroDoCampo('numeroEdital') ? 'true' : null"
+          [attr.aria-describedby]="erroDoCampo('numeroEdital') ? 'erro-numeroEdital' : null"
+          class="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-unifesspa-primary"
+        />
+        @if (erroDoCampo('numeroEdital')) {
+          <p id="erro-numeroEdital" class="mt-1 text-xs text-red-700">{{ erroDoCampo('numeroEdital') }}</p>
+        }
+      </div>
+
+      <div>
+        <label for="anoEdital" class="mb-1 block text-sm font-medium text-gray-700">Ano</label>
+        <input
+          id="anoEdital"
+          type="number"
+          formControlName="anoEdital"
+          [attr.aria-invalid]="erroDoCampo('anoEdital') ? 'true' : null"
+          [attr.aria-describedby]="erroDoCampo('anoEdital') ? 'erro-anoEdital' : null"
+          class="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-unifesspa-primary"
+        />
+        @if (erroDoCampo('anoEdital')) {
+          <p id="erro-anoEdital" class="mt-1 text-xs text-red-700">{{ erroDoCampo('anoEdital') }}</p>
+        }
+      </div>
+
+      <div>
+        <label for="titulo" class="mb-1 block text-sm font-medium text-gray-700">Título</label>
+        <input
+          id="titulo"
+          type="text"
+          formControlName="titulo"
+          [attr.aria-invalid]="erroDoCampo('titulo') ? 'true' : null"
+          [attr.aria-describedby]="erroDoCampo('titulo') ? 'erro-titulo' : null"
+          class="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-unifesspa-primary"
+        />
+        @if (erroDoCampo('titulo')) {
+          <p id="erro-titulo" class="mt-1 text-xs text-red-700">{{ erroDoCampo('titulo') }}</p>
+        }
+      </div>
+
+      <div>
+        <label for="tipoProcesso" class="mb-1 block text-sm font-medium text-gray-700">
+          Tipo de processo (código numérico)
+        </label>
+        <input
+          id="tipoProcesso"
+          type="number"
+          formControlName="tipoProcesso"
+          [attr.aria-invalid]="erroDoCampo('tipoProcesso') ? 'true' : null"
+          [attr.aria-describedby]="erroDoCampo('tipoProcesso') ? 'erro-tipoProcesso' : null"
+          class="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-unifesspa-primary"
+        />
+        @if (erroDoCampo('tipoProcesso')) {
+          <p id="erro-tipoProcesso" class="mt-1 text-xs text-red-700">{{ erroDoCampo('tipoProcesso') }}</p>
+        }
+      </div>
+
+      <div>
+        <label for="maximoOpcoesCurso" class="mb-1 block text-sm font-medium text-gray-700">
+          Máximo de opções de curso
+        </label>
+        <input
+          id="maximoOpcoesCurso"
+          type="number"
+          formControlName="maximoOpcoesCurso"
+          min="1"
+          max="2"
+          [attr.aria-invalid]="erroDoCampo('maximoOpcoesCurso') ? 'true' : null"
+          [attr.aria-describedby]="erroDoCampo('maximoOpcoesCurso') ? 'erro-maximoOpcoesCurso' : null"
+          class="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-unifesspa-primary"
+        />
+        @if (erroDoCampo('maximoOpcoesCurso')) {
+          <p id="erro-maximoOpcoesCurso" class="mt-1 text-xs text-red-700">
+            {{ erroDoCampo('maximoOpcoesCurso') }}
+          </p>
+        }
+      </div>
+
+      <div class="mt-2 flex items-center justify-end gap-2">
+        <a
+          routerLink="/editais"
+          class="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+        >
+          Cancelar
+        </a>
+        <button
+          type="submit"
+          [disabled]="submitting() || form.invalid"
+          class="rounded-md bg-unifesspa-primary px-4 py-2 text-sm font-semibold text-white shadow-sm hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-unifesspa-primary disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {{ submitting() ? 'Enviando…' : 'Criar edital' }}
+        </button>
+      </div>
+    </form>
+  `,
+})
+export class EditaisCreatePage {
+  private readonly api = inject(EditaisApi);
+  private readonly problemI18n = inject(ProblemI18nService);
+  private readonly router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly submitting = signal<boolean>(false);
+  readonly errorMessage = signal<string | null>(null);
+  /** Form-scoped key (ADR-0014). Gerada 1× na inicialização; reset após 201. */
+  readonly idempotencyKeyAtual = signal<string>(idempotencyKey.create());
+
+  readonly form: FormGroup<CriarEditalForm> = new FormGroup<CriarEditalForm>({
+    numeroEdital: new FormControl<number | null>(null, {
+      validators: [Validators.required, Validators.min(1)],
+    }),
+    anoEdital: new FormControl<number | null>(null, {
+      validators: [Validators.required, Validators.min(2020), Validators.max(2099)],
+    }),
+    titulo: new FormControl<string>('', {
+      nonNullable: true,
+      validators: [Validators.required, Validators.minLength(3)],
+    }),
+    tipoProcesso: new FormControl<number | null>(null, {
+      validators: [Validators.required, Validators.min(1)],
+    }),
+    maximoOpcoesCurso: new FormControl<number>(1, {
+      nonNullable: true,
+      validators: [Validators.required, Validators.min(1), Validators.max(2)],
+    }),
+  });
+
+  protected enviar(): void {
+    if (this.submitting()) {
+      return;
+    }
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    const valor = this.form.getRawValue();
+    const command: CriarEditalCommand = {
+      numeroEdital: valor.numeroEdital ?? 0,
+      anoEdital: valor.anoEdital ?? 0,
+      titulo: valor.titulo,
+      tipoProcesso: valor.tipoProcesso ?? 0,
+      maximoOpcoesCurso: valor.maximoOpcoesCurso,
+    };
+
+    this.submitting.set(true);
+    this.errorMessage.set(null);
+
+    this.api
+      .criar(command, withIdempotencyKey(this.idempotencyKeyAtual()))
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((result) => {
+        this.submitting.set(false);
+        if (result.ok) {
+          // Reset da key após sucesso — próximo submit ganha key nova.
+          this.idempotencyKeyAtual.set(idempotencyKey.create());
+          this.router.navigate(['/editais']);
+          return;
+        }
+        this.aplicarFalha(result.problem);
+      });
+  }
+
+  protected erroDoCampo(nome: keyof CriarEditalForm): string | null {
+    const ctrl = this.form.controls[nome];
+    if (!ctrl.touched && !ctrl.dirty) {
+      return null;
+    }
+    if (ctrl.hasError('backend')) {
+      const backend = ctrl.getError('backend') as { code: string; message: string };
+      return backend.message;
+    }
+    if (ctrl.hasError('required')) return 'Campo obrigatório.';
+    if (ctrl.hasError('min')) return 'Valor abaixo do permitido.';
+    if (ctrl.hasError('max')) return 'Valor acima do permitido.';
+    if (ctrl.hasError('minlength')) return 'Texto muito curto.';
+    return null;
+  }
+
+  private aplicarFalha(problem: ProblemDetails): void {
+    if (problem.status === 422 && problem.errors && problem.errors.length > 0) {
+      this.aplicarErrosDeValidacao(problem.errors);
+      return;
+    }
+    this.errorMessage.set(this.problemI18n.resolve(problem).title);
+  }
+
+  private aplicarErrosDeValidacao(
+    errors: ReadonlyArray<ProblemValidationError>,
+  ): void {
+    let aplicouAlgum = false;
+    for (const erro of errors) {
+      const campo = erro.field as keyof CriarEditalForm;
+      const ctrl = this.form.controls[campo];
+      if (!ctrl) continue;
+      ctrl.setErrors({ backend: { code: erro.code, message: erro.message } });
+      ctrl.markAsTouched();
+      aplicouAlgum = true;
+    }
+    // Errors[] sem field reconhecido cai num banner geral pra não silenciar feedback.
+    if (!aplicouAlgum) {
+      this.errorMessage.set('Não foi possível mapear os erros de validação. Revise os campos.');
+    }
+  }
+}

--- a/apps/selecao/src/app/features/editais/editais-list.page.spec.ts
+++ b/apps/selecao/src/app/features/editais/editais-list.page.spec.ts
@@ -5,6 +5,7 @@ import {
 } from '@angular/common/http/testing';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { provideRouter } from '@angular/router';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { apiResultInterceptor, buildVendorMimeAccept } from '@uniplus/shared-core';
 import { EditalDto, SELECAO_BASE_PATH } from '@uniplus/shared-data';
@@ -35,6 +36,7 @@ describe('EditaisListPage', () => {
       providers: [
         provideHttpClient(withInterceptors([apiResultInterceptor])),
         provideHttpClientTesting(),
+        provideRouter([]),
         { provide: SELECAO_BASE_PATH, useValue: BASE },
       ],
     });

--- a/apps/selecao/src/app/features/editais/editais-list.page.ts
+++ b/apps/selecao/src/app/features/editais/editais-list.page.ts
@@ -7,6 +7,7 @@ import {
   signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { RouterLink } from '@angular/router';
 import {
   Cursor,
   ProblemI18nService,
@@ -26,11 +27,19 @@ import { DataTableColumn, DataTableComponent } from '@uniplus/shared-ui';
   selector: 'sel-editais-list-page',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [DataTableComponent],
+  imports: [DataTableComponent, RouterLink],
   template: `
-    <header class="mb-5">
-      <h2 class="text-2xl font-bold text-gray-800">Editais</h2>
-      <p class="text-sm text-gray-600">Gestão de editais de processos seletivos.</p>
+    <header class="mb-5 flex items-start justify-between gap-4">
+      <div>
+        <h2 class="text-2xl font-bold text-gray-800">Editais</h2>
+        <p class="text-sm text-gray-600">Gestão de editais de processos seletivos.</p>
+      </div>
+      <a
+        routerLink="novo"
+        class="inline-flex shrink-0 items-center rounded-md bg-unifesspa-primary px-4 py-2 text-sm font-semibold text-white shadow-sm hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-unifesspa-primary"
+      >
+        Novo edital
+      </a>
     </header>
 
     <ui-data-table

--- a/apps/selecao/src/app/features/editais/editais.routes.ts
+++ b/apps/selecao/src/app/features/editais/editais.routes.ts
@@ -6,4 +6,9 @@ export const EDITAIS_ROUTES: Routes = [
     loadComponent: () =>
       import('./editais-list.page').then((m) => m.EditaisListPage),
   },
+  {
+    path: 'novo',
+    loadComponent: () =>
+      import('./editais-create.page').then((m) => m.EditaisCreatePage),
+  },
 ];

--- a/docs/adrs/0014-idempotency-key-cliente-via-http-context.md
+++ b/docs/adrs/0014-idempotency-key-cliente-via-http-context.md
@@ -167,3 +167,47 @@ A entrega da Story [#184](https://github.com/unifesspa-edu-br/uniplus-web/issues
 - **Validação aplicada apenas a keys explícitas.** Keys geradas internamente (UUID v7) sempre passam — o draft IETF é tolerante a hex+hyphens.
 - **`appendContextHeaders` é o ponto único de extensão** para futuros tokens HTTP-derivados (ex.: `X-Tenant-Id` se algum dia precisarmos): adicionar uma leitura ao Map. Sem necessidade de novo interceptor.
 - **`uuid@14.x.x` é a versão atual** quando esta entrega foi feita; a peerDep do `shared-core` foi pinned em `^14.0.0`. Bumps semânticos seguem políticas normais de upgrade.
+
+## Form-scoped key strategy aplicada — `EditaisCreatePage` (2026-05-06, F7)
+
+A primeira página binding a aplicar a estratégia form-scoped foi `EditaisCreatePage` (Frente F7 do plano Milestone B; Story [#198](https://github.com/unifesspa-edu-br/uniplus-web/issues/198)). O pattern concretizado:
+
+```ts
+export class EditaisCreatePage {
+  // Gerada 1× por inicialização do componente — vive no signal até reset.
+  readonly idempotencyKeyAtual = signal<string>(idempotencyKey.create());
+
+  enviar(): void {
+    if (this.submitting() || this.form.invalid) { /* ... */ return; }
+    this.submitting.set(true);
+
+    this.api
+      .criar(command, withIdempotencyKey(this.idempotencyKeyAtual()))
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((result) => {
+        this.submitting.set(false);
+        if (result.ok) {
+          // Reset SOMENTE após sucesso — próximo submit ganha key nova.
+          this.idempotencyKeyAtual.set(idempotencyKey.create());
+          this.router.navigate(['/editais']);
+          return;
+        }
+        // Em 422/409/etc., a key é PRESERVADA. Retries (com correção do payload
+        // ou simples retentativa de transient) reusam a mesma key, e o backend
+        // distingue replay legítimo de double-submit acidental conforme ADR-0027.
+        this.aplicarFalha(result.problem);
+      });
+  }
+}
+```
+
+### Decisões binding capturadas na aplicação
+
+- **Key viva no `signal`, nunca em `localStorage`/`sessionStorage`** — aderência ao padrão #20.
+- **Reset só em `result.ok`** — falhas de validação ou conflito mantêm a key porque o usuário está corrigindo o mesmo "intent de submit". Mudar a key em cada retry derrotaria o propósito do header (backend não reconheceria como replay).
+- **Falha de rede / timeout** — caller pode chamar `enviar()` de novo com a mesma key; backend dedupa. Sem retry automático embutido na page (decisão do operador humano).
+- **Cancelamento explícito (usuário clica "Cancelar"** ou navega para fora**)** — nesta page, `routerLink="/editais"` simplesmente abandona o componente; `takeUntilDestroyed` cancela qualquer subscribe pendente. A key gerada é descartada com o componente — sem necessidade de reset manual.
+
+### Trade-off conhecido
+
+A página exibe `errorMessage` (banner) ou erros inline por campo, mas **não dá feedback visual sobre estar reusando a mesma key em retries**. Para V1 isto é aceitável; se o cenário "double-submit acidental retornando 200 cacheado com `Idempotency-Replayed: true`" virar comum em telemetria, adicionar um indicador visual sutil pode ajudar UX (parqueado).

--- a/libs/shared-data/src/lib/api/selecao/editais.api.spec.ts
+++ b/libs/shared-data/src/lib/api/selecao/editais.api.spec.ts
@@ -12,8 +12,9 @@ import {
   buildVendorMimeAccept,
   createCursor,
   isApiOk,
+  withIdempotencyKey,
 } from '@uniplus/shared-core';
-import { EditaisApi, EditalDto } from './editais.api';
+import { CriarEditalCommand, EditaisApi, EditalDto } from './editais.api';
 import { SELECAO_BASE_PATH } from './tokens';
 
 const BASE = 'http://localhost:5000';
@@ -149,5 +150,109 @@ describe('EditaisApi', () => {
       expect(result.problem.code).toBe('uniplus.selecao.edital.nao_encontrado');
       expect(result.status).toBe(404);
     }
+  });
+
+  describe('criar()', () => {
+    const comando: CriarEditalCommand = {
+      numeroEdital: 42,
+      anoEdital: 2026,
+      titulo: 'PSE 2026',
+      tipoProcesso: 1,
+      maximoOpcoesCurso: 2,
+    };
+
+    it('faz POST /api/editais com Idempotency-Key e devolve 201 com o ID', async () => {
+      const key = '01890a5d-ac96-774b-bcce-b302099a8057';
+      const promise = firstValueFrom(api.criar(comando, withIdempotencyKey(key)));
+
+      const req = controller.expectOne(`${BASE}/api/editais`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.headers.get('Idempotency-Key')).toBe(key);
+      expect(req.request.body).toEqual(comando);
+      req.flush('01960000-0000-7000-0000-000000000099', {
+        status: 201,
+        statusText: 'Created',
+        headers: { Location: '/api/editais/01960000-0000-7000-0000-000000000099' },
+      });
+
+      const result = (await promise) as ApiResult<string>;
+      expect(isApiOk(result)).toBe(true);
+      if (result.ok) {
+        expect(result.data).toBe('01960000-0000-7000-0000-000000000099');
+        expect(result.headers.get('Location')).toBe('/api/editais/01960000-0000-7000-0000-000000000099');
+      }
+    });
+
+    it('mapeia 422 com errors[] como ApiFailure preservando o array de validações', async () => {
+      const key = '01890a5d-ac96-774b-bcce-b302099a8058';
+      const promise = firstValueFrom(api.criar(comando, withIdempotencyKey(key)));
+
+      controller.expectOne(`${BASE}/api/editais`).flush(
+        {
+          type: 'about:blank',
+          title: 'Falha de validação',
+          status: 422,
+          code: 'uniplus.validation.falhou',
+          traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+          errors: [
+            { field: 'titulo', code: 'NotEmpty', message: 'Título é obrigatório.' },
+            { field: 'numeroEdital', code: 'GreaterThan', message: 'Número deve ser positivo.' },
+          ],
+        },
+        { status: 422, statusText: 'Unprocessable Entity', headers: { 'Content-Type': 'application/problem+json' } },
+      );
+
+      const result = (await promise) as ApiResult<string>;
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.problem.code).toBe('uniplus.validation.falhou');
+        expect(result.problem.errors).toHaveLength(2);
+        expect(result.problem.errors?.[0].field).toBe('titulo');
+        expect(result.problem.errors?.[1].code).toBe('GreaterThan');
+      }
+    });
+
+    it('mapeia 409 conflict como ApiFailure', async () => {
+      const key = '01890a5d-ac96-774b-bcce-b302099a8059';
+      const promise = firstValueFrom(api.criar(comando, withIdempotencyKey(key)));
+
+      controller.expectOne(`${BASE}/api/editais`).flush(
+        {
+          type: 'about:blank',
+          title: 'Edital já existente',
+          status: 409,
+          code: 'uniplus.selecao.edital.duplicado',
+          traceId: '4bf92f3577b34da6a3ce929d0e0e4737',
+        },
+        { status: 409, statusText: 'Conflict', headers: { 'Content-Type': 'application/problem+json' } },
+      );
+
+      const result = (await promise) as ApiResult<string>;
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.problem.code).toBe('uniplus.selecao.edital.duplicado');
+        expect(result.status).toBe(409);
+      }
+    });
+
+    it('replay com mesma key reusa o header e o backend devolve resposta cacheada com Idempotency-Replayed: true', async () => {
+      const key = '01890a5d-ac96-774b-bcce-b302099a805a';
+
+      const promise = firstValueFrom(api.criar(comando, withIdempotencyKey(key)));
+
+      const req = controller.expectOne(`${BASE}/api/editais`);
+      expect(req.request.headers.get('Idempotency-Key')).toBe(key);
+      req.flush('01960000-0000-7000-0000-000000000099', {
+        status: 201,
+        statusText: 'Created',
+        headers: { 'Idempotency-Replayed': 'true' },
+      });
+
+      const result = (await promise) as ApiResult<string>;
+      expect(isApiOk(result)).toBe(true);
+      if (result.ok) {
+        expect(result.headers.get('Idempotency-Replayed')).toBe('true');
+      }
+    });
   });
 });

--- a/libs/shared-data/src/lib/api/selecao/editais.api.spec.ts
+++ b/libs/shared-data/src/lib/api/selecao/editais.api.spec.ts
@@ -161,13 +161,16 @@ describe('EditaisApi', () => {
       maximoOpcoesCurso: 2,
     };
 
-    it('faz POST /api/editais com Idempotency-Key e devolve 201 com o ID', async () => {
+    it('faz POST /api/editais com Idempotency-Key + Accept: application/json e devolve 201 com o ID', async () => {
       const key = '01890a5d-ac96-774b-bcce-b302099a8057';
       const promise = firstValueFrom(api.criar(comando, withIdempotencyKey(key)));
 
       const req = controller.expectOne(`${BASE}/api/editais`);
       expect(req.request.method).toBe('POST');
       expect(req.request.headers.get('Idempotency-Key')).toBe(key);
+      // Accept fixado evita que backend devolva text/plain (que quebraria
+      // responseType: 'json') quando o contrato permite ambos.
+      expect(req.request.headers.get('Accept')).toBe('application/json');
       expect(req.request.body).toEqual(comando);
       req.flush('01960000-0000-7000-0000-000000000099', {
         status: 201,

--- a/libs/shared-data/src/lib/api/selecao/editais.api.ts
+++ b/libs/shared-data/src/lib/api/selecao/editais.api.ts
@@ -1,4 +1,9 @@
-import { HttpClient, HttpContext, HttpParams } from '@angular/common/http';
+import {
+  HttpClient,
+  HttpContext,
+  HttpHeaders,
+  HttpParams,
+} from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import {
@@ -84,10 +89,17 @@ export class EditaisApi {
    * compõe num `HttpContext` próprio (ex.: `withIdempotencyKey(key).set(...)`).
    * Sem o header, o backend rejeita com `400 uniplus.idempotency.key_ausente`.
    *
-   * **Resposta 201:** body é `string` com o ID do recurso criado; header
+   * **Resposta 201:** body é `string` (o ID do recurso criado); header
    * `Location` aponta para o detalhe (ADR-0029). Replays válidos com a mesma
    * key + body idêntico recebem a resposta original cacheada com
    * `Idempotency-Replayed: true` (ADR-0027).
+   *
+   * **Accept fixado em `application/json`** porque o contrato declara também
+   * `text/plain` para 201 — sem Accept explícito, Angular envia
+   * `application/json, text/plain` (mais o wildcard genérico) e um 201 com
+   * `text/plain` body `<id>` (sem aspas) faria `responseType: 'json'` lançar
+   * JSON parse error em sucesso legítimo. Forçar JSON garante que o body
+   * chega como `string` JSON-decodificada.
    */
   criar(
     command: CriarEditalCommand,
@@ -96,7 +108,10 @@ export class EditaisApi {
     return this.http.post<ApiResult<string>>(
       `${this.basePath}/api/editais`,
       command,
-      { context },
+      {
+        context,
+        headers: new HttpHeaders({ Accept: 'application/json' }),
+      },
     );
   }
 }

--- a/libs/shared-data/src/lib/api/selecao/editais.api.ts
+++ b/libs/shared-data/src/lib/api/selecao/editais.api.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpContext, HttpParams } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import {
@@ -73,6 +73,30 @@ export class EditaisApi {
     return this.http.get<ApiResult<EditalDto>>(
       `${this.basePath}/api/editais/${encodeURIComponent(id)}`,
       { context: withVendorMime('edital', 1) },
+    );
+  }
+
+  /**
+   * POST `/api/editais` — cria um novo edital.
+   *
+   * **Header obrigatório:** `Idempotency-Key` (ADR-0027 do `uniplus-api`,
+   * ADR-0014 do consumer). O caller declara via `withIdempotencyKey(key)` ou
+   * compõe num `HttpContext` próprio (ex.: `withIdempotencyKey(key).set(...)`).
+   * Sem o header, o backend rejeita com `400 uniplus.idempotency.key_ausente`.
+   *
+   * **Resposta 201:** body é `string` com o ID do recurso criado; header
+   * `Location` aponta para o detalhe (ADR-0029). Replays válidos com a mesma
+   * key + body idêntico recebem a resposta original cacheada com
+   * `Idempotency-Replayed: true` (ADR-0027).
+   */
+  criar(
+    command: CriarEditalCommand,
+    context: HttpContext,
+  ): Observable<ApiResult<string>> {
+    return this.http.post<ApiResult<string>>(
+      `${this.basePath}/api/editais`,
+      command,
+      { context },
     );
   }
 }


### PR DESCRIPTION
## Resumo

Tela `/editais/novo` no app `selecao` — form Reactive Forms tipado para criar edital. Pattern **form-scoped Idempotency-Key**: gerada 1× na inicialização, preservada em retries (422/409/etc.), resetada apenas em `201 Created`. Backend dedupa via `Idempotency-Replayed: true` (ADR-0027).

## Mudanças

### `libs/shared-data` — service
- `editais.api.ts` — `criar(command, context)` retornando `Observable<ApiResult<string>>`. `Idempotency-Key` injetado pelo `apiResultInterceptor` quando context populado.
- 4 cenários novos no spec (201 sucesso, 422 errors[], 409 conflict, replay com mesma key + `Idempotency-Replayed: true`).

### `apps/selecao` — feature
- `EditaisCreatePage` container ADR-0017. `FormGroup<CriarEditalForm>` tipado com validators. Form-scoped key signal. Mapping de `result.problem.errors[].field` → `FormControl.setErrors({ backend: { code, message } })`. Banner `role="alert"` para 409/genéricos via `ProblemI18nService`. `takeUntilDestroyed` em todo subscribe. Guards separados de `submitting()` e `form.invalid` (evita `markAllAsTouched` em submit via Enter).
- 9 cenários no spec, incluindo o caminho **end-to-end form-scoped**: 422 popula `setErrors`, usuário corrige campo (Angular limpa o backend error no próximo `valueChange`), retry usa **mesma key** e backend cacheia → 201.
- `editais.routes.ts` — rota filha `'novo'`.
- `editais-list.page.ts` ganha botão "Novo edital" (`RouterLink`); spec ganha `provideRouter([])`.

### `apps/selecao-e2e`
- `edital-crud.spec.ts` ganha test cobrindo navegação `/editais/novo` + render do form + submit `disabled` em form vazio.

### ADR-0014 atualizada
- Nova seção "Form-scoped key strategy aplicada — `EditaisCreatePage` (2026-05-06, F7)" com snippet real, decisões binding (key no signal sem persistência, reset só em `result.ok`, `takeUntilDestroyed` cancela on destroy, cancelamento via `routerLink`) e trade-off conhecido (sem feedback visual de replay).

## Verificações executadas

- `bash tools/adr-lint/validate.sh` → 17 ADRs OK.
- `npx markdownlint-cli2 'docs/adrs/0014-*.md'` → 0 erros.
- `npx nx affected --target=lint,test,typecheck,build --base=origin/main` → todos verdes.
- `selecao:test` → 17 tests (1 app + 7 list + 9 create).
- `shared-data:test` → cobertura ampliada com 4 novos cenários do `criar()`.
- Pre-commit review por `feature-dev:code-reviewer` agent → 2 P2 corrigidos antes do push:
  - Cobertura faltante: cenário end-to-end de retry após 422 com correção de campo (form-scoped strategy).
  - `enviar()`: separar guards `submitting()` e `form.invalid` para evitar `markAllAsTouched` em submit concorrente via Enter.

## Padrões binding aplicados

- ADR-0011/0012 (`ApiResult<T>` em `shared-core`).
- ADR-0013 (`CriarEditalCommand` vindo do `schema.ts`).
- ADR-0014 (Idempotency-Key form-scoped) — **primeira aplicação binding**.
- ADR-0017 (container/presentational) — segunda aplicação após F6.
- Padrão #20 (JWT só em memória) — não tocado.
- Sem PII (Editais não carregam CPF).

## Gap de contrato registrado

`tipoProcesso` é `integer` no schema sem enum exposto — provisoriamente `<input type="number">`; follow-up para refinar contrato no `uniplus-api` quando UX virar prioridade.

## Não-escopo

- Detalhe + publicar (F8).
- Auth fixture E2E real (F9).
- Foco no primeiro erro após submit (débito UX).
- Componente `ui-form-field` extraído (mantido inline; extrair se boilerplate crescer em F8).

Closes #198