### PR TITLE
fix(shared-auth): substitui dead tokens Gov.br por equivalentes existentes (Closes #221)

### DIFF
--- a/libs/shared-auth/src/lib/components/access-denied.component.ts
+++ b/libs/shared-auth/src/lib/components/access-denied.component.ts
@@ -24,11 +24,11 @@ import { UserContextService } from '../services/user-context.service';
       <span aria-hidden="true" class="text-5xl">🚫</span>
       <div>
         <h1 class="text-2xl font-bold text-govbr-danger">Acesso negado</h1>
-        <p class="mt-2 text-govbr-text">
+        <p class="mt-2 text-govbr-gray-80">
           Sua conta não possui permissão para acessar esta área.
         </p>
         @if (user(); as profile) {
-          <p class="mt-1 text-sm text-govbr-text-secondary">
+          <p class="mt-1 text-sm text-govbr-gray-60">
             Conectado como <strong>{{ profile.username }}</strong>.
           </p>
         }
@@ -36,7 +36,7 @@ import { UserContextService } from '../services/user-context.service';
       <div class="flex flex-wrap justify-center gap-3">
         <button
           type="button"
-          class="rounded-govbr bg-govbr-primary px-4 py-2 text-white hover:bg-govbr-primary-hover"
+          class="rounded-govbr-sm bg-govbr-primary px-4 py-2 text-white hover:bg-govbr-primary-hover"
           (click)="voltar()"
         >
           Voltar ao início

--- a/libs/shared-auth/src/lib/components/auth-error-banner.component.ts
+++ b/libs/shared-auth/src/lib/components/auth-error-banner.component.ts
@@ -18,13 +18,13 @@ import { AuthService } from '../services/auth.service';
       <div
         role="alert"
         aria-live="assertive"
-        class="flex items-start gap-3 border-b border-govbr-danger bg-govbr-danger-lightest px-6 py-3 text-govbr-danger"
+        class="flex items-start gap-3 border-b border-govbr-danger bg-govbr-danger-light px-6 py-3 text-govbr-gray-80"
       >
-        <span aria-hidden="true" class="mt-0.5 text-lg">⚠</span>
+        <span aria-hidden="true" class="mt-0.5 text-lg text-govbr-danger">⚠</span>
         <div class="flex-1 text-sm">
           <strong class="block font-semibold">Serviço de autenticação indisponível</strong>
           <span class="block">{{ message }}</span>
-          <span class="block text-xs opacity-80">
+          <span class="block text-xs text-govbr-gray-60">
             Você pode continuar navegando em áreas públicas. Recursos
             protegidos ficarão indisponíveis até o restabelecimento do
             serviço.

--- a/libs/shared-auth/src/lib/components/login-error-banner.component.ts
+++ b/libs/shared-auth/src/lib/components/login-error-banner.component.ts
@@ -24,14 +24,17 @@ import { LoginErrorCode, classifyLoginError } from '../models/login-error.model'
         role="alert"
         aria-live="assertive"
         [class.border-govbr-danger]="isDanger()"
-        [class.bg-govbr-danger-lightest]="isDanger()"
-        [class.text-govbr-danger]="isDanger()"
+        [class.bg-govbr-danger-light]="isDanger()"
         [class.border-govbr-warning]="!isDanger()"
-        [class.bg-govbr-warning-lightest]="!isDanger()"
-        [class.text-govbr-warning]="!isDanger()"
-        class="flex items-start gap-3 border-b px-6 py-3"
+        [class.bg-govbr-warning-light]="!isDanger()"
+        class="flex items-start gap-3 border-b px-6 py-3 text-govbr-gray-80"
       >
-        <span aria-hidden="true" class="mt-0.5 text-lg">
+        <span
+          aria-hidden="true"
+          class="mt-0.5 text-lg"
+          [class.text-govbr-danger]="isDanger()"
+          [class.text-govbr-warning]="!isDanger()"
+        >
           {{ isDanger() ? '⚠' : 'ℹ' }}
         </span>
         <div class="flex-1 text-sm">
@@ -40,7 +43,7 @@ import { LoginErrorCode, classifyLoginError } from '../models/login-error.model'
         </div>
         <button
           type="button"
-          class="text-xs underline opacity-80 hover:opacity-100"
+          class="text-xs text-govbr-gray-60 underline hover:text-govbr-gray-80"
           (click)="dismiss()"
           aria-label="Fechar mensagem"
         >


### PR DESCRIPTION
## Resumo

Substitui tokens Gov.br não-existentes na foundation `libs/shared-ui/src/styles/govbr-tokens.css` (Tailwind purgava silenciosamente; estilos não renderizavam) por equivalentes existentes. Issue captada como pré-existente no PR #216 (D.2 do twilight-forge).

Closes #221

## Substituições

| Antes (dead token) | Depois (token foundation) | Onde |
|---|---|---|
| `bg-govbr-danger-lightest` | `bg-govbr-danger-light` (#fcf0ee) | auth-error-banner, login-error-banner |
| `bg-govbr-warning-lightest` | `bg-govbr-warning-light` (#fef0c8) | login-error-banner |
| `text-govbr-text` | `text-govbr-gray-80` (#333333) | access-denied |
| `text-govbr-text-secondary` | `text-govbr-gray-60` (#636363) | access-denied |
| `rounded-govbr` (bare) | `rounded-govbr-sm` (4px) | access-denied |

## Refator a11y adicional (Codex P2 round 2)

Após substituir `-lightest` por `-light` (background mais visível), Codex detectou regressão de contraste WCAG AA:

- `text-govbr-danger` (#e52207) em `bg-govbr-danger-light` (#fcf0ee) = **4.13:1** (abaixo do mínimo 4.5:1 para texto normal).
- `text-govbr-warning` (#ffcd07) em `bg-govbr-warning-light` (#fef0c8) = ainda pior.

**Fix:** containers usam `text-govbr-gray-80` (~12:1 contraste). Cor semântica preservada nos **ícones** (`text-lg` permite 3:1 — Large text WCAG). Texto auxiliar em `text-govbr-gray-60` mantém hierarchy visual sem perder a11y.

## Validações locais

- `npx nx run-many --target=build,lint,typecheck,vite:test` em 6 projects (incluindo apps consumindo shared-auth): verde.
- `grep -nE 'rounded-govbr(\s|"|$)|govbr-(text|danger-lightest|warning-lightest|text-secondary)' libs/shared-auth`: zero ocorrências.
- Codex local sem findings após fix a11y (round 2 limpo).

## Não-objetivos

- Não toca em `apps/selecao/src/styles.css` (`@source` para shared-auth foi adicionado defensivamente em D.2 e continua válido).
- Não adiciona tokens novos à foundation (Opção A escolhida sobre Opção B per body da issue — manter foundation Gov.br DS canônica).
- Não altera comportamento dos componentes (apenas estilos).

## Referências

- Issue #221 — task que originou este PR.
- PR #216 (D.2 twilight-forge) — captou como dead code pré-existente; adicionou `@source` defensivo.
- ADR-0019 — Tokens Gov.br compartilhados em shared-ui.
- Foundation: `libs/shared-ui/src/styles/govbr-tokens.css`.