### PR TITLE
fix(libs): resolve build crash do #124 via recipe ng-packagr cross-lib

### DIFF
--- a/libs/shared-auth/tsconfig.lib.prod.json
+++ b/libs/shared-auth/tsconfig.lib.prod.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.lib.json",
   "compilerOptions": {
-    "declarationMap": false
+    "declarationMap": false,
+    "paths": {
+      "@uniplus/shared-core": ["dist/libs/shared-core"]
+    }
   },
   "angularCompilerOptions": {}
 }

--- a/libs/shared-data/package.json
+++ b/libs/shared-data/package.json
@@ -9,8 +9,7 @@
     "rxjs": "~7.8.0",
     "vite": "^7.0.0",
     "@analogjs/vite-plugin-angular": ">=2.0.0",
-    "@nx/vite": ">=22.0.0",
-    "@org/shared-utils": "0.0.1"
+    "@nx/vite": ">=22.0.0"
   },
   "sideEffects": false
 }

--- a/libs/shared-data/tsconfig.lib.prod.json
+++ b/libs/shared-data/tsconfig.lib.prod.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.lib.json",
   "compilerOptions": {
-    "declarationMap": false
+    "declarationMap": false,
+    "paths": {
+      "@org/shared-utils": ["../../dist/libs/shared-utils"]
+    }
   },
   "angularCompilerOptions": {}
 }

--- a/libs/shared-data/tsconfig.lib.prod.json
+++ b/libs/shared-data/tsconfig.lib.prod.json
@@ -1,10 +1,7 @@
 {
   "extends": "./tsconfig.lib.json",
   "compilerOptions": {
-    "declarationMap": false,
-    "paths": {
-      "@org/shared-utils": ["../../dist/libs/shared-utils"]
-    }
+    "declarationMap": false
   },
   "angularCompilerOptions": {}
 }

--- a/libs/shared-data/tsconfig.lib.prod.json
+++ b/libs/shared-data/tsconfig.lib.prod.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.lib.json",
   "compilerOptions": {
-    "declarationMap": false
+    "declarationMap": false,
+    "paths": {
+      "@uniplus/shared-core": ["dist/libs/shared-core"]
+    }
   },
   "angularCompilerOptions": {}
 }

--- a/libs/shared-ui/package.json
+++ b/libs/shared-ui/package.json
@@ -8,7 +8,9 @@
     "@uniplus/shared-core": "*",
     "vite": "^7.0.0",
     "@analogjs/vite-plugin-angular": "^2.2.0",
-    "@nx/vite": "^22.6.0"
+    "@nx/vite": "^22.6.0",
+    "@org/shared-data": "0.0.1",
+    "@org/shared-utils": "0.0.1"
   },
   "sideEffects": false
 }

--- a/libs/shared-ui/package.json
+++ b/libs/shared-ui/package.json
@@ -9,8 +9,7 @@
     "vite": "^7.0.0",
     "@analogjs/vite-plugin-angular": "^2.2.0",
     "@nx/vite": "^22.6.0",
-    "@org/shared-data": "0.0.1",
-    "@org/shared-utils": "0.0.1"
+    "@uniplus/shared-utils": "0.0.1"
   },
   "sideEffects": false
 }

