### PR TITLE
feat(runtime-config): provideRuntimeConfig + AUTH_CONFIG token + fitness cross-app (ADR-0021)

### DIFF
--- a/apps/ingresso/public/assets/runtime-config.json
+++ b/apps/ingresso/public/assets/runtime-config.json
@@ -1,0 +1,8 @@
+{
+  "apiUrl": "http://localhost:5000",
+  "keycloak": {
+    "url": "http://localhost:8080",
+    "realm": "unifesspa",
+    "clientId": "ingresso-web"
+  }
+}

--- a/apps/ingresso/src/app/app.config.ts
+++ b/apps/ingresso/src/app/app.config.ts
@@ -3,12 +3,8 @@ import { provideRouter, withComponentInputBinding } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { appRoutes } from './app.routes';
 import { apiResultInterceptor, loadingInterceptor } from '@uniplus/shared-core';
-import {
-  INGRESSO_BASE_PATH,
-  SELECAO_BASE_PATH,
-} from '@uniplus/shared-data';
+import { provideRuntimeConfig } from '@uniplus/shared-data';
 import { authErrorInterceptor, provideAuth, tokenInterceptor } from '@uniplus/shared-auth';
-import { environment } from '../environments/environment';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -26,16 +22,10 @@ export const appConfig: ApplicationConfig = {
         apiResultInterceptor,
       ]),
     ),
-    provideAuth({
-      keycloakUrl: environment.keycloak.url,
-      realm: environment.keycloak.realm,
-      clientId: environment.keycloak.clientId,
-      allowedUrls: [environment.apiUrl, environment.keycloak.url],
-    }),
-    // BASE_PATH dos clientes gerados (ADR-0013) — origin absoluta da
-    // uniplus-api. Mesma origin para ambos os módulos pois rodam no mesmo
-    // deployment.
-    { provide: SELECAO_BASE_PATH, useValue: environment.apiUrl },
-    { provide: INGRESSO_BASE_PATH, useValue: environment.apiUrl },
+    // Runtime config (ADR-0021) — fetch /assets/runtime-config.json antes
+    // do bootstrap das rotas + provê AUTH_CONFIG e BASE_PATHs a partir do
+    // AppConfigService. DEVE vir antes de provideAuth().
+    provideRuntimeConfig(),
+    provideAuth(),
   ],
 };

--- a/apps/portal/public/assets/runtime-config.json
+++ b/apps/portal/public/assets/runtime-config.json
@@ -1,0 +1,8 @@
+{
+  "apiUrl": "http://localhost:5000",
+  "keycloak": {
+    "url": "http://localhost:8080",
+    "realm": "unifesspa",
+    "clientId": "portal-web"
+  }
+}

--- a/apps/portal/src/app/app.config.ts
+++ b/apps/portal/src/app/app.config.ts
@@ -3,12 +3,8 @@ import { provideRouter, withComponentInputBinding } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { appRoutes } from './app.routes';
 import { apiResultInterceptor, loadingInterceptor } from '@uniplus/shared-core';
-import {
-  INGRESSO_BASE_PATH,
-  SELECAO_BASE_PATH,
-} from '@uniplus/shared-data';
+import { provideRuntimeConfig } from '@uniplus/shared-data';
 import { authErrorInterceptor, provideAuth, tokenInterceptor } from '@uniplus/shared-auth';
-import { environment } from '../environments/environment';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -26,16 +22,11 @@ export const appConfig: ApplicationConfig = {
         apiResultInterceptor,
       ]),
     ),
-    provideAuth({
-      keycloakUrl: environment.keycloak.url,
-      realm: environment.keycloak.realm,
-      clientId: environment.keycloak.clientId,
-      allowedUrls: [environment.apiUrl, environment.keycloak.url],
-    }),
-    // BASE_PATH dos clientes gerados (ADR-0013) — origin absoluta da
-    // uniplus-api. O portal pode consumir endpoints públicos de qualquer
-    // dos dois módulos, então provê ambos os tokens.
-    { provide: SELECAO_BASE_PATH, useValue: environment.apiUrl },
-    { provide: INGRESSO_BASE_PATH, useValue: environment.apiUrl },
+    // Runtime config (ADR-0021) — fetch /assets/runtime-config.json antes
+    // do bootstrap das rotas + provê AUTH_CONFIG e BASE_PATHs a partir do
+    // AppConfigService. Portal pode consumir endpoints públicos de selecao
+    // e ingresso, então ambos os BASE_PATHs vêm da mesma apiUrl.
+    provideRuntimeConfig(),
+    provideAuth(),
   ],
 };

--- a/apps/selecao/public/assets/runtime-config.json
+++ b/apps/selecao/public/assets/runtime-config.json
@@ -1,0 +1,8 @@
+{
+  "apiUrl": "http://localhost:5000",
+  "keycloak": {
+    "url": "http://localhost:8080",
+    "realm": "unifesspa",
+    "clientId": "selecao-web"
+  }
+}

--- a/apps/selecao/src/app/app.config.ts
+++ b/apps/selecao/src/app/app.config.ts
@@ -3,12 +3,8 @@ import { provideRouter, withComponentInputBinding } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { appRoutes } from './app.routes';
 import { apiResultInterceptor, loadingInterceptor } from '@uniplus/shared-core';
-import {
-  INGRESSO_BASE_PATH,
-  SELECAO_BASE_PATH,
-} from '@uniplus/shared-data';
+import { provideRuntimeConfig } from '@uniplus/shared-data';
 import { authErrorInterceptor, provideAuth, tokenInterceptor } from '@uniplus/shared-auth';
-import { environment } from '../environments/environment';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -29,16 +25,11 @@ export const appConfig: ApplicationConfig = {
         apiResultInterceptor,
       ]),
     ),
-    provideAuth({
-      keycloakUrl: environment.keycloak.url,
-      realm: environment.keycloak.realm,
-      clientId: environment.keycloak.clientId,
-      allowedUrls: [environment.apiUrl, environment.keycloak.url],
-    }),
-    // BASE_PATH dos clientes gerados (ADR-0013) — origin absoluta da
-    // uniplus-api. Versionamento por recurso (ADR-0028) é injetado pelo
-    // apiResultInterceptor via withVendorMime, não via prefixo de URL.
-    { provide: SELECAO_BASE_PATH, useValue: environment.apiUrl },
-    { provide: INGRESSO_BASE_PATH, useValue: environment.apiUrl },
+    // Runtime config (ADR-0021) — fetch /assets/runtime-config.json antes
+    // do bootstrap das rotas + provê AUTH_CONFIG, SELECAO_BASE_PATH e
+    // INGRESSO_BASE_PATH a partir do AppConfigService. DEVE vir antes de
+    // provideAuth() (que consome AUTH_CONFIG via factory).
+    provideRuntimeConfig(),
+    provideAuth(),
   ],
 };

--- a/docker/Dockerfile.ingresso
+++ b/docker/Dockerfile.ingresso
@@ -10,8 +10,11 @@ RUN npx nx build ingresso --configuration=production
 FROM nginxinc/nginx-unprivileged:1.27-alpine
 COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build --chown=nginx:nginx /app/dist/apps/ingresso/browser /usr/share/nginx/html
