### PR TITLE
fix(shared-ui): IDs únicos por instância no file-upload (Codex P2 #203)

### DIFF
--- a/libs/shared-ui/src/lib/components/file-upload/file-upload.spec.ts
+++ b/libs/shared-ui/src/lib/components/file-upload/file-upload.spec.ts
@@ -273,4 +273,44 @@ describe('FileUploadComponent', () => {
     expect(component.selectedFile()).toBe(valid);
     expect(component.error()).toContain('Tipo de arquivo não permitido');
   });
+
+  it('gera IDs únicos por instância para isolar `for`/`aria-describedby` em multi-upload', () => {
+    const first = TestBed.createComponent(FileUploadComponent);
+    const second = TestBed.createComponent(FileUploadComponent);
+    first.detectChanges();
+    second.detectChanges();
+
+    expect(first.componentInstance.inputId).not.toBe(second.componentInstance.inputId);
+    expect(first.componentInstance.errorId).not.toBe(second.componentInstance.errorId);
+
+    const firstInput = first.debugElement.query(By.css('input[type="file"]')).nativeElement as HTMLInputElement;
+    const secondInput = second.debugElement.query(By.css('input[type="file"]')).nativeElement as HTMLInputElement;
+
+    expect(firstInput.id).toBe(first.componentInstance.inputId);
+    expect(secondInput.id).toBe(second.componentInstance.inputId);
+    expect(firstInput.id).not.toBe(secondInput.id);
+  });
+
+  it('aria-describedby aponta para o errorId da própria instância quando há erro', () => {
+    const { fixture, dropZone, errorMessage } = setup();
+    pickFile(fixture, OVERSIZED_PDF());
+
+    const dropZoneEl = dropZone().nativeElement as HTMLButtonElement;
+    const errorEl = errorMessage().nativeElement as HTMLElement;
+
+    expect(dropZoneEl.getAttribute('aria-describedby')).toBe(errorEl.id);
+    expect(errorEl.id).toMatch(/^ui-file-upload-\d+-error$/);
+  });
+
+  it('label[for] aponta para o inputId da própria instância', () => {
+    const { fixture } = setup();
+    fixture.componentRef.setInput('label', 'Documento de identificação');
+    fixture.detectChanges();
+
+    const labelEl = fixture.debugElement.query(By.css('label')).nativeElement as HTMLLabelElement;
+    const inputEl = fixture.debugElement.query(By.css('input[type="file"]')).nativeElement as HTMLInputElement;
+
+    expect(labelEl.htmlFor).toBe(inputEl.id);
+    expect(labelEl.htmlFor).toMatch(/^ui-file-upload-\d+-input$/);
+  });
 });