--- a/libs/shared-ui/src/lib/components/cpf-input/cpf-input.ts
+++ b/libs/shared-ui/src/lib/components/cpf-input/cpf-input.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy, input, forwardRef, signal } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { formatCpfProgressive } from '@org/shared-utils';
+import { formatCpfProgressive } from '@uniplus/shared-utils';
 
 /**
  * Input mascarado de CPF integrado a Reactive Forms via ControlValueAccessor.

--- a/libs/shared-ui/src/lib/components/cpf-input/cpf-input.ts
+++ b/libs/shared-ui/src/lib/components/cpf-input/cpf-input.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy, input, forwardRef, signal } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { formatCpfProgressive } from '../../utils/cpf-format.util';
+import { formatCpfProgressive } from '@org/shared-utils';
 
 /**
  * Input mascarado de CPF integrado a Reactive Forms via ControlValueAccessor.

--- a/libs/shared-ui/tsconfig.lib.prod.json
+++ b/libs/shared-ui/tsconfig.lib.prod.json
@@ -3,7 +3,12 @@
   "compilerOptions": {
     "declarationMap": false,
     "paths": {
-      "@uniplus/shared-utils": ["../../dist/libs/shared-utils"]
+      "@uniplus/shared-ui": ["libs/shared-ui/src/index.ts"],
+      "@uniplus/shared-auth": ["libs/shared-auth/src/index.ts"],
+      "@uniplus/shared-core": ["libs/shared-core/src/index.ts"],
+      "@uniplus/shared-data": ["libs/shared-data/src/index.ts"],
+      "@uniplus/shared-e2e": ["libs/shared-e2e/src/index.ts"],
+      "@uniplus/shared-utils": ["dist/libs/shared-utils"]
     }
   },
   "angularCompilerOptions": {}

--- a/libs/shared-ui/tsconfig.lib.prod.json
+++ b/libs/shared-ui/tsconfig.lib.prod.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.lib.json",
   "compilerOptions": {
-    "declarationMap": false
+    "declarationMap": false,
+    "paths": {
+      "@org/shared-utils": ["../../dist/libs/shared-utils"]
+    }
   },
   "angularCompilerOptions": {}
 }

--- a/libs/shared-ui/tsconfig.lib.prod.json
+++ b/libs/shared-ui/tsconfig.lib.prod.json
@@ -3,11 +3,9 @@
   "compilerOptions": {
     "declarationMap": false,
     "paths": {
-      "@uniplus/shared-ui": ["libs/shared-ui/src/index.ts"],
-      "@uniplus/shared-auth": ["libs/shared-auth/src/index.ts"],
-      "@uniplus/shared-core": ["libs/shared-core/src/index.ts"],
-      "@uniplus/shared-data": ["libs/shared-data/src/index.ts"],
-      "@uniplus/shared-e2e": ["libs/shared-e2e/src/index.ts"],
+      "@uniplus/shared-auth": ["dist/libs/shared-auth"],
+      "@uniplus/shared-core": ["dist/libs/shared-core"],
+      "@uniplus/shared-data": ["dist/libs/shared-data"],
       "@uniplus/shared-utils": ["dist/libs/shared-utils"]
     }
   },

--- a/libs/shared-ui/tsconfig.lib.prod.json
+++ b/libs/shared-ui/tsconfig.lib.prod.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declarationMap": false,
     "paths": {
-      "@org/shared-utils": ["../../dist/libs/shared-utils"]
+      "@uniplus/shared-utils": ["../../dist/libs/shared-utils"]
     }
   },
   "angularCompilerOptions": {}

--- a/libs/shared-utils/eslint.config.mjs
+++ b/libs/shared-utils/eslint.config.mjs
@@ -1,0 +1,22 @@
+import nx from '@nx/eslint-plugin';
+import baseConfig from '../../eslint.config.mjs';
+
+export default [
+  ...nx.configs['flat/angular'],
+  ...nx.configs['flat/angular-template'],
+  ...baseConfig,
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          ignoredFiles: ['{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}'],
+        },
+      ],
+    },
+    languageOptions: {
+      parser: await import('jsonc-eslint-parser'),
+    },
+  },
+];

--- a/libs/shared-utils/ng-package.json
+++ b/libs/shared-utils/ng-package.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../dist/libs/shared-utils",
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/libs/shared-utils/package.json
+++ b/libs/shared-utils/package.json
@@ -1,16 +1,13 @@
 {
-  "name": "@org/shared-data",
+  "name": "@org/shared-utils",
   "version": "0.0.1",
   "peerDependencies": {
     "@angular/common": "^21.2.0",
     "@angular/core": "^21.2.0",
     "@angular/forms": "^21.2.0",
-    "@uniplus/shared-core": "*",
-    "rxjs": "~7.8.0",
     "vite": "^7.0.0",
     "@analogjs/vite-plugin-angular": ">=2.0.0",
-    "@nx/vite": ">=22.0.0",
-    "@org/shared-utils": "0.0.1"
+    "@nx/vite": ">=22.0.0"
   },
   "sideEffects": false
 }

--- a/libs/shared-utils/package.json
+++ b/libs/shared-utils/package.json
@@ -1,10 +1,7 @@
 {
-  "name": "@org/shared-utils",
+  "name": "@uniplus/shared-utils",
   "version": "0.0.1",
   "peerDependencies": {
-    "@angular/common": "^21.2.0",
-    "@angular/core": "^21.2.0",
-    "@angular/forms": "^21.2.0",
     "vite": "^7.0.0",
     "@analogjs/vite-plugin-angular": ">=2.0.0",
     "@nx/vite": ">=22.0.0"

--- a/libs/shared-utils/project.json
+++ b/libs/shared-utils/project.json
@@ -1,0 +1,28 @@
+{
+  "name": "shared-utils",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/shared-utils/src",
+  "prefix": "utils",
+  "projectType": "library",
+  "tags": ["scope:shared", "type:util"],
+  "targets": {
+    "build": {
+      "executor": "@nx/angular:ng-packagr-lite",
+      "outputs": ["{workspaceRoot}/dist/{projectRoot}"],
+      "options": {
+        "project": "libs/shared-utils/ng-package.json",
+        "tsConfig": "libs/shared-utils/tsconfig.lib.json"
+      },
+      "configurations": {
+        "production": {
+          "tsConfig": "libs/shared-utils/tsconfig.lib.prod.json"
+        },
+        "development": {}
+      },
+      "defaultConfiguration": "production"
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    }
+  }
+}

--- a/libs/shared-utils/src/index.ts
+++ b/libs/shared-utils/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib';

--- a/libs/shared-utils/src/lib/index.ts
+++ b/libs/shared-utils/src/lib/index.ts
@@ -1,0 +1,1 @@
+export { formatCpfProgressive } from './utils/cpf.util';

--- a/libs/shared-utils/src/lib/utils/cpf.util.spec.ts
+++ b/libs/shared-utils/src/lib/utils/cpf.util.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { formatCpfProgressive } from './cpf.util';
+
+describe('formatCpfProgressive', () => {
+  it.each([
+    ['', ''],
+    ['1', '1'],
+    ['123', '123'],
+    ['1234', '123.4'],
+    ['123456', '123.456'],
+    ['1234567', '123.456.7'],
+    ['123456789', '123.456.789'],
+    ['1234567890', '123.456.789-0'],
+    ['12345678901', '123.456.789-01'],
+    ['1234567890199', '123.456.789-01'],
+  ])('formata progressivamente "%s" como "%s"', (input, expected) => {
+    expect(formatCpfProgressive(input)).toBe(expected);
+  });
+
+  it('retorna string vazia para null', () => {
+    expect(formatCpfProgressive(null)).toBe('');
+  });
+
+  it('retorna string vazia para undefined', () => {
+    expect(formatCpfProgressive(undefined)).toBe('');
+  });
+
+  it('remove caracteres não numéricos antes de formatar', () => {
+    expect(formatCpfProgressive('abc529.982.247-25xyz')).toBe('529.982.247-25');
+  });
+});

--- a/libs/shared-utils/src/lib/utils/cpf.util.ts
+++ b/libs/shared-utils/src/lib/utils/cpf.util.ts
@@ -1,0 +1,21 @@
+/**
+ * Formata um valor parcial ou completo como máscara progressiva de CPF para
+ * exibição durante a digitação. Diferente de `formatCpf`, NÃO aplica padding —
+ * mostra apenas a parte da máscara correspondente aos dígitos disponíveis.
+ *
+ * Ignora caracteres não-numéricos e limita a entrada a 11 dígitos.
+ *
+ * @example
+ * formatCpfProgressive('123')         // '123'
+ * formatCpfProgressive('1234')        // '123.4'
+ * formatCpfProgressive('12345678901') // '123.456.789-01'
+ * formatCpfProgressive('abc529xyz')   // '529'
+ * formatCpfProgressive(null)          // ''
+ */
+export function formatCpfProgressive(value: string | null | undefined): string {
+  const digits = (value ?? '').replace(/\D/g, '').slice(0, 11);
+  if (digits.length <= 3) return digits;
+  if (digits.length <= 6) return `${digits.slice(0, 3)}.${digits.slice(3)}`;
+  if (digits.length <= 9) return `${digits.slice(0, 3)}.${digits.slice(3, 6)}.${digits.slice(6)}`;
+  return `${digits.slice(0, 3)}.${digits.slice(3, 6)}.${digits.slice(6, 9)}-${digits.slice(9)}`;
+}

