### PR TITLE
feat(fitness): tests Vitest enforce padrões binding services + pages (B.5)

### DIFF
--- a/apps/selecao/src/app/features/__fitness__/no-direct-http-in-pages.fitness.spec.ts
+++ b/apps/selecao/src/app/features/__fitness__/no-direct-http-in-pages.fitness.spec.ts
@@ -1,0 +1,66 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Fitness test do app `selecao`: pages container (`*.page.ts`) NÃO importam
+ * `HttpClient` diretamente. HTTP é responsabilidade dos services em
+ * `libs/shared-data` (ADR-0017 container/presentational; pages orquestram
+ * services via `inject()`).
+ *
+ * Estratégia: glob + readFileSync + regex. Se uma futura page tentar
+ * `inject(HttpClient)` ou `import { HttpClient } from '@angular/common/http'`,
+ * o test falha — caller é direcionado a mover lógica para um service em
+ * `shared-data` que retorne `Observable<ApiResult<T>>`.
+ */
+
+const FEATURES_ROOT = path.resolve(__dirname, '..');
+
+function listarPages(root: string): string[] {
+  const arquivos: string[] = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === '__fitness__') continue;
+      arquivos.push(...listarPages(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.page.ts') && !entry.name.endsWith('.spec.ts')) {
+      arquivos.push(fullPath);
+    }
+  }
+  return arquivos;
+}
+
+const pageFiles = listarPages(FEATURES_ROOT);
+
+describe('Fitness — pages container em apps/selecao/src/app/features/', () => {
+  it('encontra ao menos 1 *.page.ts (sanity check)', () => {
+    expect(pageFiles.length).toBeGreaterThan(0);
+  });
+
+  describe.each(pageFiles)('%s', (filePath) => {
+    const source = fs.readFileSync(filePath, 'utf-8');
+    const relativePath = path.relative(path.resolve(__dirname, '../../../../../..'), filePath);
+
+    it('NÃO importa HttpClient de @angular/common/http (use service em @uniplus/shared-data)', () => {
+      // Falha se o page tem import de HttpClient — pages devem orquestrar
+      // services em shared-data via inject(EditaisApi) etc., não fazer HTTP
+      // direto. ADR-0017 container/presentational + ADR-0011/0012.
+      const importsHttpClient = /import\s+\{[^}]*\bHttpClient\b[^}]*\}\s+from\s+['"]@angular\/common\/http['"]/.test(source);
+      expect(importsHttpClient).toBe(
+        false,
+        `\nArquivo: ${relativePath}\n` +
+          `Pages container não devem importar HttpClient direto. Crie um service em libs/shared-data/src/lib/api/<modulo>/<recurso>.api.ts ` +
+          `que retorne Observable<ApiResult<T>> e injete-o via inject(<MeuApi>) na page (ADR-0017).`,
+      );
+    });
+
+    it('NÃO faz inject(HttpClient) (signal de HTTP direto na page)', () => {
+      const injectsHttpClient = /inject\(\s*HttpClient\s*\)/.test(source);
+      expect(injectsHttpClient).toBe(
+        false,
+        `\nArquivo: ${relativePath}\n` +
+          `inject(HttpClient) na page é HTTP direto — extraia para um service em shared-data.`,
+      );
+    });
+  });
+});

--- a/apps/selecao/src/app/features/__fitness__/no-direct-http-in-pages.fitness.spec.ts
+++ b/apps/selecao/src/app/features/__fitness__/no-direct-http-in-pages.fitness.spec.ts
@@ -61,8 +61,11 @@ describe('Fitness — pages container em apps/selecao/src/app/features/', () => 
       );
     });
 
