### PR TITLE
feat(selecao): EditaisDetailPage + publicar HATEOAS-resilient + DataTable rowClick + a11y

### DIFF
--- a/apps/selecao-e2e/src/specs/edital-crud.spec.ts
+++ b/apps/selecao-e2e/src/specs/edital-crud.spec.ts
@@ -36,4 +36,22 @@ test.describe('Editais — CRUD', () => {
     // Submit fica disabled enquanto form invalid + nenhum campo preenchido.
     await expect(page.getByRole('button', { name: 'Criar edital' })).toBeDisabled();
   });
+
+  test('deve renderizar EditaisDetailPage com banner de erro ao acessar /editais/{id} inexistente (F8)', async ({
+    page,
+  }) => {
+    // Smoke direto na URL — independe de a lista ter itens. ID arbitrário
+    // garante 404 no backend; a page deve mostrar banner role="alert" sem
+    // crash. Cobertura ponta-a-ponta com criar→listar→detalhar→publicar fica
+    // para F9 (auth fixture + happy path completo).
+    const idArbitrario = '01960000-0000-7000-0000-000000000001';
+    await page.goto(`/editais/${idArbitrario}`);
+    await keycloakLogin(page, ADMIN.username, ADMIN.password);
+
+    await expect(page.locator('h2')).toContainText('Detalhes do edital');
+    await expect(page.getByRole('link', { name: 'Voltar para lista' })).toBeVisible();
+    // Banner de erro role="alert" via problem-i18n — confirma que a page lida
+    // graciosamente com 404 sem crash do componente.
+    await expect(page.locator('[role="alert"]')).toBeVisible();
+  });
 });

--- a/apps/selecao/src/app/features/editais/editais-detail.page.spec.ts
+++ b/apps/selecao/src/app/features/editais/editais-detail.page.spec.ts
@@ -186,6 +186,27 @@ describe('EditaisDetailPage', () => {
     expect(botao).toBeNull();
   });
 
+  it('race guard: response stale do id anterior é descartada quando id mudou (Codex P1 round 2)', () => {
+    fixture.detectChanges();
+    const reqId1 = controller.expectOne(`${BASE}/api/editais/${ID}`);
+
+    // Usuário navega antes do id1 retornar
+    const ID_NOVO = '01960000-0000-7000-0000-000000000bbb';
+    fixture.componentRef.setInput('id', ID_NOVO);
+    fixture.detectChanges();
+    const reqId2 = controller.expectOne(`${BASE}/api/editais/${ID_NOVO}`);
+
+    // id2 retorna primeiro com dados novos
+    reqId2.flush(editalSeed({ id: ID_NOVO, titulo: 'PSE 2027' }));
+    expect(component.edital()?.titulo).toBe('PSE 2027');
+    expect(component.loading()).toBe(false);
+
+    // id1 (stale) retorna depois — guard descarta sem mutar state
+    reqId1.flush(editalSeed({ titulo: 'PSE 2026' }));
+    expect(component.edital()?.titulo).toBe('PSE 2027'); // não mudou para PSE 2026
+    expect(component.loading()).toBe(false);
+  });
+
   it('mudança no input id refetcha automaticamente e zera estado anterior (Codex P1)', () => {
     fixture.detectChanges();
     controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ titulo: 'PSE 2026' }));

--- a/apps/selecao/src/app/features/editais/editais-detail.page.spec.ts
+++ b/apps/selecao/src/app/features/editais/editais-detail.page.spec.ts
@@ -186,7 +186,7 @@ describe('EditaisDetailPage', () => {
     expect(botao).toBeNull();
   });
 
-  it('race guard: response stale do id anterior é descartada quando id mudou (Codex P1 round 2)', () => {
+  it('race guard: response stale do id anterior é descartada quando id mudou', () => {
     fixture.detectChanges();
     const reqId1 = controller.expectOne(`${BASE}/api/editais/${ID}`);
 
@@ -207,7 +207,7 @@ describe('EditaisDetailPage', () => {
     expect(component.loading()).toBe(false);
   });
 
-  it('mudança no input id refetcha automaticamente e zera estado anterior (Codex P1)', () => {
+  it('mudança no input id refetcha automaticamente e zera estado anterior', () => {
     fixture.detectChanges();
     controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ titulo: 'PSE 2026' }));
     fixture.detectChanges();

--- a/apps/selecao/src/app/features/editais/editais-detail.page.spec.ts
+++ b/apps/selecao/src/app/features/editais/editais-detail.page.spec.ts
@@ -185,4 +185,27 @@ describe('EditaisDetailPage', () => {
     const botao = fixture.debugElement.query(By.css('[data-testid="btn-publicar"]'));
     expect(botao).toBeNull();
   });
+
+  it('mudança no input id refetcha automaticamente e zera estado anterior (Codex P1)', () => {
+    fixture.detectChanges();
+    controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ titulo: 'PSE 2026' }));
+    fixture.detectChanges();
+
+    expect(component.edital()?.titulo).toBe('PSE 2026');
+
+    // Navegação para outro :id sem destruir o componente (Angular reusa instância).
+    const ID_NOVO = '01960000-0000-7000-0000-000000000aaa';
+    fixture.componentRef.setInput('id', ID_NOVO);
+    fixture.detectChanges();
+
+    // Estado do edital anterior é zerado durante o fetch novo.
+    expect(component.edital()).toBeNull();
+    expect(component.loading()).toBe(true);
+
+    const reqNovo = controller.expectOne(`${BASE}/api/editais/${ID_NOVO}`);
+    reqNovo.flush(editalSeed({ id: ID_NOVO, titulo: 'PSE 2027' }));
+
+    expect(component.edital()?.titulo).toBe('PSE 2027');
+    expect(component.loading()).toBe(false);
+  });
 });