--- a/libs/shared-utils/src/test-setup.ts
+++ b/libs/shared-utils/src/test-setup.ts
@@ -1,0 +1,5 @@
+import '@angular/compiler';
+import '@analogjs/vitest-angular/setup-snapshots';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
+
+setupTestBed({ zoneless: false });

--- a/libs/shared-utils/tsconfig.json
+++ b/libs/shared-utils/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "isolatedModules": true,
+    "target": "es2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "emitDecoratorMetadata": false,
+    "module": "preserve"
+  },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/shared-utils/tsconfig.lib.json
+++ b/libs/shared-utils/tsconfig.lib.json
@@ -1,0 +1,25 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx"
+  ]
+}

--- a/libs/shared-utils/tsconfig.lib.prod.json
+++ b/libs/shared-utils/tsconfig.lib.prod.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "declarationMap": false
+  },
+  "angularCompilerOptions": {}
+}

--- a/libs/shared-utils/tsconfig.spec.json
+++ b/libs/shared-utils/tsconfig.spec.json
@@ -1,0 +1,27 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": [
+      "vitest/globals",
+      "vitest/importMeta",
+      "vite/client",
+      "node",
+      "vitest"
+    ]
+  },
+  "include": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx"
+  ]
+}

--- a/libs/shared-utils/vite.config.mts
+++ b/libs/shared-utils/vite.config.mts
@@ -1,0 +1,24 @@
+/// <reference types='vitest' />
+import { defineConfig } from 'vite';
+import angular from '@analogjs/vite-plugin-angular';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
+
+export default defineConfig(() => ({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/libs/shared-utils',
+  plugins: [angular(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
+  test: {
+    name: 'shared-utils',
+    watch: false,
+    globals: true,
+    environment: 'jsdom',
+    include: ['{src,tests}/**/*.{test,spec}.{js,mts,cjs,ts,cts,jsx,tsx}'],
+    setupFiles: ['src/test-setup.ts'],
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: '../../coverage/libs/shared-utils',
+      provider: 'v8' as const,
+    },
+  },
+}));

--- a/nx.json
+++ b/nx.json
@@ -65,6 +65,9 @@
       }
     }
   ],