--- a/libs/shared-ui/src/lib/components/file-upload/file-upload.ts
+++ b/libs/shared-ui/src/lib/components/file-upload/file-upload.ts
@@ -18,7 +18,7 @@ type ValidationResult = { ok: true } | { ok: false; reason: string };
   template: `
     <div class="flex flex-col gap-2">
       @if (label()) {
-        <label for="file-upload-input" class="text-sm font-medium text-gray-700">{{ label() }}</label>
+        <label [attr.for]="inputId" class="text-sm font-medium text-gray-700">{{ label() }}</label>
       }
       <button
         #dropZone
@@ -27,7 +27,7 @@ type ValidationResult = { ok: true } | { ok: false; reason: string };
         [class.border-unifesspa-primary]="isDragging()"
         [class.bg-blue-50]="isDragging()"
         [attr.aria-label]="ariaLabel()"
-        [attr.aria-describedby]="error() ? 'file-upload-error' : null"
+        [attr.aria-describedby]="error() ? errorId : null"
         (click)="openFilePicker()"
         (dragover)="$event.preventDefault(); onDragOver()"
         (dragleave)="onDragLeave()"
@@ -45,7 +45,7 @@ type ValidationResult = { ok: true } | { ok: false; reason: string };
       </button>
       <input
         #fileInput
-        id="file-upload-input"
+        [id]="inputId"
         type="file"
         class="hidden"
         [accept]="accept()"
@@ -66,12 +66,20 @@ type ValidationResult = { ok: true } | { ok: false; reason: string };
         </div>
       }
       @if (error(); as message) {
-        <small id="file-upload-error" class="text-xs text-red-600" role="alert">{{ message }}</small>
+        <small [id]="errorId" class="text-xs text-red-600" role="alert">{{ message }}</small>
       }
     </div>
   `,
 })
 export class FileUploadComponent {
+  // Garante IDs únicos por instância para isolar `for`/`aria-describedby`
+  // quando há múltiplos `<ui-file-upload>` na mesma página.
+  private static instanceCount = 0;
+  private readonly instanceId = `ui-file-upload-${++FileUploadComponent.instanceCount}`;
+
+  readonly inputId = `${this.instanceId}-input`;
+  readonly errorId = `${this.instanceId}-error`;
+
   readonly label = input<string>('');
   readonly accept = input<string>('.pdf,.jpg,.jpeg,.png');
   readonly allowedMimeTypes = input<readonly string[]>([


### PR DESCRIPTION
## Resumo

Endereça o **finding P2 do Codex** no PR #203 (não atendido antes do merge) sobre `id` hard-coded no componente `FileUploadComponent`. Mergeia em `feature/6-file-upload-validation` (branch do @denilson-santos-unifesspa) — não em `main`.

> Olá @denilson-santos-unifesspa! Codex apontou no #203 que os IDs `file-upload-input` e `file-upload-error` eram fixos, e na sua aprovação rápida o finding passou desapercebido. Como o problema afeta acessibilidade real (impossível ter 2+ uploads na mesma página com leitor de tela funcionando), abri esse pequeno PR para fechar a lacuna. Mesmo padrão do #203: dá `Merge` aqui e o seu PR #177 absorve.

## Bug original

Codex apontou no commit `a13c4ed`:

```
libs/shared-ui/src/lib/components/file-upload/file-upload.ts:69
[P2] Generate unique error IDs per component instance

Using a hard-coded id="file-upload-error" makes every ui-file-upload
instance on the same page emit the same DOM id, so each button's
aria-describedby can point to the wrong error node (or multiple nodes),
which breaks accessible name/description resolution for assistive
technologies in multi-upload forms.
```

O mesmo aplica para `id="file-upload-input"` (que vinha do PR original `#177` antes do refactor) — `<label for>` em multi-upload aponta sempre para o primeiro input.

**Cenário real:** formulário de inscrição do candidato com upload de RG, CPF, comprovante de residência e histórico escolar. Quatro `<ui-file-upload>` na mesma página → quatro labels apontam para o primeiro input, e a região `aria-describedby` do botão de cada upload referencia todas as mensagens de erro como descrição. WCAG 2.1 AA quebrado para usuários de leitor de tela.

## Correção

Contador estático na classe + dois campos derivados:

```ts
private static instanceCount = 0;
private readonly instanceId = `ui-file-upload-${++FileUploadComponent.instanceCount}`;

readonly inputId = `${this.instanceId}-input`;
readonly errorId = `${this.instanceId}-error`;
```

Template substitui literais por bindings:

```diff
- <label for="file-upload-input" ...>
+ <label [attr.for]="inputId" ...>

- <input id="file-upload-input" ... />
+ <input [id]="inputId" ... />

- [attr.aria-describedby]="error() ? 'file-upload-error' : null"
+ [attr.aria-describedby]="error() ? errorId : null"

- <small id="file-upload-error" role="alert" ...>
+ <small [id]="errorId" role="alert" ...>
```

Counter estático foi escolhido em vez de `crypto.randomUUID()` por ser determinístico, sem dependência de runtime, e suficiente para o domínio (IDs CSS-safe sem chars especiais).

## Cobertura

`libs/shared-ui` na branch deste PR:

- `nx vite:test shared-ui` → **25/25 testes verdes** (era 22; +3 testes de IDs únicos)
- `nx lint shared-ui` → ✅ clean
- `nx typecheck shared-ui` → ✅ clean
- `nx build shared-ui` (ng-packagr) → ✅ 604ms

Testes novos:
- `gera IDs únicos por instância para isolar `for`/`aria-describedby` em multi-upload`
- `aria-describedby aponta para o errorId da própria instância quando há erro`
- `label[for] aponta para o inputId da própria instância`

## Como aplicar

**Opção A (recomendada):** clicar em **Merge pull request** aqui — o `feature/6-file-upload-validation` recebe o commit e o PR #177 atualiza automaticamente.

**Opção B:** cherry-pick `194a555` localmente.