### PR TITLE
refactor(libs): renomeia @org/shared-data e @org/shared-ui para @uniplus/* (Closes #228)

### DIFF
--- a/libs/shared-data/package.json
+++ b/libs/shared-data/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@org/shared-data",
+  "name": "@uniplus/shared-data",
   "version": "0.0.1",
   "peerDependencies": {
     "@angular/common": "^21.2.0",

--- a/libs/shared-ui/package.json
+++ b/libs/shared-ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@org/shared-ui",
+  "name": "@uniplus/shared-ui",
   "version": "0.0.1",
   "peerDependencies": {
     "@angular/common": "^21.2.0",


### PR DESCRIPTION
## Resumo

Cleanup mecânico do legacy `@org/*` do scaffold Nx em duas libs remanescentes — `shared-auth` já havia sido renomeada na PR #226 (commit `3fd4528`). Esta PR fecha o gap.

Closes #228

## Diff

| Arquivo | Antes | Depois |
|---|---|---|
| `libs/shared-data/package.json` | `name: "@org/shared-data"` | `name: "@uniplus/shared-data"` |
| `libs/shared-ui/package.json` | `name: "@org/shared-ui"` | `name: "@uniplus/shared-ui"` |

2 arquivos, +2/-2 linhas.

## Por que importa

Inconsistência silenciosa em DEV — `tsconfig.base.json` `paths` resolve via path alias para source-tree (`libs/<lib>/src/index.ts`), e nenhum import no monorepo usa o nome `@org/*` diretamente (mapeamento exaustivo via `grep -rn "@org/" libs apps` confirma).

Em **publicação real** (futuro `uniplus-developers` portal, sister-IFES via Termo de Cooperação, npm registry), consumer instalando `@org/shared-data` receberia pacote cujo emit JS faz `import from '@uniplus/shared-data'` — falha em resolution. ADR-0019 §"Esta ADR não decide" registra explicitamente que publicação real não está ativa hoje, mas o cleanup deixa o invariante naming consistente para qualquer trigger futuro.

## Validações locais

- `npx nx run-many --target=build,lint,typecheck,vite:test --projects=shared-utils,shared-core,shared-auth,shared-data,shared-ui,selecao,ingresso,portal --skip-nx-cache` — verde nos 8 projects.
- `@nx/dependency-checks` lint aceita as peerDeps já existentes (`@uniplus/shared-core`, `@uniplus/shared-utils`, `@uniplus/shared-auth`).
- `grep -rn "@org/shared" libs apps` retorna 0 ocorrências pós-mudança.
- Codex local sem findings.

## Não-objetivos

- Não move libs nem reorganiza estrutura (escopo Compozy `frontend-libs-architecture`).
- Não habilita publicação real para registry (continua bloqueada por ADR-0019 §"Esta ADR não decide").
- Não toca em `tsconfig.base.json` paths (já estão como `@uniplus/*`).

## Referências

- Issue #228 — task que originou este PR.
- PR #226 commit `3fd4528a` — renomeou `shared-auth`, deixou `shared-data` e `shared-ui` como follow-up.
- ADR-0019 — Tokens Gov.br compartilhados.
- ADR-0021 — Runtime config (PR #226).