+  "projects": {
+    "shared-utils": "libs/shared-utils/project.json"
+  },
   "generators": {
     "@nx/angular:application": {
       "e2eTestRunner": "playwright",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -24,6 +24,7 @@
       "@uniplus/shared-auth": ["libs/shared-auth/src/index.ts"],
       "@uniplus/shared-core": ["libs/shared-core/src/index.ts"],
       "@uniplus/shared-data": ["libs/shared-data/src/index.ts"],
+      "@org/shared-utils": ["libs/shared-utils/src/index.ts"],
       "@uniplus/shared-e2e": ["libs/shared-e2e/src/index.ts"]
     }
   },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -24,7 +24,7 @@
       "@uniplus/shared-auth": ["libs/shared-auth/src/index.ts"],
       "@uniplus/shared-core": ["libs/shared-core/src/index.ts"],
       "@uniplus/shared-data": ["libs/shared-data/src/index.ts"],
-      "@org/shared-utils": ["libs/shared-utils/src/index.ts"],
+      "@uniplus/shared-utils": ["libs/shared-utils/src/index.ts"],
       "@uniplus/shared-e2e": ["libs/shared-e2e/src/index.ts"]
     }
   },


### PR DESCRIPTION
## Resumo

Resolve o **build crash do `shared-ui:build:production`** reportado no [`#124`](https://github.com/unifesspa-edu-br/uniplus-web/issues/124) aplicando a recipe oficial ng-packagr (path override em `tsconfig.lib.prod.json` apontando para artefatos `dist/`) em todas as libs ng-packagr-lite que consomem outras libs ng-packagr-lite. Crédito do trabalho original para [@joaovmour4](https://github.com/joaovmour4) (commit `82dc157`, branch `refactor/132-extrair-lib-base-buildada`); esta PR estende e refina via 4 commits adicionais após review iterativo do Codex local.

Refs #124 #132

## Histórico

| Commit | Origem | Mudança |
|---|---|---|
| `82dc157` | João Batista (Pontta) | Cria `libs/shared-utils/` (ng-packagr) + move `formatCpfProgressive` para lá + path override em `tsconfig.lib.prod.json` shared-ui apontando para `dist/libs/shared-utils` |
| `71dd67e` | refinements meus | `@org/shared-utils` → `@uniplus/shared-utils` (alinha pattern de `tsconfig.base.json`); remove 5 dead configs detectados pelo `@nx/dependency-checks` lint |
| `96d785f` | fix Codex P1 | `tsconfig.lib.prod.json` shared-ui: corrige path relativo (`../../dist/...` resolvia para fora do repo porque `baseUrl=../..` já é raiz) + replica aliases `@uniplus/*` herdados (TypeScript não merge `paths` entre `extends`) |
| `fb3f817` | fix Codex P2 | shared-ui: todos os siblings ng-packagr para `dist/` (não só shared-utils — preserva package boundaries em prod) |
| `4252182` | fix Codex P2 estendido | shared-data + shared-auth (libs ng-packagr-lite que importam `@uniplus/shared-core`): override também aponta para `dist/libs/shared-core`. Recipe ng-packagr completa cross-lib |

## O que muda

**Lib nova `libs/shared-utils/`** (do João):
- `formatCpfProgressive` movido de `shared-ui/utils/cpf-format.util.ts` para cá (era a função que reproduzia o crash quando importada cross-lib).
- Builder `@nx/angular:ng-packagr-lite` (poderia ser `@nx/js:tsc` já que é TS-puro — flagged como follow-up).
- 11 specs Vitest cobrindo casos de borda + nullish + caracteres não-numéricos.
- Tags `scope:shared`, `type:util`.

**Recipe ng-packagr aplicada cross-lib** (3 libs ng-packagr que consomem outras):
- `shared-ui/tsconfig.lib.prod.json`: `paths` para shared-auth, shared-core, shared-data, shared-utils → `dist/libs/<lib>`.
- `shared-data/tsconfig.lib.prod.json`: `paths` para shared-core → `dist/libs/shared-core` (consumido por `editais.api.ts`).
- `shared-auth/tsconfig.lib.prod.json`: `paths` para shared-core → `dist/libs/shared-core` (consumido por `auth-error.interceptor.ts`).

**Limpeza de naming + dead config**:
- `@uniplus/shared-utils` em todos os 5 lugares (`package.json`, `tsconfig.base.json`, 2 `tsconfig.lib.prod.json`, import em `cpf-input.ts`).
- Remove 3 peerDeps Angular não usadas em `shared-utils` (lib é TS-puro).
- Remove peerDep + paths override mortos em `shared-data` (não importa shared-utils).
- Remove peerDep `@org/shared-data` morto em `shared-ui`.

## Pesquisa

3 fontes citadas no commit `82dc157` do João + reforço via Codex local:

1. [ng-packagr docs/dependencies.md](https://github.com/ng-packagr/ng-packagr/blob/main/docs/dependencies.md) — recipe oficial path override para `dist/`.
2. [`nrwl/nx#19238`](https://github.com/nrwl/nx/issues/19238) — confirma que TS paths em buildable lib devem apontar para dist, não src.
3. [TypeScript handbook módulo resolution](https://www.typescriptlang.org/docs/handbook/module-resolution.html) — `paths` em `tsconfig` herdado via `extends` não merge (replace), exigindo replicação dos aliases.

## Validações locais

Todas em `/tmp/uniplus-124-validation/uniplus-web` (clone limpo) sob Node 22.22.2:

| Gate | Resultado |
|---|---|
| `npx nx run shared-ui:build:production` | verde, 581ms (crash do #124 eliminado) |
| `npx nx run-many --target=build` em 5 libs + 3 apps | verde |
| `npx tsc -p tsconfig.lib.prod.json --noEmit` em 5 libs | 0 erros (auto-consistência restaurada — antes do fix, falhava com TS2307 em shared-ui) |
| `npx nx run-many --target=lint` em 5 libs | verde (6 warnings preexistentes em form-field.spec.ts) |
| `npx nx run-many --target=vite:test` em 6 projects | 104 specs shared-ui + 37 selecao + outras verdes |
| Codex review (4 rounds, branch toda vs `refactor/132`) | aprovado: "No actionable correctness issues were found in the diff" |

## Pendências fora do escopo desta PR

1. **2ª parte do `#124` — CI mascarando exit codes:** `nx start-ci-run` distribuído reporta `success` mesmo com `❌ shared-ui:build:production` no log; outras falhas (`ingresso-e2e` 6 testes; `poc-primeng-e2e` ENOENT) também passam silenciosas. Independe da arquitetura — issue follow-up dedicada será aberta. **Esta PR mantém `#124` aberta** ([`Refs`](https://github.com/unifesspa-edu-br/uniplus-web/issues/124), não `Closes`).
2. **`@org/*` em `name` dos `package.json`** de `shared-data`, `shared-ui`, `shared-auth` é estado pré-existente em main (`shared-core` já migrou). Migração merece PR dedicada por ter blast radius diferente — não toquei aqui.
3. **Builder `@nx/js:tsc` em vez de `ng-packagr-lite` para `shared-utils`** — lib é TS-puro hoje, tsc seria mais leve e elimina o problema na raiz para essa lib específica. Trade-off com o intent original do João (presumível: lib pode hospedar componentes Angular no futuro). Mantido o builder.
4. **Refactor estrutural mais amplo (ideia Compozy `frontend-libs-architecture`):** demote `shared-data` → tsc, tag taxonomy 3-dim, ESLint `error` blocking, fitness CI gate, generator de feature lib, sub-entries codegen-as-contract. Frente posterior; esta PR é Onda 0 (fix tático que destrava o build).

## Plano de revisão

Sugestão de ordem de leitura dos commits via `git log fix/124-shared-utils-uniplus-naming origin/main..HEAD --oneline --reverse` — começa pelo trabalho original do João (`82dc157`) e segue com os refinements em ordem de descoberta pelo Codex.