### PR TITLE
refactor(ci): codegen-drift-check em job dedicado + required check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,35 @@ jobs:
         # dev↔CI (script local invoca o mesmo binary).
         run: npx --yes markdownlint-cli2@0.22.1 'docs/adrs/**/*.md'
 
+  # Drift check do codegen OpenAPI (ADR-0013): regenera e diffa
+  # libs/shared-data/src/lib/api/{selecao,ingresso}/schema.ts contra o
+  # committed em HEAD. Falha se o spec mudou e o gerado não foi committed
+  # junto. Job dedicado (em vez de step do `main`) torna o gate visível em
+  # branch protection settings — ver `required_status_checks.contexts`.
+  codegen-drift-check:
+    name: codegen-drift-check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Instalar dependências
+        run: npm ci --no-audit --no-fund
+
+      - name: Verificar drift do codegen OpenAPI (shared-data)
+        run: npx nx run shared-data:codegen-api-check
+
   main:
     runs-on: ubuntu-latest
     steps:
@@ -138,12 +167,8 @@ jobs:
       - if: steps.gate.outputs.run == 'true'
         run: npx nx record -- echo Hello World
 
-      # Drift check do codegen OpenAPI (ADR-0013): regenera e diffa
-      # libs/shared-data/src/lib/api/{selecao,ingresso}/schema.ts contra o
-      # committed. Falha se o spec mudou e o gerado não foi committed junto.
-      - name: Verificar drift do codegen OpenAPI (shared-data)
-        if: steps.gate.outputs.run == 'true'
-        run: npx nx run shared-data:codegen-api-check
+      # Drift check do codegen OpenAPI vive em job dedicado `codegen-drift-check`
+      # (ver acima) — required check em branch protection desde 2026-05-09.
 
       # Em pull_request, usamos `nx affected` para rodar apenas os projects
       # impactados pelo diff contra a branch base. Em push para main, fazemos


### PR DESCRIPTION
## Resumo

Extrai o drift check do codegen OpenAPI (ADR-0013) do step embutido no job `main` para um job dedicado `codegen-drift-check`. Torna o gate visível no painel de branch protection settings e impossível de apagar silenciosamente por refactor de `ci.yml`.

## Problema

`nx run shared-data:codegen-api-check` rodava como step gated dentro de `main` (linhas 141-146 antes desta PR). Como `main` já é required, o efeito de bloqueio existia — mas:

- Zero visibilidade em branch protection settings.
- Refactor que `comment-out`, remove ou wrap o step com `--continue-on-error` apaga o gate sem alarme.
- Auditoria operacional ("o codegen é mesmo required?") exigia abrir o `ci.yml` em vez de consultar o setting da branch.

## Mudanças

- Novo job `codegen-drift-check` em `.github/workflows/ci.yml`:
  - `runs-on: ubuntu-latest`, `permissions: { contents: read }`, `timeout-minutes: 5`.
  - `actions/checkout@v4` com `fetch-depth: 0` (script `verify-codegen.sh` compara contra `HEAD` via `git show`).
  - `actions/setup-node@v4` lendo `.nvmrc` (Node 22).
  - `npm ci --no-audit --no-fund`.
  - `npx nx run shared-data:codegen-api-check`.
- Step duplicado removido do job `main` (substituído por comentário apontando para o novo job).

## Validação local

| Gate | Resultado |
|---|---|
| `npx nx run shared-data:codegen-api-check` | verde, sem drift |

## Sequência operacional (≤ 15 min entre merge e PUT da branch protection)

### Antes (snapshot)

```json
{
  "strict": true,
  "contexts": [
    "main",
    "nx run-many --target=lint --all",
    "PR author is org member"
  ]
}
```

### Comando pós-merge

```bash
gh api POST /repos/unifesspa-edu-br/uniplus-web/branches/main/protection/required_status_checks/contexts \
  --input - <<<'["codegen-drift-check"]'
```

### Audit pós-PUT

```bash
gh api /repos/unifesspa-edu-br/uniplus-web/branches/main/protection \
  | jq '.required_status_checks.contexts'
# Esperado: ["main", "nx run-many --target=lint --all", "PR author is org member", "codegen-drift-check"]
```

## Janela de inconsistência

Entre o merge do PR e a aplicação do `gh api POST`, qualquer outro PR pode mergear sem o novo context required. Mitigação: aplico o `POST` em ≤ 15 min após o merge desta PR; segurarei merges concorrentes manualmente até a audit step retornar verde.

## Verificação off-tree (mutation test)

Não rodada nesta PR. O contrato ADR-0013 + script `verify-codegen.sh` já é exercitado pelo dev-loop quando devs editam OpenAPI specs sem regenerar; a mudança aqui é puramente de localização do step.

## Critérios de aceite

- [x] `.github/workflows/ci.yml` tem job `codegen-drift-check` dedicado.
- [x] Step duplicado removido do job `main`.
- [ ] `required_status_checks.contexts` em branch protection inclui `codegen-drift-check` (aplicado em ≤ 15 min pós-merge).
- [ ] PR com drift deliberado em `schema.ts` falha o check (validação operacional pós-merge, opcional).

## Riscos / rollback

Risco baixo. Rollback: `git revert` + `gh api DELETE /repos/.../branches/main/protection/required_status_checks/contexts -f context=codegen-drift-check`.

Closes #248

Refs Epic #243