### PR TITLE
refactor(shared-ui): aplica review do PR #178 (confirm-dialog — testabilidade desacoplada)

### DIFF
--- a/libs/shared-ui/src/lib/components/confirm-dialog/confirm-dialog.spec.ts
+++ b/libs/shared-ui/src/lib/components/confirm-dialog/confirm-dialog.spec.ts
@@ -1,165 +1,164 @@
 import { By } from '@angular/platform-browser';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ConfirmDialogComponent } from './confirm-dialog';
 
 describe('ConfirmDialogComponent', () => {
-  const DEFAULT_CONFIRM_LABEL = 'Confirmar';
-  const DEFAULT_CANCEL_LABEL = 'Cancelar';
-
   beforeEach(() => {
     TestBed.configureTestingModule({ imports: [ConfirmDialogComponent] });
   });
 
-  function setup(opt?: { confirmLabel?: string, cancelLabel?: string } ) {
+  function setup() {
     const fixture: ComponentFixture<ConfirmDialogComponent> =
       TestBed.createComponent(ConfirmDialogComponent);
-    fixture.detectChanges();
     const component = fixture.componentInstance;
-    const getDialogEl = () =>
-      fixture.debugElement.query(By.css('[role="dialog"]')).nativeElement as HTMLDivElement;
-    const getButtons = () => fixture.debugElement.queryAll(By.css('button'));
-    const getCancelButtonEl = () => getButtons().find(b => b.nativeElement.textContent.trim() === (opt?.cancelLabel ?? DEFAULT_CANCEL_LABEL))?.nativeElement as HTMLButtonElement;
-    const getConfirmButtonEl = () => getButtons().find(b => b.nativeElement.textContent.trim() === (opt?.confirmLabel ?? DEFAULT_CONFIRM_LABEL))?.nativeElement as HTMLButtonElement;
-    const confirmedOutputSpy = vi.spyOn(component.confirmed, 'emit');
-    const cancelledOutputSpy = vi.spyOn(component.cancelled, 'emit');
+
+    const dialog = () => fixture.debugElement.query(By.css('[role="dialog"]'));
+    const heading = () => fixture.debugElement.query(By.css('h3'));
+    const message = () => fixture.debugElement.query(By.css('p'));
+    const cancelButton = () =>
+      fixture.debugElement.query(By.css('[data-testid="confirm-dialog-cancel"]'));
+    const confirmButton = () =>
+      fixture.debugElement.query(By.css('[data-testid="confirm-dialog-confirm"]'));
+    const confirmedSpy = vi.spyOn(component.confirmed, 'emit');
+    const cancelledSpy = vi.spyOn(component.cancelled, 'emit');
+
     return {
       fixture,
       component,
-      getDialogEl,
-      getCancelButtonEl,
-      getConfirmButtonEl,
-      confirmedOutputSpy,
-      cancelledOutputSpy
+      dialog,
+      heading,
+      message,
+      cancelButton,
+      confirmButton,
+      confirmedSpy,
+      cancelledSpy,
     };
   }
 
-  it('inicializa o componente corretamente', () => {
-    const { component } = setup();
-    expect(component).toBeTruthy();
-  });
-
-  it('renderiza o componente sem nós filhos no DOM quando visible() é false (default)', () => {
-    const { fixture } = setup();
-    expect(fixture.debugElement.children.length).toBe(0);
-  });
-
-  it('renderiza o dialog quando o input visible() é inicializado com o valor true', () => {
-    const { fixture, getDialogEl, getCancelButtonEl, getConfirmButtonEl } = setup();
+  function open(fixture: ComponentFixture<ConfirmDialogComponent>): void {
     fixture.componentRef.setInput('visible', true);
     fixture.detectChanges();
+  }
 
-    const headingEl = fixture.debugElement.query(By.css('h3')).nativeElement as HTMLHeadingElement;
-    const paragraphEl = fixture.debugElement.query(By.css('p')).nativeElement as HTMLParagraphElement;
-    const cancelButtonEl = getCancelButtonEl();
-    const confirmButtonEl = getConfirmButtonEl();
-    const dialogEl = getDialogEl();
+  describe('estado inicial', () => {
+    it('inicializa o componente sem erros', () => {
+      const { component } = setup();
+      expect(component).toBeTruthy();
+    });
 
-    expect(dialogEl).toBeTruthy();
-    expect(headingEl).toBeTruthy();
-    expect(headingEl.textContent).toBe('Confirmação');
-    expect(paragraphEl.textContent).toBe('Deseja realmente prosseguir?');
-    expect(confirmButtonEl.textContent?.trim()).toBe('Confirmar');
-    expect(cancelButtonEl.textContent?.trim()).toBe('Cancelar');
+    it('não renderiza nada quando visible() é false (default)', () => {
+      const { fixture } = setup();
+      fixture.detectChanges();
+      expect(fixture.debugElement.children.length).toBe(0);
+    });
   });
 
-  it('emite um evento de output cancelled() quando clicar no botão cancelar', () => {
-    const { fixture, component, getCancelButtonEl, cancelledOutputSpy } = setup();
-    fixture.componentRef.setInput('visible', true);
-    fixture.detectChanges();
+  describe('quando visible() é true', () => {
+    it('renderiza o dialog com role e aria-modal corretos para leitores de tela', () => {
+      const { fixture, dialog } = setup();
+      open(fixture);
 
-    const cancelButtonEl = getCancelButtonEl();
-    cancelButtonEl.click();
-    fixture.detectChanges();
+      const dialogEl = dialog().nativeElement as HTMLElement;
+      expect(dialogEl.getAttribute('role')).toBe('dialog');
+      expect(dialogEl.getAttribute('aria-modal')).toBe('true');
+    });
 
-    expect(component.visible()).toBe(false);
-    expect(cancelledOutputSpy).toHaveBeenCalled();
+    it('usa textos default de título, mensagem e labels', () => {
+      const { fixture, heading, message, cancelButton, confirmButton } = setup();
+      open(fixture);
+
+      expect(heading().nativeElement.textContent.trim()).toBe('Confirmação');
+      expect(message().nativeElement.textContent.trim()).toBe('Deseja realmente prosseguir?');
+      expect(cancelButton().nativeElement.textContent.trim()).toBe('Cancelar');
+      expect(confirmButton().nativeElement.textContent.trim()).toBe('Confirmar');
+    });
   });
 
-  it('emite um evento de output confirmed() quando clicar no botão confirmar', () => {
-    const { fixture, component, getConfirmButtonEl, confirmedOutputSpy } = setup();
-    fixture.componentRef.setInput('visible', true);
-    fixture.detectChanges();
+  describe('emissão de eventos', () => {
+    it('emite cancelled() e fecha o dialog ao clicar em Cancelar', () => {
+      const { fixture, component, cancelButton, cancelledSpy } = setup();
+      open(fixture);
 
-    const confirmButtonEl = getConfirmButtonEl();
-    confirmButtonEl.click();
-    fixture.detectChanges();
+      (cancelButton().nativeElement as HTMLButtonElement).click();
+      fixture.detectChanges();
 
-    expect(component.visible()).toBe(false);
-    expect(confirmedOutputSpy).toHaveBeenCalled();
+      expect(cancelledSpy).toHaveBeenCalledOnce();
+      expect(component.visible()).toBe(false);
+    });
+
+    it('emite confirmed() e fecha o dialog ao clicar em Confirmar', () => {
+      const { fixture, component, confirmButton, confirmedSpy } = setup();
+      open(fixture);
+
+      (confirmButton().nativeElement as HTMLButtonElement).click();
+      fixture.detectChanges();
+
+      expect(confirmedSpy).toHaveBeenCalledOnce();
+      expect(component.visible()).toBe(false);
+    });
+
+    it('não emite cancelled() quando o usuário clica em Confirmar', () => {
+      const { fixture, confirmButton, cancelledSpy } = setup();
+      open(fixture);
+
+      (confirmButton().nativeElement as HTMLButtonElement).click();
+      fixture.detectChanges();
+
+      expect(cancelledSpy).not.toHaveBeenCalled();
+    });
   });
 
-  it('renderiza um título customizado', () => {
-    const { fixture, component } = setup();
-    fixture.componentRef.setInput('visible', true);
-    const title = 'Tela de Confirmação';
-    fixture.componentRef.setInput('title', title);
-    fixture.detectChanges();
+  describe('inputs customizados', () => {
+    it('aceita título customizado', () => {
+      const { fixture, heading } = setup();
+      const titulo = 'Tela de Confirmação';
+      fixture.componentRef.setInput('title', titulo);
+      open(fixture);
 
-    const headingEl = fixture.debugElement.query(By.css('h3')).nativeElement as HTMLHeadingElement;
+      expect(heading().nativeElement.textContent.trim()).toBe(titulo);
+    });
 
-    expect(component.title()).toBe(title);
-    expect(headingEl.textContent?.trim()).toBe(component.title());
+    it('aceita mensagem customizada', () => {
+      const { fixture, message } = setup();
+      const mensagem = 'Deseja realmente prosseguir com a operação?';
+      fixture.componentRef.setInput('message', mensagem);
+      open(fixture);
+
+      expect(message().nativeElement.textContent.trim()).toBe(mensagem);
+    });
+
+    it('aceita label customizado para o botão de confirmação', () => {
+      const { fixture, confirmButton } = setup();
+      fixture.componentRef.setInput('confirmLabel', 'Aprovar matrícula');
+      open(fixture);
+
+      expect(confirmButton().nativeElement.textContent.trim()).toBe('Aprovar matrícula');
+    });
+
+    it('aceita label customizado para o botão de cancelar', () => {
+      const { fixture, cancelButton } = setup();
+      fixture.componentRef.setInput('cancelLabel', 'Voltar');
+      open(fixture);
+
+      expect(cancelButton().nativeElement.textContent.trim()).toBe('Voltar');
+    });
   });
 
-  it('renderiza um parágrafo customizado', () => {
-    const { fixture, component } = setup();
-    fixture.componentRef.setInput('visible', true);
-    const message = 'Deseja realmente prosseguir com a operação?';
-    fixture.componentRef.setInput('message', message);
-    fixture.detectChanges();
+  describe('confirmVariant()', () => {
+    it('aplica variant primary por default', () => {
+      const { fixture, confirmButton } = setup();
+      open(fixture);
 
-    const paragraphEl = fixture.debugElement.query(By.css('p')).nativeElement as HTMLParagraphElement;
+      expect(confirmButton().nativeElement.getAttribute('data-variant')).toBe('primary');
+    });
 
-    expect(component.message()).toBe(message);
-    expect(paragraphEl.textContent?.trim()).toBe(component.message());
-  });
+    it('aplica variant danger quando configurado', () => {
+      const { fixture, confirmButton } = setup();
+      fixture.componentRef.setInput('confirmVariant', 'danger');
+      open(fixture);
 
-  it('renderiza botão de confirmação com um texto customizado', () => {
-    const confirmLabel = 'Confirmar Operação';
-    const { fixture, component, getConfirmButtonEl } = setup({ confirmLabel: confirmLabel });
-    fixture.componentRef.setInput('visible', true);
-    fixture.componentRef.setInput('confirmLabel', confirmLabel);
-    fixture.detectChanges();
-
-    const confirmButtonEl = getConfirmButtonEl();
-
-    expect(confirmButtonEl.textContent?.trim()).toBe(confirmLabel);
-    expect(confirmButtonEl.textContent?.trim()).toBe(component.confirmLabel());
-  });
-
-  it('renderiza botão de cancelar com texto customizado', () => {
-    const cancelLabel = 'Cancelar Operação';
-    const { fixture, getCancelButtonEl } = setup({ cancelLabel: cancelLabel });
-    fixture.componentRef.setInput('visible', true);
-    fixture.componentRef.setInput('cancelLabel', cancelLabel);
-    fixture.detectChanges();
-
-    const cancelButtonEl = getCancelButtonEl();
-
-    expect(cancelButtonEl.textContent?.trim()).toBe(cancelLabel);
-  });
-
-  it('aplica classes css no botão de confirmação quando o input confirmVariant() é "primary" (default)', () => {
-    const { fixture, getConfirmButtonEl } = setup();
-    fixture.componentRef.setInput('visible', true);
-    fixture.detectChanges();
-
-    const confirmButtonEl = getConfirmButtonEl();
-
-    expect(confirmButtonEl.classList).toContain('bg-unifesspa-primary');
-    expect(confirmButtonEl.classList).toContain('hover:bg-blue-800');
-  });
-
-  it('aplica classes css no botão de confirmação quando o input confirmVariant() é "danger"', () => {
-    const { fixture, getConfirmButtonEl } = setup();
-    fixture.componentRef.setInput('visible', true);
-    fixture.componentRef.setInput('confirmVariant', 'danger');
-    fixture.detectChanges();
-
-    const confirmButtonEl = getConfirmButtonEl();
-
-    expect(confirmButtonEl.classList).toContain('bg-red-600');
-    expect(confirmButtonEl.classList).toContain('hover:bg-red-700');
+      expect(confirmButton().nativeElement.getAttribute('data-variant')).toBe('danger');
+    });
   });
 });

--- a/libs/shared-ui/src/lib/components/confirm-dialog/confirm-dialog.ts
+++ b/libs/shared-ui/src/lib/components/confirm-dialog/confirm-dialog.ts
@@ -15,6 +15,7 @@ import { CommonModule } from '@angular/common';
           <div class="mt-6 flex justify-end gap-3">
             <button
               type="button"
+              data-testid="confirm-dialog-cancel"
               class="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
               (click)="onCancel()"
             >
@@ -22,6 +23,8 @@ import { CommonModule } from '@angular/common';
             </button>
             <button
               type="button"
+              data-testid="confirm-dialog-confirm"
+              [attr.data-variant]="confirmVariant()"
               class="rounded-md px-4 py-2 text-sm font-medium text-white"
               [ngClass]="confirmVariant() === 'danger' ? 'bg-red-600 hover:bg-red-700' : 'bg-unifesspa-primary hover:bg-blue-800'"
               (click)="onConfirm()"


### PR DESCRIPTION
## Resumo

PR-de-correção endereçando os findings da revisão do [PR #178](https://github.com/unifesspa-edu-br/uniplus-web/pull/178). Mergeia diretamente em `175-confirm-dialog-test-coverage` (branch do @denilson-santos-unifesspa) — não em `main`.

> Olá @denilson-santos-unifesspa! Mesmo padrão do #203/#211/#212. Diferente do #193, aqui **não há regressão funcional** — o codex review não apontou findings. As mudanças são de **elevação de qualidade** alinhadas aos padrões da sessão (testabilidade desacoplada, AAA, organização semântica). Se concordar, mergeia este PR e o #178 absorve.

## Findings endereçados

### Importantes — testabilidade desacoplada de implementação

**[I1] Testes acoplados a classes Tailwind (brittle)**

Antes:
```ts
expect(confirmButtonEl.classList).toContain('bg-unifesspa-primary');
expect(confirmButtonEl.classList).toContain('hover:bg-blue-800');
```

Esses asserts testam **implementação de estilização**, não comportamento. Quando o componente migrar para tokens Gov.br via PassThrough (estratégia ADR-018), trocar `[ngClass]` por `[class.X]`, ou reorganizar utilities Tailwind, esses testes quebram **sem mudança de contrato**.

Solução: adicionar `[attr.data-variant]="confirmVariant()"` no componente — o `data-variant` é o **contrato testável** do input. Classes ficam livres para evoluir.

```ts
expect(confirmButton().nativeElement.getAttribute('data-variant')).toBe('danger');
```

**[I2] `opt` no `setup()` exigia sincronização manual**

Antes:
```ts
const { fixture, ..., getConfirmButtonEl } = setup({ confirmLabel: 'Confirmar Operação' });
fixture.componentRef.setInput('visible', true);
fixture.componentRef.setInput('confirmLabel', 'Confirmar Operação');  // duplicação
```

O label entrava duas vezes — uma para o setup achar o botão pelo texto, outra para configurar o componente. Erro fácil esquecer em um dos lugares.

Solução: localizar botões por **`data-testid`** (estável, independente de label). `opt` removido.

**[I3] Falta cobertura de marcação ARIA**

`role="dialog"` e `aria-modal="true"` estão no template mas não eram testados — quebra silenciosa de a11y é possível.

Adicionado:
```ts
it('renderiza o dialog com role e aria-modal corretos para leitores de tela', () => {
  // ...
  expect(dialogEl.getAttribute('role')).toBe('dialog');
  expect(dialogEl.getAttribute('aria-modal')).toBe('true');
});
```

**[I4] Falta teste cross-event (isolamento dos outputs)**

Os testes provavam que clicar em Cancelar emite `cancelled()` e que clicar em Confirmar emite `confirmed()`, mas não provavam que clicar em Confirmar **NÃO emite** `cancelled()` — um bug onde ambos fossem emitidos passaria sem detecção.

Adicionado:
```ts
it('não emite cancelled() quando o usuário clica em Confirmar', () => { ... });
```

**[I5] Setup sem helper para "abrir o dialog"**

Cada teste fazia `setInput('visible', true) + detectChanges()` repetidamente. Helper `open(fixture)` extraído.

### Sugestões aplicadas

- **Asserções de classes substituídas** por `data-variant`: 2 asserts brittle → 2 asserts semânticos.
- **`toHaveBeenCalledOnce()`** substitui `toHaveBeenCalled()` — falha se for chamado 2× (bug detection real).
- **5 `describe` blocks** organizam testes por concern (estado inicial, visible true, eventos, inputs custom, variant) — leitura linear do contrato.
- **AAA explícito** com linhas em branco entre arrange/act/assert.
- **Constantes `DEFAULT_CONFIRM_LABEL`/`DEFAULT_CANCEL_LABEL` removidas** — não eram necessárias após eliminar a busca por texto.

## Mudanças no componente

```diff
  <button
    type="button"
+   data-testid="confirm-dialog-cancel"
    class="rounded-md border border-gray-300 bg-white px-4 py-2 ..."
    (click)="onCancel()"
  >
    {{ cancelLabel() }}
  </button>
  <button
    type="button"
+   data-testid="confirm-dialog-confirm"
+   [attr.data-variant]="confirmVariant()"
    class="rounded-md px-4 py-2 text-sm font-medium text-white"
    [ngClass]="confirmVariant() === 'danger' ? 'bg-red-600 hover:bg-red-700' : 'bg-unifesspa-primary hover:bg-blue-800'"
    (click)="onConfirm()"
  >
    {{ confirmLabel() }}
  </button>
```

3 atributos novos (2 `data-testid` + 1 `data-variant`). `[ngClass]` **mantido** — refactor de styling fica para PR separado se desejado.

## Cobertura

`libs/shared-ui` na branch deste PR:

- `nx vite:test shared-ui` → **57/57 testes verdes** — destes, **13 em `confirm-dialog.spec.ts`** (era 11).
- `nx lint shared-ui` → ✅ clean
- `nx typecheck shared-ui` → ✅ clean
- `nx build shared-ui` (ng-packagr) → ✅ clean

## Sobre a oportunidade de evolução

Algumas reflexões — espero que sejam úteis:

1. **Testes devem testar o contrato, não a implementação.** Classes CSS são detalhe de implementação; `data-variant` é contrato. Quando o teste falha, deve ser porque o **comportamento** mudou, não porque o nome de uma classe Tailwind mudou.

2. **`data-testid` é o padrão moderno para localização em testes.** Independente de localização (pt-BR, en-US), independente de reorganização de DOM, independente de mudança de texto. Vale para Vitest, Playwright e Cypress.

3. **`describe` é estrutura, não decoração.** Agrupar por concern (`'inputs customizados'`, `'emissão de eventos'`) torna o spec uma documentação executável do contrato. Quando alguém abre o spec para entender o componente, lê em ordem natural.

4. **Helpers extraídos eliminam noise.** `open(fixture)` em uma linha substitui 2 linhas em 9 testes. Não é só DRY — é foco: o teste fala sobre o **caso específico**, não sobre boilerplate.

5. **Cross-event tests pegam acoplamentos invisíveis.** "Cancelar emite cancelled" + "Confirmar emite confirmed" + "Confirmar não emite cancelled" cobre os 3 vértices do contrato. Sem o terceiro, um bug onde ambos eventos disparam passa.

## Como aplicar

**Opção A (recomendada):** clicar em **Merge pull request** aqui — o `175-confirm-dialog-test-coverage` recebe o commit e o PR #178 atualiza automaticamente.

**Opção B:** cherry-pick `64d023f` localmente.