-# Runtime config placeholder (ADR-0020 + #84). Sobrescrito por ConfigMap K8s
-# em produção; presença do arquivo evita 404 + Cache-Control no-store.
+# Sobrescreve o runtime-config.json copiado do dist (que tem URLs DEV
+# de localhost) por placeholders inválidos. Garante que produção sem
+# ConfigMap montado FALHA RÁPIDO no fetch de auth/API em vez de
+# silenciosamente tentar localhost. ConfigMap K8s em produção monta
+# sobre este path com URLs reais (ADR-0021 + ADR-0020).
 COPY --chown=nginx:nginx docker/runtime-config.json /usr/share/nginx/html/assets/runtime-config.json
 EXPOSE 8080
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker/Dockerfile.portal
+++ b/docker/Dockerfile.portal
@@ -10,8 +10,11 @@ RUN npx nx build portal --configuration=production
 FROM nginxinc/nginx-unprivileged:1.27-alpine
 COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build --chown=nginx:nginx /app/dist/apps/portal/browser /usr/share/nginx/html
-# Runtime config placeholder (ADR-0020 + #84). Sobrescrito por ConfigMap K8s
-# em produção; presença do arquivo evita 404 + Cache-Control no-store.
+# Sobrescreve o runtime-config.json copiado do dist (que tem URLs DEV
+# de localhost) por placeholders inválidos. Garante que produção sem
+# ConfigMap montado FALHA RÁPIDO no fetch de auth/API em vez de
+# silenciosamente tentar localhost. ConfigMap K8s em produção monta
+# sobre este path com URLs reais (ADR-0021 + ADR-0020).
 COPY --chown=nginx:nginx docker/runtime-config.json /usr/share/nginx/html/assets/runtime-config.json
 EXPOSE 8080
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker/Dockerfile.selecao
+++ b/docker/Dockerfile.selecao
@@ -10,8 +10,11 @@ RUN npx nx build selecao --configuration=production
 FROM nginxinc/nginx-unprivileged:1.27-alpine
 COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build --chown=nginx:nginx /app/dist/apps/selecao/browser /usr/share/nginx/html
-# Runtime config placeholder (ADR-0020 + #84). Sobrescrito por ConfigMap K8s
-# em produção; presença do arquivo evita 404 + Cache-Control no-store.
+# Sobrescreve o runtime-config.json copiado do dist (que tem URLs DEV
+# de localhost) por placeholders inválidos. Garante que produção sem
+# ConfigMap montado FALHA RÁPIDO no fetch de auth/API em vez de
+# silenciosamente tentar localhost. ConfigMap K8s em produção monta
+# sobre este path com URLs reais (ADR-0021 + ADR-0020).
 COPY --chown=nginx:nginx docker/runtime-config.json /usr/share/nginx/html/assets/runtime-config.json
 EXPOSE 8080
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker/runtime-config.json
+++ b/docker/runtime-config.json
@@ -1,1 +1,8 @@
-{}
+{
+  "apiUrl": "https://configmap-nao-montado.invalid",
+  "keycloak": {
+    "url": "https://configmap-nao-montado.invalid",
+    "realm": "PLACEHOLDER_REALM",
+    "clientId": "PLACEHOLDER_CLIENT_ID"
+  }
+}

