### PR TITLE
docs(adr): adiciona ADR-0020 — GHCR e estratégia de tagging das imagens da uniplus-web

### DIFF
--- a/docs/adrs/0020-registry-ghcr-e-tagging.md
+++ b/docs/adrs/0020-registry-ghcr-e-tagging.md
@@ -1,0 +1,111 @@
+---
+status: "proposed"
+date: "2026-05-08"
+decision-makers:
+  - "Tech Lead"
+consulted:
+  - "DevOps"
+informed:
+  - "Equipe `uniplus-web`"
+---
+
+# ADR-0020: GitHub Container Registry e estratégia de tagging das imagens da `uniplus-web`
+
+## Contexto e enunciado do problema
+
+A Fase 5 do plano de deploy (cluster standalone) está bloqueada porque as imagens dos três frontends (`uniplus-portal`, `uniplus-web-selecao`, `uniplus-web-ingresso`) ainda não são publicadas em um registry acessível pelo cluster. Os Dockerfiles existem (`docker/Dockerfile.portal`, `docker/Dockerfile.selecao`, `docker/Dockerfile.ingresso`) e o pipeline de lint/test/build/E2E já é verde via Nx Cloud — mas não há workflow de publish, não há convenção de naming nem política de tagging.
+
+Diferentemente do backend, os frontends carregam configuração de runtime (URL do Keycloak, base URL da API) que **não pode** ficar embutida na imagem — a Story [#84](https://github.com/unifesspa-edu-br/uniplus-web/issues/84) define `provideAppInitializer` + `ConfigMap` do Kubernetes como ponto de injeção. A imagem distribuída precisa ser idêntica em todos os ambientes; só o `ConfigMap` muda. Adicionalmente, os Dockerfiles atuais têm dívida de hardening ([#4](https://github.com/unifesspa-edu-br/uniplus-web/issues/4)): rodam nginx como root e não têm os headers de segurança no nginx.conf — pré-requisito a ser resolvido antes ou junto do primeiro publish para evitar republicar tags 5 minutos depois.
+
+A organização já valida GHCR como registry institucional (imagem composta `ghcr.io/unifesspa-edu-br/uniplus-keycloak:1.x`). A `uniplus-api` adota a mesma estratégia em ADR pareada (`ADR-0050` no `uniplus-api`). Manter o mesmo registry e a mesma convenção de tagging entre backend e frontend simplifica auditoria, scan de CVE e provisão de credenciais no ArgoCD.
+
+## Drivers da decisão
+
+- Destravar Fase 5 (deploy das 3 apps no cluster standalone)
+- Paridade de registry e tagging com `uniplus-api` (auditoria e ArgoCD homogêneos)
+- Imagem única por app + runtime config via `ConfigMap` ([#84](https://github.com/unifesspa-edu-br/uniplus-web/issues/84)) — nunca embutir URL de Keycloak/API
+- Hardening de containers/nginx ([#4](https://github.com/unifesspa-edu-br/uniplus-web/issues/4)) aplicado antes ou no mesmo PR do primeiro publish
+- Custo zero para registry de repositório público
+- Login via `GITHUB_TOKEN`, sem PAT nem secret externo
+
+## Opções consideradas
+
+- **GHCR (`ghcr.io/unifesspa-edu-br/<imagem>`)** — registry institucional já validado, paridade com `uniplus-api`
+- **Docker Hub (`unifesspa/<imagem>`)** — registry público externo
+- **Registry interno Unifesspa** — registry on-prem hospedado em DC institucional
+
+## Resultado da decisão
+
+**Escolhida:** "GHCR (`ghcr.io/unifesspa-edu-br/<imagem>`)", porque é o registry já em produção na organização (imagem composta do Keycloak), tem paridade com a decisão simétrica em `uniplus-api/docs/adrs/0050-registry-ghcr-e-tagging.md`, autentica via `GITHUB_TOKEN` sem credencial extra e tem custo zero para repositórios públicos.
+
+A convenção de naming distingue o portal dos demais: `ghcr.io/unifesspa-edu-br/uniplus-portal` (sem prefixo `web-` por ser o consumidor final público), `ghcr.io/unifesspa-edu-br/uniplus-web-selecao`, `ghcr.io/unifesspa-edu-br/uniplus-web-ingresso`. As tags publicadas seguem a mesma política do backend: `sha-<7-curto>` imutável, `main` em push para `main`, `v<major>.<minor>.<patch>` em git tag, `latest` apenas em push para `main`. Multi-arch limitado a `linux/amd64` neste momento.
+
+A imagem **nunca** embute URL de Keycloak ou API. O nginx serve `/assets/runtime-config.json` lido por `provideAppInitializer` antes do bootstrap Angular ([#84](https://github.com/unifesspa-edu-br/uniplus-web/issues/84)); o `ConfigMap` do Kubernetes monta esse arquivo no path correto. O Dockerfile recebe `dist/apps/<app>` como build context (saída do `nx build`), aplica hardening (`nginxinc/nginx-unprivileged` ou `USER nginx` explícito, `server_tokens off`, headers HSTS/Permissions-Policy/CSP parametrizáveis) e expõe um `/health.json` estático para smoke pós-build.
+
+SBOM e attestation cosign keyless via OIDC do GitHub ficam deferidos como follow-up — registrados em backlog mas fora do escopo de unblock.
+
+## Consequências
+
+### Positivas
+
+- Fase 5 destrava com 1 workflow novo (`publish-images.yml`) consumindo GHCR já validado
+- Mesma convenção de tagging do `uniplus-api`: ArgoCD, Trivy e auditoria de packages tratam ambos repositórios uniformemente
+- Imagem única por app + runtime config via `ConfigMap` permite promover **a mesma tag** entre DEV, HML e PROD
+- Adicionar/renomear app exige apenas append na matriz do workflow
+- Sem credenciais externas: `GITHUB_TOKEN` com escopo `packages: write` resolve auth
+
+### Negativas
+
+- Acoplamento ao GitHub como registry (lock-in moderado, igual ao backend)
+- Hardening ([#4](https://github.com/unifesspa-edu-br/uniplus-web/issues/4)) precisa ser aplicado no mesmo PR ou imediatamente antes — caso contrário o primeiro publish já carrega imagem insegura que precisará ser republicada
+- Sem multi-arch ARM (workstations Apple Silicon usam `nx serve` local sem container, mitigando)
+
+### Neutras
+
+- Visibilidade pública das imagens espelha a do repositório (`uniplus-web` é público)
+- Build assume Nx affected: PRs que não tocam apps específicas não republicam imagens dessas apps (economia, mas exige cuidado em refactors cross-app)
+
+## Confirmação
+
+Verificável por:
+
+- Workflow `.github/workflows/publish-images.yml` presente e verde em push para `main`
+- `gh api /orgs/unifesspa-edu-br/packages?package_type=container --jq '.[].name'` lista `uniplus-portal`, `uniplus-web-selecao`, `uniplus-web-ingresso`
+- `docker pull ghcr.io/unifesspa-edu-br/uniplus-portal:main` funciona sem auth
+- Container roda como UID não-root (`docker inspect` confirma `Config.User != ""`)
+- `curl -s http://<container>/health.json` retorna 200 e JSON com `{"status":"ok"}`
+- `curl -s -I http://<container>/` mostra `Server: nginx` (sem versão) e ausência de `X-Powered-By`
+- Tag `v0.1.0` via `git tag` produz `ghcr.io/unifesspa-edu-br/uniplus-portal:v0.1.0`
+
+## Prós e contras das opções
+
+### GHCR
+
+- Bom, porque já está em produção na organização (imagem composta `uniplus-keycloak`)
+- Bom, porque tem paridade com a decisão simétrica em `uniplus-api`
+- Bom, porque autentica via `GITHUB_TOKEN` sem PAT externo
+- Bom, porque tem custo zero para repositórios públicos
+- Ruim, porque acopla registry ao provedor de SCM (lock-in moderado)
+- Ruim, porque cleanup de tags antigas exige Action externa
+
+### Docker Hub
+
+- Bom, porque é o registry público mais conhecido
+- Ruim, porque exige conta institucional separada com credenciais fora do GitHub
+- Ruim, porque rate limit anônimo de pull (100/6h) afeta cluster e devs locais
+- Ruim, porque quebra paridade com `uniplus-api`
+
+### Registry interno Unifesspa
+
+- Bom, porque mantém imagens dentro da rede institucional
+- Ruim, porque não existe ainda — bloqueia Fase 5 indefinidamente
+- Ruim, porque cluster standalone ainda não tem conectividade configurada para registry on-prem
+
+## Mais informações
+
+- Story de implementação: a ser criada como sub-issue do Epic [#12](https://github.com/unifesspa-edu-br/uniplus-web/issues/12) (Fundação técnica do frontend)
+- Hardening de containers/nginx: [#4](https://github.com/unifesspa-edu-br/uniplus-web/issues/4) — pré-requisito ou conjunto
+- Runtime config via `ConfigMap`: [#84](https://github.com/unifesspa-edu-br/uniplus-web/issues/84)
+- ADR pareada no backend: `uniplus-api/docs/adrs/0050-registry-ghcr-e-tagging.md`
+- Identity provider OIDC: [ADR-0009](0009-keycloak-como-identity-provider-oidc.md)
+- Origem: pré-requisito da Fase 5 do plano de deploy do cluster standalone (snapshot 2026-05-07)

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -48,6 +48,7 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0017](0017-pattern-feature-page-container-presentational.md) | Páginas de feature no padrão container/presentational — `XxxPage` smart + `ui-*` dumb | accepted | 2026-05-06 |
 | [0018](0018-adocao-httpresource-via-wrapper-use-api-resource.md) | Adoção de `httpResource` Angular 21 via wrapper `useApiResource` em `shared-core` | accepted | 2026-05-07 |
 | [0019](0019-tokens-govbr-compartilhados-em-shared-ui.md) | Tokens Gov.br compartilhados em `libs/shared-ui/src/styles/govbr-tokens.css` + migração Tailwind 3→4 cross-app | proposed | 2026-05-07 |
+| [0020](0020-registry-ghcr-e-tagging.md) | GitHub Container Registry e estratégia de tagging das imagens da `uniplus-web` | proposed | 2026-05-08 |
 
 ## Como adicionar um novo ADR
 


### PR DESCRIPTION
## Resumo

Adiciona ADR-0020 (status `proposed`) formalizando GitHub Container Registry como registry institucional das imagens da `uniplus-web` e a estratégia de tagging — pareada com ADR-0050 do `uniplus-api`.

## Contexto

Pré-requisito da **Fase 5** (deploy das apps no cluster standalone): os ApplicationSets do ArgoCD aguardam imagens publicadas em `ghcr.io/unifesspa-edu-br/{uniplus-portal,uniplus-web-selecao,uniplus-web-ingresso}`. Hoje o repositório tem `docker/Dockerfile.{portal,selecao,ingresso}` + CI verde via Nx Cloud, mas nenhum workflow de publish das imagens das apps (existe `e2e-runner-image.yml`, escopo diferente).

## Decisões binding

- **Registry:** `ghcr.io/unifesspa-edu-br/<imagem>`
- **Naming:** `uniplus-portal` (sem prefixo `web-` por ser consumidor final), `uniplus-web-selecao`, `uniplus-web-ingresso`
- **Tags:** `sha-<7>`, `<branch-sanitizado>`, `v<major>.<minor>.<patch>` em git tag, `latest` apenas em `main`
- **Multi-arch:** somente `linux/amd64` (ARM deferido)
- **Login:** `GITHUB_TOKEN` (sem PAT)
- **Imagem nunca embute URL de Keycloak/API:** runtime config via `provideAppInitializer` + `ConfigMap` (#84)
- **Hardening (#4):** pré-requisito ou aplicado no mesmo PR do primeiro publish — base `nginxinc/nginx-unprivileged`, `server_tokens off`, headers HSTS/Permissions-Policy/CSP

## Pareada com

`uniplus-api/docs/adrs/0050-registry-ghcr-e-tagging.md` — mesma decisão simétrica para o backend.

## Implementação

Story #217 (sub-issue do Epic #12) implementa o workflow `publish-images.yml` consumindo as decisões deste ADR.

## Promoção a `accepted`

Padrão do projeto: ADR fica `proposed` no merge e é promovido a `accepted` em commit posterior, após o primeiro publish verde da Story #217 (precedente: #0018, #0019).

## Checklist

- [x] `bash tools/adr-lint/validate.sh` passou (20 ADRs)
- [x] `npx markdownlint-cli2 'docs/adrs/**/*.md'` sem erros
- [x] Índice em `docs/adrs/README.md` atualizado

## Referências

- Story de implementação: #217
- Epic pai: #12
- Hardening: #4
- Runtime config: #84