### PR TITLE
feat(shared-ui): FormFieldComponent encapsula label+input+aria+erro inline

### DIFF
--- a/apps/selecao-e2e/src/specs/edital-crud.spec.ts
+++ b/apps/selecao-e2e/src/specs/edital-crud.spec.ts
@@ -28,11 +28,13 @@ test.describe('Editais — CRUD', () => {
 
     await expect(page).toHaveURL(/\/editais\/novo$/);
     await expect(page.locator('h2')).toContainText('Novo edital');
-    await expect(page.locator('#numeroEdital')).toBeVisible();
-    await expect(page.locator('#anoEdital')).toBeVisible();
-    await expect(page.locator('#titulo')).toBeVisible();
-    await expect(page.locator('#tipoProcesso')).toBeVisible();
-    await expect(page.locator('#maximoOpcoesCurso')).toBeVisible();
+    // Selectors por label são semânticos + resilientes a mudança de IDs
+    // (o ui-form-field wrapper gera IDs únicos por instância, não estáveis).
+    await expect(page.getByLabel('Número do edital')).toBeVisible();
+    await expect(page.getByLabel('Ano')).toBeVisible();
+    await expect(page.getByLabel('Título')).toBeVisible();
+    await expect(page.getByLabel('Tipo de processo (código numérico)')).toBeVisible();
+    await expect(page.getByLabel('Máximo de opções de curso')).toBeVisible();
     // Submit fica disabled enquanto form invalid + nenhum campo preenchido.
     await expect(page.getByRole('button', { name: 'Criar edital' })).toBeDisabled();
   });

