### PR TITLE
chore(ci): adicionar job adr-lint ao workflow CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,31 @@ permissions:
   pull-requests: read
 
 jobs:
+  adr-lint:
+    name: ADR lint (MADR 4.0)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Validar ADRs (MADR 4.0)
+        run: bash tools/adr-lint/validate.sh
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Markdown lint (markdownlint-cli2)
+        # Versão pinada em sincronia com tools/adr-lint/validate.sh:
+        # bump exige edição coordenada dos dois para preservar paridade
+        # dev↔CI (script local invoca o mesmo binary).
+        run: npx --yes markdownlint-cli2@0.22.1 'docs/adrs/**/*.md'
+
   main:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Resumo

Espelha o gate `adr-lint` que já existe em `uniplus-api/.github/workflows/ci.yml` — valida frontmatter MADR 4.0 via `tools/adr-lint/validate.sh` + `markdownlint-cli2@0.22.1` contra `docs/adrs/**/*.md` em todo PR e push para main.

## Contexto

O tooling em `tools/adr-lint/` já existia no repo (script `validate.sh` + README), mas não estava plugado ao workflow de CI — gap percebido ao abrir o PR #219 (ADR-0020). Como resultado, ADRs entravam sem validação automática de schema (status, date, decision-makers, sections obrigatórias) — divergência silenciosa em relação ao backend.

## Decisões

- Job paralelo a `main` (não depende dos gates frontend, não é gated pelo paths-filter de `apps/**` / `libs/**`)
- Sem trigger por `paths` próprio: ADR é raro e fast — overhead de rodar em todo PR é desprezível
- `markdownlint-cli2` pinado em `0.22.1`, mesma versão do `validate.sh`, comentário no YAML pede edição coordenada em bumps
- Espelho exato do job no `uniplus-api` (paridade dev↔CI mantida cross-repo)

## Verificação

- [x] `bash tools/adr-lint/validate.sh` passou local (19 ADRs)
- [x] `npx --yes markdownlint-cli2@0.22.1 'docs/adrs/**/*.md'` sem erros local
- [ ] CI roda verde neste PR (validação self-hosted: gate roda contra os ADRs já existentes)

## Follow-up

Após merge, rebase do #219 (ADR-0020) em `origin/main` faz o gate validar ADR-0020 antes do merge. Padrão a aplicar em ADRs futuras do `uniplus-web`.

## Referências

- Job equivalente em `uniplus-api`: `.github/workflows/ci.yml` job `adr-lint`
- Tooling: `tools/adr-lint/README.md`, `tools/adr-lint/validate.sh`
- PR ADR-0020 (consumidor imediato): #219