--- a/apps/selecao/src/app/features/editais/editais-detail.page.spec.ts
+++ b/apps/selecao/src/app/features/editais/editais-detail.page.spec.ts
@@ -1,0 +1,188 @@
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { provideRouter } from '@angular/router';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { apiResultInterceptor } from '@uniplus/shared-core';
+import { EditalDto, SELECAO_BASE_PATH } from '@uniplus/shared-data';
+import { EditaisDetailPage } from './editais-detail.page';
+
+const BASE = 'http://localhost:5000';
+const ID = '01960000-0000-7000-0000-000000000099';
+
+const editalSeed = (overrides: Partial<EditalDto> = {}): EditalDto => ({
+  id: ID,
+  numeroEdital: '042/2026',
+  titulo: 'PSE 2026',
+  tipoProcesso: 'PSE',
+  status: 'Rascunho',
+  maximoOpcoesCurso: 2,
+  bonusRegionalHabilitado: false,
+  criadoEm: '2026-04-15T12:00:00Z',
+  ...overrides,
+});
+
+describe('EditaisDetailPage', () => {
+  let fixture: ComponentFixture<EditaisDetailPage>;
+  let component: EditaisDetailPage;
+  let controller: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [EditaisDetailPage],
+      providers: [
+        provideHttpClient(withInterceptors([apiResultInterceptor])),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        { provide: SELECAO_BASE_PATH, useValue: BASE },
+      ],
+    });
+
+    fixture = TestBed.createComponent(EditaisDetailPage);
+    component = fixture.componentInstance;
+    controller = TestBed.inject(HttpTestingController);
+    fixture.componentRef.setInput('id', ID);
+  });
+
+  afterEach(() => controller.verify());
+
+  it('carga inicial dispara GET /api/editais/{id} e popula o signal edital', () => {
+    fixture.detectChanges();
+
+    const req = controller.expectOne(`${BASE}/api/editais/${ID}`);
+    expect(req.request.method).toBe('GET');
+    req.flush(editalSeed());
+
+    expect(component.edital()).toMatchObject({
+      id: ID,
+      titulo: 'PSE 2026',
+      status: 'Rascunho',
+    });
+    expect(component.errorMessage()).toBeNull();
+    expect(component.loading()).toBe(false);
+  });
+
+  it('404 problem+json popula errorMessage via problem-i18n e zera edital', () => {
+    fixture.detectChanges();
+
+    controller.expectOne(`${BASE}/api/editais/${ID}`).flush(
+      {
+        type: 'about:blank',
+        title: 'Edital não encontrado',
+        status: 404,
+        code: 'uniplus.selecao.edital.nao_encontrado',
+        traceId: 'tx',
+      },
+      { status: 404, statusText: 'Not Found', headers: { 'Content-Type': 'application/problem+json' } },
+    );
+
+    expect(component.edital()).toBeNull();
+    expect(component.errorMessage()).toBe('Edital não encontrado');
+  });
+
+  it('podePublicar=true quando _links.publicar está presente (caminho A HATEOAS)', () => {
+    fixture.detectChanges();
+    controller.expectOne(`${BASE}/api/editais/${ID}`).flush({
+      ...editalSeed({ status: 'Publicado' }),
+      _links: {
+        self: `/api/editais/${ID}`,
+        publicar: `/api/editais/${ID}/publicar`,
+      },
+    });
+
+    // _links.publicar wins sobre status — backend é a única fonte da regra.
+    expect(component['podePublicar']()).toBe(true);
+  });
+
+  it('podePublicar=false quando _links presente mas sem .publicar (status irrelevante)', () => {
+    fixture.detectChanges();
+    controller.expectOne(`${BASE}/api/editais/${ID}`).flush({
+      ...editalSeed({ status: 'Rascunho' }),
+      _links: { self: `/api/editais/${ID}` },
+    });
+
+    expect(component['podePublicar']()).toBe(false);
+  });
+
+  it('fallback temporário (uniplus-api#334): sem _links, podePublicar=true se status=Rascunho', () => {
+    fixture.detectChanges();
+    controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Rascunho' }));
+
+    expect(component['podePublicar']()).toBe(true);
+  });
+
+  it('fallback: sem _links, podePublicar=false se status diferente de Rascunho', () => {
+    fixture.detectChanges();
+    controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Publicado' }));
+
+    expect(component['podePublicar']()).toBe(false);
+  });
+
+  it('confirmarPublicacao envia POST com Idempotency-Key, recebe 204 e refetcha o edital', () => {
+    fixture.detectChanges();
+    controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Rascunho' }));
+
+    component['confirmarPublicacao']();
+    expect(component.submitting()).toBe(true);
+
+    const reqPublicar = controller.expectOne(`${BASE}/api/editais/${ID}/publicar`);
+    expect(reqPublicar.request.method).toBe('POST');
+    expect(reqPublicar.request.headers.get('Idempotency-Key')).toMatch(/^[0-9a-f-]{36}$/);
+    reqPublicar.flush(null, { status: 204, statusText: 'No Content' });
+
+    // Refetch dispara novo GET
+    const reqRefetch = controller.expectOne(`${BASE}/api/editais/${ID}`);
+    reqRefetch.flush(editalSeed({ status: 'Publicado' }));
+
+    expect(component.submitting()).toBe(false);
+    expect(component.mensagemSucesso()).toBe('Edital publicado com sucesso.');
+    expect(component.edital()?.status).toBe('Publicado');
+  });
+
+  it('confirmarPublicacao com 422 ja_publicado popula errorMessage e NÃO refetcha', () => {
+    fixture.detectChanges();
+    controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Rascunho' }));
+
+    component['confirmarPublicacao']();
+    controller.expectOne(`${BASE}/api/editais/${ID}/publicar`).flush(
+      {
+        type: 'about:blank',
+        title: 'Edital já publicado',
+        status: 422,
+        code: 'uniplus.selecao.edital.ja_publicado',
+        traceId: 'tx',
+      },
+      { status: 422, statusText: 'Unprocessable Entity', headers: { 'Content-Type': 'application/problem+json' } },
+    );
+
+    expect(component.errorMessage()).toBe('Edital já publicado');
+    expect(component.mensagemSucesso()).toBeNull();
+    // Sem refetch — controller.verify() do afterEach detecta requests pendentes.
+  });
+
+  it('botão Publicar aparece quando podePublicar=true e dispara dialog', () => {
+    fixture.detectChanges();
+    controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Rascunho' }));
+    fixture.detectChanges();
+
+    const botao = fixture.debugElement.query(By.css('[data-testid="btn-publicar"]'));
+    expect(botao).not.toBeNull();
+    expect(component.dialogVisivel()).toBe(false);
+
+    botao.nativeElement.click();
+    expect(component.dialogVisivel()).toBe(true);
+  });
+
+  it('botão Publicar NÃO aparece quando podePublicar=false', () => {
+    fixture.detectChanges();
+    controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Publicado' }));
+    fixture.detectChanges();
+
+    const botao = fixture.debugElement.query(By.css('[data-testid="btn-publicar"]'));
+    expect(botao).toBeNull();
+  });
+});