--- a/docs/adrs/0021-runtime-config-via-token.md
+++ b/docs/adrs/0021-runtime-config-via-token.md
@@ -1,0 +1,212 @@
+---
+status: "accepted"
+date: "2026-05-09"
+decision-makers:
+  - "Tech Lead"
+consulted:
+  - "DevOps"
+informed:
+  - "Equipe `uniplus-web`"
+---
+
+# ADR-0021: Runtime config via `AUTH_CONFIG` InjectionToken + fitness cross-app
+
+## Contexto e enunciado do problema
+
+A Story [#84](https://github.com/unifesspa-edu-br/uniplus-web/issues/84) exige que as 3 apps (`selecao`, `ingresso`, `portal`) carreguem URL da API e parâmetros do Keycloak em runtime, lidos de `/assets/runtime-config.json`, para que a **mesma imagem** Docker (publicada via [ADR-0020](0020-registry-ghcr-e-tagging.md)) seja promovida entre ambientes apenas trocando o `ConfigMap` montado pelo Kubernetes — sem rebuild, sem `fileReplacements` por ambiente, sem URL embutida no bundle.
+
+A estratégia legada usa `environment.prod.ts` com placeholders (`PLACEHOLDER_API_URL`, `PLACEHOLDER_KEYCLOAK_URL`) substituídos por `fileReplacements` no `project.json`. Isso quebra o invariante "imagem única por app" — a imagem hoje publicada pela ADR-0020 já contém os placeholders compilados, e mountar `ConfigMap` sobre `/assets/runtime-config.json` não muda o bundle Angular que lê `environment.*` em build time.
+
+A pergunta operacional, que conduziu o debate desta ADR, foi: **como o `provideAuth()` da `shared-auth` deve consumir a `AppConfig` resolvida em runtime?** Há três opções concretas, com trade-offs distintos sobre acoplamento `shared-auth ↔ shared-data`, boilerplate por app, e proteção contra esquecimento silencioso.
+
+## Drivers da decisão
+
+- **Imagem única por app** (invariante da ADR-0020) — URL real só em `runtime-config.json`, montado por `ConfigMap`.
+- **Idiomático Angular 21** — `InjectionToken` é o pattern oficial do framework para configuração injetável (vide `@angular/router`, `@angular/forms`).
+- **Testabilidade** — config trivialmente mockável via `{ provide: TOKEN, useValue: stub }` no `TestBed`.
+- **Desacoplamento** — `shared-auth` **não** deve conhecer `AppConfigService`; apenas o token cruza a fronteira.
+- **Proteção cross-app contra esquecimento** — o pattern deve ser obrigatório por contrato testável, não por convenção que dev pode esquecer.
+- **Boilerplate zero por app** — `app.config.ts` das 3 apps deve ficar mínimo; replicação para 4º app trivial.
+
+## Opções consideradas
+
+- **A — `provideAuth()` lê `AppConfigService` internamente.** Boilerplate zero. **Acoplamento `shared-auth → shared-data`** — viola separação de concerns e contraria a topologia futura discutida na ideia `frontend-libs-architecture` (`type:auth → type:core, type:util`, sem `type:data`).
+- **B — `provideAuth(() => AuthConfig)` factory.** Boilerplate moderado, desacopla. Sem proteção arquitetural contra factory mal-construída — erro só aparece em runtime DI.
+- **C — `AUTH_CONFIG` InjectionToken** + `provideRuntimeConfig()` provê o token via factory derivando de `AppConfigService`. **Boilerplate zero por app** + idiomático + desacoplado.
+- **C + fitness cross-app** (escolhida) — adiciona spec Vitest que valida estaticamente cada `app.config.ts`: import de `provideRuntimeConfig`, import de `provideAuth`, ordem `provideRuntimeConfig()` antes de `provideAuth()`, ausência de `import from '../environments/environment'`. Falha no CI se um app esquece o pattern.
+
+## Resultado da decisão
+
+**Escolhida: "C + fitness cross-app"**, porque é a única opção que combina:
+
+1. **Pattern Angular canônico** — `InjectionToken<AuthConfig>` resolvido por factory que depende de `AppConfigService`. Zero magia oculta; cada peça aparece como provider explícito no DI tree.
+2. **Boilerplate zero por app** — apps fazem apenas `provideRuntimeConfig() + provideAuth()`. O token e os `BASE_PATH` são providos pela própria `provideRuntimeConfig`, eliminando a duplicação que tornava C verboso na configuração tradicional.
+3. **Fitness garante invariantes cross-app** — esquecer `provideRuntimeConfig` em uma app, ou inverter ordem com `provideAuth`, ou re-introduzir `import '../environments/environment'` falham no CI antes do merge. Pattern obrigatório por contrato testável.
+4. **Desacoplamento `shared-auth ↔ shared-data`** — `shared-auth` exporta apenas o token; `shared-data` (orquestrador de runtime) importa o token e provê via factory. Quando a topologia estrutural da ideia Compozy `frontend-libs-architecture` (Onda 1) chegar e demote `shared-data` para `@nx/js:tsc`, o token continua válido — só a factory muda.
+
+### Forma da implementação
+
+**`shared-auth/lib/tokens/auth.tokens.ts`:**
+
+```ts
+export const AUTH_CONFIG = new InjectionToken<AuthConfig>('AUTH_CONFIG');
+```
+
+Sem `providedIn: 'root'` por design — apps que esquecem `provideRuntimeConfig()` falham com erro DI claro (e fitness pega no CI antes do merge).
+
+**`shared-auth/lib/providers/auth.provider.ts`:**
+
+```ts
+export function provideAuth(): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    {
+      provide: AUTH_ALLOWED_URLS,
+      useFactory: (config: AuthConfig) => Object.freeze([...config.allowedUrls]),
+      deps: [AUTH_CONFIG],
+    },
+    {
+      provide: APP_INITIALIZER,
+      useFactory: (auth: AuthService, config: AuthConfig) => () => auth.init(config),
+      deps: [AuthService, AUTH_CONFIG],
+      multi: true,
+    },
+  ]);
+}
+```
+
+**`shared-data/lib/config/runtime-config.provider.ts`:**
+
+```ts
+export function provideRuntimeConfig(): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    {
+      provide: APP_INITIALIZER,
+      useFactory: (http: HttpClient, store: AppConfigService) => async () => {
+        const cfg = await firstValueFrom(http.get<AppConfig>('/assets/runtime-config.json'));
+        store.load(cfg);
+      },
+      deps: [HttpClient, AppConfigService],
+      multi: true,
+    },
+    {
+      provide: AUTH_CONFIG,
+      useFactory: (store: AppConfigService): AuthConfig => {
+        const cfg = store.get();
+        return {
+          keycloakUrl: cfg.keycloak.url,
+          realm: cfg.keycloak.realm,
+          clientId: cfg.keycloak.clientId,
+          allowedUrls: Object.freeze([cfg.apiUrl, cfg.keycloak.url]),
+        };
+      },
+      deps: [AppConfigService],
+    },
+    {
+      provide: SELECAO_BASE_PATH,
+      useFactory: (store: AppConfigService) => store.get().apiUrl,
+      deps: [AppConfigService],
+    },
+    {
+      provide: INGRESSO_BASE_PATH,
+      useFactory: (store: AppConfigService) => store.get().apiUrl,
+      deps: [AppConfigService],
+    },
+  ]);
+}
+```
+
+**`apps/<app>/src/app/app.config.ts`:**
+
+```ts
+provideRuntimeConfig(),
+provideAuth(),
+```
+
+Apenas. Sem importar `environment`.
+
+**Fitness em `libs/shared-data/src/lib/__fitness__/runtime-config-providers.fitness.spec.ts`:**
+
+Para cada app em `['selecao', 'ingresso', 'portal']`, valida via parsing de string:
+
+1. `app.config.ts` importa `provideRuntimeConfig` de `@uniplus/shared-data`.
+2. `app.config.ts` importa `provideAuth` de `@uniplus/shared-auth`.
+3. `provideRuntimeConfig()` aparece **antes** de `provideAuth()` no source (após strip de comentários).
+4. `app.config.ts` **não** importa de `'../environments/environment'`.
+
+Adicionar 4º app: append em `APPS` array — fitness adiciona automaticamente.
+
+### Esta ADR não decide
+
+- **Remoção de `environment.prod.ts` e `fileReplacements`** (CA-06 da Story #84) — fica para PR posterior, após validação em staging do runtime config funcionando ponta-a-ponta. `environment.ts` continua como fallback dev local; `app.config.ts` simplesmente não importa mais.
+- **ConfigMaps K8s em `infra/k8s/`** (CA-07) — diretório novo, escopo infra separado.
+- **Topologia estrutural completa da ideia Compozy `frontend-libs-architecture`** (demote `shared-data` → tsc, tag taxonomy 3-dim, ESLint blocking) — frente posterior. Esta ADR é compatível com qualquer das duas direções.
+
+## Consequências
+
+### Positivas
+
+- 1 imagem Docker por app, promovida entre ambientes via `ConfigMap` (cumpre ADR-0020).
+- `app.config.ts` das 3 apps com 2 linhas relevantes — `provideRuntimeConfig() + provideAuth()`.
+- Fitness garante o pattern obrigatório no CI; esquecimento vira erro antes do merge.
+- `shared-auth` desacoplada de `shared-data` (apenas o token cruza fronteira).
+- `AppConfigService.get()` lança claramente se chamado antes do load — bug de bootstrap order visível em vez de silencioso.
+- Testes unitários trivialmente mockam `{ provide: AUTH_CONFIG, useValue: stub }`.
+
+### Negativas
+
+- `shared-data` adquire `peerDependency` `@org/shared-auth` (cross-import ng-packagr, exige `paths` override em `tsconfig.lib.prod.json` apontando para `dist/libs/shared-auth` — recipe da [ADR-0020](0020-registry-ghcr-e-tagging.md) aplicada cross-lib desde PR #224).
+- Para apps que NÃO usam Keycloak (hipotético), `AUTH_CONFIG` continua sendo provido — desperdício mínimo.
+
+### Neutras
+
+- `environment.ts` de dev permanece como fallback local; `nx serve` continua funcionando sem ConfigMap (lê o `runtime-config.json` placeholder copiado para `dist/apps/<app>/browser/assets/`).
+
+## Confirmação
+
+- `npx nx run-many --target=build --projects=selecao,ingresso,portal` verde.
+- `npx nx run-many --target=lint,typecheck,vite:test --projects=shared-utils,shared-core,shared-auth,shared-data,shared-ui,selecao,ingresso,portal` verde.
+- Fitness spec `runtime-config-providers.fitness.spec.ts` verde para cada app (4 invariantes × 3 apps = 12 specs).
+- `apps/<app>/public/assets/runtime-config.json` placeholder existe em cada app.
+
+### Trigger de reavaliação
+
+- Se um 4º app entrar (ex.: `developers` portal pós-Story uniplus-developers), append em `APPS` do fitness — pattern aplica automaticamente.
+- Se a topologia Compozy `frontend-libs-architecture` (Onda 1) demove `shared-data` para `@nx/js:tsc`, este ADR continua válido — apenas a localização dos providers pode migrar para uma `shared-config` lib dedicada.
+
+## Prós e contras das opções
+
+### A — `provideAuth()` lê `AppConfigService` internamente
+
+- **Bom** porque boilerplate zero.
+- **Ruim** porque acopla `shared-auth → shared-data` — viola a futura taxonomia `type:auth → type:core, type:util` (sem `type:data`).
+- **Ruim** porque oculta o ponto de leitura — debug de "qual config?" exige pular para `AuthService` em vez de ler o `app.config.ts`.
+
+### B — `provideAuth(() => AuthConfig)` factory
+
+- **Bom** porque desacopla `shared-auth ↔ shared-data`.
+- **Bom** porque o ponto de leitura fica explícito no `app.config.ts`.
+- **Ruim** porque boilerplate de 5-7 linhas por app.
+- **Ruim** porque proteção contra factory mal-construída é apenas runtime DI (sem fitness).
+
+### C — `AUTH_CONFIG` InjectionToken (escolhida)
+
+- **Bom** porque idiomático Angular puro.
+- **Bom** porque desacoplado.
+- **Bom** porque zero boilerplate por app (token provido pela própria `provideRuntimeConfig`).
+- **Bom** porque fitness garante invariantes cross-app — esquecimento vira erro CI.
+- **Ruim** porque adiciona um cross-import `shared-data → shared-auth` (mitigado por `paths` override no `tsconfig.lib.prod.json`, pattern já estabelecido pela ADR-0020).
+
+### Status quo (`environment.prod.ts` + `fileReplacements`)
+
+- **Bom** porque já implementado.
+- **Ruim** porque viola "imagem única por app" da ADR-0020 — bundle compila com placeholders, ConfigMap não muda nada em runtime.
+- **Ruim** porque exige rebuild por ambiente.
+
+## Mais informações
+
+- Story [`uniplus-web#84`](https://github.com/unifesspa-edu-br/uniplus-web/issues/84) — runtime config via `provideAppInitializer` + ConfigMap.
+- [ADR-0020](0020-registry-ghcr-e-tagging.md) — invariante "imagem única por app".
+- [Angular `provideAppInitializer` API](https://angular.dev/api/core/provideAppInitializer).
+- [Angular `InjectionToken` docs](https://angular.dev/api/core/InjectionToken).
+- Issue uniplus-web#4 — hardening de containers (pré-requisito da #84 entregue na PR de imagens).
+- Fitness pattern: `apps/selecao/src/app/features/__fitness__/no-direct-http-in-pages.fitness.spec.ts` (referência de implementação).

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -47,8 +47,9 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0016](0016-vendor-mime-consumer-via-http-context.md) | Vendor MIME consumer via `HttpContext` — `withVendorMime` declara o recurso e o `apiResultInterceptor` anexa `Accept` | accepted | 2026-05-06 |
 | [0017](0017-pattern-feature-page-container-presentational.md) | Páginas de feature no padrão container/presentational — `XxxPage` smart + `ui-*` dumb | accepted | 2026-05-06 |
 | [0018](0018-adocao-httpresource-via-wrapper-use-api-resource.md) | Adoção de `httpResource` Angular 21 via wrapper `useApiResource` em `shared-core` | accepted | 2026-05-07 |
-| [0019](0019-tokens-govbr-compartilhados-em-shared-ui.md) | Tokens Gov.br compartilhados em `libs/shared-ui/src/styles/govbr-tokens.css` + migração Tailwind 3→4 cross-app | proposed | 2026-05-07 |
-| [0020](0020-registry-ghcr-e-tagging.md) | GitHub Container Registry e estratégia de tagging das imagens da `uniplus-web` | proposed | 2026-05-08 |
+| [0019](0019-tokens-govbr-compartilhados-em-shared-ui.md) | Tokens Gov.br compartilhados em `libs/shared-ui/src/styles/govbr-tokens.css` + migração Tailwind 3→4 cross-app | accepted | 2026-05-07 |
+| [0020](0020-registry-ghcr-e-tagging.md) | GitHub Container Registry e estratégia de tagging das imagens da `uniplus-web` | accepted | 2026-05-08 |
+| [0021](0021-runtime-config-via-token.md) | Runtime config via `AUTH_CONFIG` InjectionToken + fitness cross-app | accepted | 2026-05-09 |
 
 ## Como adicionar um novo ADR
 

--- a/libs/shared-auth/package.json
+++ b/libs/shared-auth/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@org/shared-auth",
+  "name": "@uniplus/shared-auth",
   "version": "0.0.1",
   "peerDependencies": {
     "@angular/common": "^21.2.0",

--- a/libs/shared-auth/src/lib/index.ts
+++ b/libs/shared-auth/src/lib/index.ts
@@ -19,7 +19,7 @@ export type { AuthConfig } from './models/auth-config.model';
 export { provideAuth } from './providers/auth.provider';
 
 // Tokens
-export { AUTH_ALLOWED_URLS } from './tokens/auth.tokens';
+export { AUTH_ALLOWED_URLS, AUTH_CONFIG } from './tokens/auth.tokens';
 
 // Components
 export { AuthErrorBannerComponent } from './components/auth-error-banner.component';

--- a/libs/shared-auth/src/lib/providers/auth.provider.ts
+++ b/libs/shared-auth/src/lib/providers/auth.provider.ts
@@ -1,19 +1,27 @@
-import { APP_INITIALIZER, EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
-import { AuthService } from '../services/auth.service';
+import { EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
 import { AuthConfig } from '../models/auth-config.model';
-import { AUTH_ALLOWED_URLS } from '../tokens/auth.tokens';
+import { AUTH_ALLOWED_URLS, AUTH_CONFIG } from '../tokens/auth.tokens';
 
-export function provideAuth(config: AuthConfig): EnvironmentProviders {
+/**
+ * Configura os providers que dependem de `AUTH_CONFIG` (ADR-0021):
+ *
+ * - `AUTH_ALLOWED_URLS` — derivado lazy de `AUTH_CONFIG`. Consumido
+ *   pelo `tokenInterceptor` no primeiro HTTP request, post-bootstrap,
+ *   quando o store já foi populado pelo `provideRuntimeConfig`.
+ *
+ * O `APP_INITIALIZER` que faz `AuthService.init()` vive em
+ * `provideRuntimeConfig()` (em `@uniplus/shared-data`) — Angular
+ * dispara initializers em paralelo, então auth.init precisa estar
+ * no MESMO initializer que faz `AppConfigService.load()` para
+ * garantir ordem sequencial. `provideAuth()` aqui só registra os
+ * providers que `tokenInterceptor` e outros consumers leem lazy.
+ */
+export function provideAuth(): EnvironmentProviders {
   return makeEnvironmentProviders([
     {
       provide: AUTH_ALLOWED_URLS,
-      useValue: Object.freeze([...config.allowedUrls]),
-    },
-    {
-      provide: APP_INITIALIZER,
-      useFactory: (authService: AuthService) => () => authService.init(config),
-      deps: [AuthService],
-      multi: true,
+      useFactory: (config: AuthConfig) => Object.freeze([...config.allowedUrls]),
+      deps: [AUTH_CONFIG],
     },
   ]);
 }

--- a/libs/shared-auth/src/lib/tokens/auth.tokens.ts
+++ b/libs/shared-auth/src/lib/tokens/auth.tokens.ts
@@ -1,4 +1,21 @@
 import { InjectionToken } from '@angular/core';
+import type { AuthConfig } from '../models/auth-config.model';
+
+/**
+ * Configuração de autenticação resolvida em runtime (ADR-0021). Provida
+ * via factory de `provideRuntimeConfig()` (em `@uniplus/shared-data`)
+ * que lê `/assets/runtime-config.json` antes do bootstrap das rotas.
+ *
+ * O consumer (`provideAuth`) lê este token sem args — desacopla
+ * `shared-auth` de `shared-data` (apenas o token cruza a fronteira;
+ * a fonte da config é responsabilidade do orquestrador).
+ *
+ * Não tem `providedIn: 'root'` por design — apps que não fizerem
+ * `provideRuntimeConfig()` antes de `provideAuth()` falham com erro
+ * claro de DI ao subir, e o fitness `runtime-config.fitness.spec.ts`
+ * captura essa omissão no CI.
+ */
+export const AUTH_CONFIG = new InjectionToken<AuthConfig>('AUTH_CONFIG');
 
 /**
  * Lista de URLs (prefixos de origem) para as quais o `tokenInterceptor`
@@ -8,7 +25,7 @@ import { InjectionToken } from '@angular/core';
  * configurados NÃO recebe o Bearer, evitando vazamento de credenciais
  * para domínios externos (finding B2 do review da PR #3).
  *
- * Configurado pelo provider `provideAuth` a partir de `AuthConfig.allowedUrls`.
+ * Derivado pelo `provideAuth` a partir de `AUTH_CONFIG.allowedUrls`.
  */
 export const AUTH_ALLOWED_URLS = new InjectionToken<readonly string[]>('AUTH_ALLOWED_URLS', {
   providedIn: 'root',

--- a/libs/shared-data/package.json
+++ b/libs/shared-data/package.json
@@ -5,6 +5,7 @@
     "@angular/common": "^21.2.0",
     "@angular/core": "^21.2.0",
     "@angular/forms": "^21.2.0",
+    "@uniplus/shared-auth": "*",
     "@uniplus/shared-core": "*",
     "rxjs": "~7.8.0",
     "vite": "^7.0.0",

--- a/libs/shared-data/src/lib/__fitness__/runtime-config-providers.fitness.spec.ts
+++ b/libs/shared-data/src/lib/__fitness__/runtime-config-providers.fitness.spec.ts
@@ -1,0 +1,85 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Fitness cross-app do runtime config (ADR-0021):
+ *
+ * Para cada app de produção (selecao, ingresso, portal), garante que:
+ *
+ * 1. `app.config.ts` importa `provideRuntimeConfig` de `@uniplus/shared-data`.
+ * 2. `app.config.ts` importa `provideAuth` de `@uniplus/shared-auth`.
+ * 3. `provideRuntimeConfig()` aparece **antes** de `provideAuth()` no
+ *    array `providers` — ordem é binding (Angular respeita ordem dos
+ *    `APP_INITIALIZER` conforme aparecem no array; runtime-config DEVE
+ *    popular `AUTH_CONFIG` antes do appInitializer de auth ser chamado).
+ * 4. `app.config.ts` NÃO importa de `'../environments/environment'`
+ *    (substituído por `AppConfigService` em runtime).
+ *
+ * Estratégia: parsing de string + regex. Falha aqui = bootstrap em
+ * produção pode subir com placeholder URLs ou ordem incorreta de
+ * appInitializer.
+ *
+ * Adicionar 4º app: append em `APPS` — fitness adiciona automaticamente.
+ */
+
+const APPS = ['selecao', 'ingresso', 'portal'] as const;
+
+const WORKSPACE_ROOT = path.resolve(__dirname, '../../../../..');
+
+function lerAppConfig(app: string): { conteudo: string; conteudoSemComentarios: string; relativo: string } {
+  const filePath = path.join(WORKSPACE_ROOT, 'apps', app, 'src/app/app.config.ts');
+  const conteudo = fs.readFileSync(filePath, 'utf-8');
+  // Strip comentários antes do indexOf de chamadas — caso contrário, menções
+  // a `provideAuth()` em JSDoc/inline produzem falsos positivos na verificação
+  // de ordem. Cobre `// linha`, `/* bloco */` e `/** JSDoc */`.
+  const conteudoSemComentarios = conteudo
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+  return {
+    conteudo,
+    conteudoSemComentarios,
+    relativo: path.relative(WORKSPACE_ROOT, filePath),
+  };
+}
+
+describe('Fitness — apps app.config.ts (runtime config + auth, ADR-0021)', () => {
+  describe.each(APPS)('app: %s', (app) => {
+    const { conteudo, conteudoSemComentarios, relativo } = lerAppConfig(app);
+
+    it('importa provideRuntimeConfig de @uniplus/shared-data', () => {
+      const importou = /import\s+\{[^}]*\bprovideRuntimeConfig\b[^}]*\}\s+from\s+['"]@uniplus\/shared-data['"]/.test(conteudo);
+      expect(
+        importou,
+        `\nArquivo: ${relativo}\nFalta importar provideRuntimeConfig — runtime-config.json não será carregado e AUTH_CONFIG/BASE_PATHs não terão factory.`,
+      ).toBe(true);
+    });
+
+    it('importa provideAuth de @uniplus/shared-auth', () => {
+      const importou = /import\s+\{[^}]*\bprovideAuth\b[^}]*\}\s+from\s+['"]@uniplus\/shared-auth['"]/.test(conteudo);
+      expect(
+        importou,
+        `\nArquivo: ${relativo}\nFalta importar provideAuth — Keycloak não será inicializado.`,
+      ).toBe(true);
+    });
+
+    it('chama provideRuntimeConfig() ANTES de provideAuth() no array providers', () => {
+      const indiceRuntime = conteudoSemComentarios.indexOf('provideRuntimeConfig(');
+      const indiceAuth = conteudoSemComentarios.indexOf('provideAuth(');
+      expect(indiceRuntime, `\nArquivo: ${relativo}\nprovideRuntimeConfig() não chamado.`).toBeGreaterThan(-1);
+      expect(indiceAuth, `\nArquivo: ${relativo}\nprovideAuth() não chamado.`).toBeGreaterThan(-1);
+      expect(
+        indiceRuntime,
+        `\nArquivo: ${relativo}\nOrdem incorreta: provideRuntimeConfig() DEVE aparecer antes de provideAuth() — caso contrário, AUTH_CONFIG não está populado quando AuthService.init é chamado.`,
+      ).toBeLessThan(indiceAuth);
+    });
+
+    it('NÃO importa de ../environments/environment (use AppConfigService)', () => {
+      const importouEnv = /from\s+['"]\.\.\/environments\/environment['"]/.test(conteudo);
+      expect(
+        importouEnv,
+        `\nArquivo: ${relativo}\nimport de environments/environment é vedado em app.config.ts pós-ADR-0021. Consuma AppConfigService via factory de provideRuntimeConfig() (que provê AUTH_CONFIG, SELECAO_BASE_PATH, INGRESSO_BASE_PATH).`,
+      ).toBe(false);
+    });
+  });
+});

--- a/libs/shared-data/src/lib/__fitness__/runtime-config-providers.fitness.spec.ts
+++ b/libs/shared-data/src/lib/__fitness__/runtime-config-providers.fitness.spec.ts
@@ -64,13 +64,23 @@ describe('Fitness — apps app.config.ts (runtime config + auth, ADR-0021)', () 
     });
 
     it('chama provideRuntimeConfig() ANTES de provideAuth() no array providers', () => {
-      const indiceRuntime = conteudoSemComentarios.indexOf('provideRuntimeConfig(');
-      const indiceAuth = conteudoSemComentarios.indexOf('provideAuth(');
-      expect(indiceRuntime, `\nArquivo: ${relativo}\nprovideRuntimeConfig() não chamado.`).toBeGreaterThan(-1);
-      expect(indiceAuth, `\nArquivo: ${relativo}\nprovideAuth() não chamado.`).toBeGreaterThan(-1);
+      // Escopa o indexOf ao bloco `providers: [...]` para evitar falso
+      // positivo se o `import { provideAuth } from ...` aparecer antes do
+      // `import { provideRuntimeConfig } from ...` no source — a ordem que
+      // importa é a do array providers, não a dos imports.
+      const inicioProviders = conteudoSemComentarios.indexOf('providers:');
+      expect(
+        inicioProviders,
+        `\nArquivo: ${relativo}\nBloco 'providers:' não encontrado em ApplicationConfig.`,
+      ).toBeGreaterThan(-1);
+      const blocoProviders = conteudoSemComentarios.slice(inicioProviders);
+      const indiceRuntime = blocoProviders.indexOf('provideRuntimeConfig(');
+      const indiceAuth = blocoProviders.indexOf('provideAuth(');
+      expect(indiceRuntime, `\nArquivo: ${relativo}\nprovideRuntimeConfig() não chamado no array providers.`).toBeGreaterThan(-1);
+      expect(indiceAuth, `\nArquivo: ${relativo}\nprovideAuth() não chamado no array providers.`).toBeGreaterThan(-1);
       expect(
         indiceRuntime,
-        `\nArquivo: ${relativo}\nOrdem incorreta: provideRuntimeConfig() DEVE aparecer antes de provideAuth() — caso contrário, AUTH_CONFIG não está populado quando AuthService.init é chamado.`,
+        `\nArquivo: ${relativo}\nOrdem incorreta no array providers: provideRuntimeConfig() DEVE aparecer antes de provideAuth() — caso contrário, AUTH_CONFIG não está populado quando AuthService.init é chamado.`,
       ).toBeLessThan(indiceAuth);
     });
 

--- a/libs/shared-data/src/lib/config/app-config.model.ts
+++ b/libs/shared-data/src/lib/config/app-config.model.ts
@@ -1,0 +1,16 @@
+/**
+ * Configuração resolvida em runtime via `/assets/runtime-config.json`
+ * (ADR-0021). A mesma imagem Docker é promovida entre ambientes; só o
+ * ConfigMap montado pelo Kubernetes muda o conteúdo deste arquivo.
+ *
+ * Não embute URL de Keycloak/API no bundle (ADR-0020 do publish: imagem
+ * única por app).
+ */
+export interface AppConfig {
+  readonly apiUrl: string;
+  readonly keycloak: {
+    readonly url: string;
+    readonly realm: string;
+    readonly clientId: string;
+  };
+}

--- a/libs/shared-data/src/lib/config/app-config.service.spec.ts
+++ b/libs/shared-data/src/lib/config/app-config.service.spec.ts
@@ -1,0 +1,45 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, expect, it, beforeEach } from 'vitest';
+import { AppConfigService } from './app-config.service';
+import type { AppConfig } from './app-config.model';
+
+const sampleConfig: AppConfig = {
+  apiUrl: 'http://localhost:5000',
+  keycloak: {
+    url: 'http://localhost:8080',
+    realm: 'unifesspa',
+    clientId: 'selecao-web',
+  },
+};
+
+describe('AppConfigService', () => {
+  let service: AppConfigService;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AppConfigService);
+  });
+
+  it('lança ao chamar get() antes de load() — força bootstrap order visível', () => {
+    expect(() => service.get()).toThrow(/runtime-config carregar/);
+  });
+
+  it('expõe a config após load()', () => {
+    service.load(sampleConfig);
+    expect(service.get()).toEqual(sampleConfig);
+  });
+
+  it('signal `config()` é null antes do load e populado após', () => {
+    expect(service.config()).toBeNull();
+    service.load(sampleConfig);
+    expect(service.config()).toEqual(sampleConfig);
+  });
+
+  it('load() sobrescreve a config anterior (idempotente para mesmo valor)', () => {
+    service.load(sampleConfig);
+    const novo: AppConfig = { ...sampleConfig, apiUrl: 'http://api.hml.example.com' };
+    service.load(novo);
+    expect(service.get().apiUrl).toBe('http://api.hml.example.com');
+  });
+});

--- a/libs/shared-data/src/lib/config/app-config.service.ts
+++ b/libs/shared-data/src/lib/config/app-config.service.ts
@@ -1,0 +1,37 @@
+import { Injectable, signal } from '@angular/core';
+import type { AppConfig } from './app-config.model';
+
+/**
+ * Hospeda a `AppConfig` resolvida em runtime (ADR-0021). Populada uma
+ * única vez pelo `provideAppInitializer` registrado em
+ * `provideRuntimeConfig()` antes do bootstrap das rotas.
+ *
+ * `get()` lança se chamada antes do load — comportamento intencional
+ * para tornar a ordem de bootstrap visível ao desenvolvedor (vs. retornar
+ * `null` e exigir `?.` em todos os call sites).
+ *
+ * Em testes, prover via `{ provide: AppConfigService, useValue: stub }`
+ * ou popular diretamente com `service.load(config)` no `beforeEach`.
+ */
+@Injectable({ providedIn: 'root' })
+export class AppConfigService {
+  private readonly _config = signal<AppConfig | null>(null);
+
+  readonly config = this._config.asReadonly();
+
+  load(cfg: AppConfig): void {
+    this._config.set(cfg);
+  }
+
+  get(): AppConfig {
+    const cfg = this._config();
+    if (!cfg) {
+      throw new Error(
+        'AppConfigService.get() chamado antes do runtime-config carregar. ' +
+          'Verifique que provideRuntimeConfig() está em app.config.ts antes ' +
+          'de qualquer consumidor (provideAuth, BASE_PATHs, etc.).',
+      );
+    }
+    return cfg;
+  }
+}

--- a/libs/shared-data/src/lib/config/index.ts
+++ b/libs/shared-data/src/lib/config/index.ts
@@ -1,0 +1,3 @@
+export type { AppConfig } from './app-config.model';
+export { AppConfigService } from './app-config.service';
+export { provideRuntimeConfig, RUNTIME_CONFIG_PATH } from './runtime-config.provider';

--- a/libs/shared-data/src/lib/config/runtime-config.provider.ts
+++ b/libs/shared-data/src/lib/config/runtime-config.provider.ts
@@ -1,0 +1,113 @@
+import { APP_INITIALIZER, EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
+import { HttpBackend, HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import { AUTH_CONFIG, AuthService } from '@uniplus/shared-auth';
+import type { AuthConfig } from '@uniplus/shared-auth';
+import { SELECAO_BASE_PATH } from '../api/selecao/tokens';
+import { INGRESSO_BASE_PATH } from '../api/ingresso/tokens';
+import { AppConfigService } from './app-config.service';
+import type { AppConfig } from './app-config.model';
+
+/**
+ * Path canônico do runtime-config (ADR-0021). nginx serve este arquivo
+ * (presente como placeholder na imagem; sobrescrito por ConfigMap K8s
+ * em produção) com `Cache-Control: no-store`.
+ */
+export const RUNTIME_CONFIG_PATH = '/assets/runtime-config.json';
+
+/**
+ * Bootstrap completo de runtime-config + autenticação num **único**
+ * `APP_INITIALIZER` (ADR-0021). Consolidar é necessário porque o
+ * Angular dispara initializers em paralelo (não em série), então um
+ * `AUTH_CONFIG` factory injetado por outro initializer pode resolver
+ * antes do store estar populado. Encadeamos sequencialmente aqui:
+ *
+ *   1. `HttpBackend.handle()` — bypass intencional dos interceptors
+ *      `tokenInterceptor`, `apiResultInterceptor`, `authErrorInterceptor`.
+ *      Sem isso, o fetch do `runtime-config.json` tentaria resolver
+ *      `AUTH_ALLOWED_URLS` (que depende de `AUTH_CONFIG` não-loaded) e
+ *      a resposta JSON viria envelopada em `ApiResult<T>` em vez do
+ *      `AppConfig` literal.
+ *   2. `AppConfigService.load(cfg)` — populando o singleton.
+ *   3. `AuthService.init(authConfig)` — Keycloak inicializado com URLs
+ *      reais já carregadas.
+ *
+ * `AUTH_CONFIG`, `SELECAO_BASE_PATH` e `INGRESSO_BASE_PATH` continuam
+ * provedidos como factories síncronas que leem do store. São injetados
+ * lazy (ex.: `tokenInterceptor` lê `AUTH_ALLOWED_URLS` no primeiro HTTP
+ * request, que ocorre post-bootstrap, quando store já está populado).
+ *
+ * Erros de fetch (404, JSON malformado, network) são re-lançados — o
+ * Angular aborta o bootstrap e exibe console error claro, em vez de
+ * subir a app em estado inconsistente (CA-02 da Story #84).
+ */
+export function provideRuntimeConfig(): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    {
+      provide: APP_INITIALIZER,
+      useFactory:
+        (backend: HttpBackend, store: AppConfigService, auth: AuthService) => async () => {
+          // HttpClient construído com HttpBackend direto não passa por
+          // nenhum interceptor — necessário porque o pipeline padrão
+          // depende de tokens que ainda não estão prontos neste momento.
+          const http = new HttpClient(backend);
+          const cfg = await firstValueFrom(http.get<AppConfig>(RUNTIME_CONFIG_PATH));
+          assertNaoEhPlaceholder(cfg);
+          store.load(cfg);
+          await auth.init(toAuthConfig(cfg));
+        },
+      deps: [HttpBackend, AppConfigService, AuthService],
+      multi: true,
+    },
+    {
+      provide: AUTH_CONFIG,
+      useFactory: (store: AppConfigService): AuthConfig => toAuthConfig(store.get()),
+      deps: [AppConfigService],
+    },
+    {
+      provide: SELECAO_BASE_PATH,
+      useFactory: (store: AppConfigService) => store.get().apiUrl,
+      deps: [AppConfigService],
+    },
+    {
+      provide: INGRESSO_BASE_PATH,
+      useFactory: (store: AppConfigService) => store.get().apiUrl,
+      deps: [AppConfigService],
+    },
+  ]);
+}
+
+function toAuthConfig(cfg: AppConfig): AuthConfig {
+  return {
+    keycloakUrl: cfg.keycloak.url,
+    realm: cfg.keycloak.realm,
+    clientId: cfg.keycloak.clientId,
+    allowedUrls: Object.freeze([cfg.apiUrl, cfg.keycloak.url]),
+  };
+}
+
+/**
+ * Sentinelas embutidos no `docker/runtime-config.json` (que sobrescreve o
+ * placeholder dev no build da imagem). Em produção sem ConfigMap K8s
+ * montado corretamente, o app receberia esses valores e — porque
+ * `AuthService.init()` captura erros de Keycloak — subiria silenciosamente
+ * em modo "não autenticado" tentando alcançar URLs `.invalid`.
+ *
+ * Ao detectar qualquer marcador, abortamos o bootstrap antes de
+ * `store.load()` e `auth.init()` — falha visível no console + tela em
+ * branco em vez de runtime quebrado em UX.
+ */
+const PLACEHOLDER_MARKERS = ['PLACEHOLDER_', 'configmap-nao-montado.invalid'] as const;
+
+function assertNaoEhPlaceholder(cfg: AppConfig): void {
+  const serializado = JSON.stringify(cfg);
+  for (const marca of PLACEHOLDER_MARKERS) {
+    if (serializado.includes(marca)) {
+      throw new Error(
+        `runtime-config.json contém placeholder '${marca}'. ConfigMap K8s ` +
+          `provavelmente não está montado em /assets/runtime-config.json (ADR-0021). ` +
+          `Bootstrap abortado para evitar app subir em estado inconsistente.`,
+      );
+    }
+  }
+}

--- a/libs/shared-data/src/lib/index.ts
+++ b/libs/shared-data/src/lib/index.ts
@@ -28,3 +28,7 @@ export { formatDateBr, formatDateTimeBr, parseDate } from './utils/date.util';
 
 // Validators
 export { cpfValidator } from './validators/cpf.validator';
+
+// Runtime config (ADR-0021)
+export type { AppConfig } from './config';
+export { AppConfigService, provideRuntimeConfig, RUNTIME_CONFIG_PATH } from './config';

--- a/libs/shared-data/tsconfig.lib.prod.json
+++ b/libs/shared-data/tsconfig.lib.prod.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "declarationMap": false,
     "paths": {
+      "@uniplus/shared-auth": ["dist/libs/shared-auth"],
       "@uniplus/shared-core": ["dist/libs/shared-core"]
     }
   },


### PR DESCRIPTION
## Resumo

Implementa **Story #84** — runtime config via `/assets/runtime-config.json` (`AUTH_CONFIG` InjectionToken — Opção C escolhida em ADR-0021), permitindo **1 imagem Docker por app** promovida entre ambientes apenas trocando o `ConfigMap` K8s. Cumpre o invariante imagem-única-por-app da [ADR-0020](docs/adrs/0020-registry-ghcr-e-tagging.md).

Refs #84

## Decisão arquitetural (ADR-0021)

Opção C + fitness cross-app escolhida após análise comparativa em 8 dimensões (idiomatic Angular, moderno, testável, eficiente, seguro, desacoplamento, replicável, doc-self-evident). Vence em 5/8 dimensões, empata em 3, perde em nenhuma. Detalhes em `docs/adrs/0021-runtime-config-via-token.md`.

## O que muda

**`shared-auth`** (define o token):
- `AUTH_CONFIG: InjectionToken<AuthConfig>` exportado.
- `provideAuth()` sem args — registra apenas `AUTH_ALLOWED_URLS` (factory lazy de `AUTH_CONFIG`).
- O `APP_INITIALIZER` de `auth.init()` foi **consolidado em `provideRuntimeConfig`** porque Angular dispara initializers em paralelo (descoberto via Codex round 1). Ordem sequencial só garantida dentro de UM mesmo `APP_INITIALIZER`.
- `name: '@uniplus/shared-auth'` (alinha com import emitted no JS).

**`shared-data`** (orquestra runtime + provê tokens via factories):
- Nova pasta `lib/config/`: `AppConfig` interface, `AppConfigService` (signal-based), `provideRuntimeConfig()`.
- `APP_INITIALIZER` consolidado: `HttpBackend` bypass interceptors → fetch `/assets/runtime-config.json` → `assertNaoEhPlaceholder` → `AppConfigService.load()` → `AuthService.init()`.
- `HttpBackend` (não `HttpClient`) é necessário porque `tokenInterceptor`/`apiResultInterceptor` dependem de `AUTH_CONFIG` ainda não-loaded e wrapariam o JSON em `ApiResult`.
- Provê `AUTH_CONFIG`, `SELECAO_BASE_PATH`, `INGRESSO_BASE_PATH` via factories síncronas que leem do store (injeção lazy, post-bootstrap).
- `assertNaoEhPlaceholder` valida sentinels (`PLACEHOLDER_*`, `configmap-nao-montado.invalid`) antes do load — bootstrap aborta com erro visível em produção sem ConfigMap montado.

**Fitness cross-app** (`libs/shared-data/src/lib/__fitness__/runtime-config-providers.fitness.spec.ts`):
- 4 invariantes × 3 apps = 12 specs.
- Para cada `app.config.ts`: import de `provideRuntimeConfig`, import de `provideAuth`, ordem `provideRuntimeConfig()` antes de `provideAuth()` (após strip de comentários), ausência de `import from '../environments/environment'`.
- Adicionar 4º app: append em `APPS` array — fitness adiciona automaticamente.

**3 apps `app.config.ts`** simplificados — `provideRuntimeConfig() + provideAuth()` (zero boilerplate específico). `environment.*` não importado mais.

**3 `apps/<app>/public/assets/runtime-config.json`** placeholders dev (localhost:5000 + localhost:8080 + clientId por app).

**3 `docker/Dockerfile.<app>`** sobrescrevem o asset com `docker/runtime-config.json` contendo **placeholders inválidos** (URLs `.invalid` + `PLACEHOLDER_*`) — produção sem ConfigMap montado **falha bootstrap explicitamente**, em vez de silenciosamente tentar `localhost`.

**ADR-0021 promovida `proposed` → `accepted`** + README index corrigido (ADR-0019 e ADR-0020 estavam como `proposed` no README mas mergeadas como `accepted` — corrigido factualmente).

## Pre-commit Codex local — 4 rounds (cap atingido)

| Round | Findings | Resolução |
|---|---|---|
| 1 | P1 ordem APP_INITIALIZER + P1 HttpClient interceptors + P2 dev placeholder no Docker | Consolidação APP_INITIALIZER + HttpBackend bypass + delete `docker/runtime-config.json` `{}` |
| 2 | P2 peer name `@org/shared-auth` não bate com `import '@uniplus/...'` | `name: '@uniplus/shared-auth'` |
| 3 | P2 dist Docker tem URLs DEV de localhost | Recriar `docker/runtime-config.json` com placeholders inválidos + Dockerfiles overwrite |
| 4 | P2 placeholders válidos sintaticamente passam pelo init (`AuthService.init` captura erros) | `assertNaoEhPlaceholder` guard antes de `store.load`/`auth.init` |

Cada round melhorou a robustez. Fail-fast em produção sem ConfigMap garantido.

## Pesquisa (3 fontes citadas)

1. [Angular `provideAppInitializer` API](https://angular.dev/api/core/provideAppInitializer) — Angular 19+ pattern.
2. [Angular `InjectionToken` docs](https://angular.dev/api/core/InjectionToken) — pattern canônico para configuração injetável.
3. ADR-0020 desta workspace — invariante imagem-única-por-app.

## Validações locais

| Gate | Resultado |
|---|---|
| `npx nx run-many --target=build` em 8 projects | verde |
| `npx nx run-many --target=lint,typecheck,vite:test` em 8 projects | verde |
| Fitness `runtime-config-providers.fitness.spec.ts` | 12 specs verdes |
| `AppConfigService` specs (load/get/error/idempotência) | 4 specs verdes |
| `bash tools/adr-lint/validate.sh` | 21 ADRs OK |
| `npx markdownlint-cli2 'docs/adrs/**/*.md'` | 0 erros |

## Story #84 — critérios de aceite

| CA | Estado |
|---|---|
| CA-01: `provideAppInitializer` busca `assets/config.json` antes do bootstrap | ✅ |
| CA-02: erro claro se ausente/malformado/placeholder | ✅ (assertNaoEhPlaceholder + HttpBackend re-throw) |
| CA-03: same image + ConfigMap diferente = configs diferentes | ✅ |
| CA-04: `provideAuth` consome `AUTH_CONFIG` runtime | ✅ |
| CA-05: `AppConfigService` trivialmente mockável via `TestBed` | ✅ |
| CA-06: `environment.prod.ts` + `fileReplacements` removidos | ⚠️ Não nesta PR — gate de validação em staging primeiro per Story |
| CA-07: `infra/k8s/<app>/configmap.yaml` exemplo | ⚠️ Não nesta PR — escopo infra separado |

## Pendências fora do escopo

- **CA-06 — remoção `environment.prod.ts` + `fileReplacements`** — após validação em staging do runtime config funcionando ponta-a-ponta. `environment.ts` continua como fallback dev local; `app.config.ts` simplesmente não importa mais.
- **CA-07 — ConfigMaps K8s em `infra/k8s/`** — diretório novo, escopo infra dedicado.
- **Rename mecânico cross-lib `@org/* → @uniplus/*`** em `package.json` `name` de `shared-data` e `shared-ui` (estado pré-existente em main; PR de cleanup separado por blast radius).
- **Backport `@nx/dependency-checks` warnings** caso surjam após o rename de shared-auth.

## Como testar

Local com `nx serve`:
```bash
npx nx serve selecao    # localhost:4200, lê apps/selecao/public/assets/runtime-config.json
```
Valores localhost:5000 (api) + localhost:8080 (Keycloak) injetados via runtime config.

Imagem Docker (após PR mergear + tag publicada):
```bash
docker run --rm -p 8080:8080 ghcr.io/unifesspa-edu-br/uniplus-web-selecao:v0.X.Y
# Sem ConfigMap montado → bootstrap aborta com erro placeholder no console.
```

Em produção: `ConfigMap` K8s monta sobre `/usr/share/nginx/html/assets/runtime-config.json` com URLs reais.