### PR TITLE
fix(selecao): EditaisDetailPage.podePublicar lê apenas status (cleanup pós uniplus-api#335)

### DIFF
--- a/apps/selecao/src/app/features/editais/editais-detail.page.spec.ts
+++ b/apps/selecao/src/app/features/editais/editais-detail.page.spec.ts
@@ -84,42 +84,50 @@ describe('EditaisDetailPage', () => {
     expect(component.errorMessage()).toBe('Edital não encontrado');
   });
 
-  it('podePublicar=true quando _links.publicar está presente (caminho A HATEOAS)', () => {
-    fixture.detectChanges();
-    controller.expectOne(`${BASE}/api/editais/${ID}`).flush({
-      ...editalSeed({ status: 'Publicado' }),
-      _links: {
-        self: `/api/editais/${ID}`,
-        publicar: `/api/editais/${ID}/publicar`,
-      },
-    });
-
-    // _links.publicar wins sobre status — backend é a única fonte da regra.
-    expect(component['podePublicar']()).toBe(true);
-  });
-
-  it('podePublicar=false quando _links presente mas sem .publicar (status irrelevante)', () => {
-    fixture.detectChanges();
-    controller.expectOne(`${BASE}/api/editais/${ID}`).flush({
-      ...editalSeed({ status: 'Rascunho' }),
-      _links: { self: `/api/editais/${ID}` },
-    });
-
-    expect(component['podePublicar']()).toBe(false);
-  });
-
-  it('fallback temporário (uniplus-api#334): sem _links, podePublicar=true se status=Rascunho', () => {
+  it('podePublicar=true quando status === "Rascunho" (única transição permitida)', () => {
     fixture.detectChanges();
     controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Rascunho' }));
 
     expect(component['podePublicar']()).toBe(true);
   });
 
-  it('fallback: sem _links, podePublicar=false se status diferente de Rascunho', () => {
+  it('podePublicar=false quando status diferente de "Rascunho"', () => {
     fixture.detectChanges();
     controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Publicado' }));
 
     expect(component['podePublicar']()).toBe(false);
+  });
+
+  it('_links.publicar no payload NUNCA habilita o botão (vedação ADR-0029 honrada — gate só por status)', () => {
+    fixture.detectChanges();
+    // Cenário hipotético defensivo: backend (incorretamente) emite _links.publicar.
+    // Frontend deve ignorar — gating é exclusivamente por status do recurso.
+    controller.expectOne(`${BASE}/api/editais/${ID}`).flush({
+      ...editalSeed({ status: 'Publicado' }),
+      _links: {
+        self: `/api/editais/${ID}`,
+        collection: '/api/editais',
+        publicar: `/api/editais/${ID}/publicar`,
+      },
+    } as never);
+
+    expect(component['podePublicar']()).toBe(false);
+  });
+
+  it('_links navigation (self/collection) presente em recurso single per ADR-0029', () => {
+    fixture.detectChanges();
+    controller.expectOne(`${BASE}/api/editais/${ID}`).flush({
+      ...editalSeed({ status: 'Rascunho' }),
+      _links: {
+        self: `/api/editais/${ID}`,
+        collection: '/api/editais',
+      },
+    });
+
+    expect(component.edital()?._links?.['self']).toBe(`/api/editais/${ID}`);
+    expect(component.edital()?._links?.['collection']).toBe('/api/editais');
+    // Action links nunca aparecem em _links (descobertos via OpenAPI).
+    expect(component.edital()?._links?.['publicar']).toBeUndefined();
   });
 
   it('confirmarPublicacao envia POST com Idempotency-Key, recebe 204 e refetcha o edital', () => {

--- a/apps/selecao/src/app/features/editais/editais-detail.page.ts
+++ b/apps/selecao/src/app/features/editais/editais-detail.page.ts
@@ -20,30 +20,15 @@ import { EditaisApi, EditalDto } from '@uniplus/shared-data';
 import { ConfirmDialogComponent } from '@uniplus/shared-ui';
 
 /**
- * Extensão local de `EditalDto` para `_links` (HATEOAS Level 1, ADR-0029
- * backend). Hoje o backend ainda não emite `_links` em `EditalDto` — issue
- * tracked em [uniplus-api#334](https://github.com/unifesspa-edu-br/uniplus-api/issues/334).
- *
- * Quando o backend implementar, o codegen pegará a mudança automaticamente
- * (a propriedade já fica opcional aqui, então o cast é seguro). A page lê
- * `_links?.publicar` preferencialmente; se ausente, cai num fallback baseado
- * em `status === 'Rascunho'`. O fallback é temporário e será removido quando
- * `uniplus-api#334` fechar.
- */
-type EditalComLinks = EditalDto & {
-  readonly _links?: {
-    readonly self?: string;
-    readonly collection?: string;
-    readonly publicar?: string;
-  };
-};
-
-/**
  * Container (ADR-0017) da feature Editais — detalhe + ação Publicar.
  *
- * **Gating do botão "Publicar" (ADR-0029 backend):** preferencialmente
- * HATEOAS-driven via `_links?.publicar`; fallback temporário a
- * `status === 'Rascunho'` enquanto o backend não emite `_links` (uniplus-api#334).
+ * **Gating do botão "Publicar":** baseado em `status === 'Rascunho'` (única
+ * transição permitida hoje per `Edital.Publicar()` no domínio backend).
+ * **Action links NÃO entram em `_links`** per ADR-0029 do `uniplus-api`
+ * (vedação binding §"Esta ADR não decide" — operações de mutação são
+ * descobertas via OpenAPI, ADR-0030). O `EditalDto._links` carrega apenas
+ * navigation links (`self`, `collection`) — útil para self-identification
+ * e back-nav, sem interferir no gating de UI.
  *
  * **Idempotency-Key (ADR-0014):** gerada a cada submit (não form-scoped — a
  * ação "Publicar" não tem rascunho de form para preservar; replay protege
@@ -149,7 +134,7 @@ export class EditaisDetailPage {
   private readonly problemI18n = inject(ProblemI18nService);
   private readonly destroyRef = inject(DestroyRef);
 
-  readonly edital = signal<EditalComLinks | null>(null);
+  readonly edital = signal<EditalDto | null>(null);
   readonly loading = signal<boolean>(false);
   readonly errorMessage = signal<string | null>(null);
   readonly submitting = signal<boolean>(false);
@@ -157,17 +142,14 @@ export class EditaisDetailPage {
   readonly dialogVisivel = signal<boolean>(false);
 
   /**
-   * Caminho A (HATEOAS-driven, ADR-0029): se `_links.publicar` presente,
-   * gating vem do servidor. Caminho B (fallback temporário): se `_links`
-   * ausente (uniplus-api#334), gate por `status === 'Rascunho'`.
+   * Gating do botão "Publicar" — `status === 'Rascunho'` é a única transição
+   * permitida hoje (per `Edital.Publicar()` no domínio backend). Action links
+   * (`publicar`) são vedados em `_links` por ADR-0029 (operações de mutação
+   * descobertas via OpenAPI, ADR-0030); por isso o gate vem do `status`.
    */
   protected readonly podePublicar = computed(() => {
     const dto = this.edital();
-    if (!dto) return false;
-    if (dto._links !== undefined) {
-      return Boolean(dto._links.publicar);
-    }
-    return dto.status === 'Rascunho';
+    return dto?.status === 'Rascunho';
   });
 
   constructor() {
@@ -247,7 +229,7 @@ export class EditaisDetailPage {
         }
         this.loading.set(false);
         if (result.ok) {
-          this.edital.set(result.data as EditalComLinks);
+          this.edital.set(result.data);
           return;
         }
         this.edital.set(null);

--- a/libs/shared-data/openapi/selecao.openapi.json
+++ b/libs/shared-data/openapi/selecao.openapi.json
@@ -561,6 +561,15 @@
           "criadoEm": {
             "type": "string",
             "format": "date-time"
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
           }
         }
       },

--- a/libs/shared-data/src/lib/api/selecao/editais.api.ts
+++ b/libs/shared-data/src/lib/api/selecao/editais.api.ts
@@ -38,9 +38,8 @@ export type CriarEditalCommand = components['schemas']['CriarEditalCommand'];
  * versionamento via vendor MIME `application/vnd.uniplus.edital.v1+json`
  * (ADR-0028 do `uniplus-api`) é declarado por `withVendorMime('edital', 1)`.
  *
- * Métodos `criar()` e `publicar()` ficam para PRs subsequentes — `criar`
- * depende do helper `withIdempotencyKey` (Frente 3) e `publicar` depende dos
- * `_links` HATEOAS (Frente 8).
+ * Métodos `criar()` e `publicar()` consomem `withIdempotencyKey` (ADR-0014;
+ * pattern entregue na F3 do Milestone B); detalhes em cada método abaixo.
  */
 @Injectable({ providedIn: 'root' })
 export class EditaisApi {

--- a/libs/shared-data/src/lib/api/selecao/schema.ts
+++ b/libs/shared-data/src/lib/api/selecao/schema.ts
@@ -351,6 +351,9 @@ export interface components {
             readonly bonusRegionalHabilitado: boolean;
             /** Format: date-time */
             readonly criadoEm: string;
+            readonly _links?: null | {
+                readonly [key: string]: string;
+            };
         };
         readonly ProblemDetails: {
             readonly type?: null | string;


### PR DESCRIPTION
## Resumo

Limpeza do débito da F8 do Milestone B agora que [uniplus-api#335](https://github.com/unifesspa-edu-br/uniplus-api/pull/335) está mergeado. Backend implementou HATEOAS Level 1 com `_links.self` + `_links.collection`, mas **action links continuam vedados em `_links`** per ADR-0029 (operações de mutação são descobertas via OpenAPI/ADR-0030).

A F8 (PR #201) tinha implementado `podePublicar` com check `_links?.publicar` + fallback para `status === 'Rascunho'` por interpretação errada minha da ADR-0029. Como `_links.publicar` jamais existirá, o "fallback" sempre foi o caminho canônico — esta PR remove o branch indevido.

## Mudanças

### `libs/shared-data` (sync codegen)
- `openapi/selecao.openapi.json` — sync com baseline backend (campo `_links` adicionado ao `EditalDto` schema).
- `src/lib/api/selecao/schema.ts` — regenerado via `npm run generate:api`. `EditalDto` ganha `_links?: null | { [key: string]: string }` no codegen.
- `editais.api.ts` — JSDoc atualizado (remove referência stale a `publicar()` como pendente — já entregue na F8).

### `apps/selecao` (cleanup página)
- `editais-detail.page.ts`:
  - Remove type alias local `EditalComLinks` (codegen popula `EditalDto`).
  - **`podePublicar` simplificado**: `dto?.status === 'Rascunho'`. Sem branch `_links.publicar`.
  - JSDoc atualizado: explica vedação ADR-0029 (action links via OpenAPI), remove menção a fallback temporário.
  - Substitui `as EditalComLinks` por uso direto de `EditalDto`.
- `editais-detail.page.spec.ts`:
  - Remove 4 cenários obsoletos (`_links.publicar` presente; `_links` sem publicar; fallback Rascunho; fallback non-Rascunho).
  - Adiciona 4 cenários novos:
    1. `status === 'Rascunho'` → `podePublicar = true`.
    2. `status` diferente de Rascunho → `podePublicar = false`.
    3. **Defensivo**: `_links.publicar` indevido **NUNCA** habilita o botão (regression test contra interpretação errada).
    4. Navigation links (`self`/`collection`) chegam ao componente quando backend emite.

## Verificações executadas

- `npm run generate:api` → OK; `EditalDto._links` populado no schema gerado.
- `npx nx affected --target=lint,test,typecheck,build --base=origin/main` → todos verdes.
- `selecao:test` → 29 tests (1 app + 7 list + 9 create + 12 detail).
- Pre-commit review por `feature-dev:code-reviewer` agent → **APROVADO**; 1 P3 aplicado (JSDoc stale do `editais.api.ts` mencionando `publicar` como pendente).

## Padrões binding aplicados

- ADR-0029 backend (HATEOAS Level 1) — interpretação correta: action links vetados em V1.
- ADR-0030 backend (OpenAPI 3.1) — operações descobertas via OpenAPI.
- ADR-0017 (container/presentational) — preservado.
- ADR-0011/0012/0013 — `ApiResult<T>` + codegen Node-only mantidos.
- Strings user-facing pt-BR.
- Sem PII.

## Não-escopo

- `_links` em coleção — ADR-0026 §"Coleção" diz que coleção usa header `Link`, não `_links` body. Backend já suprime `_links` em arrays via `[JsonIgnoreCondition.WhenWritingNull]`; frontend não precisa fazer nada.
- UI mostrando `_links.self` (debug overlay, copy-to-clipboard, etc.) — débito UX futuro.

## Issue fechada upstream

[uniplus-api#334](https://github.com/unifesspa-edu-br/uniplus-api/issues/334) — fechada via PR backend; este PR remove o débito frontend correspondente.