### PR TITLE
feat(shared-core): useApiResource adota httpResource Angular 21 + ADR-0018

### DIFF
--- a/apps/selecao/src/app/features/editais/editais-detail.page.spec.ts
+++ b/apps/selecao/src/app/features/editais/editais-detail.page.spec.ts
@@ -3,6 +3,7 @@ import {
   HttpTestingController,
   provideHttpClientTesting,
 } from '@angular/common/http/testing';
+import { ApplicationRef } from '@angular/core';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideRouter } from '@angular/router';
@@ -30,6 +31,7 @@ describe('EditaisDetailPage', () => {
   let fixture: ComponentFixture<EditaisDetailPage>;
   let component: EditaisDetailPage;
   let controller: HttpTestingController;
+  let appRef: ApplicationRef;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -45,17 +47,30 @@ describe('EditaisDetailPage', () => {
     fixture = TestBed.createComponent(EditaisDetailPage);
     component = fixture.componentInstance;
     controller = TestBed.inject(HttpTestingController);
+    appRef = TestBed.inject(ApplicationRef);
     fixture.componentRef.setInput('id', ID);
   });
 
   afterEach(() => controller.verify());
 
-  it('carga inicial dispara GET /api/editais/{id} e popula o signal edital', () => {
+  // Helper: dreina o microtask queue para o `httpResource` propagar valores
+  // aos signals após `controller.flush(...)`. `appRef.whenStable()` deadlocka
+  // em testes de fixture com subscriptions ativas (publish flow); usar
+  // `Promise.resolve()` é o equivalente sem Zone.js para "deixe microtasks
+  // do signal scheduler rodarem antes da próxima asserção".
+  const propagate = async () => {
+    await Promise.resolve();
+    appRef.tick();
+  };
+
+  it('carga inicial dispara GET /api/editais/{id} e popula data() do resource', async () => {
     fixture.detectChanges();
 
     const req = controller.expectOne(`${BASE}/api/editais/${ID}`);
     expect(req.request.method).toBe('GET');
+    expect(req.request.headers.get('Accept')).toBe('application/vnd.uniplus.edital.v1+json');
     req.flush(editalSeed());
+    await propagate();
 
     expect(component.edital()).toMatchObject({
       id: ID,
@@ -66,7 +81,7 @@ describe('EditaisDetailPage', () => {
     expect(component.loading()).toBe(false);
   });
 
-  it('404 problem+json popula errorMessage via problem-i18n e zera edital', () => {
+  it('404 problem+json popula errorMessage via problem-i18n e mantém edital=null', async () => {
     fixture.detectChanges();
 
     controller.expectOne(`${BASE}/api/editais/${ID}`).flush(
@@ -79,26 +94,29 @@ describe('EditaisDetailPage', () => {
       },
       { status: 404, statusText: 'Not Found', headers: { 'Content-Type': 'application/problem+json' } },
     );
+    await propagate();
 
     expect(component.edital()).toBeNull();
     expect(component.errorMessage()).toBe('Edital não encontrado');
   });
 
-  it('podePublicar=true quando status === "Rascunho" (única transição permitida)', () => {
+  it('podePublicar=true quando status === "Rascunho" (única transição permitida)', async () => {
     fixture.detectChanges();
     controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Rascunho' }));
+    await propagate();
 
     expect(component['podePublicar']()).toBe(true);
   });
 
-  it('podePublicar=false quando status diferente de "Rascunho"', () => {
+  it('podePublicar=false quando status diferente de "Rascunho"', async () => {
     fixture.detectChanges();
     controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Publicado' }));
+    await propagate();
 
     expect(component['podePublicar']()).toBe(false);
   });
 
-  it('_links.publicar no payload NUNCA habilita o botão (vedação ADR-0029 honrada — gate só por status)', () => {
+  it('_links.publicar no payload NUNCA habilita o botão (vedação ADR-0029 honrada — gate só por status)', async () => {
     fixture.detectChanges();
     // Cenário hipotético defensivo: backend (incorretamente) emite _links.publicar.
     // Frontend deve ignorar — gating é exclusivamente por status do recurso.
@@ -110,11 +128,12 @@ describe('EditaisDetailPage', () => {
         publicar: `/api/editais/${ID}/publicar`,
       },
     } as never);
+    await propagate();
 
     expect(component['podePublicar']()).toBe(false);
   });
 
-  it('_links navigation (self/collection) presente em recurso single per ADR-0029', () => {
+  it('_links navigation (self/collection) presente em recurso single per ADR-0029', async () => {
     fixture.detectChanges();
     controller.expectOne(`${BASE}/api/editais/${ID}`).flush({
       ...editalSeed({ status: 'Rascunho' }),
@@ -123,6 +142,7 @@ describe('EditaisDetailPage', () => {
         collection: '/api/editais',
       },
     });
+    await propagate();
 
     expect(component.edital()?._links?.['self']).toBe(`/api/editais/${ID}`);
     expect(component.edital()?._links?.['collection']).toBe('/api/editais');
@@ -130,9 +150,10 @@ describe('EditaisDetailPage', () => {
     expect(component.edital()?._links?.['publicar']).toBeUndefined();
   });
 
-  it('confirmarPublicacao envia POST com Idempotency-Key, recebe 204 e refetcha o edital', () => {
+  it('confirmarPublicacao envia POST com Idempotency-Key, recebe 204 e refetcha o edital', async () => {
     fixture.detectChanges();
     controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Rascunho' }));
+    await propagate();
 
     component['confirmarPublicacao']();
     expect(component.submitting()).toBe(true);
@@ -141,19 +162,22 @@ describe('EditaisDetailPage', () => {
     expect(reqPublicar.request.method).toBe('POST');
     expect(reqPublicar.request.headers.get('Idempotency-Key')).toMatch(/^[0-9a-f-]{36}$/);
     reqPublicar.flush(null, { status: 204, statusText: 'No Content' });
+    await propagate();
 
-    // Refetch dispara novo GET
+    // Refetch via editalResource.reload() — dispara novo GET preservando URL atual.
     const reqRefetch = controller.expectOne(`${BASE}/api/editais/${ID}`);
     reqRefetch.flush(editalSeed({ status: 'Publicado' }));
+    await propagate();
 
     expect(component.submitting()).toBe(false);
     expect(component.mensagemSucesso()).toBe('Edital publicado com sucesso.');
     expect(component.edital()?.status).toBe('Publicado');
   });
 
-  it('confirmarPublicacao com 422 ja_publicado popula errorMessage e NÃO refetcha', () => {
+  it('confirmarPublicacao com 422 ja_publicado popula errorMessage e NÃO refetcha', async () => {
     fixture.detectChanges();
     controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Rascunho' }));
+    await propagate();
 
     component['confirmarPublicacao']();
     controller.expectOne(`${BASE}/api/editais/${ID}/publicar`).flush(
@@ -166,15 +190,17 @@ describe('EditaisDetailPage', () => {
       },
       { status: 422, statusText: 'Unprocessable Entity', headers: { 'Content-Type': 'application/problem+json' } },
     );
+    await propagate();
 
     expect(component.errorMessage()).toBe('Edital já publicado');
     expect(component.mensagemSucesso()).toBeNull();
     // Sem refetch — controller.verify() do afterEach detecta requests pendentes.
   });
 
-  it('botão Publicar aparece quando podePublicar=true e dispara dialog', () => {
+  it('botão Publicar aparece quando podePublicar=true e dispara dialog', async () => {
     fixture.detectChanges();
     controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Rascunho' }));
+    await propagate();
     fixture.detectChanges();
 
     const botao = fixture.debugElement.query(By.css('[data-testid="btn-publicar"]'));
@@ -185,56 +211,99 @@ describe('EditaisDetailPage', () => {
     expect(component.dialogVisivel()).toBe(true);
   });
 
-  it('botão Publicar NÃO aparece quando podePublicar=false', () => {
+  it('botão Publicar NÃO aparece quando podePublicar=false', async () => {
     fixture.detectChanges();
     controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Publicado' }));
+    await propagate();
     fixture.detectChanges();
 
     const botao = fixture.debugElement.query(By.css('[data-testid="btn-publicar"]'));
     expect(botao).toBeNull();
   });
 
-  it('race guard: response stale do id anterior é descartada quando id mudou', () => {
+  it('mudança no input id cancela GET stale e dispara nova request (httpResource race-cancellation nativa)', async () => {
     fixture.detectChanges();
     const reqId1 = controller.expectOne(`${BASE}/api/editais/${ID}`);
+    expect(reqId1.cancelled).toBe(false);
 
-    // Usuário navega antes do id1 retornar
+    // Usuário navega antes do id1 retornar — Angular reusa a instância do componente.
     const ID_NOVO = '01960000-0000-7000-0000-000000000bbb';
     fixture.componentRef.setInput('id', ID_NOVO);
     fixture.detectChanges();
+    // Drena microtasks do scheduler de signals — sem isto o assert de
+    // cancellation pode ser flaky se o httpResource scheduler atrasar o
+    // unsubscribe da request stale para a próxima microtask.
+    await propagate();
+
+    // httpResource cancela a request anterior automaticamente quando dependências
+    // reativas mudam — substitui o race guard manual ("if (this.id() !== id) return")
+    // do pattern legado.
+    expect(reqId1.cancelled).toBe(true);
+
     const reqId2 = controller.expectOne(`${BASE}/api/editais/${ID_NOVO}`);
-
-    // id2 retorna primeiro com dados novos
     reqId2.flush(editalSeed({ id: ID_NOVO, titulo: 'PSE 2027' }));
-    expect(component.edital()?.titulo).toBe('PSE 2027');
-    expect(component.loading()).toBe(false);
+    await propagate();
 
-    // id1 (stale) retorna depois — guard descarta sem mutar state
-    reqId1.flush(editalSeed({ titulo: 'PSE 2026' }));
-    expect(component.edital()?.titulo).toBe('PSE 2027'); // não mudou para PSE 2026
+    expect(component.edital()?.titulo).toBe('PSE 2027');
     expect(component.loading()).toBe(false);
   });
 
-  it('mudança no input id refetcha automaticamente e zera estado anterior', () => {
+  it('confirmarPublicacao ignora chamada dupla enquanto submitting=true (guard de double-submit)', async () => {
     fixture.detectChanges();
-    controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ titulo: 'PSE 2026' }));
+    controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Rascunho' }));
+    await propagate();
+
+    component['confirmarPublicacao']();
+    // Segunda chamada antes do flush do POST — guard ignora silenciosamente.
+    component['confirmarPublicacao']();
+
+    // Deve haver exatamente 1 POST em voo, não 2 — caso contrário o
+    // expectOne lançaria "Match URL ... found 2 requests" e o teste falharia.
+    controller
+      .expectOne(`${BASE}/api/editais/${ID}/publicar`)
+      .flush(null, { status: 204, statusText: 'No Content' });
+    await propagate();
+
+    controller
+      .expectOne(`${BASE}/api/editais/${ID}`)
+      .flush(editalSeed({ status: 'Publicado' }));
+    await propagate();
+
+    expect(component.submitting()).toBe(false);
+    expect(component.mensagemSucesso()).toBe('Edital publicado com sucesso.');
+  });
+
+  it('mudança no input id zera mensagemSucesso e errorMessage do publish anterior', async () => {
     fixture.detectChanges();
+    controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Rascunho' }));
+    await propagate();
 
-    expect(component.edital()?.titulo).toBe('PSE 2026');
+    // Simula publish bem-sucedido — popula mensagemSucesso.
+    component['confirmarPublicacao']();
+    controller
+      .expectOne(`${BASE}/api/editais/${ID}/publicar`)
+      .flush(null, { status: 204, statusText: 'No Content' });
+    await propagate();
+    controller
+      .expectOne(`${BASE}/api/editais/${ID}`)
+      .flush(editalSeed({ status: 'Publicado' }));
+    await propagate();
+    expect(component.mensagemSucesso()).toBe('Edital publicado com sucesso.');
 
-    // Navegação para outro :id sem destruir o componente (Angular reusa instância).
+    // Navegação para outro :id sem destruir o componente.
     const ID_NOVO = '01960000-0000-7000-0000-000000000aaa';
     fixture.componentRef.setInput('id', ID_NOVO);
     fixture.detectChanges();
 
-    // Estado do edital anterior é zerado durante o fetch novo.
+    // Effect zera signals locais (publish flow); httpResource zera value() automaticamente.
+    expect(component.mensagemSucesso()).toBeNull();
     expect(component.edital()).toBeNull();
     expect(component.loading()).toBe(true);
 
-    const reqNovo = controller.expectOne(`${BASE}/api/editais/${ID_NOVO}`);
-    reqNovo.flush(editalSeed({ id: ID_NOVO, titulo: 'PSE 2027' }));
-
+    controller
+      .expectOne(`${BASE}/api/editais/${ID_NOVO}`)
+      .flush(editalSeed({ id: ID_NOVO, titulo: 'PSE 2027' }));
+    await propagate();
     expect(component.edital()?.titulo).toBe('PSE 2027');
-    expect(component.loading()).toBe(false);
   });
 });

--- a/apps/selecao/src/app/features/editais/editais-detail.page.ts
+++ b/apps/selecao/src/app/features/editais/editais-detail.page.ts
@@ -14,13 +14,30 @@ import { RouterLink } from '@angular/router';
 import {
   ProblemI18nService,
   idempotencyKey,
+  useApiResource,
   withIdempotencyKey,
+  withVendorMime,
 } from '@uniplus/shared-core';
-import { EditaisApi, EditalDto } from '@uniplus/shared-data';
+import {
+  EditaisApi,
+  EditalDto,
+  SELECAO_BASE_PATH,
+} from '@uniplus/shared-data';
 import { ConfirmDialogComponent } from '@uniplus/shared-ui';
 
 /**
  * Container (ADR-0017) da feature Editais — detalhe + ação Publicar.
+ *
+ * **GET reativo via `useApiResource` (ADR-0018):** o helper envelopa o
+ * `httpResource` Angular 21 sobre o `apiResultInterceptor`, exibindo
+ * `data()`/`problem()`/`isLoading()` como signals. Quando o input `id` muda,
+ * o helper cancela a request anterior automaticamente — substitui o race
+ * guard manual do pattern legado.
+ *
+ * **POST `publicar` continua via `EditaisApi` + `HttpClient`** (guidance
+ * Angular oficial: `httpResource` é GET-only — mutações via HttpClient direto).
+ * O race guard do publish (id capturado no closure do submit) **fica** porque
+ * é mutação one-shot, não fetch reativo.
  *
  * **Gating do botão "Publicar":** baseado em `status === 'Rascunho'` (única
  * transição permitida hoje per `Edital.Publicar()` no domínio backend).
@@ -43,8 +60,8 @@ import { ConfirmDialogComponent } from '@uniplus/shared-ui';
     <header class="mb-5 flex items-start justify-between gap-4">
       <div>
         <h2 class="text-2xl font-bold text-gray-800">Detalhes do edital</h2>
-        @if (edital()) {
-          <p class="text-sm text-gray-600">{{ edital()!.numeroEdital }} — {{ edital()!.titulo }}</p>
+        @if (edital(); as e) {
+          <p class="text-sm text-gray-600">{{ e.numeroEdital }} — {{ e.titulo }}</p>
         }
       </div>
       <a
@@ -55,21 +72,21 @@ import { ConfirmDialogComponent } from '@uniplus/shared-ui';
       </a>
     </header>
 
-    @if (errorMessage()) {
+    @if (errorMessage(); as msg) {
       <div
         class="mb-4 flex items-start gap-2 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800"
         role="alert"
       >
-        <span class="font-semibold">{{ errorMessage() }}</span>
+        <span class="font-semibold">{{ msg }}</span>
       </div>
     }
 
-    @if (mensagemSucesso()) {
+    @if (mensagemSucesso(); as sucesso) {
       <div
         class="mb-4 flex items-start gap-2 rounded-md border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-800"
         role="status"
       >
-        <span class="font-semibold">{{ mensagemSucesso() }}</span>
+        <span class="font-semibold">{{ sucesso }}</span>
       </div>
     }
 
@@ -133,10 +150,44 @@ export class EditaisDetailPage {
   private readonly api = inject(EditaisApi);
   private readonly problemI18n = inject(ProblemI18nService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly basePath = inject(SELECAO_BASE_PATH);
 
-  readonly edital = signal<EditalDto | null>(null);
-  readonly loading = signal<boolean>(false);
-  readonly errorMessage = signal<string | null>(null);
+  /**
+   * Resource reativo do GET `/api/editais/{id}`. Re-dispara automaticamente
+   * quando `id()` muda; a request anterior é cancelada nativamente pelo
+   * `httpResource` (race-cancellation — substitui o guard manual do pattern
+   * legado). Vendor MIME `edital v1` declarado no `HttpContext`
+   * (ADR-0028 backend, ADR-0016 cliente).
+   */
+  private readonly editalResource = useApiResource<EditalDto>(() => ({
+    url: `${this.basePath}/api/editais/${encodeURIComponent(this.id())}`,
+    context: withVendorMime('edital', 1),
+  }));
+
+  readonly edital = this.editalResource.data;
+  readonly loading = this.editalResource.isLoading;
+
+  /**
+   * Mensagem de erro consolidada — combina o `problem` da request GET
+   * (cancelado/limpo automaticamente quando `id` muda) com o erro do POST
+   * `publicar` (signal local, resetado via `effect` em mudança de `id`) e
+   * com o canal de erro do `httpResource` para o caso raro em que um
+   * interceptor não-HTTP lança fora do contrato `ApiResult` (ex.: erro
+   * síncrono em interceptor de auth/logging) — sem este fallback, o
+   * spinner desapareceria sem mensagem ao usuário.
+   */
+  private readonly publishErrorMessage = signal<string | null>(null);
+  readonly errorMessage = computed<string | null>(() => {
+    const httpProblem = this.editalResource.problem();
+    if (httpProblem) {
+      return this.problemI18n.resolve(httpProblem).title;
+    }
+    if (this.editalResource.error()) {
+      return 'Erro inesperado ao carregar edital.';
+    }
+    return this.publishErrorMessage();
+  });
+
   readonly submitting = signal<boolean>(false);
   readonly mensagemSucesso = signal<string | null>(null);
   readonly dialogVisivel = signal<boolean>(false);
@@ -153,21 +204,15 @@ export class EditaisDetailPage {
   });
 
   constructor() {
-    // Recarrega sempre que o input `id` mudar — caso de navegação entre
-    // /editais/:id1 → /editais/:id2 quando Angular reusa a mesma instância
-    // do componente. Sem isto, `edital()` ficaria stale e
-    // `confirmarPublicacao()` agiria contra o ID novo enquanto a UI mostra
-    // dados do anterior. `untracked` evita que mutations dentro do fetch
-    // re-disparem o effect.
+    // Reset de signals locais (publish flow) quando o input `id` muda. O
+    // estado do GET (`edital`/`loading`/`problem`) já é resetado nativamente
+    // pelo httpResource ao trocar dependências reativas — só precisamos
+    // limpar o que vive fora do Resource.
     effect(() => {
-      const currentId = this.id();
+      this.id();
       untracked(() => {
-        // Reset de estado dependente do ID anterior — só dispara quando o
-        // input muda. O refetch via publish (`confirmarPublicacao`) preserva
-        // `mensagemSucesso` porque chama `executarObterPorId` direto.
-        this.edital.set(null);
+        this.publishErrorMessage.set(null);
         this.mensagemSucesso.set(null);
-        this.executarObterPorId(currentId);
       });
     });
   }
@@ -182,7 +227,7 @@ export class EditaisDetailPage {
     }
     const idDoSubmit = this.id();
     this.submitting.set(true);
-    this.errorMessage.set(null);
+    this.publishErrorMessage.set(null);
     this.mensagemSucesso.set(null);
 
     this.api
@@ -199,41 +244,12 @@ export class EditaisDetailPage {
         }
         if (result.ok) {
           this.mensagemSucesso.set('Edital publicado com sucesso.');
-          // Refetch — bypassa guarda de `loading` para garantir reload
-          // pós-publicar mesmo se houver outra carga em voo. O guard interno
-          // de `executarObterPorId` ainda protege contra response stale.
-          this.executarObterPorId(idDoSubmit);
+          // Refetch via httpResource — cancela qualquer request em voo e
+          // dispara nova com a mesma URL atual.
+          this.editalResource.reload();
           return;
         }
-        this.errorMessage.set(this.problemI18n.resolve(result.problem).title);
-      });
-  }
-
-  private executarObterPorId(id: string): void {
-    this.loading.set(true);
-    this.errorMessage.set(null);
-    // Mantém `edital` e `mensagemSucesso` intactos — quem chamou (`effect`
-    // de mudança de id ou refetch pós-publicar) decide o reset apropriado.
-
-    this.api
-      .obter(id)
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((result) => {
-        // Race guard: se o `id` corrente do componente mudou desde o início
-        // desta request (usuário navegou para outro `:id` mid-fetch), descarta
-        // a response stale. Sem isto, late response do id antigo poderia
-        // sobrescrever `edital`/`loading` do fetch do id novo (ADR-0017
-        // container responsabilidade — UI só reflete estado do id atual).
-        if (this.id() !== id) {
-          return;
-        }
-        this.loading.set(false);
-        if (result.ok) {
-          this.edital.set(result.data);
-          return;
-        }
-        this.edital.set(null);
-        this.errorMessage.set(this.problemI18n.resolve(result.problem).title);
+        this.publishErrorMessage.set(this.problemI18n.resolve(result.problem).title);
       });
   }
 }

--- a/docs/adrs/0018-adocao-httpresource-via-wrapper-use-api-resource.md
+++ b/docs/adrs/0018-adocao-httpresource-via-wrapper-use-api-resource.md
@@ -79,7 +79,9 @@ O `apiResultInterceptor` neutraliza o canal de erro do RxJS — captura `HttpErr
 
 Isso significa que `error()` é praticamente sempre `undefined` no contrato Uni+ — toda discriminação success/failure é via `value().ok`, e o helper expõe `data()` / `problem()` como atalhos signal-based.
 
-**Callers DEVEM tratar `error()` como fallback** — sem isso, um interceptor não-HTTP lançando síncrono faria `isLoading()` voltar a `false` sem mensagem ao usuário (spinner desapareceria silenciosamente). O `EditaisDetailPage` consolida esse fallback no `errorMessage` computed:
+**Invariante crítica do helper:** o `Resource.value()` nativo do Angular **lança `ResourceValueError` quando `status()` é `'error'`** (vide `_resource-chunk.mjs` em `@angular/core` 21). O wrapper guarda explicitamente — `value`/`data`/`problem` checam `error()` antes de ler `value()` interno e retornam ausência segura (`undefined`/`null`). Sem este guard, qualquer leitura desses signals em estado de erro propagaria a exceção durante change detection e crasharia a página em vez de renderizar a mensagem de erro. Specs do helper validam (`expect(() => resource.data()).not.toThrow()`).
+
+**Callers PODEM tratar `error()` como fallback opcional** — para distinguir "escape de interceptor" de "ainda carregando" e exibir mensagem específica. Sem o tratamento, o usuário vê o spinner sumir sem feedback. O `EditaisDetailPage` consolida o fallback no `errorMessage` computed:
 
 ```ts
 readonly errorMessage = computed<string | null>(() => {

--- a/docs/adrs/0018-adocao-httpresource-via-wrapper-use-api-resource.md
+++ b/docs/adrs/0018-adocao-httpresource-via-wrapper-use-api-resource.md
@@ -1,0 +1,174 @@
+---
+status: "proposed"
+date: "2026-05-07"
+decision-makers:
+  - "Tech Lead (CTIC)"
+---
+
+# ADR-0018: Adoção de `httpResource` Angular 21 via wrapper `useApiResource` em `shared-core`
+
+## Contexto e enunciado do problema
+
+A `EditaisDetailPage` (entregue na F8 do Milestone B) implementa GET reativo por route param `:id` com pattern manual: `signal<EditalDto | null>` + `signal<boolean>(loading)` + `effect(() => { id; untracked(() => { reset; executarObterPorId(id); }) })` + `subscribe()` ao Observable do service + race guard explícito (`if (this.id() !== id) return`) para descartar respostas stale quando o usuário navega entre `/editais/:id1` e `/editais/:id2` (Angular reusa a instância do componente).
+
+Esse pattern repete-se ~80 linhas só para load + race + error handling. Quando aparecer a 2ª/3ª detail page (Inscrição, Recurso, Classificação), a duplicação custa caro — inclusive o risco de cada caller esquecer alguma defesa (race guard, reset de estado prévio, cleanup via `takeUntilDestroyed`).
+
+Angular 21 expõe `httpResource` (`@experimental` desde 19.2) — wrapper reativo de `HttpClient` que retorna `HttpResourceRef<T>` com signals nativos para `value`/`status`/`error`/`isLoading` e cancela request anterior automaticamente quando dependências reativas mudam. Adotar resolveria o boilerplate, mas levanta duas perguntas: **(a) como compor com `apiResultInterceptor`** que envelopa todas respostas em `ApiResult<T>` (RFC 9457 + extensions Uni+) — o `httpResource` veria o envelope ou o body cru? **(b) qual escopo adotar** — qualquer GET, qualquer HTTP request, só este caso?
+
+A guidance oficial Angular (`https://angular.dev/guide/http/http-resource` § Best practices) é explícita: **"Avoid using `httpResource` for mutations like POST or PUT. Instead, prefer directly using the underlying HttpClient APIs."** O status `@experimental` reforça cautela — a API pode mudar antes de promoção a stable.
+
+## Drivers da decisão
+
+- **Eliminar boilerplate de race guard manual** — cada detail page hoje paga ~30 linhas só para descartar response stale; `httpResource` resolve nativamente.
+- **Preservar a discriminated union `ApiResult<T>`** — F1–F8 + fitness suite (B.5) consomem `ApiResult<T>` em todos os pontos. Mudar essa invariante requer refator cross-cutting.
+- **Limitar blast radius do status experimental** — se a API do `httpResource` mudar entre 19.2 e GA, o impacto deve ficar contido a 1 arquivo.
+- **Respeitar guidance Angular oficial** — GET-only (mutações continuam HttpClient direto via service).
+- **Pattern reusável para futuras detail pages** — Inscrição, Recurso, Classificação devem consumir o mesmo helper sem reinvenção.
+- **Testabilidade** — pattern deve permitir specs Vitest determinísticos sem `fakeAsync`/`flushMicrotasks` (incompatíveis com Vitest no Angular 21).
+
+## Opções consideradas
+
+- **A. Adoção direta nativa** — `EditaisDetailPage` chama `httpResource(() => ({ url: ..., context: withVendorMime('edital', 1) }))` direto e lê `resource.value()?.ok ? resource.value()!.data : null` no template.
+- **B. Wrapper `useApiResource<T>` em `libs/shared-core/src/lib/http/`** — encapsula `httpResource<ApiResult<T>>` e expõe signals derivados (`data()`, `problem()`) que extraem do envelope, mantendo `value()` como escape-hatch.
+- **C. Manter pattern manual** — não migrar; aceitar boilerplate até quando refator cross-cutting compensar.
+
+## Resultado da decisão
+
+**Escolhida:** "B — Wrapper `useApiResource<T>` em `shared-core/http`", porque é a única opção que combina:
+
+1. **Preserva `ApiResult<T>`** — services continuam retornando `Observable<ApiResult<T>>` para mutações (POST publish/criar continuam idênticos); o wrapper apenas adapta o envelope para signals derivados sem mudar o contrato cross-cutting.
+2. **Aproveita race-cancellation nativa** — `httpResource` cancela request anterior quando signal reativo do `request()` muda; o spec valida explicitamente (`expect(reqAntiga.cancelled).toBe(true)`).
+3. **Centraliza adaptação `ApiResult → Resource`** em UM ponto — futuras detail pages reusam direto sem reinventar a extração `.data`/`.problem`.
+4. **Limita blast radius do experimental** — mudanças na API de `httpResource` afetam apenas `use-api-resource.ts` (1 arquivo, ~70 linhas), não cada caller.
+5. **Respeita guidance Angular** — wrapper é GET-only (encadeia apenas overloads de `httpResource` que aceitam request signal), forçando mutações pelo HttpClient direto.
+
+### Forma do helper
+
+```ts
+export interface UseApiResourceRef<T> {
+  readonly value: Signal<ApiResult<T> | undefined>;
+  readonly data: Signal<T | null>;
+  readonly problem: Signal<ProblemDetails | null>;
+  readonly isLoading: Signal<boolean>;
+  readonly status: Signal<ResourceStatus>;
+  readonly statusCode: Signal<number | undefined>;
+  readonly headers: Signal<HttpHeaders | undefined>;
+  readonly error: Signal<Error | undefined>;
+  hasValue(): boolean;
+  reload(): boolean;
+  destroy(): void;
+}
+
+export function useApiResource<T>(
+  request: () => string | HttpResourceRequest | undefined,
+  options?: Omit<HttpResourceOptions<ApiResult<T>, unknown>, 'defaultValue' | 'parse'>,
+): UseApiResourceRef<T>;
+```
+
+### Comportamento ApiResult ↔ httpResource (validado por specs)
+
+O `apiResultInterceptor` neutraliza o canal de erro do RxJS — captura `HttpErrorResponse` em 4xx/5xx e re-emite via `of(new HttpResponse({ body: apiFailure(...), status: error.status }))`. Consequência observável no wrapper:
+
+| Resposta backend | `httpResource.status()` | `httpResource.value()` | `data()` | `problem()` | `error()` |
+|---|---|---|---|---|---|
+| 200/201/204 | `'resolved'` | `ApiOk<T>` | `T` | `null` | `undefined` |
+| 4xx/5xx + `application/problem+json` | `'resolved'` | `ApiFailure` | `null` | `ProblemDetails` | `undefined` |
+| Network error (status 0) | `'resolved'` | `ApiFailure` (NETWORK\_ERROR) | `null` | sintetizado | `undefined` |
+| Body fora do contrato | `'resolved'` | `ApiFailure` (UNEXPECTED\_RESPONSE) | `null` | sintetizado | `undefined` |
+| Erro fora do interceptor (ex.: throw síncrono em interceptor de auth/logging) | `'error'` | `undefined` | `null` | `null` | `Error` |
+
+Isso significa que `error()` é praticamente sempre `undefined` no contrato Uni+ — toda discriminação success/failure é via `value().ok`, e o helper expõe `data()` / `problem()` como atalhos signal-based.
+
+**Callers DEVEM tratar `error()` como fallback** — sem isso, um interceptor não-HTTP lançando síncrono faria `isLoading()` voltar a `false` sem mensagem ao usuário (spinner desapareceria silenciosamente). O `EditaisDetailPage` consolida esse fallback no `errorMessage` computed:
+
+```ts
+readonly errorMessage = computed<string | null>(() => {
+  const httpProblem = this.editalResource.problem();
+  if (httpProblem) return this.problemI18n.resolve(httpProblem).title;
+  if (this.editalResource.error()) return 'Erro inesperado ao carregar edital.';
+  return this.publishErrorMessage();
+});
+```
+
+### Esta ADR não decide
+
+- **Mutações via `httpResource`** — proibido pela guidance Angular oficial. POST/PUT/PATCH/DELETE continuam via service + `HttpClient` + `Observable<ApiResult<T>>`. O publish flow do `EditaisDetailPage` mantém `EditaisApi.publicar()` + `subscribe()` + race guard manual no closure (mutação one-shot).
+- **Cursor pagination via `httpResource`** — a `EditaisListPage` (F6) consome cursor + `Link` header via service Observable; migração fica para frente futura quando 2ª list page aparecer.
+- **`useApiResource` como obrigatório em todo GET reativo** — recomendado, mas serviços que precisam de controle fino do Observable (combineLatest, retry com backoff custom, debounceTime específico) podem continuar com HttpClient direto.
+
+### Pattern de teste (lição)
+
+`fakeAsync`/`flushMicrotasks` exigem Zone.js test mode e são **incompatíveis com Vitest** no Angular 21 (per documentação oficial). O pattern que funciona:
+
+- **Specs do helper isolado:** `await ApplicationRef.whenStable()` após `controller.flush(...)` propaga valores aos signals do resource.
+- **Specs com `ComponentFixture`:** `await Promise.resolve(); appRef.tick();` (helper `propagate()`) — `whenStable()` deadlocka na presença de subscriptions Observable concorrentes (publish flow).
+
+## Consequências
+
+### Positivas
+
+- `EditaisDetailPage` perde ~50 linhas (signals manuais, `effect`, `untracked`, `executarObterPorId`, race guard manual) e ganha 4 linhas de `useApiResource(...)`.
+- Race-cancellation testada como invariante explícita — substitui guard "if id mudou, descarta" por comportamento nativo do framework.
+- Pattern reusável documentado — futuras detail pages (Inscrição, Recurso, Classificação) consomem o mesmo helper.
+- Risco do status experimental fica isolado a 1 arquivo (`use-api-resource.ts`).
+- Specs do helper documentam comportamento contratual — fitness contra regressões na adaptação `ApiResult → Resource`.
+
+### Negativas
+
+- 1 indireção a mais entre componente e `httpResource` — leitor precisa abrir o helper para entender o adapter (mitigado por JSDoc rico no helper e por specs auto-documentados).
+- Dependência de API `@experimental` — breaking change entre 19.2 e GA forçaria atualização do helper (mas nada além).
+- Pattern de teste assíncrono (`await propagate()` ou `await whenStable()`) é mais verboso que o pattern síncrono do Observable + subscribe — inerente ao modelo signal-based, não específico do wrapper.
+
+### Neutras
+
+- Helper coexiste com `EditaisApi.obter()` Observable (que continua exportado para callers que ainda precisam de Observable, ex.: testes legados, código fora de injection context).
+
+## Confirmação
+
+- **Spec do helper:** `libs/shared-core/src/lib/http/use-api-resource.spec.ts` cobre 11 cenários — carga inicial, race-cancellation, 4xx/5xx, network error, reload, undefined request, HttpContext arbitrário, headers, hasValue, 422 com errors[].
+- **Spec da page refatorada:** `apps/selecao/src/app/features/editais/editais-detail.page.spec.ts` mantém 12 cenários, validando que a UX externa não muda — mesma assinatura para `edital()`, `loading()`, `errorMessage()`, `confirmarPublicacao()`.
+- **Race guard nativo testado explicitamente:** `expect(reqAntiga.cancelled).toBe(true)` após mudança do input `id`.
+- **Não há fitness test cross-app proibindo uso de `httpResource` direto fora do wrapper** — a recomendação é capturada na guidance da ADR; revisão de PR pode citar quando aplicável.
+
+### Trigger de reavaliação
+
+- Se `httpResource` for promovido a stable sem breaking changes, ADR fica firme e nenhuma ação é necessária.
+- Se houver breaking change na API entre 19.2 e GA, atualizar APENAS `use-api-resource.ts` para acomodar — callers permanecem inalterados.
+- Se aparecer caso real de necessidade de mutação reativa (ex.: PATCH baseado em signals), reabrir e considerar `rxResource` ou `resource()` (reactive primitives mais genéricos).
+
+## Prós e contras das opções
+
+### A — Adoção direta nativa
+
+- **Bom**, porque é o caminho documentado pelo Angular team — sem indireção.
+- **Ruim**, porque acopla cada caller à extração `value().ok ? value().data : null` — duplicação cresce a cada nova detail page e a chance de erro de leitura também (`value()` durante loading é `undefined`, fácil esquecer no template).
+- **Ruim**, porque expõe diretamente `httpResource` a múltiplos call sites — breaking changes futuros têm blast radius proporcional ao número de callers.
+
+### B — Wrapper `useApiResource<T>` (escolhida)
+
+- **Bom**, porque centraliza adaptação `ApiResult → Resource` num único ponto auditável.
+- **Bom**, porque limita blast radius de breaking changes a 1 arquivo.
+- **Bom**, porque mantém o vocabulário familiar (`data()`, `problem()`) já consolidado pelo `apiResultInterceptor`.
+- **Ruim**, porque adiciona 1 indireção (leitor precisa abrir o helper para ver o adapter).
+- **Ruim**, porque o helper precisa ser mantido em paridade com a API de `httpResource` (mas é isolado, e specs documentam regressões).
+
+### C — Manter pattern manual
+
+- **Bom**, porque zero risco de adoção de API experimental.
+- **Bom**, porque pattern já está em produção (entregue na F8) — funciona.
+- **Ruim**, porque cada detail page paga ~30 linhas de race guard manual + cleanup via `takeUntilDestroyed` + `effect` para reset de estado.
+- **Ruim**, porque race guard manual depende de disciplina do autor — esquecimentos viram bugs sutis (response stale sobrescrevendo state correto).
+- **Ruim**, porque adia decisão sem reduzir custo — quando 2ª/3ª detail page aparecer, refator vai precisar tocar mais código.
+
+## Mais informações
+
+- [Angular guide — HTTP Resource](https://angular.dev/guide/http/http-resource) — fonte da guidance binding "avoid mutations".
+- [`HttpResourceFn` API reference](https://angular.dev/api/common/http/HttpResourceFn) — forms (`url` vs `request`), overloads, status `@experimental`.
+- [`HttpResourceRequest` API reference](https://angular.dev/api/common/http/HttpResourceRequest) — propriedades suportadas (incluindo `context: HttpContext` para `withVendorMime`).
+- [`HttpResourceRef` API reference](https://angular.dev/api/common/http/HttpResourceRef) — signals expostos (`value`, `status`, `error`, `isLoading`, `headers`, `statusCode`).
+- [ADR-0011](0011-consumer-adapter-api-result.md) — origem do `ApiResult<T>`.
+- [ADR-0012](0012-placement-api-result-em-shared-core.md) — placement em `shared-core`.
+- [ADR-0014](0014-idempotency-key-cliente-via-http-context.md) — pattern HttpContext (referência para `withVendorMime`).
+- [ADR-0016](0016-vendor-mime-consumer-via-http-context.md) — vendor MIME via HttpContext (composto pelo helper).
+- [ADR-0017](0017-pattern-feature-page-container-presentational.md) — `EditaisDetailPage` é container; helper é consumido na camada container.
+- Issue [`uniplus-web#206`](https://github.com/unifesspa-edu-br/uniplus-web/issues/206) — parqueamento original do plano de adoção.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -46,6 +46,7 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0015](0015-cursor-pagination-consumer-link-header.md) | Cursor pagination consumer via parser de `Link` header — decode no caller, não no interceptor | accepted | 2026-05-06 |
 | [0016](0016-vendor-mime-consumer-via-http-context.md) | Vendor MIME consumer via `HttpContext` — `withVendorMime` declara o recurso e o `apiResultInterceptor` anexa `Accept` | accepted | 2026-05-06 |
 | [0017](0017-pattern-feature-page-container-presentational.md) | Páginas de feature no padrão container/presentational — `XxxPage` smart + `ui-*` dumb | accepted | 2026-05-06 |
+| [0018](0018-adocao-httpresource-via-wrapper-use-api-resource.md) | Adoção de `httpResource` Angular 21 via wrapper `useApiResource` em `shared-core` | proposed | 2026-05-07 |
 
 ## Como adicionar um novo ADR
 

--- a/libs/shared-core/src/lib/http/index.ts
+++ b/libs/shared-core/src/lib/http/index.ts
@@ -43,6 +43,9 @@ export type {
   ProblemOverride,
 } from './problem-i18n.service';
 
+export { useApiResource } from './use-api-resource';
+export type { UseApiResourceRef } from './use-api-resource';
+
 export {
   buildVendorMimeAccept,
   VENDOR_MIME_TOKEN,

--- a/libs/shared-core/src/lib/http/use-api-resource.spec.ts
+++ b/libs/shared-core/src/lib/http/use-api-resource.spec.ts
@@ -1,0 +1,291 @@
+import {
+  HttpContext,
+  HttpContextToken,
+  HttpResourceRequest,
+  provideHttpClient,
+  withInterceptors,
+} from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { ApplicationRef, Injector, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { apiResultInterceptor } from './api-result.interceptor';
+import { ProblemDetails } from './problem-details';
+import { useApiResource, UseApiResourceRef } from './use-api-resource';
+import { withVendorMime } from './vendor-mime';
+
+interface Edital {
+  readonly id: string;
+  readonly numero: number;
+}
+
+const PROBLEM_HEADERS = { 'Content-Type': 'application/problem+json' };
+const baseProblem: ProblemDetails = {
+  type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.selecao.edital.nao_encontrado',
+  title: 'Edital não encontrado',
+  status: 404,
+  code: 'uniplus.selecao.edital.nao_encontrado',
+  traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+};
+
+/**
+ * Pattern de teste oficial do Angular team para `httpResource`
+ * (https://angular.dev/guide/http/http-resource):
+ *
+ * 1. `TestBed.tick()` dispara o effect interno do `httpResource` (que cria a
+ *    request a partir do request signal).
+ * 2. `controller.flush(...)` resolve a HttpClient call.
+ * 3. `await appRef.whenStable()` propaga o valor para os signals do resource.
+ *
+ * Não é possível usar `fakeAsync`/`flushMicrotasks` porque essas APIs exigem
+ * Zone.js e o Angular team explicitamente desabilita ambas no Vitest runner.
+ */
+function setup() {
+  TestBed.configureTestingModule({
+    providers: [
+      provideHttpClient(withInterceptors([apiResultInterceptor])),
+      provideHttpClientTesting(),
+    ],
+  });
+  const appRef = TestBed.inject(ApplicationRef);
+  const injector = TestBed.inject(Injector);
+  return {
+    controller: TestBed.inject(HttpTestingController),
+    create: <T>(
+      requestFn: () => string | HttpResourceRequest | undefined,
+    ): UseApiResourceRef<T> =>
+      TestBed.runInInjectionContext(() => useApiResource<T>(requestFn, { injector })),
+    tickEffects: () => TestBed.tick(),
+    stable: () => appRef.whenStable(),
+  };
+}
+
+describe('useApiResource', () => {
+  let env: ReturnType<typeof setup>;
+
+  beforeEach(() => {
+    env = setup();
+  });
+
+  afterEach(() => env.controller.verify());
+
+  it('carga inicial com URL string dispara GET e popula data() em 200', async () => {
+    const resource = env.create<Edital>(() => '/api/editais/edt-1');
+    env.tickEffects();
+
+    expect(resource.isLoading()).toBe(true);
+    expect(resource.data()).toBeNull();
+
+    const seed: Edital = { id: 'edt-1', numero: 42 };
+    env.controller
+      .expectOne('/api/editais/edt-1')
+      .flush(seed, { status: 200, statusText: 'OK' });
+    await env.stable();
+
+    expect(resource.data()).toEqual(seed);
+    expect(resource.problem()).toBeNull();
+    expect(resource.isLoading()).toBe(false);
+    expect(resource.status()).toBe('resolved');
+    expect(resource.statusCode()).toBe(200);
+    expect(resource.value()?.ok).toBe(true);
+  });
+
+  it('mudança reativa do URL cancela request anterior e dispara nova (race-cancellation nativa)', async () => {
+    const id = signal('edt-1');
+    const resource = env.create<Edital>(() => `/api/editais/${id()}`);
+    env.tickEffects();
+
+    const reqAntiga = env.controller.expectOne('/api/editais/edt-1');
+    expect(reqAntiga.cancelled).toBe(false);
+
+    id.set('edt-2');
+    env.tickEffects();
+
+    // httpResource cancela a request anterior automaticamente quando dependências
+    // reativas mudam — substitui o race guard manual ("if (this.id() !== id) return").
+    expect(reqAntiga.cancelled).toBe(true);
+
+    const reqNova = env.controller.expectOne('/api/editais/edt-2');
+    reqNova.flush({ id: 'edt-2', numero: 99 }, { status: 200, statusText: 'OK' });
+    await env.stable();
+
+    expect(resource.data()).toEqual({ id: 'edt-2', numero: 99 });
+  });
+
+  it('404 problem+json popula problem() e mantém data()=null', async () => {
+    const resource = env.create<Edital>(() => '/api/editais/missing');
+    env.tickEffects();
+
+    env.controller
+      .expectOne('/api/editais/missing')
+      .flush(baseProblem, { status: 404, statusText: 'Not Found', headers: PROBLEM_HEADERS });
+    await env.stable();
+
+    expect(resource.data()).toBeNull();
+    expect(resource.problem()).toMatchObject({
+      code: 'uniplus.selecao.edital.nao_encontrado',
+      status: 404,
+    });
+    expect(resource.value()?.ok).toBe(false);
+    // status do Resource é resolved porque o interceptor envelopa o erro em
+    // ApiResult.fail e re-emite via next — error() do Resource fica undefined.
+    expect(resource.status()).toBe('resolved');
+    expect(resource.error()).toBeUndefined();
+  });
+
+  it('network error (status 0) é envelopado como ApiFailure com code uniplus.client.network_error', async () => {
+    const resource = env.create<Edital>(() => '/api/editais/edt-1');
+    env.tickEffects();
+
+    env.controller
+      .expectOne('/api/editais/edt-1')
+      .error(new ProgressEvent('error'), { status: 0, statusText: 'Unknown Error' });
+    await env.stable();
+
+    expect(resource.data()).toBeNull();
+    expect(resource.problem()?.code).toBe('uniplus.client.network_error');
+    expect(resource.problem()?.status).toBe(0);
+  });
+
+  it('reload() refaz a request preservando dependências reativas atuais', async () => {
+    const resource = env.create<Edital>(() => '/api/editais/edt-1');
+    env.tickEffects();
+
+    env.controller
+      .expectOne('/api/editais/edt-1')
+      .flush({ id: 'edt-1', numero: 1 }, { status: 200, statusText: 'OK' });
+    await env.stable();
+
+    expect(resource.data()).toEqual({ id: 'edt-1', numero: 1 });
+
+    resource.reload();
+    env.tickEffects();
+
+    env.controller
+      .expectOne('/api/editais/edt-1')
+      .flush({ id: 'edt-1', numero: 2 }, { status: 200, statusText: 'OK' });
+    await env.stable();
+
+    expect(resource.data()).toEqual({ id: 'edt-1', numero: 2 });
+  });
+
+  it('request() retorna undefined => nenhum GET disparado, status=idle', async () => {
+    const ativo = signal(false);
+    const resource = env.create<Edital>(() =>
+      ativo() ? '/api/editais/edt-1' : undefined,
+    );
+    env.tickEffects();
+
+    expect(resource.status()).toBe('idle');
+    expect(resource.data()).toBeNull();
+    expect(resource.value()).toBeUndefined();
+    // controller.verify() no afterEach garante que nenhuma request foi disparada.
+
+    ativo.set(true);
+    env.tickEffects();
+
+    env.controller
+      .expectOne('/api/editais/edt-1')
+      .flush({ id: 'edt-1', numero: 7 }, { status: 200, statusText: 'OK' });
+    await env.stable();
+
+    expect(resource.data()).toEqual({ id: 'edt-1', numero: 7 });
+  });
+
+  it('aceita HttpResourceRequest com context (compõe withVendorMime no Accept)', async () => {
+    const resource = env.create<Edital>(() => ({
+      url: '/api/editais/edt-1',
+      context: withVendorMime('edital', 1),
+    }));
+    env.tickEffects();
+
+    const req = env.controller.expectOne('/api/editais/edt-1');
+    expect(req.request.headers.get('Accept')).toBe('application/vnd.uniplus.edital.v1+json');
+
+    req.flush({ id: 'edt-1', numero: 42 }, { status: 200, statusText: 'OK' });
+    await env.stable();
+
+    expect(resource.data()?.id).toBe('edt-1');
+  });
+
+  it('aceita HttpResourceRequest com context arbitrário (não amarrado a vendorMime)', async () => {
+    // Token de exemplo para garantir que helper não acopla a um token específico —
+    // qualquer HttpContext do caller é propagado intacto pelo httpResource.
+    const FLAG_TOKEN = new HttpContextToken<boolean>(() => false);
+    const resource = env.create<Edital>(() => ({
+      url: '/api/editais/edt-1',
+      context: new HttpContext().set(FLAG_TOKEN, true),
+    }));
+    env.tickEffects();
+
+    const req = env.controller.expectOne('/api/editais/edt-1');
+    expect(req.request.context.get(FLAG_TOKEN)).toBe(true);
+    req.flush({ id: 'edt-1', numero: 1 }, { status: 200, statusText: 'OK' });
+    await env.stable();
+
+    expect(resource.data()?.numero).toBe(1);
+  });
+
+  it('headers() expõe response headers (ex.: Link rel="next" para cursor pagination)', async () => {
+    const resource = env.create<readonly Edital[]>(() => '/api/editais');
+    env.tickEffects();
+
+    env.controller.expectOne('/api/editais').flush(
+      [{ id: 'edt-1', numero: 1 }],
+      {
+        status: 200,
+        statusText: 'OK',
+        headers: { Link: '</api/editais?cursor=ABC>; rel="next"' },
+      },
+    );
+    await env.stable();
+
+    expect(resource.headers()?.get('Link')).toBe('</api/editais?cursor=ABC>; rel="next"');
+  });
+
+  it('hasValue() reflete presença de envelope (loading=false e value definido)', async () => {
+    const resource = env.create<Edital>(() => '/api/editais/edt-1');
+    env.tickEffects();
+
+    expect(resource.hasValue()).toBe(false);
+
+    env.controller
+      .expectOne('/api/editais/edt-1')
+      .flush({ id: 'edt-1', numero: 5 }, { status: 200, statusText: 'OK' });
+    await env.stable();
+
+    expect(resource.hasValue()).toBe(true);
+  });
+
+  it('422 com errors[] de validação preserva o array no problem()', async () => {
+    const resource = env.create<Edital>(() => '/api/editais');
+    env.tickEffects();
+
+    env.controller.expectOne('/api/editais').flush(
+      {
+        ...baseProblem,
+        type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.validacao',
+        title: 'Erro de validação',
+        status: 422,
+        code: 'uniplus.validacao',
+        errors: [
+          { field: 'titulo', code: 'Titulo.Vazio', message: 'Título obrigatório' },
+        ],
+      },
+      { status: 422, statusText: 'Unprocessable Entity', headers: PROBLEM_HEADERS },
+    );
+    await env.stable();
+
+    const problem = resource.problem();
+    expect(problem?.code).toBe('uniplus.validacao');
+    expect(problem?.errors).toHaveLength(1);
+    expect(problem?.errors?.[0]).toEqual({
+      field: 'titulo',
+      code: 'Titulo.Vazio',
+      message: 'Título obrigatório',
+    });
+  });
+});

--- a/libs/shared-core/src/lib/http/use-api-resource.spec.ts
+++ b/libs/shared-core/src/lib/http/use-api-resource.spec.ts
@@ -1,6 +1,7 @@
 import {
   HttpContext,
   HttpContextToken,
+  HttpInterceptorFn,
   HttpResourceRequest,
   provideHttpClient,
   withInterceptors,
@@ -287,5 +288,52 @@ describe('useApiResource', () => {
       code: 'Titulo.Vazio',
       message: 'Título obrigatório',
     });
+  });
+});
+
+/**
+ * Cenário isolado em describe próprio porque exige um interceptor adicional
+ * (`throwingInterceptor`) que faz o `Resource.value()` nativo do Angular
+ * lançar `ResourceValueError`. O wrapper deve isolar o caller — `data()`/
+ * `problem()`/`value()` retornam ausência segura em estado `'error'`, em vez
+ * de propagar a exceção e crashar a página durante change detection.
+ */
+describe('useApiResource — guarda contra Resource.value() throw em status error', () => {
+  it('data()/problem()/value() retornam ausência sem lançar quando status=error', async () => {
+    // Interceptor sintético que lança Error não-HttpErrorResponse ANTES do
+    // request sair (caso real: interceptor de auth/logging/telemetria com bug
+    // síncrono). O throw escapa do `envelopeFailure` do apiResultInterceptor
+    // (que só captura HttpErrorResponse — linha 89: `if (!(error instanceof
+    // HttpErrorResponse)) throw error;`) e chega ao httpResource em status
+    // 'error', causando `Resource.value()` a lançar `ResourceValueError` se
+    // chamado sem guard.
+    const throwingInterceptor: HttpInterceptorFn = () => {
+      throw new Error('synthetic non-HTTP failure (e.g. logging interceptor)');
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([apiResultInterceptor, throwingInterceptor])),
+        provideHttpClientTesting(),
+      ],
+    });
+    const appRef = TestBed.inject(ApplicationRef);
+    const injector = TestBed.inject(Injector);
+    const resource = TestBed.runInInjectionContext(() =>
+      useApiResource<Edital>(() => '/api/editais/edt-1', { injector }),
+    );
+    appRef.tick();
+    await appRef.whenStable();
+
+    // Status do Resource é 'error' (interceptor throwing escapou da chain),
+    // mas o helper isola: data()/problem()/value() retornam ausência segura.
+    expect(resource.status()).toBe('error');
+    expect(resource.error()).toBeInstanceOf(Error);
+    expect(() => resource.data()).not.toThrow();
+    expect(() => resource.problem()).not.toThrow();
+    expect(() => resource.value()).not.toThrow();
+    expect(resource.data()).toBeNull();
+    expect(resource.problem()).toBeNull();
+    expect(resource.value()).toBeUndefined();
   });
 });

--- a/libs/shared-core/src/lib/http/use-api-resource.ts
+++ b/libs/shared-core/src/lib/http/use-api-resource.ts
@@ -68,9 +68,12 @@ export interface UseApiResourceRef<T> {
   readonly headers: Signal<HttpHeaders | undefined>;
   /**
    * Erro **fora** do contrato `ApiResult` — raro, porque o
-   * `apiResultInterceptor` envelopa todo HttpErrorResponse. Populado apenas
+   * `apiResultInterceptor` envelopa todo `HttpErrorResponse`. Populado apenas
    * quando algo escapa de toda a chain de interceptors (ex.: erro síncrono
-   * lançado por outro interceptor).
+   * lançado por outro interceptor de auth/logging). **Nunca lança** — leitura
+   * segura. Quando `error()` é truthy, `value()`/`data()`/`problem()` retornam
+   * ausência (`undefined`/`null`) por contrato deste helper, isolando o caller
+   * do throw nativo de `Resource.value()` em status `'error'`.
    */
   readonly error: Signal<Error | undefined>;
   /**
@@ -135,21 +138,32 @@ export function useApiResource<T>(
     return typeof next === 'string' ? { url: next } : next;
   }, options);
 
+  // `Resource.value()` **lança `ResourceValueError`** quando `status() ===
+  // 'error'` (caso real: interceptor não-HTTP que escapa do envelope `ApiResult`
+  // — vide ADR-0018 §"esta ADR não decide"). Sem o guard contra `error()`,
+  // `value()`/`data()`/`problem()` propagam a exceção durante change detection
+  // e a página crasha em vez de renderizar a mensagem de erro. O helper
+  // padroniza: em estado de erro, todos os derivados retornam ausência
+  // (`undefined`/`null`) e o caller diferencia via `error()` (que nunca lança).
+  const value: Signal<ApiResult<T> | undefined> = computed(() =>
+    resource.error() ? undefined : resource.value(),
+  );
+
   const data: Signal<T | null> = computed(() => {
+    if (resource.error()) {
+      return null;
+    }
     const envelope = resource.value();
     return envelope?.ok ? envelope.data : null;
   });
 
   const problem: Signal<ProblemDetails | null> = computed(() => {
+    if (resource.error()) {
+      return null;
+    }
     const envelope = resource.value();
     return envelope && !envelope.ok ? envelope.problem : null;
   });
-
-  // `httpResource.value` é `WritableSignal` em runtime — envelopar em
-  // `computed` garante que o consumer público receba um `Signal` somente-
-  // leitura genuíno (não apenas pelo tipo declarado), bloqueando `.set()`
-  // externo que driftaria do `status`/`statusCode`/`headers` do resource.
-  const value: Signal<ApiResult<T> | undefined> = computed(() => resource.value());
 
   return {
     value,

--- a/libs/shared-core/src/lib/http/use-api-resource.ts
+++ b/libs/shared-core/src/lib/http/use-api-resource.ts
@@ -1,0 +1,167 @@
+import {
+  HttpHeaders,
+  HttpResourceOptions,
+  HttpResourceRequest,
+  httpResource,
+} from '@angular/common/http';
+import { ResourceStatus, Signal, computed } from '@angular/core';
+import { ApiResult } from './api-result';
+import { ProblemDetails } from './problem-details';
+
+/**
+ * Wrapper reativo que adapta `httpResource` ao envelope `ApiResult<T>` do
+ * `apiResultInterceptor` (ADR-0011 + ADR-0012). Pattern canônico para
+ * **detail/list pages que fazem GET reativo por signals** (ADR-0018).
+ *
+ * **Quando usar:**
+ * - GET cujo URL/query params dependem de signals (route param, filtro UI,
+ *   cursor de paginação) — `httpResource` cancela request anterior nativamente.
+ * - Composição com `computed`/`effect`/`linkedSignal` no template.
+ *
+ * **Quando NÃO usar (guidance Angular oficial — ADR-0018):**
+ * - Mutações (POST/PUT/PATCH/DELETE) — use `HttpClient` direto via service.
+ *   `httpResource` é GET-only por design e o time Angular recomenda
+ *   explicitamente evitar para mutações.
+ * - Fire-and-forget side effects sem mapeamento natural pra Resource.
+ * - Operações que precisam controle fino do Observable (`combineLatest`,
+ *   `retry` com backoff custom, `debounceTime` específico) — HttpClient
+ *   continua melhor.
+ *
+ * **Risco residual:** `httpResource` está marcado `@experimental` desde Angular
+ * 19.2 (Angular 21 ainda não promoveu). Adoção isolada por este wrapper limita
+ * o blast radius de breaking changes a este arquivo.
+ */
+export interface UseApiResourceRef<T> {
+  /**
+   * Envelope `ApiResult<T>` cru — `undefined` durante loading inicial. Use
+   * quando precisar inspecionar `headers`/`status` do envelope (ex.: extrair
+   * cursor `Link` rel="next" pós-listagem). Para o caminho feliz de leitura,
+   * prefira `data()`/`problem()`.
+   */
+  readonly value: Signal<ApiResult<T> | undefined>;
+  /**
+   * Dado tipado quando `value().ok === true`. `null` durante loading, em
+   * failure (4xx/5xx) ou em erro fora do contrato. Pensado para binding
+   * direto no template (`@if (resource.data(); as edital)`).
+   */
+  readonly data: Signal<T | null>;
+  /**
+   * `ProblemDetails` (RFC 9457 + extensions Uni+) quando `value().ok === false`.
+   * `null` durante loading, em sucesso ou em erro fora do contrato. Pensado
+   * para binding com `ProblemI18nService`.
+   */
+  readonly problem: Signal<ProblemDetails | null>;
+  /**
+   * `true` enquanto `httpResource` está em `loading` ou `reloading`. Reflete
+   * exatamente `HttpResourceRef.isLoading`.
+   */
+  readonly isLoading: Signal<boolean>;
+  /**
+   * Estado bruto do `Resource` (`idle | loading | reloading | resolved |
+   * error | local`). Use para casos avançados; `data()`/`problem()`/`isLoading()`
+   * cobrem 99% dos templates.
+   */
+  readonly status: Signal<ResourceStatus>;
+  /** Status HTTP da última resposta, quando disponível. */
+  readonly statusCode: Signal<number | undefined>;
+  /** Headers da última resposta — útil para Link rel="next" (cursor). */
+  readonly headers: Signal<HttpHeaders | undefined>;
+  /**
+   * Erro **fora** do contrato `ApiResult` — raro, porque o
+   * `apiResultInterceptor` envelopa todo HttpErrorResponse. Populado apenas
+   * quando algo escapa de toda a chain de interceptors (ex.: erro síncrono
+   * lançado por outro interceptor).
+   */
+  readonly error: Signal<Error | undefined>;
+  /**
+   * `true` se já há um `value` carregado (qualquer ApiResult). Leitura
+   * point-in-time — proxy direto de `HttpResourceRef.hasValue()`. **Não é
+   * signal reativo:** `@if (resource.hasValue())` no template só re-avalia
+   * quando outro signal lido na mesma expressão muda; para gating reativo,
+   * prefira `@if (resource.value())` (signal) ou um `computed` derivado.
+   */
+  hasValue(): boolean;
+  /**
+   * Força nova execução do `requestFn` atual (mesma URL/dependências
+   * reativas). Útil pós-mutação (ex.: refetch após `POST publicar`).
+   */
+  reload(): boolean;
+  /** Cleanup manual; o `DestroyRef` do contexto de injeção faz isto sozinho. */
+  destroy(): void;
+}
+
+/**
+ * Cria um `UseApiResourceRef<T>` ancorado em `httpResource` + envelope
+ * `ApiResult<T>`. Deve ser chamado em contexto de injeção (constructor de
+ * componente, factory, ou `runInInjectionContext`).
+ *
+ * Aceita as duas formas suportadas por `httpResource`:
+ *
+ * - **String reativa** — quando só a URL muda:
+ *   ```ts
+ *   const r = useApiResource<EditalDto>(() => `/api/editais/${this.id()}`);
+ *   ```
+ * - **`HttpResourceRequest` reativo** — quando precisa de `params`/`headers`/
+ *   `context` (vendor MIME, etc.):
+ *   ```ts
+ *   const r = useApiResource<EditalDto>(() => ({
+ *     url: `/api/editais/${this.id()}`,
+ *     context: withVendorMime('edital', 1),
+ *   }));
+ *   ```
+ *
+ * Quando `request()` retorna `undefined`, nenhuma request é disparada
+ * (status fica em `idle`) — útil para condicionar a presença de um valor
+ * dependente.
+ *
+ * `options.defaultValue` e `options.parse` são vedados aqui:
+ * - `defaultValue` quebraria a discriminação `value === undefined` ⇄ "ainda
+ *   não carregou" — o helper já modela "ausência" como `data() === null`.
+ * - `parse` violaria o contrato com o `apiResultInterceptor` (que sempre
+ *   envelopa em `ApiResult<T>`).
+ */
+export function useApiResource<T>(
+  request: () => string | HttpResourceRequest | undefined,
+  options?: Omit<
+    HttpResourceOptions<ApiResult<T>, unknown>,
+    'defaultValue' | 'parse'
+  >,
+): UseApiResourceRef<T> {
+  const resource = httpResource<ApiResult<T>>(() => {
+    const next = request();
+    if (next === undefined) {
+      return undefined;
+    }
+    return typeof next === 'string' ? { url: next } : next;
+  }, options);
+
+  const data: Signal<T | null> = computed(() => {
+    const envelope = resource.value();
+    return envelope?.ok ? envelope.data : null;
+  });
+
+  const problem: Signal<ProblemDetails | null> = computed(() => {
+    const envelope = resource.value();
+    return envelope && !envelope.ok ? envelope.problem : null;
+  });
+
+  // `httpResource.value` é `WritableSignal` em runtime — envelopar em
+  // `computed` garante que o consumer público receba um `Signal` somente-
+  // leitura genuíno (não apenas pelo tipo declarado), bloqueando `.set()`
+  // externo que driftaria do `status`/`statusCode`/`headers` do resource.
+  const value: Signal<ApiResult<T> | undefined> = computed(() => resource.value());
+
+  return {
+    value,
+    data,
+    problem,
+    isLoading: resource.isLoading,
+    status: resource.status,
+    statusCode: resource.statusCode,
+    headers: resource.headers,
+    error: resource.error,
+    hasValue: () => resource.hasValue(),
+    reload: () => resource.reload(),
+    destroy: () => resource.destroy(),
+  };
+}


### PR DESCRIPTION
## Sumário

Adota o `httpResource` Angular 21 (`@experimental` desde 19.2) via wrapper `useApiResource<T>` em `libs/shared-core/src/lib/http/`. Refatora `EditaisDetailPage` para consumir o helper, eliminando boilerplate de race guard manual + `effect`/`untracked` + `executarObterPorId` (~50 linhas) por declaração reativa em 4 linhas.

Closes #206

## Decisões binding

**[ADR-0018](docs/adrs/0018-adocao-httpresource-via-wrapper-use-api-resource.md)** documenta:

- **Decisão B (wrapper)** entre as opções A (adoção direta), B (wrapper), C (manter manual) — escolha justificada por: preservar `ApiResult<T>` em todos os call sites, aproveitar race-cancellation nativa, centralizar adaptação `ApiResult → Resource` em 1 ponto, limitar blast radius do status experimental.
- **Guidance Angular oficial honrada:** httpResource é GET-only (\"Avoid using \`httpResource\` for mutations like POST or PUT\" — https://angular.dev/guide/http/http-resource § Best practices). Mutações continuam via HttpClient direto. Publish flow do `EditaisDetailPage` mantém Observable + race guard manual no closure.
- **Tabela de comportamento `ApiResult ↔ httpResource`** documentando como o `apiResultInterceptor` neutraliza o canal de erro (4xx/5xx → `status: 'resolved'` com `value() = ApiFailure`) e o caso raro `'error'` (escape de interceptor não-HTTP).
- **Trigger de reavaliação** se httpResource for promovido a stable, se houver breaking change, ou se aparecer caso real de mutação reativa.

## Mudanças

### Helper novo (`libs/shared-core/src/lib/http/use-api-resource.ts`)

- Aceita \`() => string | HttpResourceRequest | undefined\` (overloads do httpResource).
- Expõe \`value\` como \`Signal\` somente-leitura via \`computed()\` — bloqueia \`.set()\` externo que driftaria de \`status\`/\`statusCode\`/\`headers\`.
- \`data()\` extrai \`.data\` se \`ok\`; \`problem()\` extrai \`.problem\` se failure.
- \`hasValue()\` documentado como point-in-time read (não signal reativo).
- \`options.defaultValue\` e \`options.parse\` vedados via \`Omit<...>\` (quebrariam contrato com interceptor / discriminação \`undefined\` ⇄ \"ainda não carregou\").

### Refator `EditaisDetailPage`

- Remove signals manuais \`edital\`/\`loading\`, \`effect\`/\`untracked\`/\`executarObterPorId\`.
- \`editalResource = useApiResource<EditalDto>(() => ({ url, context: withVendorMime('edital', 1) }))\`.
- \`errorMessage\` consolida 3 fontes — \`problem()\` (HTTP), \`error()\` (interceptor não-HTTP, fallback \"Erro inesperado ao carregar edital.\"), \`publishErrorMessage\` (POST publish). Sem o fallback de \`error()\`, spinner desapareceria silente.
- Refetch pós-publish via \`editalResource.reload()\`.
- Race guard manual do publish **fica** (mutação one-shot, não fetch reativo).

### Pattern de teste para Vitest

- **Specs do helper isolado:** \`await ApplicationRef.whenStable()\` após \`controller.flush(...)\`.
- **Specs com \`ComponentFixture\`:** \`await Promise.resolve(); appRef.tick()\` (helper \`propagate()\`) — \`whenStable()\` deadlocka com Observable subscriptions concorrentes.
- \`fakeAsync\`/\`flushMicrotasks\` são **incompatíveis com Vitest** no Angular 21 (per docs oficiais).

## Cobertura

- **11 specs novos** do helper: carga inicial, race-cancellation reativa, 4xx + 422 errors[], network error sintetizado, reload, undefined request → idle, HttpContext arbitrário, vendor MIME, headers (Link rel=next), hasValue.
- **12 specs adaptados** da page mantendo UX externa idêntica (mesma assinatura para \`edital()\`, \`loading()\`, \`errorMessage()\`).
- **1 spec novo** do guard de double-submit no \`confirmarPublicacao\`.
- Race-cancellation testada explicitamente via \`expect(reqAntiga.cancelled).toBe(true)\`.

## Validação local

- \`bash tools/adr-lint/validate.sh\` — 18 ADRs OK
- \`npx markdownlint-cli2 'docs/adrs/0018-*.md' 'docs/adrs/README.md'\` — 0 errors
- \`npx nx affected --target=lint --base=origin/main\` — 11 projects passing
- \`npx nx affected --target=typecheck --base=origin/main\` — 7 projects passing
- \`npx nx affected --target=build --base=origin/main\` — 7 projects passing
- \`npx nx vite:test shared-core --run\` — 104/104 passing
- \`npx nx vite:test selecao --run\` — 37/37 passing

## Pré-revisão

Pre-commit review pelo \`feature-dev:code-reviewer\` agent — round 1 levantou 4 P2 (value como WritableSignal exposto, race-cancellation assert flaky, error() não surfaced, double-submit sem cobertura); round 2 verificou todos resolvidos sem regressões. Verdict: APROVADO.

## Test plan

- [ ] \`npm ci && npx nx vite:test shared-core --run && npx nx vite:test selecao --run\`
- [ ] \`bash tools/adr-lint/validate.sh\`
- [ ] CI verde