### PR TITLE
chore(selecao-e2e): extrai EXCLUDED_FROM_UI_LOGIN_PROJECTS const no playwright.config

### DIFF
--- a/apps/selecao-e2e/playwright.config.ts
+++ b/apps/selecao-e2e/playwright.config.ts
@@ -14,6 +14,18 @@ const isCI = !!process.env['CI'];
 const storageStateAdmin = path.resolve(__dirname, STORAGE_STATE_PATH_ADMIN);
 
 /**
+ * Patterns excluídos dos projects de UI login (chromium/firefox/webkit) para
+ * evitar que specs especiais sejam executadas sem o setup correspondente:
+ * - `*.authenticated.spec.ts` rodam apenas no project `selecao-authenticated`
+ *   (com `storageState`); rodar sem o storage causa redirect ao Keycloak.
+ * - `auth.setup.ts` é o test do setup project — não é um spec funcional.
+ *
+ * Adicionar novos sufixos especiais à alternation; demais projects herdam
+ * automaticamente. Reduz drift quando 3º+ sufixo surgir (ex.: `.smoke`).
+ */
+const EXCLUDED_FROM_UI_LOGIN_PROJECTS = /(.*\.authenticated\.spec\.ts|auth\.setup\.ts)$/;
+
+/**
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
  */
@@ -53,19 +65,19 @@ export default defineConfig({
 
     {
       name: 'chromium',
-      testIgnore: /(.*\.authenticated\.spec\.ts|auth\.setup\.ts)$/,
+      testIgnore: EXCLUDED_FROM_UI_LOGIN_PROJECTS,
       use: { ...devices['Desktop Chrome'] },
     },
 
     {
       name: 'firefox',
-      testIgnore: /(.*\.authenticated\.spec\.ts|auth\.setup\.ts)$/,
+      testIgnore: EXCLUDED_FROM_UI_LOGIN_PROJECTS,
       use: { ...devices['Desktop Firefox'] },
     },
 
     ...(isCI ? [{
       name: 'webkit',
-      testIgnore: /(.*\.authenticated\.spec\.ts|auth\.setup\.ts)$/,
+      testIgnore: EXCLUDED_FROM_UI_LOGIN_PROJECTS,
       use: { ...devices['Desktop Safari'] },
     }] : []),
 


### PR DESCRIPTION
## Resumo

Refator trivial — sugestão S1 da revisão da F9 (Milestone B). O regex composto `/(.*\.authenticated\.spec\.ts|auth\.setup\.ts)$/` estava duplicado em 3 places no `apps/selecao-e2e/playwright.config.ts` (`chromium`, `firefox`, `webkit`). Quando 3º sufixo especial surgir (ex.: `.smoke.spec.ts`, `.a11y.spec.ts`), edição em 3 lugares vira drift.

## Mudanças

- `apps/selecao-e2e/playwright.config.ts`:
  - Extrai `const EXCLUDED_FROM_UI_LOGIN_PROJECTS = /(.*\.authenticated\.spec\.ts|auth\.setup\.ts)$/` no topo.
  - JSDoc explica o porquê de cada sufixo atual (authenticated → storageState; auth.setup → setup project).
  - Aplica nos 3 projects de UI login (chromium/firefox/webkit) substituindo o regex inline.

## Verificações executadas

- `KEYCLOAK_ADMIN_PASSWORD=dummy npx playwright test --config=apps/selecao-e2e/playwright.config.ts --list` → 29 tests em 6 files (mesma distribuição de antes do refator: nenhum spec de project errado).
- `npx nx affected --target=lint --base=origin/main` → todos verdes.

## Não-escopo

- Aplicar pattern em `ingresso-e2e`/`portal-e2e` futuros — esses projects ainda não têm specs autenticadas; quando precisarem, o pattern já está documentado em `libs/shared-e2e/README.md` (F9).

## Frente do plano

B.1 do plano `~/.claude/plans/post-milestone-b-anchored-cornerstone.md`.