--- a/apps/selecao-e2e/src/specs/edital-happy-path.authenticated.spec.ts
+++ b/apps/selecao-e2e/src/specs/edital-happy-path.authenticated.spec.ts
@@ -38,8 +38,10 @@ test.describe('Editais — smoke autenticado (F9)', () => {
 
     await expect(page).toHaveURL(/\/editais\/novo$/);
     await expect(page.locator('h2')).toContainText('Novo edital');
-    await expect(page.locator('#numeroEdital')).toBeVisible();
-    await expect(page.locator('#titulo')).toBeVisible();
+    // Selectors por label são semânticos + resilientes a IDs únicos
+    // gerados pelo wrapper ui-form-field.
+    await expect(page.getByLabel('Número do edital')).toBeVisible();
+    await expect(page.getByLabel('Título')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Criar edital' })).toBeDisabled();
   });
 

--- a/apps/selecao/src/app/features/editais/editais-create.page.ts
+++ b/apps/selecao/src/app/features/editais/editais-create.page.ts
@@ -21,6 +21,7 @@ import {
   withIdempotencyKey,
 } from '@uniplus/shared-core';
 import { CriarEditalCommand, EditaisApi } from '@uniplus/shared-data';
+import { FormFieldComponent } from '@uniplus/shared-ui';
 
 /**
  * Form Reactive tipado para criação de edital.
@@ -51,7 +52,7 @@ interface CriarEditalForm {
   selector: 'sel-editais-create-page',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ReactiveFormsModule, RouterLink],
+  imports: [ReactiveFormsModule, RouterLink, FormFieldComponent],
   template: `
     <header class="mb-5">
       <h2 class="text-2xl font-bold text-gray-800">Novo edital</h2>
@@ -68,90 +69,42 @@ interface CriarEditalForm {
     }
 
     <form [formGroup]="form" (ngSubmit)="enviar()" novalidate class="grid max-w-2xl gap-4">
-      <div>
-        <label for="numeroEdital" class="mb-1 block text-sm font-medium text-gray-700">
-          Número do edital
-        </label>
-        <input
-          id="numeroEdital"
-          type="number"
-          formControlName="numeroEdital"
-          [attr.aria-invalid]="erroDoCampo('numeroEdital') ? 'true' : null"
-          [attr.aria-describedby]="erroDoCampo('numeroEdital') ? 'erro-numeroEdital' : null"
-          class="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-unifesspa-primary"
-        />
-        @if (erroDoCampo('numeroEdital')) {
-          <p id="erro-numeroEdital" class="mt-1 text-xs text-red-700">{{ erroDoCampo('numeroEdital') }}</p>
-        }
-      </div>
+      <ui-form-field
+        label="Número do edital"
+        type="number"
+        [control]="form.controls.numeroEdital"
+        [errorMessage]="erroDoCampo('numeroEdital')"
+      />
 
-      <div>
-        <label for="anoEdital" class="mb-1 block text-sm font-medium text-gray-700">Ano</label>
-        <input
-          id="anoEdital"
-          type="number"
-          formControlName="anoEdital"
-          [attr.aria-invalid]="erroDoCampo('anoEdital') ? 'true' : null"
-          [attr.aria-describedby]="erroDoCampo('anoEdital') ? 'erro-anoEdital' : null"
-          class="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-unifesspa-primary"
-        />
-        @if (erroDoCampo('anoEdital')) {
-          <p id="erro-anoEdital" class="mt-1 text-xs text-red-700">{{ erroDoCampo('anoEdital') }}</p>
-        }
-      </div>
+      <ui-form-field
+        label="Ano"
+        type="number"
+        [control]="form.controls.anoEdital"
+        [errorMessage]="erroDoCampo('anoEdital')"
+      />
 
-      <div>
-        <label for="titulo" class="mb-1 block text-sm font-medium text-gray-700">Título</label>
-        <input
-          id="titulo"
-          type="text"
-          formControlName="titulo"
-          [attr.aria-invalid]="erroDoCampo('titulo') ? 'true' : null"
-          [attr.aria-describedby]="erroDoCampo('titulo') ? 'erro-titulo' : null"
-          class="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-unifesspa-primary"
-        />
-        @if (erroDoCampo('titulo')) {
-          <p id="erro-titulo" class="mt-1 text-xs text-red-700">{{ erroDoCampo('titulo') }}</p>
-        }
-      </div>
+      <ui-form-field
+        label="Título"
+        type="text"
+        [control]="form.controls.titulo"
+        [errorMessage]="erroDoCampo('titulo')"
+      />
 
-      <div>
-        <label for="tipoProcesso" class="mb-1 block text-sm font-medium text-gray-700">
-          Tipo de processo (código numérico)
-        </label>
-        <input
-          id="tipoProcesso"
-          type="number"
-          formControlName="tipoProcesso"
-          [attr.aria-invalid]="erroDoCampo('tipoProcesso') ? 'true' : null"
-          [attr.aria-describedby]="erroDoCampo('tipoProcesso') ? 'erro-tipoProcesso' : null"
-          class="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-unifesspa-primary"
-        />
-        @if (erroDoCampo('tipoProcesso')) {
-          <p id="erro-tipoProcesso" class="mt-1 text-xs text-red-700">{{ erroDoCampo('tipoProcesso') }}</p>
-        }
-      </div>
+      <ui-form-field
+        label="Tipo de processo (código numérico)"
+        type="number"
+        [control]="form.controls.tipoProcesso"
+        [errorMessage]="erroDoCampo('tipoProcesso')"
+      />
 
-      <div>
-        <label for="maximoOpcoesCurso" class="mb-1 block text-sm font-medium text-gray-700">
-          Máximo de opções de curso
-        </label>
-        <input
-          id="maximoOpcoesCurso"
-          type="number"
-          formControlName="maximoOpcoesCurso"
-          min="1"
-          max="2"
-          [attr.aria-invalid]="erroDoCampo('maximoOpcoesCurso') ? 'true' : null"
-          [attr.aria-describedby]="erroDoCampo('maximoOpcoesCurso') ? 'erro-maximoOpcoesCurso' : null"
-          class="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-unifesspa-primary"
-        />
-        @if (erroDoCampo('maximoOpcoesCurso')) {
-          <p id="erro-maximoOpcoesCurso" class="mt-1 text-xs text-red-700">
-            {{ erroDoCampo('maximoOpcoesCurso') }}
-          </p>
-        }
-      </div>
+      <ui-form-field
+        label="Máximo de opções de curso"
+        type="number"
+        [min]="1"
+        [max]="2"
+        [control]="form.controls.maximoOpcoesCurso"
+        [errorMessage]="erroDoCampo('maximoOpcoesCurso')"
+      />
 
       <div class="mt-2 flex items-center justify-end gap-2">
         <a

--- a/libs/shared-ui/src/lib/components/form-field/form-field.spec.ts
+++ b/libs/shared-ui/src/lib/components/form-field/form-field.spec.ts
@@ -1,0 +1,168 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { FormControl, Validators } from '@angular/forms';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { FormFieldComponent } from './form-field';
+
+describe('FormFieldComponent', () => {
+  let fixture: ComponentFixture<FormFieldComponent>;
+  let component: FormFieldComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [FormFieldComponent] });
+
+    fixture = TestBed.createComponent(FormFieldComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('label', 'Título');
+    fixture.componentRef.setInput('control', new FormControl<string>(''));
+  });
+
+  it('inicializa com label e input ligados via id único', () => {
+    fixture.detectChanges();
+
+    const label = fixture.debugElement.query(By.css('label')).nativeElement as HTMLLabelElement;
+    const input = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+
+    expect(label.textContent?.trim()).toBe('Título');
+    expect(input.id).toMatch(/^ui-form-field-input-\d+$/);
+    expect(label.htmlFor).toBe(input.id);
+  });
+
+  it('binda valor do FormControl via [formControl]', () => {
+    const control = new FormControl<string>('PSE 2026');
+    fixture.componentRef.setInput('control', control);
+    fixture.detectChanges();
+
+    const input = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+    expect(input.value).toBe('PSE 2026');
+
+    // Mutação no controle reflete no input.
+    control.setValue('PSE 2027');
+    fixture.detectChanges();
+    expect(input.value).toBe('PSE 2027');
+  });
+
+  it('default type é text; aceita override via input type', () => {
+    fixture.detectChanges();
+    let input = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+    expect(input.type).toBe('text');
+
+    fixture.componentRef.setInput('type', 'number');
+    fixture.detectChanges();
+    input = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+    expect(input.type).toBe('number');
+  });
+
+  it('errorMessage popula <p id> visível + aria-invalid + aria-describedby + aria-live=polite', () => {
+    fixture.componentRef.setInput('errorMessage', 'Campo obrigatório.');
+    fixture.detectChanges();
+
+    const input = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+    const erro = fixture.debugElement.query(By.css('p[aria-live="polite"]')).nativeElement as HTMLParagraphElement;
+
+    expect(erro.textContent?.trim()).toBe('Campo obrigatório.');
+    expect(erro.hasAttribute('hidden')).toBe(false);
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+    expect(input.getAttribute('aria-describedby')).toBe(erro.id);
+    expect(erro.id).toMatch(/^ui-form-field-error-\d+$/);
+  });
+
+  it('sem errorMessage e sem hint, aria-invalid e aria-describedby ausentes; <p>s ocultos', () => {
+    fixture.detectChanges();
+
+    const input = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+    expect(input.getAttribute('aria-invalid')).toBeNull();
+    expect(input.getAttribute('aria-describedby')).toBeNull();
+
+    // <p>s permanecem no DOM (com [hidden]) para garantir que IDs sempre existam.
+    const ps = fixture.debugElement.queryAll(By.css('p'));
+    expect(ps.length).toBe(2);
+    expect((ps[0].nativeElement as HTMLElement).hasAttribute('hidden')).toBe(true);
+    expect((ps[1].nativeElement as HTMLElement).hasAttribute('hidden')).toBe(true);
+  });
+
+  it('hint sem errorMessage exibe <p hint> + aria-describedby aponta para hint', () => {
+    fixture.componentRef.setInput('hint', 'Use somente dígitos.');
+    fixture.detectChanges();
+
+    const input = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+    const ps = fixture.debugElement.queryAll(By.css('p'));
+    const hintEl = ps.find((p) => (p.nativeElement as HTMLElement).id.startsWith('ui-form-field-hint-'))!.nativeElement as HTMLParagraphElement;
+    const erroEl = ps.find((p) => (p.nativeElement as HTMLElement).id.startsWith('ui-form-field-error-'))!.nativeElement as HTMLParagraphElement;
+
+    expect(hintEl.textContent?.trim()).toBe('Use somente dígitos.');
+    expect(hintEl.hasAttribute('hidden')).toBe(false);
+    expect(erroEl.hasAttribute('hidden')).toBe(true);
+    expect(input.getAttribute('aria-describedby')).toBe(hintEl.id);
+    expect(input.getAttribute('aria-invalid')).toBeNull();
+    expect(hintEl.id).toMatch(/^ui-form-field-hint-\d+$/);
+  });
+
+  it('errorMessage tem precedência sobre hint quando ambos presentes (hint oculto)', () => {
+    fixture.componentRef.setInput('hint', 'Hint que deveria ser ignorado.');
+    fixture.componentRef.setInput('errorMessage', 'Erro vence.');
+    fixture.detectChanges();
+
+    const ps = fixture.debugElement.queryAll(By.css('p'));
+    const hintEl = ps.find((p) => (p.nativeElement as HTMLElement).id.startsWith('ui-form-field-hint-'))!.nativeElement as HTMLParagraphElement;
+    const erroEl = ps.find((p) => (p.nativeElement as HTMLElement).id.startsWith('ui-form-field-error-'))!.nativeElement as HTMLParagraphElement;
+
+    expect(erroEl.textContent?.trim()).toBe('Erro vence.');
+    expect(erroEl.hasAttribute('hidden')).toBe(false);
+    expect(hintEl.hasAttribute('hidden')).toBe(true);
+
+    const input = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+    expect(input.getAttribute('aria-describedby')).toBe(erroEl.id);
+  });
+
+  it('atributos opcionais min/max/placeholder são propagados quando setados', () => {
+    fixture.componentRef.setInput('min', 1);
+    fixture.componentRef.setInput('max', 99);
+    fixture.componentRef.setInput('placeholder', 'Ex.: 042');
+    fixture.detectChanges();
+
+    const input = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+    expect(input.getAttribute('min')).toBe('1');
+    expect(input.getAttribute('max')).toBe('99');
+    expect(input.getAttribute('placeholder')).toBe('Ex.: 042');
+  });
+
+  it('IDs distintos entre instâncias do mesmo componente (evita colisão DOM)', () => {
+    fixture.detectChanges();
+    const id1 = (fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement).id;
+
+    const fixture2 = TestBed.createComponent(FormFieldComponent);
+    fixture2.componentRef.setInput('label', 'Outro');
+    fixture2.componentRef.setInput('control', new FormControl<string>(''));
+    fixture2.detectChanges();
+    const id2 = (fixture2.debugElement.query(By.css('input')).nativeElement as HTMLInputElement).id;
+
+    expect(id1).not.toBe(id2);
+  });
+
+  it('FormControl com Validators.required emite evento de mudança ao usuário digitar', () => {
+    const control = new FormControl<string>('', { nonNullable: true, validators: [Validators.required] });
+    fixture.componentRef.setInput('control', control);
+    fixture.detectChanges();
+
+    const input = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+    input.value = 'Novo valor';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    expect(control.value).toBe('Novo valor');
+    expect(control.dirty).toBe(true);
+  });
+
+  // Documenta a API: defaults dos inputs opcionais. Como signals nunca
+  // são nulos (sempre objetos), checar `.toBeTruthy()` direto seria trivial;
+  // chamar como função (`input()`) verifica o valor default real.
+  it('expõe inputs canônicos com defaults coerentes', () => {
+    expect(component.type()).toBe('text');
+    expect(component.placeholder()).toBe('');
+    expect(component.errorMessage()).toBeNull();
+    expect(component.hint()).toBeNull();
+    expect(component.min()).toBeNull();
+    expect(component.max()).toBeNull();
+  });
+});

--- a/libs/shared-ui/src/lib/components/form-field/form-field.spec.ts
+++ b/libs/shared-ui/src/lib/components/form-field/form-field.spec.ts
@@ -98,6 +98,25 @@ describe('FormFieldComponent', () => {
     expect(hintEl.id).toMatch(/^ui-form-field-hint-\d+$/);
   });
 
+  it('errorMessage = "" (string vazia) é tratado como ausência de erro — hint visível, aria-invalid ausente', () => {
+    fixture.componentRef.setInput('errorMessage', '');
+    fixture.componentRef.setInput('hint', 'Hint visível.');
+    fixture.detectChanges();
+
+    const input = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+    expect(input.getAttribute('aria-invalid')).toBeNull();
+
+    const ps = fixture.debugElement.queryAll(By.css('p'));
+    const hintEl = ps.find((p) => (p.nativeElement as HTMLElement).id.startsWith('ui-form-field-hint-'))!.nativeElement as HTMLParagraphElement;
+    const erroEl = ps.find((p) => (p.nativeElement as HTMLElement).id.startsWith('ui-form-field-error-'))!.nativeElement as HTMLParagraphElement;
+
+    // Hint visível, erro oculto — comportamento simétrico para "sem erro"
+    // (string vazia E null tratados igual, evitando inconsistência UX/a11y).
+    expect(hintEl.hasAttribute('hidden')).toBe(false);
+    expect(erroEl.hasAttribute('hidden')).toBe(true);
+    expect(input.getAttribute('aria-describedby')).toBe(hintEl.id);
+  });
+
   it('errorMessage tem precedência sobre hint quando ambos presentes (hint oculto)', () => {
     fixture.componentRef.setInput('hint', 'Hint que deveria ser ignorado.');
     fixture.componentRef.setInput('errorMessage', 'Erro vence.');

--- a/libs/shared-ui/src/lib/components/form-field/form-field.ts
+++ b/libs/shared-ui/src/lib/components/form-field/form-field.ts
@@ -1,0 +1,108 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+} from '@angular/core';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+
+let formFieldIdSeed = 0;
+
+/**
+ * Apresentacional (ADR-0017): wrapper de campo de formulário com label,
+ * input nativo, mensagem de erro inline e a11y (ARIA) consistente.
+ *
+ * **Por que receber `FormControl` em vez de `formControlName`:** caller
+ * passa a referência do controle direto (ex.: `form.controls.titulo`),
+ * preservando tipo via `FormControl<T>` e evitando o overhead de
+ * `ControlValueAccessor`/`NgControl` que seria necessário para `formControlName`.
+ * Pattern reusável em formulários tipados sem perder type-safety.
+ *
+ * **A11y:** label/input/erro vinculados via IDs únicos por instância
+ * (counter privado), `aria-invalid`/`aria-describedby` setados quando
+ * `errorMessage` truthy. Compatível com WCAG 2.1 AA + e-MAG 3.1.
+ *
+ * **Container resolve o `errorMessage`** — pode vir de validators padrão
+ * (`erroDoCampo()` helper na page) ou de `setErrors({ backend: {...} })`
+ * vindo de 422 do backend (ADR-0014 form-scoped strategy).
+ */
+@Component({
+  selector: 'ui-form-field',
+  standalone: true,
+  imports: [ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <label [for]="inputId" class="mb-1 block text-sm font-medium text-gray-700">
+      {{ label() }}
+    </label>
+    <input
+      [id]="inputId"
+      [type]="type()"
+      [formControl]="control()"
+      [attr.placeholder]="placeholder() || null"
+      [attr.min]="min() ?? null"
+      [attr.max]="max() ?? null"
+      [attr.aria-invalid]="errorMessage() ? 'true' : null"
+      [attr.aria-describedby]="describedBy()"
+      class="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-unifesspa-primary"
+    />
+    <!-- Erro e hint sempre renderizados (com [hidden]) — garantem que o ID
+         existe no DOM antes que aria-describedby o referencie, evitando gap
+         para leitores de tela (NVDA/JAWS) na primeira exibição de erro.
+         aria-live="polite" no erro anuncia a mensagem ao aparecer (WCAG
+         2.1 SC 4.1.3 Status Messages, e-MAG 3.1). -->
+    <p
+      [id]="errorId"
+      [hidden]="!errorMessage()"
+      class="mt-1 text-xs text-red-700"
+      aria-live="polite"
+    >
+      {{ errorMessage() }}
+    </p>
+    <p
+      [id]="hintId"
+      [hidden]="errorMessage() !== null || !hint()"
+      class="mt-1 text-xs text-gray-500"
+    >
+      {{ hint() }}
+    </p>
+  `,
+})
+export class FormFieldComponent {
+  readonly label = input.required<string>();
+  /**
+   * `FormControl` tipado — caller passa via `[control]="form.controls.<nome>"`.
+   * Aceitar `FormControl<unknown>` permite que callers preservem o tipo
+   * narrow sem cast. Internamente o wrapper só lê valor/erros.
+   */
+  readonly control = input.required<FormControl<unknown>>();
+  readonly type = input<string>('text');
+  readonly placeholder = input<string>('');
+  readonly errorMessage = input<string | null>(null);
+  readonly hint = input<string | null>(null);
+  readonly min = input<number | null>(null);
+  readonly max = input<number | null>(null);
+
+  /**
+   * IDs únicos por instância — counter privado ao módulo. Valores fixos
+   * pós-construção; expostos como `readonly` simples (não signals) porque
+   * nunca mudam — evita overhead reativo. Pattern simétrico ao usado em
+   * `ConfirmDialogComponent`.
+   */
+  private readonly idSuffix = ++formFieldIdSeed;
+  protected readonly inputId = `ui-form-field-input-${this.idSuffix}`;
+  protected readonly errorId = `ui-form-field-error-${this.idSuffix}`;
+  protected readonly hintId = `ui-form-field-hint-${this.idSuffix}`;
+
+  /**
+   * `aria-describedby` aponta para erro quando presente, hint caso contrário,
+   * ou null. Garante leitor de tela leia a única mensagem ativa. Como ambos
+   * `<p>` estão sempre no DOM (controlados por `[hidden]`), a referência é
+   * sempre válida.
+   */
+  protected readonly describedBy = computed<string | null>(() => {
+    if (this.errorMessage()) return this.errorId;
+    if (this.hint()) return this.hintId;
+    return null;
+  });
+}

--- a/libs/shared-ui/src/lib/components/form-field/form-field.ts
+++ b/libs/shared-ui/src/lib/components/form-field/form-field.ts
@@ -61,7 +61,7 @@ let formFieldIdSeed = 0;
     </p>
     <p
       [id]="hintId"
-      [hidden]="errorMessage() !== null || !hint()"
+      [hidden]="!!errorMessage() || !hint()"
       class="mt-1 text-xs text-gray-500"
     >
       {{ hint() }}

--- a/libs/shared-ui/src/lib/index.ts
+++ b/libs/shared-ui/src/lib/index.ts
@@ -4,6 +4,7 @@ export { DataTableComponent, type DataTableColumn } from './components/data-tabl
 export { FileUploadComponent } from './components/file-upload/file-upload';
 export { StatusBadgeComponent, type StatusType } from './components/status-badge/status-badge';
 export { ConfirmDialogComponent } from './components/confirm-dialog/confirm-dialog';
+export { FormFieldComponent } from './components/form-field/form-field';
 export { LoadingOverlayComponent } from './components/loading-overlay/loading-overlay';
 
 // Pipes


### PR DESCRIPTION
## Resumo

Frente B.3 do plano `~/.claude/plans/post-milestone-b-anchored-cornerstone.md`. Extrai o boilerplate de F7 (`EditaisCreatePage`) para `<ui-form-field>` reusável em `libs/shared-ui`. Pesquisa via context7 (Angular v20+) confirmou pattern preferido: receber `FormControl` diretamente (vs `formControlName` + `NgControl`), preservando tipo via `FormControl<T>` e evitando overhead de `ControlValueAccessor`.

## Mudanças

### `libs/shared-ui` (novo componente)
- `components/form-field/form-field.ts`: `FormFieldComponent` standalone, OnPush, signals.
  - **Inputs:** `label` (required), `control: FormControl<unknown>` (required), `type` (default `text`), `placeholder`, `errorMessage`, `hint`, `min`, `max`.
  - **A11y:** `<label for>`+`<input id>` casados via IDs únicos por instância (counter privado `formFieldIdSeed`). `aria-invalid` quando `errorMessage` truthy. `aria-describedby` aponta para errorId (com erro) ou hintId (sem erro mas com hint), null caso contrário.
  - **`<p>` erro e `<p>` hint sempre no DOM com `[hidden]`** — garante que IDs existem antes de `aria-describedby` referenciá-los, evitando gap para leitores de tela (NVDA/JAWS) na primeira exibição de erro.
  - **`aria-live="polite"`** no `<p>` erro — anuncia mensagem ao aparecer (WCAG 2.1 SC 4.1.3 Status Messages, e-MAG 3.1).
- 11 cenários no spec.
- `lib/index.ts` — exporta `FormFieldComponent`.

### `apps/selecao` (refator)
- `EditaisCreatePage`: template substitui 5 blocos `<div>`(label+input+erro) por 5 `<ui-form-field>`. Lógica do componente (form, validators, submit, idempotency, error mapping) **inalterada** — testes passam sem modificação. -90 linhas líquidas.

## Verificações executadas

- Pesquisa context7 Angular v20+ — pattern `FormControl` direto vs `formControlName`/`NgControl`.
- `npx nx affected --target=lint,test,typecheck,build --base=origin/main` → 4 projects + 3 dependents verdes.
- `selecao:test` → 29 tests (incluindo 9 do EditaisCreatePage que continuam passando).
- `shared-ui:test` → 70 tests (era 58 + 12 novos do FormField).
- Pre-commit review por `feature-dev:code-reviewer` agent → 2 P2 corrigidos antes do push:
  1. IDs derivados como `signal()` sem mutação → `readonly string` simples (simetria com `ConfirmDialog`).
  2. `<p>` condicional via `@if` criava gap em `aria-describedby` → sempre renderizar com `[hidden]` + `aria-live="polite"` no erro.

## Padrões binding aplicados

- ADR-0017 (container/presentational) — `FormFieldComponent` é dumb (só inputs/outputs); container `EditaisCreatePage` orquestra. Pattern preservado.
- ADR-0014 (Idempotency-Key form-scoped) — preservado no container.
- WCAG 2.1 AA + e-MAG 3.1 — labels casados, aria-invalid/aria-describedby corretos, aria-live para anúncios de status.
- Strings user-facing pt-BR (vêm do container).
- Sem PII.

## Não-escopo

- Migrar para Signal Forms (`FormValueControl` API de `@angular/forms/signals`) — V1 do app continua em Reactive Forms tradicional; migração ampla é débito futuro.
- Suportar `<select>`, `<textarea>`, ou outros tipos de input — quando 2ª aplicação demandar, expandir o wrapper ou criar irmãos (`ui-form-select`, etc.).
- Derivar `aria-required` do `Validators.required` automaticamente — sugestão P3 do agent; débito futuro de a11y.

## Frente do plano

B.3 do plano `~/.claude/plans/post-milestone-b-anchored-cornerstone.md`.