### PR TITLE
docs(adr-0020): publish apenas em tag v*; remove canais main/latest

### DIFF
--- a/docs/adrs/0020-registry-ghcr-e-tagging.md
+++ b/docs/adrs/0020-registry-ghcr-e-tagging.md
@@ -38,7 +38,20 @@ A organização já valida GHCR como registry institucional (imagem composta `gh
 
 **Escolhida:** "GHCR (`ghcr.io/unifesspa-edu-br/<imagem>`)", porque é o registry já em produção na organização (imagem composta do Keycloak), tem paridade com a decisão simétrica em `uniplus-api/docs/adrs/0050-registry-ghcr-e-tagging.md`, autentica via `GITHUB_TOKEN` sem credencial extra e tem custo zero para repositórios públicos.
 
-A convenção de naming distingue o portal dos demais: `ghcr.io/unifesspa-edu-br/uniplus-portal` (sem prefixo `web-` por ser o consumidor final público), `ghcr.io/unifesspa-edu-br/uniplus-web-selecao`, `ghcr.io/unifesspa-edu-br/uniplus-web-ingresso`. As tags publicadas seguem a mesma política do backend: `sha-<7-curto>` imutável, `main` em push para `main`, `v<major>.<minor>.<patch>` em git tag, `latest` apenas em push para `main`. Multi-arch limitado a `linux/amd64` neste momento.
+A convenção de naming distingue o portal dos demais: `ghcr.io/unifesspa-edu-br/uniplus-portal` (sem prefixo `web-` por ser o consumidor final público), `ghcr.io/unifesspa-edu-br/uniplus-web-selecao`, `ghcr.io/unifesspa-edu-br/uniplus-web-ingresso`.
+
+**Trigger de publish:** o workflow só dispara em `push` de tag `v*` (ex.: `v0.1.0`). Push em `main` **não** publica imagem. Disciplina de release explícito — sem rolling tag mutável, sem ambiguidade sobre "qual é o estado atual de DEV". Devs de DEV usam `nx serve` (sem container) ou `docker compose` com build context. ArgoCD e Helm em qualquer ambiente sempre pinam um semver ou um sha — nunca um canal mutável.
+
+**Tags publicadas para cada release `v<X>.<Y>.<Z>`:**
+
+- `sha-<7-curto>` — identidade imutável do commit (sempre publicada)
+- `v<X>.<Y>.<Z>` — release exata (imutável)
+- `v<X>.<Y>` — pin de minor (rola com patches subsequentes)
+- `v<X>` — pin de major (rola com minors+patches subsequentes)
+
+Sem `latest` — convenção é dispensável quando `v<X>` já fornece soft-pinning automático. Sem `main` — nenhum consumidor produtivo deve apontar para um canal de branch.
+
+Multi-arch limitado a `linux/amd64` neste momento.
 
 A imagem **nunca** embute URL de Keycloak ou API. O nginx serve `/assets/runtime-config.json` lido por `provideAppInitializer` antes do bootstrap Angular ([#84](https://github.com/unifesspa-edu-br/uniplus-web/issues/84)); o `ConfigMap` do Kubernetes monta esse arquivo no path correto. O Dockerfile recebe `dist/apps/<app>` como build context (saída do `nx build`), aplica hardening (`nginxinc/nginx-unprivileged` ou `USER nginx` explícito, `server_tokens off`, headers HSTS/Permissions-Policy/CSP parametrizáveis) e expõe um `/health.json` estático para smoke pós-build.
 
@@ -69,13 +82,15 @@ SBOM e attestation cosign keyless via OIDC do GitHub ficam deferidos como follow
 
 Verificável por:
 
-- Workflow `.github/workflows/publish-images.yml` presente e verde em push para `main`
-- `gh api /orgs/unifesspa-edu-br/packages?package_type=container --jq '.[].name'` lista `uniplus-portal`, `uniplus-web-selecao`, `uniplus-web-ingresso`
-- `docker pull ghcr.io/unifesspa-edu-br/uniplus-portal:main` funciona sem auth
+- Workflow `.github/workflows/publish-images.yml` presente, sem trigger em `push: branches`, apenas em `push: tags v*`
+- `gh api /orgs/unifesspa-edu-br/packages?package_type=container --jq '.[].name'` lista `uniplus-portal`, `uniplus-web-selecao`, `uniplus-web-ingresso` após o primeiro `git tag v* && git push --tags`
+- `docker pull ghcr.io/unifesspa-edu-br/uniplus-portal:v0.1.0` funciona sem auth (visibilidade pública)
+- `docker pull ghcr.io/unifesspa-edu-br/uniplus-portal:main` falha com 404 — `main` **não** é tag publicada
+- Tag de release `v0.1.0` produz simultaneamente `:v0.1.0`, `:v0.1`, `:v0` e `:sha-<7>`
 - Container roda como UID não-root (`docker inspect` confirma `Config.User != ""`)
 - `curl -s http://<container>/health.json` retorna 200 e JSON com `{"status":"ok"}`
 - `curl -s -I http://<container>/` mostra `Server: nginx` (sem versão) e ausência de `X-Powered-By`
-- Tag `v0.1.0` via `git tag` produz `ghcr.io/unifesspa-edu-br/uniplus-portal:v0.1.0`
+- Helm chart consome tag por `Values.image.tag` (semver explícito), sem hardcode e sem `latest`
 
 ## Prós e contras das opções
 


### PR DESCRIPTION
## Resumo

Espelha a revisão da política de tagging em `uniplus-api/ADR-0050` (PR uniplus-api#340): imagem só nasce quando o operador aplica `git tag v*` em commit já mergeado em main. Push em main **não** publica.

## Decisões revisadas

| Item | Antes | Depois |
|---|---|---|
| Trigger | `push: main` + `push: tags v*` | apenas `push: tags v*` |
| Tags em main push | `sha-<7>`, `main`, `latest` | (não publica) |
| Tags em tag push | `sha-<7>`, `v<semver>` | `sha-<7>`, `v<X>.<Y>.<Z>`, `v<X>.<Y>`, `v<X>` |
| `latest` | sim, em main | removida |
| `main` | sim, em main | removida |

## Mudanças

- **Resultado da decisão:** trigger único `push: tags v*`; tags publicadas explicitadas; sem `latest`/`main`
- **Confirmação:** verificação de pull `v0.1.0` + 404 em `:main`
- DEV local continua via `nx serve` ou `docker compose` com build context

## Status do ADR

Mantém `proposed`. Será promovido para `accepted` após o primeiro publish verde da Story #217 (precedente: padrão do projeto, ver #0018, #0019).

## Implementação

A Story #217 implementará o workflow espelhado com a política revisada — sem trigger em main, mesma matriz `[portal, selecao, ingresso]`, mesma estratégia de tags semver.

## Pareada com

- `uniplus-api/ADR-0050` revisada em PR uniplus-api#340 (mergeado primeiro, idealmente)