-    it('NÃO faz inject(HttpClient) (signal de HTTP direto na page)', () => {
-      const injectsHttpClient = /inject\(\s*HttpClient\s*\)/.test(source);
+    it('NÃO faz inject(HttpClient) (incluindo variantes com options)', () => {
+      // Cobre `inject(HttpClient)`, `inject(HttpClient, { optional: true })`,
+      // `inject(HttpClient, { skipSelf: true })` etc. Vírgula OU parêntese
+      // depois de HttpClient — qualquer variante de inject() do Angular DI.
+      const injectsHttpClient = /inject\(\s*HttpClient\s*[,)]/.test(source);
       expect(injectsHttpClient).toBe(
         false,
         `\nArquivo: ${relativePath}\n` +

--- a/apps/selecao/src/app/features/__fitness__/no-direct-http-in-pages.fitness.spec.ts
+++ b/apps/selecao/src/app/features/__fitness__/no-direct-http-in-pages.fitness.spec.ts
@@ -38,8 +38,15 @@ describe('Fitness — pages container em apps/selecao/src/app/features/', () => 
   });
 
   describe.each(pageFiles)('%s', (filePath) => {
-    const source = fs.readFileSync(filePath, 'utf-8');
+    const rawSource = fs.readFileSync(filePath, 'utf-8');
     const relativePath = path.relative(path.resolve(__dirname, '../../../../../..'), filePath);
+
+    // Strip comentários antes dos checks para evitar que exemplos em JSDoc
+    // (ex.: "// evitar inject(HttpClient)") quebrem o fitness com falsos
+    // positivos. Cobre `// linha`, `/* bloco */` e `/** JSDoc */`.
+    const source = rawSource
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/.*$/gm, '');
 
     it('NÃO importa HttpClient de @angular/common/http (use service em @uniplus/shared-data)', () => {
       // Falha se o page tem import de HttpClient — pages devem orquestrar

--- a/libs/shared-data/src/lib/api/__fitness__/api-services.fitness.spec.ts
+++ b/libs/shared-data/src/lib/api/__fitness__/api-services.fitness.spec.ts
@@ -1,0 +1,134 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Fitness tests dos services HTTP do `shared-data`. Enforce padrões binding
+ * estabelecidos no Frontend Milestone B (ADRs 0011/0012/0013/0014/0016):
+ *
+ * 1. Toda classe `@Injectable` em `*.api.ts` retorna `Observable<ApiResult<T>>`
+ *    (nunca `Observable<T>` cru) — discriminated union ApiResult é o boundary
+ *    canônico do consumer (ADR-0011/0012).
+ * 2. Toda chamada HTTP em `*.api.ts` declara vendor MIME via
+ *    `withVendorMime(...)` no `HttpContext` — versionamento per-resource
+ *    (ADR-0028 backend, ADR-0016 cliente).
+ *
+ * Estratégia: glob + readFileSync + regex. Frágil-mas-suficiente: pega
+ * regression cosmético (caller esquece pattern); não substitui code review
+ * humano. Quando 5+ services existirem, considerar AST analysis via ts-morph.
+ */
+
+const API_GLOB_ROOT = path.resolve(__dirname, '..');
+
+/**
+ * Colapsa assinaturas multi-linha em linhas únicas. Algoritmo simples:
+ * conta `(` e `)` linha-a-linha; quando uma linha tem mais aberturas que
+ * fechamentos, agrupa as subsequentes até o saldo zerar. Cobre o caso de
+ * `metodo(\n  arg1,\n  arg2,\n): ReturnType` que é a prática idiomática
+ * para 2+ argumentos. Ignora parens dentro de strings ou comentários por
+ * simplicidade — basta pra source TypeScript real (raros edge cases).
+ */
+function collapseMultilineParens(lines: readonly string[]): string[] {
+  const resultado: string[] = [];
+  let buffer = '';
+  let parenSaldo = 0;
+
+  for (const line of lines) {
+    if (parenSaldo === 0) {
+      buffer = line;
+    } else {
+      buffer += ' ' + line.trim();
+    }
+
+    for (const ch of line) {
+      if (ch === '(') parenSaldo++;
+      else if (ch === ')') parenSaldo--;
+    }
+
+    if (parenSaldo === 0) {
+      resultado.push(buffer);
+      buffer = '';
+    }
+  }
+
+  // Linha aberta no final do arquivo (não deveria acontecer em source válido).
+  if (buffer.length > 0) resultado.push(buffer);
+
+  return resultado;
+}
+
+function listarApiFiles(root: string): string[] {
+  const arquivos: string[] = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      // Skip the __fitness__ folder itself.
+      if (entry.name === '__fitness__') continue;
+      arquivos.push(...listarApiFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.api.ts') && !entry.name.endsWith('.spec.ts')) {
+      arquivos.push(fullPath);
+    }
+  }
+  return arquivos;
+}
+
+const apiFiles = listarApiFiles(API_GLOB_ROOT);
+
+describe('Fitness — services HTTP em libs/shared-data/src/lib/api/', () => {
+  it('encontra ao menos 1 arquivo *.api.ts (sanity check)', () => {
+    expect(apiFiles.length).toBeGreaterThan(0);
+  });
+
+  describe.each(apiFiles)('%s', (filePath) => {
+    const source = fs.readFileSync(filePath, 'utf-8');
+
+    it('expõe classe @Injectable', () => {
+      expect(source).toMatch(/@Injectable\(\{[^}]*providedIn:\s*'root'[^}]*\}\)/);
+    });
+
+    it('todo método público que retorna Observable também retorna ApiResult<T>', () => {
+      // Normaliza assinaturas multi-linha colapsando-as numa única linha
+      // antes da análise. Algoritmo: paren counter — quando uma linha abre
+      // `(` sem fechar na mesma linha, junta linhas subsequentes até o paren
+      // count zerar. Cobre `criar(\n  arg1,\n  arg2,\n): Observable<...>`
+      // sem cair no problema do regex `[\s\S]*?` greedy-lazy que atravessa
+      // múltiplos blocos.
+      const lines = collapseMultilineParens(source.split('\n'));
+      const violacoes: string[] = [];
+
+      for (const line of lines) {
+        // Linhas com `): Observable<` ou `): Promise<` em método public top-level.
+        const isMethodSignature = /^\s{2}(?!private|protected|static|constructor)\w+[^(]*\([^)]*\):\s*(Observable|Promise)</.test(line);
+        if (!isMethodSignature) continue;
+
+        // Promise é proibido em service HTTP — toda chamada deve usar Observable
+        // (HttpClient é Observable-first; Promise quebra interceptor pipeline).
+        if (/\):\s*Promise</.test(line)) {
+          violacoes.push(`Promise no retorno: ${line.trim()}`);
+          continue;
+        }
+
+        // Para Observable: deve envelopar em ApiResult.
+        if (!/Observable<\s*ApiResult\s*</.test(line)) {
+          violacoes.push(`Observable cru sem ApiResult: ${line.trim()}`);
+        }
+      }
+
+      expect(violacoes).toEqual([] as string[]);
+    });
+
+    it('importa withVendorMime de @uniplus/shared-core (versionamento per-resource ADR-0016/0028)', () => {
+      expect(source).toMatch(/from\s+['"]@uniplus\/shared-core['"]/);
+      expect(source).toMatch(/withVendorMime/);
+    });
+
+    it('chama withVendorMime em pelo menos 1 ponto do código (uso real, não só import)', () => {
+      // Regex conta call sites — `withVendorMime(` em meio ao código (não só
+      // na linha de import). Pelo menos 1 = pelo menos 1 endpoint declara
+      // versão. Múltiplos seria preferível (cobre todos endpoints), mas
+      // forcar isto requer AST analysis — por ora, sinal mínimo.
+      const callSites = source.match(/withVendorMime\([^)]+\)/g) ?? [];
+      expect(callSites.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/libs/shared-data/src/lib/api/__fitness__/api-services.fitness.spec.ts
+++ b/libs/shared-data/src/lib/api/__fitness__/api-services.fitness.spec.ts
@@ -117,9 +117,14 @@ describe('Fitness — services HTTP em libs/shared-data/src/lib/api/', () => {
       expect(violacoes).toEqual([] as string[]);
     });
 
-    it('importa withVendorMime de @uniplus/shared-core (versionamento per-resource ADR-0016/0028)', () => {
-      expect(source).toMatch(/from\s+['"]@uniplus\/shared-core['"]/);
-      expect(source).toMatch(/withVendorMime/);
+    it('importa withVendorMime DE @uniplus/shared-core (regex bind import-source ADR-0016/0028)', () => {
+      // Regex única que valida `withVendorMime` está na lista de imports de
+      // `@uniplus/shared-core` — proíbe falso negativo onde o service importa
+      // ApiResult de shared-core mas withVendorMime de outra lib qualquer.
+      // Cobre imports multi-linha via [\s\S] dentro de {}.
+      expect(source).toMatch(
+        /import\s+(?:type\s+)?\{[\s\S]*?\bwithVendorMime\b[\s\S]*?\}\s+from\s+['"]@uniplus\/shared-core['"]/,
+      );
     });
 
     it('chama withVendorMime em pelo menos 1 ponto do código (uso real, não comentário)', () => {

--- a/libs/shared-data/src/lib/api/__fitness__/api-services.fitness.spec.ts
+++ b/libs/shared-data/src/lib/api/__fitness__/api-services.fitness.spec.ts
@@ -122,12 +122,17 @@ describe('Fitness — services HTTP em libs/shared-data/src/lib/api/', () => {
       expect(source).toMatch(/withVendorMime/);
     });
 
-    it('chama withVendorMime em pelo menos 1 ponto do código (uso real, não só import)', () => {
-      // Regex conta call sites — `withVendorMime(` em meio ao código (não só
-      // na linha de import). Pelo menos 1 = pelo menos 1 endpoint declara
-      // versão. Múltiplos seria preferível (cobre todos endpoints), mas
-      // forcar isto requer AST analysis — por ora, sinal mínimo.
-      const callSites = source.match(/withVendorMime\([^)]+\)/g) ?? [];
+    it('chama withVendorMime em pelo menos 1 ponto do código (uso real, não comentário)', () => {
+      // Strip comentários antes de contar — exemplos em JSDoc com
+      // `withVendorMime('edital', 1)` poderiam contar como call site real,
+      // criando falso negativo (suíte passaria mesmo se TODOS call sites
+      // executáveis fossem removidos). Strip cobre `// linha`, `/* bloco */`
+      // (incl. multi-line) e `/** JSDoc */`.
+      const sourceSemComentarios = source
+        .replace(/\/\*[\s\S]*?\*\//g, '') // /* ... */ e /** ... */
+        .replace(/\/\/.*$/gm, '');         // // linha
+
+      const callSites = sourceSemComentarios.match(/withVendorMime\([^)]+\)/g) ?? [];
       expect(callSites.length).toBeGreaterThan(0);
     });
   });

--- a/libs/shared-data/src/lib/api/__fitness__/api-services.fitness.spec.ts
+++ b/libs/shared-data/src/lib/api/__fitness__/api-services.fitness.spec.ts
@@ -80,7 +80,15 @@ describe('Fitness — services HTTP em libs/shared-data/src/lib/api/', () => {
   });
 
   describe.each(apiFiles)('%s', (filePath) => {
-    const source = fs.readFileSync(filePath, 'utf-8');
+    const rawSource = fs.readFileSync(filePath, 'utf-8');
+
+    // Strip comentários globalmente — todos os checks operam sobre código
+    // executável, não JSDoc/inline. Evita falsos negativos onde exemplos
+    // em comentários satisfazem regex de production code (problema
+    // recorrente em fitness baseado em regex).
+    const source = rawSource
+      .replace(/\/\*[\s\S]*?\*\//g, '') // /* ... */ e /** ... */
+      .replace(/\/\/.*$/gm, '');         // // linha
 
     it('expõe classe @Injectable', () => {
       expect(source).toMatch(/@Injectable\(\{[^}]*providedIn:\s*'root'[^}]*\}\)/);
@@ -127,17 +135,9 @@ describe('Fitness — services HTTP em libs/shared-data/src/lib/api/', () => {
       );
     });
 
-    it('chama withVendorMime em pelo menos 1 ponto do código (uso real, não comentário)', () => {
-      // Strip comentários antes de contar — exemplos em JSDoc com
-      // `withVendorMime('edital', 1)` poderiam contar como call site real,
-      // criando falso negativo (suíte passaria mesmo se TODOS call sites
-      // executáveis fossem removidos). Strip cobre `// linha`, `/* bloco */`
-      // (incl. multi-line) e `/** JSDoc */`.
-      const sourceSemComentarios = source
-        .replace(/\/\*[\s\S]*?\*\//g, '') // /* ... */ e /** ... */
-        .replace(/\/\/.*$/gm, '');         // // linha
-
-      const callSites = sourceSemComentarios.match(/withVendorMime\([^)]+\)/g) ?? [];
+    it('chama withVendorMime em pelo menos 1 ponto do código (uso real)', () => {
+      // `source` já está sem comentários (strip global no escopo do describe.each).
+      const callSites = source.match(/withVendorMime\([^)]+\)/g) ?? [];
       expect(callSites.length).toBeGreaterThan(0);
     });
   });

--- a/libs/shared-data/src/lib/api/__fitness__/api-services.fitness.spec.ts
+++ b/libs/shared-data/src/lib/api/__fitness__/api-services.fitness.spec.ts
@@ -135,10 +135,26 @@ describe('Fitness — services HTTP em libs/shared-data/src/lib/api/', () => {
       );
     });
 
-    it('chama withVendorMime em pelo menos 1 ponto do código (uso real)', () => {
-      // `source` já está sem comentários (strip global no escopo do describe.each).
-      const callSites = source.match(/withVendorMime\([^)]+\)/g) ?? [];
-      expect(callSites.length).toBeGreaterThan(0);
+    it('toda chamada this.http.get(...) compõe withVendorMime no contexto (ADR-0016)', () => {
+      // ADR-0016 cobre vendor MIME em GETs (Accept versionado). Mutações
+      // (POST/PUT/PATCH) ficam fora — body de mutação é versionado por
+      // Content-Type quando aplicável, decisão fica para ADR futura
+      // (ADR-0016 §"Esta ADR não decide" sobre POST/PUT). Invariante: ≥1
+      // call site de withVendorMime() para cada this.http.get<> existente.
+      const getCalls = (source.match(/this\.http\.get</g) ?? []).length;
+      const vendorMimeCalls = (source.match(/withVendorMime\([^)]+\)/g) ?? []).length;
+
+      // Sanity: arquivo sem GETs (futuro service só de mutação) ainda passa
+      // sem withVendorMime — não força redundância.
+      if (getCalls === 0) {
+        return;
+      }
+
+      expect(vendorMimeCalls).toBeGreaterThanOrEqual(
+        getCalls,
+        `\nEsperado ≥${getCalls} call sites de withVendorMime() (1 por this.http.get<>); ` +
+          `encontrado ${vendorMimeCalls}. ADR-0016 exige Accept versionado em todo GET de recurso versionado.`,
+      );
     });
   });
 });


### PR DESCRIPTION
## Resumo

Frente B.5 do plano. Adiciona 2 fitness suites Vitest que detectam regression contra padrões binding estabelecidos no Frontend Milestone B (services HTTP retornam `ApiResult<T>`, pages container não fazem HTTP direto).

Estratégia pragmática: glob recursivo + `readFileSync` + regex, com helper `collapseMultilineParens` (paren counter) para normalizar assinaturas multi-linha. Frágil-mas-suficiente — pega regression cosmético; não substitui code review humano.

## Mudanças

### `libs/shared-data/src/lib/api/__fitness__/api-services.fitness.spec.ts` (novo)
Para cada `*.api.ts` encontrado:
- `@Injectable({ providedIn: 'root' })` presente.
- Todo método público retorna `Observable<ApiResult<T>>` (não `Observable<T>` cru, não `Promise`) — ADR-0011/0012.
- Importa `withVendorMime` de `@uniplus/shared-core` — ADR-0028/0016.
- Chama `withVendorMime(...)` em pelo menos 1 ponto.

### `apps/selecao/src/app/features/__fitness__/no-direct-http-in-pages.fitness.spec.ts` (novo)
Para cada `*.page.ts` encontrado:
- Não importa `HttpClient` direto.
- Não chama `inject(HttpClient)`.

(HTTP é responsabilidade dos services em `shared-data` — ADR-0017 container/presentational.)

## Verificações executadas

- `npx nx affected --target=lint,test,typecheck,build --base=origin/main` → 8 projects + 3 dependents verdes.
- `shared-data:test` → 48 tests (incluindo 5 novos do fitness).
- `selecao:test` → 36 tests (incluindo 7 novos do fitness).
- Sanity manual: helper `collapseMultilineParens` captura todos 4 métodos do `EditaisApi` (`listar`, `obter`, `criar`, `publicar`) — incluindo `criar()` que tem signature multi-linha.
- Pre-commit review por `feature-dev:code-reviewer` agent → **APROVADO**; 1 P2 corrigido — versão inicial usava regex `\(\s*\n([\s\S]*?)\n\s*\):` greedy-lazy que atravessava múltiplos blocos (falsos negativos: 2 dos 4 métodos escapavam). Substituído por `collapseMultilineParens` com paren counter (algoritmo deterministic).

## Padrões binding aplicados

- ADR-0011/0012 (`ApiResult<T>` em services HTTP) — fitness 1.
- ADR-0016 (vendor MIME consumer) — fitness 1.
- ADR-0017 (container/presentational) — fitness 2.
- Strings user-facing pt-BR (mensagens de violação).

## Não-escopo

- AST analysis via ts-morph — over-engineering para V1; regex + paren counter cobre os patterns binding atuais. Considerar migração quando 5+ services existirem ou patterns complexos surgirem.
- Cobertura de outros padrões binding (ADR-0014 form-scoped key, ADR-0017 selector prefixes, etc.) — débito futuro; cada pattern vira 1 fitness suite quando o cenário emergir.
- Fitness para `ingresso`/`portal` — esses apps ainda não têm pages container; quando houverem, replicar o pattern do `selecao`.

## Frente do plano

B.5 do plano `~/.claude/plans/post-milestone-b-anchored-cornerstone.md`.