### PR TITLE
docs(adr-0020): formaliza lockstep release como decisão consciente

### DIFF
--- a/docs/adrs/0020-registry-ghcr-e-tagging.md
+++ b/docs/adrs/0020-registry-ghcr-e-tagging.md
@@ -57,6 +57,18 @@ A imagem **nunca** embute URL de Keycloak ou API. O nginx serve `/assets/runtime
 
 SBOM e attestation cosign keyless via OIDC do GitHub ficam deferidos como follow-up — registrados em backlog mas fora do escopo de unblock.
 
+**Estratégia de release: lockstep.** Uma tag `v<X>.<Y>.<Z>` dispara o build/publish das 3 imagens da matriz (`uniplus-portal`, `uniplus-web-selecao`, `uniplus-web-ingresso`) simultaneamente, independentemente de qual app recebeu mudança no commit alvo. Todas as 3 imagens recebem o mesmo número de versão. A motivação:
+
+- *Auditoria simples*: um único número (`v0.1.2`) descreve o estado completo do produto em um momento. ArgoCD pina uma única tag e promove conjunto coerente entre ambientes.
+- *Sem drift*: per-app (ex.: `uniplus-portal:v0.1.2` + `uniplus-web-selecao:v0.1.5`) acumula tags em ritmos diferentes; o consumer perde a noção de "qual combinação de versões compõe a release X" e a auditoria precisa cruzar 3 streams de tags.
+- *Custo controlado*: o cache GHA `mode=max` com `scope=<module>` torna o rebuild de app não-tocado quase noop (~30–90s para resolver manifest e republicar layers já em cache). Em matriz de 3 apps, ~3min adicionais na pior hipótese — uma vez por release. Com Nx affected o custo do build interno do app não-tocado é ainda menor.
+
+Paths-filter (skip de apps não-tocados na matriz) foi rejeitado porque quebra a invariante "para toda tag `v<X>.<Y>.<Z>` publicada, existem 3 imagens com essa tag". Skip introduziria 404 em GHCR para apps não-rebuilt — ArgoCD tentando `pull` em ambiente que pinou `v0.1.2` falharia e quebraria o sync de Helm.
+
+Cada release publica 3 manifestos com **digests diferentes** do release anterior, mesmo quando o conteúdo estático servido por nginx (HTML/JS/CSS de `dist/apps/<app>`) é byte-idêntico. Isso vem das labels OCI (`org.opencontainers.image.version`, `org.opencontainers.image.revision`, `created`) que mudam por release. Essa diferença é **intencional**: dá ao ArgoCD um sinal não-ambíguo de "uma nova versão chegou" mesmo sem mudança de código, e mantém auditoria de release coerente.
+
+Per-app versioning não está vetado, apenas deferido. Se a equipe um dia tiver releases muito assimétricas (ex.: portal evolui 10× mais rápido que selecao) e o custo de ~3min por release lockstep se tornar limitante, esta ADR pode ser revista em ADR sucessora.
+
 ## Consequências
 
 ### Positivas


### PR DESCRIPTION
## Resumo

Pareado com `uniplus-api` PR de mesma temática (link no commit). Adiciona ao ADR-0020 uma seção explícita sobre **lockstep release** — toda tag `v<X>.<Y>.<Z>` dispara o build/publish das 3 apps (`uniplus-portal`, `uniplus-web-selecao`, `uniplus-web-ingresso`) simultaneamente, mesmo que o commit alvo só tenha mudado uma delas.

## Por que formalizar agora

Mesma motivação do par no `uniplus-api`: a decisão estava implícita na matriz do `publish-images.yml`. Documentar evita "otimizações" futuras (paths-filter, per-app tags) que têm trade-offs reais não-óbvios:

| Alternativa | Por que rejeitada |
|---|---|
| Per-app tags (`uniplus-portal:v0.1.2` desincronizado de `uniplus-web-selecao:v0.1.5`) | Drift entre apps; perde "número do produto"; auditoria precisa cruzar 3 streams |
| Paths-filter na matriz | Quebra invariante "para toda tag `v<X>.<Y>.<Z>` publicada, existem 3 imagens" — ArgoCD pinando `v0.1.2` que não existe em algum app causa 404 e quebra sync |

## Reconhecimentos explícitos

- Cada release publica 3 manifestos com digests diferentes do anterior, mesmo quando o conteúdo estático servido por nginx é byte-idêntico (labels OCI mudam por release) — **feature**, não bug
- Custo de ~3min/release lockstep mitigado por cache GHA `mode=max` + Nx affected (rebuild interno de app não-tocado é praticamente instantâneo)
- Per-app **deferido** (não vetado)

## Pareada com

PR `uniplus-api` paralelo com mesma seção em ADR-0050.

## Status

ADR mantém `status: proposed`. Promoção para `accepted` virá no commit pós primeiro publish da Story #217.

## Verificação

- [x] `bash tools/adr-lint/validate.sh` passa
- [x] `markdownlint-cli2` passa