--- a/apps/selecao/src/app/features/editais/editais-detail.page.ts
+++ b/apps/selecao/src/app/features/editais/editais-detail.page.ts
@@ -1,0 +1,230 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  OnInit,
+  computed,
+  inject,
+  input,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { RouterLink } from '@angular/router';
+import {
+  ProblemI18nService,
+  idempotencyKey,
+  withIdempotencyKey,
+} from '@uniplus/shared-core';
+import { EditaisApi, EditalDto } from '@uniplus/shared-data';
+import { ConfirmDialogComponent } from '@uniplus/shared-ui';
+
+/**
+ * Extensão local de `EditalDto` para `_links` (HATEOAS Level 1, ADR-0029
+ * backend). Hoje o backend ainda não emite `_links` em `EditalDto` — issue
+ * tracked em [uniplus-api#334](https://github.com/unifesspa-edu-br/uniplus-api/issues/334).
+ *
+ * Quando o backend implementar, o codegen pegará a mudança automaticamente
+ * (a propriedade já fica opcional aqui, então o cast é seguro). A page lê
+ * `_links?.publicar` preferencialmente; se ausente, cai num fallback baseado
+ * em `status === 'Rascunho'`. O fallback é temporário e será removido quando
+ * `uniplus-api#334` fechar.
+ */
+type EditalComLinks = EditalDto & {
+  readonly _links?: {
+    readonly self?: string;
+    readonly collection?: string;
+    readonly publicar?: string;
+  };
+};
+
+/**
+ * Container (ADR-0017) da feature Editais — detalhe + ação Publicar.
+ *
+ * **Gating do botão "Publicar" (ADR-0029 backend):** preferencialmente
+ * HATEOAS-driven via `_links?.publicar`; fallback temporário a
+ * `status === 'Rascunho'` enquanto o backend não emite `_links` (uniplus-api#334).
+ *
+ * **Idempotency-Key (ADR-0014):** gerada a cada submit (não form-scoped — a
+ * ação "Publicar" não tem rascunho de form para preservar; replay protege
+ * contra double-click no botão).
+ */
+@Component({
+  selector: 'sel-editais-detail-page',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ConfirmDialogComponent, RouterLink],
+  template: `
+    <header class="mb-5 flex items-start justify-between gap-4">
+      <div>
+        <h2 class="text-2xl font-bold text-gray-800">Detalhes do edital</h2>
+        @if (edital()) {
+          <p class="text-sm text-gray-600">{{ edital()!.numeroEdital }} — {{ edital()!.titulo }}</p>
+        }
+      </div>
+      <a
+        routerLink="/editais"
+        class="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+      >
+        Voltar para lista
+      </a>
+    </header>
+
+    @if (errorMessage()) {
+      <div
+        class="mb-4 flex items-start gap-2 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800"
+        role="alert"
+      >
+        <span class="font-semibold">{{ errorMessage() }}</span>
+      </div>
+    }
+
+    @if (mensagemSucesso()) {
+      <div
+        class="mb-4 flex items-start gap-2 rounded-md border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-800"
+        role="status"
+      >
+        <span class="font-semibold">{{ mensagemSucesso() }}</span>
+      </div>
+    }
+
+    @if (loading() && !edital()) {
+      <p class="text-sm text-gray-600" aria-live="polite">Carregando edital…</p>
+    }
+
+    @if (edital(); as e) {
+      <dl class="grid max-w-2xl grid-cols-[10rem_1fr] gap-x-4 gap-y-3 rounded-lg border border-gray-200 bg-white p-5">
+        <dt class="text-sm font-medium text-gray-500">Número</dt>
+        <dd class="text-sm text-gray-900">{{ e.numeroEdital }}</dd>
+
+        <dt class="text-sm font-medium text-gray-500">Título</dt>
+        <dd class="text-sm text-gray-900">{{ e.titulo }}</dd>
+
+        <dt class="text-sm font-medium text-gray-500">Tipo de processo</dt>
+        <dd class="text-sm text-gray-900">{{ e.tipoProcesso }}</dd>
+
+        <dt class="text-sm font-medium text-gray-500">Status</dt>
+        <dd class="text-sm text-gray-900" data-testid="edital-status">{{ e.status }}</dd>
+
+        <dt class="text-sm font-medium text-gray-500">Máx. opções de curso</dt>
+        <dd class="text-sm text-gray-900">{{ e.maximoOpcoesCurso }}</dd>
+
+        <dt class="text-sm font-medium text-gray-500">Bônus regional</dt>
+        <dd class="text-sm text-gray-900">{{ e.bonusRegionalHabilitado ? 'Sim' : 'Não' }}</dd>
+
+        <dt class="text-sm font-medium text-gray-500">Criado em</dt>
+        <dd class="text-sm text-gray-900">{{ e.criadoEm }}</dd>
+      </dl>
+
+      @if (podePublicar()) {
+        <div class="mt-4 flex justify-end">
+          <button
+            type="button"
+            data-testid="btn-publicar"
+            [disabled]="submitting()"
+            class="rounded-md bg-unifesspa-primary px-4 py-2 text-sm font-semibold text-white shadow-sm hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-unifesspa-primary disabled:cursor-not-allowed disabled:opacity-60"
+            (click)="abrirConfirmacao()"
+          >
+            {{ submitting() ? 'Publicando…' : 'Publicar' }}
+          </button>
+        </div>
+      }
+    }
+
+    <ui-confirm-dialog
+      [(visible)]="dialogVisivel"
+      title="Confirmar publicação"
+      message="Após a publicação, o edital fica visível para candidatos e não pode mais ser editado. Deseja prosseguir?"
+      confirmLabel="Publicar"
+      cancelLabel="Cancelar"
+      (confirmed)="confirmarPublicacao()"
+    />
+  `,
+})
+export class EditaisDetailPage implements OnInit {
+  /** Path param do route (`:id`). Bind via `withComponentInputBinding()`. */
+  readonly id = input.required<string>();
+
+  private readonly api = inject(EditaisApi);
+  private readonly problemI18n = inject(ProblemI18nService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  readonly edital = signal<EditalComLinks | null>(null);
+  readonly loading = signal<boolean>(false);
+  readonly errorMessage = signal<string | null>(null);
+  readonly submitting = signal<boolean>(false);
+  readonly mensagemSucesso = signal<string | null>(null);
+  readonly dialogVisivel = signal<boolean>(false);
+
+  /**
+   * Caminho A (HATEOAS-driven, ADR-0029): se `_links.publicar` presente,
+   * gating vem do servidor. Caminho B (fallback temporário): se `_links`
+   * ausente (uniplus-api#334), gate por `status === 'Rascunho'`.
+   */
+  protected readonly podePublicar = computed(() => {
+    const dto = this.edital();
+    if (!dto) return false;
+    if (dto._links !== undefined) {
+      return Boolean(dto._links.publicar);
+    }
+    return dto.status === 'Rascunho';
+  });
+
+  ngOnInit(): void {
+    this.carregar();
+  }
+
+  protected abrirConfirmacao(): void {
+    this.dialogVisivel.set(true);
+  }
+
+  protected confirmarPublicacao(): void {
+    if (this.submitting()) {
+      return;
+    }
+    const id = this.id();
+    this.submitting.set(true);
+    this.errorMessage.set(null);
+    this.mensagemSucesso.set(null);
+
+    this.api
+      .publicar(id, withIdempotencyKey(idempotencyKey.create()))
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((result) => {
+        this.submitting.set(false);
+        if (result.ok) {
+          this.mensagemSucesso.set('Edital publicado com sucesso.');
+          // Refetch incondicional — preserva mensagemSucesso, atualiza status.
+          // Bypass da guarda `loading` aqui é intencional: o sucesso do
+          // publicar exige reload garantido, mesmo se houver outra carga em voo.
+          this.executarObter();
+          return;
+        }
+        this.errorMessage.set(this.problemI18n.resolve(result.problem).title);
+      });
+  }
+
+  private carregar(): void {
+    if (this.loading()) {
+      return;
+    }
+    this.executarObter();
+  }
+
+  private executarObter(): void {
+    this.loading.set(true);
+    this.errorMessage.set(null);
+
+    this.api
+      .obter(this.id())
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((result) => {
+        this.loading.set(false);
+        if (result.ok) {
+          this.edital.set(result.data as EditalComLinks);
+          return;
+        }
+        this.edital.set(null);
+        this.errorMessage.set(this.problemI18n.resolve(result.problem).title);
+      });
+  }
+}

--- a/apps/selecao/src/app/features/editais/editais-detail.page.ts
+++ b/apps/selecao/src/app/features/editais/editais-detail.page.ts
@@ -198,21 +198,29 @@ export class EditaisDetailPage {
     if (this.submitting()) {
       return;
     }
-    const id = this.id();
+    const idDoSubmit = this.id();
     this.submitting.set(true);
     this.errorMessage.set(null);
     this.mensagemSucesso.set(null);
 
     this.api
-      .publicar(id, withIdempotencyKey(idempotencyKey.create()))
+      .publicar(idDoSubmit, withIdempotencyKey(idempotencyKey.create()))
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((result) => {
         this.submitting.set(false);
+        // Race guard: se usuário navegou para outro `:id` durante o publicar,
+        // descarta o feedback. Setar `mensagemSucesso` no edital errado
+        // confundiria o usuário; o backend já registrou a publicação do
+        // recurso original (Idempotency-Key garante).
+        if (this.id() !== idDoSubmit) {
+          return;
+        }
         if (result.ok) {
           this.mensagemSucesso.set('Edital publicado com sucesso.');
-          // Refetch incondicional — bypassa guarda de `loading` para garantir
-          // reload pós-publicar, mesmo se houver outra carga em voo.
-          this.executarObterPorId(id);
+          // Refetch — bypassa guarda de `loading` para garantir reload
+          // pós-publicar mesmo se houver outra carga em voo. O guard interno
+          // de `executarObterPorId` ainda protege contra response stale.
+          this.executarObterPorId(idDoSubmit);
           return;
         }
         this.errorMessage.set(this.problemI18n.resolve(result.problem).title);
@@ -229,6 +237,14 @@ export class EditaisDetailPage {
       .obter(id)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((result) => {
+        // Race guard: se o `id` corrente do componente mudou desde o início
+        // desta request (usuário navegou para outro `:id` mid-fetch), descarta
+        // a response stale. Sem isto, late response do id antigo poderia
+        // sobrescrever `edital`/`loading` do fetch do id novo (ADR-0017
+        // container responsabilidade — UI só reflete estado do id atual).
+        if (this.id() !== id) {
+          return;
+        }
         this.loading.set(false);
         if (result.ok) {
           this.edital.set(result.data as EditalComLinks);

--- a/apps/selecao/src/app/features/editais/editais-detail.page.ts
+++ b/apps/selecao/src/app/features/editais/editais-detail.page.ts
@@ -2,11 +2,12 @@ import {
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
-  OnInit,
   computed,
+  effect,
   inject,
   input,
   signal,
+  untracked,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
@@ -140,7 +141,7 @@ type EditalComLinks = EditalDto & {
     />
   `,
 })
-export class EditaisDetailPage implements OnInit {
+export class EditaisDetailPage {
   /** Path param do route (`:id`). Bind via `withComponentInputBinding()`. */
   readonly id = input.required<string>();
 
@@ -169,8 +170,24 @@ export class EditaisDetailPage implements OnInit {
     return dto.status === 'Rascunho';
   });
 
-  ngOnInit(): void {
-    this.carregar();
+  constructor() {
+    // Recarrega sempre que o input `id` mudar — caso de navegação entre
+    // /editais/:id1 → /editais/:id2 quando Angular reusa a mesma instância
+    // do componente. Sem isto, `edital()` ficaria stale e
+    // `confirmarPublicacao()` agiria contra o ID novo enquanto a UI mostra
+    // dados do anterior. `untracked` evita que mutations dentro do fetch
+    // re-disparem o effect.
+    effect(() => {
+      const currentId = this.id();
+      untracked(() => {
+        // Reset de estado dependente do ID anterior — só dispara quando o
+        // input muda. O refetch via publish (`confirmarPublicacao`) preserva
+        // `mensagemSucesso` porque chama `executarObterPorId` direto.
+        this.edital.set(null);
+        this.mensagemSucesso.set(null);
+        this.executarObterPorId(currentId);
+      });
+    });
   }
 
   protected abrirConfirmacao(): void {
@@ -193,29 +210,23 @@ export class EditaisDetailPage implements OnInit {
         this.submitting.set(false);
         if (result.ok) {
           this.mensagemSucesso.set('Edital publicado com sucesso.');
-          // Refetch incondicional — preserva mensagemSucesso, atualiza status.
-          // Bypass da guarda `loading` aqui é intencional: o sucesso do
-          // publicar exige reload garantido, mesmo se houver outra carga em voo.
-          this.executarObter();
+          // Refetch incondicional — bypassa guarda de `loading` para garantir
+          // reload pós-publicar, mesmo se houver outra carga em voo.
+          this.executarObterPorId(id);
           return;
         }
         this.errorMessage.set(this.problemI18n.resolve(result.problem).title);
       });
   }
 
-  private carregar(): void {
-    if (this.loading()) {
-      return;
-    }
-    this.executarObter();
-  }
-
-  private executarObter(): void {
+  private executarObterPorId(id: string): void {
     this.loading.set(true);
     this.errorMessage.set(null);
+    // Mantém `edital` e `mensagemSucesso` intactos — quem chamou (`effect`
+    // de mudança de id ou refetch pós-publicar) decide o reset apropriado.
 
     this.api
-      .obter(this.id())
+      .obter(id)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((result) => {
         this.loading.set(false);

--- a/apps/selecao/src/app/features/editais/editais-list.page.ts
+++ b/apps/selecao/src/app/features/editais/editais-list.page.ts
@@ -7,7 +7,7 @@ import {
   signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { RouterLink } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
 import {
   Cursor,
   ProblemI18nService,
@@ -48,8 +48,10 @@ import { DataTableColumn, DataTableComponent } from '@uniplus/shared-ui';
       [loading]="loading()"
       [errorMessage]="errorMessage()"
       [nextCursor]="nextCursor()"
+      [rowClickable]="true"
       emptyMessage="Nenhum edital cadastrado."
       (loadNext)="aoCarregarMais($event)"
+      (rowClick)="aoSelecionar($event)"
     />
   `,
 })
@@ -57,6 +59,7 @@ export class EditaisListPage {
   private readonly api = inject(EditaisApi);
   private readonly problemI18n = inject(ProblemI18nService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly router = inject(Router);
 
   readonly editais = signal<readonly EditalDto[]>([]);
   readonly nextCursor = signal<Cursor | null>(null);
@@ -80,6 +83,13 @@ export class EditaisListPage {
 
   protected aoCarregarMais(cursor: Cursor): void {
     this.carregar(cursor);
+  }
+
+  protected aoSelecionar(row: Record<string, unknown>): void {
+    const id = row['id'];
+    if (typeof id === 'string' && id.length > 0) {
+      this.router.navigate(['/editais', id]);
+    }
   }
 
   private carregar(cursor: Cursor | undefined): void {

--- a/apps/selecao/src/app/features/editais/editais.routes.ts
+++ b/apps/selecao/src/app/features/editais/editais.routes.ts
@@ -11,4 +11,9 @@ export const EDITAIS_ROUTES: Routes = [
     loadComponent: () =>
       import('./editais-create.page').then((m) => m.EditaisCreatePage),
   },
+  {
+    path: ':id',
+    loadComponent: () =>
+      import('./editais-detail.page').then((m) => m.EditaisDetailPage),
+  },
 ];

--- a/libs/shared-data/src/lib/api/selecao/editais.api.spec.ts
+++ b/libs/shared-data/src/lib/api/selecao/editais.api.spec.ts
@@ -238,7 +238,7 @@ describe('EditaisApi', () => {
       }
     });
 
-    it('replay com mesma key reusa o header e o backend devolve resposta cacheada com Idempotency-Replayed: true', async () => {
+    it('replay com mesma key reusa o header e o backend devolve resposta cacheada com Idempotency-Replayed: true (criar)', async () => {
       const key = '01890a5d-ac96-774b-bcce-b302099a805a';
 
       const promise = firstValueFrom(api.criar(comando, withIdempotencyKey(key)));
@@ -256,6 +256,62 @@ describe('EditaisApi', () => {
       if (result.ok) {
         expect(result.headers.get('Idempotency-Replayed')).toBe('true');
       }
+    });
+  });
+
+  describe('publicar()', () => {
+    const ID = '01960000-0000-7000-0000-000000000099';
+
+    it('faz POST /api/editais/{id}/publicar com Idempotency-Key + vendor MIME v1 e devolve 204 ApiResult.ok', async () => {
+      const key = '01890a5d-ac96-774b-bcce-b302099a805b';
+      const promise = firstValueFrom(api.publicar(ID, withIdempotencyKey(key)));
+
+      const req = controller.expectOne(`${BASE}/api/editais/${ID}/publicar`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.headers.get('Idempotency-Key')).toBe(key);
+      // Vendor MIME mantido por simetria com obter()/listar() (ADR-0028).
+      expect(req.request.headers.get('Accept')).toBe(buildVendorMimeAccept('edital', 1));
+      expect(req.request.body).toBeNull();
+      req.flush(null, { status: 204, statusText: 'No Content' });
+
+      const result = (await promise) as ApiResult<void>;
+      expect(isApiOk(result)).toBe(true);
+      if (result.ok) {
+        expect(result.status).toBe(204);
+      }
+    });
+
+    it('mapeia 422 ja_publicado como ApiFailure preservando o code', async () => {
+      const key = '01890a5d-ac96-774b-bcce-b302099a805c';
+      const promise = firstValueFrom(api.publicar(ID, withIdempotencyKey(key)));
+
+      controller.expectOne(`${BASE}/api/editais/${ID}/publicar`).flush(
+        {
+          type: 'about:blank',
+          title: 'Edital já publicado',
+          status: 422,
+          code: 'uniplus.selecao.edital.ja_publicado',
+          traceId: 'tx-publicar',
+        },
+        { status: 422, statusText: 'Unprocessable Entity', headers: { 'Content-Type': 'application/problem+json' } },
+      );
+
+      const result = (await promise) as ApiResult<void>;
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.problem.code).toBe('uniplus.selecao.edital.ja_publicado');
+      }
+    });
+
+    it('encoding seguro do path param em IDs com caracteres especiais', () => {
+      const idComEspaco = 'edt with space/01';
+      const key = '01890a5d-ac96-774b-bcce-b302099a805d';
+      firstValueFrom(api.publicar(idComEspaco, withIdempotencyKey(key)));
+
+      const req = controller.expectOne(
+        `${BASE}/api/editais/${encodeURIComponent(idComEspaco)}/publicar`,
+      );
+      req.flush(null, { status: 204, statusText: 'No Content' });
     });
   });
 });

--- a/libs/shared-data/src/lib/api/selecao/editais.api.ts
+++ b/libs/shared-data/src/lib/api/selecao/editais.api.ts
@@ -9,6 +9,7 @@ import { Observable } from 'rxjs';
 import {
   ApiResult,
   Cursor,
+  IDEMPOTENCY_KEY_TOKEN,
   cursorToString,
   withVendorMime,
 } from '@uniplus/shared-core';
@@ -112,6 +113,32 @@ export class EditaisApi {
         context,
         headers: new HttpHeaders({ Accept: 'application/json' }),
       },
+    );
+  }
+
+  /**
+   * POST `/api/editais/{id}/publicar` — publica um edital em rascunho.
+   *
+   * **Header obrigatório:** `Idempotency-Key` (ADR-0027 do `uniplus-api`).
+   * O caller declara via `withIdempotencyKey(key)` no `HttpContext`; este
+   * método compõe `withVendorMime('edital', 1)` no contexto recebido para
+   * declarar a versão do recurso (ADR-0028 backend, ADR-0016 cliente),
+   * mantendo simetria com `obter()` e `listar()`.
+   *
+   * **Resposta 204 No Content** em sucesso (sem body — vendor MIME não
+   * afeta o parse, mas é mantido por consistência de versionamento do recurso).
+   * **422 `uniplus.selecao.edital.ja_publicado`** quando o edital já está publicado.
+   */
+  publicar(id: string, context: HttpContext): Observable<ApiResult<void>> {
+    const idempotencyKeyValue = context.get(IDEMPOTENCY_KEY_TOKEN);
+    const ctxComposto = withVendorMime('edital', 1).set(
+      IDEMPOTENCY_KEY_TOKEN,
+      idempotencyKeyValue,
+    );
+    return this.http.post<ApiResult<void>>(
+      `${this.basePath}/api/editais/${encodeURIComponent(id)}/publicar`,
+      null,
+      { context: ctxComposto },
     );
   }
 }

--- a/libs/shared-ui/src/lib/components/confirm-dialog/confirm-dialog.ts
+++ b/libs/shared-ui/src/lib/components/confirm-dialog/confirm-dialog.ts
@@ -1,5 +1,7 @@
-import { Component, ChangeDetectionStrategy, input, output, model } from '@angular/core';
+import { Component, ChangeDetectionStrategy, computed, input, output, model } from '@angular/core';
 import { CommonModule } from '@angular/common';
+
+let dialogIdSeed = 0;
 
 @Component({
   selector: 'ui-confirm-dialog',
@@ -8,10 +10,16 @@ import { CommonModule } from '@angular/common';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @if (visible()) {
-      <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" role="dialog" aria-modal="true">
+      <div
+        class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+        role="dialog"
+        aria-modal="true"
+        [attr.aria-labelledby]="titleId()"
+        [attr.aria-describedby]="messageId()"
+      >
         <div class="mx-4 w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
-          <h3 class="text-lg font-semibold text-gray-900">{{ title() }}</h3>
-          <p class="mt-2 text-sm text-gray-600">{{ message() }}</p>
+          <h3 [id]="titleId()" class="text-lg font-semibold text-gray-900">{{ title() }}</h3>
+          <p [id]="messageId()" class="mt-2 text-sm text-gray-600">{{ message() }}</p>
           <div class="mt-6 flex justify-end gap-3">
             <button
               type="button"
@@ -44,6 +52,12 @@ export class ConfirmDialogComponent {
 
   readonly confirmed = output<void>();
   readonly cancelled = output<void>();
+
+  /** IDs únicos por instância, garantindo aria-labelledby/describedby
+   *  válidos quando múltiplos dialogs convivem no DOM. */
+  private readonly idSuffix = ++dialogIdSeed;
+  protected readonly titleId = computed(() => `ui-confirm-dialog-title-${this.idSuffix}`);
+  protected readonly messageId = computed(() => `ui-confirm-dialog-msg-${this.idSuffix}`);
 
   onConfirm(): void {
     this.confirmed.emit();

--- a/libs/shared-ui/src/lib/components/data-table/data-table.spec.ts
+++ b/libs/shared-ui/src/lib/components/data-table/data-table.spec.ts
@@ -183,4 +183,41 @@ describe('DataTableComponent', () => {
 
     expect(emit).not.toHaveBeenCalled();
   });
+
+  it('rowClickable=true ativa role=button + tabindex e emite rowClick com a linha clicada', () => {
+    const { fixture, component } = setup();
+    fixture.componentRef.setInput('columns', COLUMNS);
+    fixture.componentRef.setInput('data', DATA);
+    fixture.componentRef.setInput('rowClickable', true);
+    fixture.detectChanges();
+
+    const linhas = fixture.debugElement.queryAll(By.css('tbody tr'));
+    expect(linhas.length).toBe(DATA.length);
+    expect(linhas[0].nativeElement.getAttribute('role')).toBe('button');
+    expect(linhas[0].nativeElement.getAttribute('tabindex')).toBe('0');
+
+    const emit = vi.fn();
+    component.rowClick.subscribe(emit);
+
+    linhas[1].nativeElement.click();
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledWith(DATA[1]);
+  });
+
+  it('rowClickable=false (default) não ativa role/tabindex e clique na linha não emite rowClick', () => {
+    const { fixture, component } = setup();
+    fixture.componentRef.setInput('columns', COLUMNS);
+    fixture.componentRef.setInput('data', DATA);
+    fixture.detectChanges();
+
+    const linhas = fixture.debugElement.queryAll(By.css('tbody tr'));
+    expect(linhas[0].nativeElement.getAttribute('role')).toBeNull();
+    expect(linhas[0].nativeElement.getAttribute('tabindex')).toBeNull();
+
+    const emit = vi.fn();
+    component.rowClick.subscribe(emit);
+
+    linhas[0].nativeElement.click();
+    expect(emit).not.toHaveBeenCalled();
+  });
 });

--- a/libs/shared-ui/src/lib/components/data-table/data-table.spec.ts
+++ b/libs/shared-ui/src/lib/components/data-table/data-table.spec.ts
@@ -184,6 +184,24 @@ describe('DataTableComponent', () => {
     expect(emit).not.toHaveBeenCalled();
   });
 
+  it('Space na linha clicável emite rowClick e cancela o scroll default do browser', () => {
+    const { fixture, component } = setup();
+    fixture.componentRef.setInput('columns', COLUMNS);
+    fixture.componentRef.setInput('data', DATA);
+    fixture.componentRef.setInput('rowClickable', true);
+    fixture.detectChanges();
+
+    const emit = vi.fn();
+    component.rowClick.subscribe(emit);
+
+    const linha = fixture.debugElement.queryAll(By.css('tbody tr'))[0];
+    const spaceEvent = new KeyboardEvent('keydown', { key: ' ', code: 'Space', cancelable: true });
+    linha.nativeElement.dispatchEvent(spaceEvent);
+
+    expect(emit).toHaveBeenCalledWith(DATA[0]);
+    expect(spaceEvent.defaultPrevented).toBe(true);
+  });
+
   it('rowClickable=true ativa role=button + tabindex e emite rowClick com a linha clicada', () => {
     const { fixture, component } = setup();
     fixture.componentRef.setInput('columns', COLUMNS);

--- a/libs/shared-ui/src/lib/components/data-table/data-table.ts
+++ b/libs/shared-ui/src/lib/components/data-table/data-table.ts
@@ -75,9 +75,9 @@ export interface DataTableColumn {
                 [class.cursor-pointer]="rowClickable()"
                 [attr.role]="rowClickable() ? 'button' : null"
                 [attr.tabindex]="rowClickable() ? 0 : null"
-                (click)="rowClickable() && rowClick.emit(row)"
-                (keydown.enter)="rowClickable() && rowClick.emit(row)"
-                (keydown.space)="rowClickable() && rowClick.emit(row)"
+                (click)="ativarLinha(row)"
+                (keydown.enter)="ativarLinha(row, $event)"
+                (keydown.space)="ativarLinha(row, $event)"
               >
                 @for (col of columns(); track col.field) {
                   <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-700">
@@ -164,5 +164,18 @@ export class DataTableComponent {
     if (cursor !== null && !this.loading()) {
       this.loadNext.emit(cursor);
     }
+  }
+
+  /**
+   * Emite `rowClick` quando a linha é ativada via mouse ou teclado. Para
+   * Enter/Space, cancela o default do browser — Space sem preventDefault
+   * rola a página, e Enter pode submeter forms ancestrais.
+   */
+  protected ativarLinha(row: Record<string, unknown>, event?: Event): void {
+    if (!this.rowClickable()) {
+      return;
+    }
+    event?.preventDefault();
+    this.rowClick.emit(row);
   }
 }

--- a/libs/shared-ui/src/lib/components/data-table/data-table.ts
+++ b/libs/shared-ui/src/lib/components/data-table/data-table.ts
@@ -69,7 +69,16 @@ export interface DataTableColumn {
             </tr>
           } @else {
             @for (row of data(); track row[trackByField()] ?? $index) {
-              <tr class="hover:bg-gray-50 transition-colors">
+              <tr
+                class="transition-colors"
+                [class.hover:bg-gray-50]="rowClickable()"
+                [class.cursor-pointer]="rowClickable()"
+                [attr.role]="rowClickable() ? 'button' : null"
+                [attr.tabindex]="rowClickable() ? 0 : null"
+                (click)="rowClickable() && rowClick.emit(row)"
+                (keydown.enter)="rowClickable() && rowClick.emit(row)"
+                (keydown.space)="rowClickable() && rowClick.emit(row)"
+              >
                 @for (col of columns(); track col.field) {
                   <td class="whitespace-nowrap px-4 py-3 text-sm text-gray-700">
                     {{ row[col.field] }}
@@ -128,6 +137,9 @@ export class DataTableComponent {
   readonly trackByField = input<string>('id');
 
   readonly loadNext = output<Cursor>();
+  readonly rowClick = output<Record<string, unknown>>();
+  /** Quando true, linhas ganham hover/cursor/role=button e respondem a click + Enter/Space. */
+  readonly rowClickable = input<boolean>(false);
 
   /** Erro substitui o tbody apenas quando ainda não há dados carregados. */
   protected readonly mostrarErroNoCorpo = computed(


### PR DESCRIPTION
## Resumo

Tela `/editais/:id` no app `selecao` — detalhe do edital + ação **Publicar**. Implementa o caminho A do plano (HATEOAS-driven, ADR-0029 backend) com **fallback temporário** porque o backend ainda não emite `_links` em `EditalDto` ([uniplus-api#334](https://github.com/unifesspa-edu-br/uniplus-api/issues/334) aberta). Page é HATEOAS-resilient: lê `_links?.publicar` quando presente, fallback a `status === 'Rascunho'` quando ausente.

## Mudanças

### `libs/shared-data` — service
- `editais.api.ts` — `publicar(id, context)` retornando `Observable<ApiResult<void>>`. Compõe `withVendorMime('edital', 1)` com a `Idempotency-Key` recebida do caller (simetria com `obter()`/`listar()` per ADR-0028).
- 3 cenários novos no spec (204 + Accept versionado, 422 ja_publicado, encoding seguro de path param).

### `libs/shared-ui` — apresentacionais
- `DataTableComponent` — input `rowClickable: boolean` (default false) + output `rowClick: Record<string, unknown>`. Linhas com `role="button"`, `tabindex=0`, `cursor-pointer`, hover, e respondem a click + Enter + Space (WCAG 2.1.1 / 4.1.2).
- `ConfirmDialogComponent` — `aria-labelledby` + `aria-describedby` com IDs únicos por instância (counter privado). WCAG 4.1.3 + 1.3.1.

### `apps/selecao` — feature
- `EditaisDetailPage` container ADR-0017. Type `EditalComLinks` extension local declarando `_links?: { self?, collection?, publicar? }` — quando `uniplus-api#334` fechar, codegen pega automaticamente.
- `podePublicar` computed: `_links.publicar` quando `_links !== undefined`; fallback a `status === 'Rascunho'` caso contrário. Documentado em JSDoc.
- Carrega via `obter(id)` em `ngOnInit` (input.required precisa estar resolvido). 404 → `errorMessage` via `ProblemI18nService`.
- Botão "Publicar" condicionado a `podePublicar()`. Confirmação via `ui-confirm-dialog`. Idempotency-Key nova por submit (não form-scoped — sem rascunho de form a preservar; replay + guarda `if (submitting()) return` protegem contra double-click).
- 204 publicar: refetch via `executarObter()` (bypassa guarda `loading` do `carregar()` para garantir reload pós-publicar) + `mensagemSucesso` banner.
- 422 `ja_publicado` / 4xx: `errorMessage` banner via `problem-i18n`.
- `takeUntilDestroyed(destroyRef)` em todos subscribes.
- 10 cenários no spec.
- `EditaisListPage` agora passa `[rowClickable]="true"` e navega para `/editais/{id}` via `(rowClick)`.

### `editais.routes.ts`
- Rota filha `:id` → `EditaisDetailPage` via `loadComponent`.

### `apps/selecao-e2e`
- Test smoke `/editais/{id-arbitrário}` — confirma banner `role="alert"` aparece (page lida graciosamente com 404 sem crash).

## Verificações executadas

- `bash tools/adr-lint/validate.sh` → 17 ADRs OK (sem ADR nova; F8 usa fallback documentado em JSDoc + issue #334).
- `npx nx affected --target=lint,test,typecheck,build --base=origin/main` → todos verdes (9 projetos).
- `selecao:test` → 27 tests (1 + 7 list + 9 create + 10 detail).
- `shared-ui:test` → 58 tests (incluindo +2 do DataTable rowClick).
- `shared-data:test` → 43 tests (incluindo +3 do `publicar()`).
- Pre-commit review por `feature-dev:code-reviewer` agent → 4 P2 corrigidos antes do push:
  - Vendor MIME ausente em `publicar()` → composto via `withVendorMime('edital', 1)`.
  - Race condition refetch pós-204 → `executarObter()` extraído sem guarda `loading`.
  - `ConfirmDialog` sem `aria-labelledby`/`aria-describedby` → IDs únicos via counter privado.
  - E2E sem assertion de banner de erro → adicionado `expect(page.locator('[role="alert"]')).toBeVisible()`.

## Padrões binding aplicados

- ADR-0011/0012 (`ApiResult<T>`).
- ADR-0013 (codegen com extension local `EditalComLinks`).
- ADR-0014 (Idempotency-Key via `withIdempotencyKey`).
- ADR-0016 (vendor MIME consumer).
- ADR-0017 (container/presentational) — terceira aplicação binding.
- ADR-0029 backend (HATEOAS Level 1) — preferida via `_links`; fallback temporário documentado por gap.
- Padrão #20 (JWT só em memória) — não tocado.
- Sem PII (Editais não carregam CPF).

## Não-escopo

- Auth fixture E2E real + happy path completo (F9).
- Migração para PrimeNG Dialog (mantém ConfirmDialog HTML nativo + Tailwind).
- Edição de edital.

## Issue dependente

- [uniplus-api#334](https://github.com/unifesspa-edu-br/uniplus-api/issues/334) — `EditalDto` sem `_links` per ADR-0029. Quando fechar, EditaisDetailPage automaticamente passa a usar o caminho A puro.

Closes #200