### PR TITLE
feat(eslint): enforce-module-boundaries com depConstraints type:*

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,12 @@ export default [
         {
           enforceBuildableLibDependency: true,
           allow: ['^.*/eslint(\\.base)?\\.config\\.[cm]?[jt]s$'],
+          // Eixo `scope:*` (vertical) + eixo `type:*` (horizontal). Toda lib carrega
+          // `[scope:<X>, type:<Y>]`. Apps de produção (`type:app`) e suítes E2E
+          // (`type:e2e`) ficam fora do eixo `type` como leaf consumers — não há
+          // entrada `sourceTag: 'type:app'` ou `'type:e2e'` aqui porque eles
+          // dependem de qualquer combinação `scope:*` permitida pelo eixo scope
+          // sem restrição adicional no eixo type.
           depConstraints: [
             {
               sourceTag: 'scope:shared',
@@ -31,6 +37,46 @@ export default [
             {
               sourceTag: 'scope:portal',
               onlyDependOnLibsWithTags: ['scope:portal', 'scope:shared'],
+            },
+            {
+              sourceTag: 'type:feature',
+              onlyDependOnLibsWithTags: [
+                'type:ui',
+                'type:data-access',
+                'type:util',
+                'type:core',
+                'type:auth',
+                'type:data',
+              ],
+            },
+            {
+              sourceTag: 'type:ui',
+              onlyDependOnLibsWithTags: ['type:util', 'type:core'],
+            },
+            {
+              sourceTag: 'type:data-access',
+              onlyDependOnLibsWithTags: ['type:util', 'type:core'],
+            },
+            {
+              sourceTag: 'type:util',
+              onlyDependOnLibsWithTags: ['type:util'],
+            },
+            {
+              // `type:core` é leaf no eixo type — não importa nada de outras libs
+              // pelo type. Lista vazia bloqueia qualquer dep cross-type.
+              sourceTag: 'type:core',
+              onlyDependOnLibsWithTags: [],
+            },
+            {
+              sourceTag: 'type:auth',
+              onlyDependOnLibsWithTags: ['type:core', 'type:util'],
+            },
+            {
+              // `type:data` admite `type:auth` porque
+              // `libs/shared-data/src/lib/config/runtime-config.provider.ts`
+              // importa `AUTH_CONFIG` de `@uniplus/shared-auth` (ADR-0021).
+              sourceTag: 'type:data',
+              onlyDependOnLibsWithTags: ['type:core', 'type:util', 'type:auth'],
             },
           ],
         },


### PR DESCRIPTION
## Resumo

Estende `@nx/enforce-module-boundaries` para enforçar o eixo `type:*` em todos os edges do workspace. Antes, só `scope:*` era enforçado — apps e libs cross-type ficavam silenciosamente livres para acoplar.

## Mudanças

`eslint.config.mjs` — 7 novas entradas `depConstraints` no eixo `type:*` (`type:feature`, `type:ui`, `type:data-access`, `type:util`, `type:core`, `type:auth`, `type:data`):

| sourceTag | onlyDependOnLibsWithTags |
|---|---|
| `type:feature` | `type:ui`, `type:data-access`, `type:util`, `type:core`, `type:auth`, `type:data` |
| `type:ui` | `type:util`, `type:core` |
| `type:data-access` | `type:util`, `type:core` |
| `type:util` | `type:util` |
| `type:core` | `[]` (leaf — não importa nada do eixo type) |
| `type:auth` | `type:core`, `type:util` |
| `type:data` | `type:core`, `type:util`, `type:auth` |

Comentários inline explicam:

- `type:data → type:auth` é caso especial: `libs/shared-data/src/lib/config/runtime-config.provider.ts` importa `AUTH_CONFIG` de `@uniplus/shared-auth` (ADR-0021).
- `type:app` e `type:e2e` ficam de fora do eixo type como leaf consumers — não há entrada `sourceTag: 'type:app'` aqui porque eles dependem de qualquer combinação `scope:*` permitida pelo eixo scope sem restrição adicional no eixo type.

Severity `error` em todas. Total: 11 entradas (4 `scope:*` existentes + 7 `type:*` novas).

## Validação

| Gate | Resultado |
|---|---|
| `nx run-many --target=lint --all` (workspace atual) | 12/12 verde |
| Mutation test off-tree | falha conforme esperado, ver abaixo |

### Mutation test off-tree (detalhe)

Inject de `import type { EditalDto } from '@uniplus/shared-data'` em arquivo temporário `libs/shared-utils/src/lib/mutation-test-violation.ts` (`type:util` → `type:data`):

```
✖ 2 problems (2 errors, 0 warnings)
  error  A project tagged with "scope:shared" can only depend on libs tagged with "scope:shared"  @nx/enforce-module-boundaries
  error  A project tagged with "type:util" can only depend on libs tagged with "type:util"  @nx/enforce-module-boundaries

NX   Running target lint for project shared-utils failed
```

Branch nunca commitada; arquivo removido após validação.

## Critérios de aceite

- [x] 11 entradas em `depConstraints` (4 `scope:*` + 7 `type:*`).
- [x] Severity `error` em todas.
- [x] Workspace lint verde.
- [x] Mutation test confirmado.

## Follow-ups identificados na review (#253 review comment)

- [#254](https://github.com/unifesspa-edu-br/uniplus-web/issues/254) — reavaliar `type:data-access → type:data` antes do generator F5/#247 ser efetivamente usado (S1).
- [#246](https://github.com/unifesspa-edu-br/uniplus-web/issues/246) — fitness spec já coberta cobrirá o edge case `type:core` leaf via DFS sobre o graph + helpers `admiteDependencia` (S2).

## Riscos / rollback

Risco baixo. Nenhuma dep cross-type real do workspace atual viola a matriz. Rollback: `git revert`.

Closes #245

Refs Epic #243