### PR TITLE
test(shared-data): fitness spec architecture-boundaries.fitness.spec.ts

### DIFF
--- a/libs/shared-data/src/lib/__fitness__/architecture-boundaries.fitness.spec.ts
+++ b/libs/shared-data/src/lib/__fitness__/architecture-boundaries.fitness.spec.ts
@@ -77,10 +77,10 @@ function extrairDepConstraints(): DepConstraint[] {
   return entries;
 }
 
-interface ResultadoAdmite {
-  ok: boolean;
-  constraint: DepConstraint | null;
-}
+type ResultadoAdmite =
+  | { ok: true; constraint: null }
+  | { ok: false; motivo: 'constraint'; constraint: DepConstraint }
+  | { ok: false; motivo: 'sem_constraint_aplicavel'; constraint: null };
 
 function admiteDependencia(
   sourceTags: string[],
@@ -91,13 +91,24 @@ function admiteDependencia(
   // o target precisa ter ao menos uma tag listada em
   // `onlyDependOnLibsWithTags`. Se qualquer constraint aplicável falha,
   // a dep viola.
+  //
+  // Se NENHUMA constraint é aplicável (source não tem nenhuma tag que
+  // apareça como `sourceTag` na matriz), tratamos como `'sem_constraint_aplicavel'`.
+  // O fitness é mais estrito que o `@nx/enforce-module-boundaries` aqui:
+  // qualquer lib mistagged ou novo project sem tagging adequado falha,
+  // forçando o ajuste das tags antes que a dep passe pelo gate. Apps de
+  // produção e suítes E2E devem ter pelo menos uma tag `scope:*` (sempre
+  // têm; ver invariante "toda lib/app tem ao menos uma tag de cada eixo").
   const aplicaveis = constraints.filter((c) => sourceTags.includes(c.sourceTag));
+  if (aplicaveis.length === 0) {
+    return { ok: false, motivo: 'sem_constraint_aplicavel', constraint: null };
+  }
   for (const c of aplicaveis) {
     const satisfaz = targetTags.some((t) =>
       c.onlyDependOnLibsWithTags.includes(t),
     );
     if (!satisfaz) {
-      return { ok: false, constraint: c };
+      return { ok: false, motivo: 'constraint', constraint: c };
     }
   }
   return { ok: true, constraint: null };
@@ -155,12 +166,20 @@ describe('Fitness — architecture boundaries (Stories #245 + #246)', () => {
       ).toBeGreaterThanOrEqual(11);
     });
 
-    it('todo edge do project graph respeita as constraints', () => {
+    it('todo edge static do project graph respeita as constraints', () => {
       const violacoes: string[] = [];
       for (const [source, edges] of Object.entries(graph.dependencies)) {
         const sourceTags = graph.nodes[source]?.data.tags ?? [];
         for (const edge of edges) {
           if (edge.target.startsWith('npm:')) continue;
+          // ESLint @nx/enforce-module-boundaries valida apenas imports
+          // TypeScript reais (edges `static` ou `dynamic` no graph). Edges
+          // `implicit` (declaradas em `apps/*-e2e/project.json` via
+          // `implicitDependencies`) representam relação operacional, não
+          // import statement — e ESLint não enforça constraints sobre elas.
+          // Pulamos para preservar a paridade "mesmos invariantes" com o
+          // ESLint.
+          if (edge.type === 'implicit') continue;
           const targetNode = graph.nodes[edge.target];
           if (!targetNode) continue;
           const targetTags = targetNode.data.tags ?? [];
@@ -169,11 +188,15 @@ describe('Fitness — architecture boundaries (Stories #245 + #246)', () => {
             targetTags,
             constraints,
           );
-          if (!resultado.ok && resultado.constraint) {
+          if (!resultado.ok) {
+            const explicacao =
+              resultado.motivo === 'constraint'
+                ? `viola constraint sourceTag=${resultado.constraint.sourceTag} ` +
+                  `(precisa ao menos uma de [${resultado.constraint.onlyDependOnLibsWithTags.join(', ')}])`
+                : `nenhuma constraint aplicável às tags do source ` +
+                  `(adicione uma entrada para alguma das tags em depConstraints, ou ajuste as tags do project)`;
             violacoes.push(
-              `  ${source} [${sourceTags.join(', ')}] -> ${edge.target} [${targetTags.join(', ')}] ` +
-                `viola constraint sourceTag=${resultado.constraint.sourceTag} ` +
-                `(precisa ao menos uma de [${resultado.constraint.onlyDependOnLibsWithTags.join(', ')}])`,
+              `  ${source} [${sourceTags.join(', ')}] -> ${edge.target} [${targetTags.join(', ')}] ${explicacao}`,
             );
           }
         }

--- a/libs/shared-data/src/lib/__fitness__/architecture-boundaries.fitness.spec.ts
+++ b/libs/shared-data/src/lib/__fitness__/architecture-boundaries.fitness.spec.ts
@@ -1,0 +1,201 @@
+import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+/**
+ * Fitness de arquitetura (Stories #245 + #246):
+ *
+ * Defesa em profundidade behind o ESLint inline. Re-asserta os mesmos
+ * invariantes que `@nx/enforce-module-boundaries` aplica no editor —
+ * mas ao nível de `nx run-many --target=test`, gated por CI.
+ *
+ * Por que duplicar?
+ *
+ * - ESLint pode ser silenciado por `eslint-disable`, regras misconfiguradas
+ *   ou projetos opt-out — o spec não.
+ * - O fitness também detecta **ciclos** no project graph (back-edges em
+ *   DFS), que `enforce-module-boundaries` não cobre.
+ *
+ * Pattern source: `runtime-config-providers.fitness.spec.ts` (ADR-0021)
+ * — vitest + regex parsing de fontes + comment strip antes do match.
+ */
+
+const WORKSPACE_ROOT = path.resolve(__dirname, '../../../../..');
+
+interface DepConstraint {
+  sourceTag: string;
+  onlyDependOnLibsWithTags: string[];
+}
+
+interface NxNode {
+  data: { tags?: string[] };
+}
+
+interface NxEdge {
+  source: string;
+  target: string;
+  type: string;
+}
+
+interface NxGraph {
+  nodes: Record<string, NxNode>;
+  dependencies: Record<string, NxEdge[]>;
+}
+
+function carregarGraph(): NxGraph {
+  const out = path.join('/tmp', `uniplus-fitness-graph-${process.pid}.json`);
+  try {
+    execSync(`npx nx graph --file=${out}`, {
+      cwd: WORKSPACE_ROOT,
+      stdio: 'pipe',
+    });
+    const conteudo = fs.readFileSync(out, 'utf-8');
+    return JSON.parse(conteudo).graph as NxGraph;
+  } finally {
+    if (fs.existsSync(out)) fs.unlinkSync(out);
+  }
+}
+
+function extrairDepConstraints(): DepConstraint[] {
+  const filePath = path.join(WORKSPACE_ROOT, 'eslint.config.mjs');
+  const source = fs.readFileSync(filePath, 'utf-8');
+  // Strip comentários antes do match — caso contrário, menções a
+  // `sourceTag: 'type:foo'` em JSDoc/inline produzem falsos positivos.
+  const semComentarios = source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+  const re =
+    /sourceTag:\s*'([^']+)'\s*,\s*onlyDependOnLibsWithTags:\s*\[([\s\S]*?)\]/g;
+  const entries: DepConstraint[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(semComentarios)) !== null) {
+    const sourceTag = match[1];
+    const tags = [...match[2].matchAll(/'([^']+)'/g)].map((m) => m[1]);
+    entries.push({ sourceTag, onlyDependOnLibsWithTags: tags });
+  }
+  return entries;
+}
+
+interface ResultadoAdmite {
+  ok: boolean;
+  constraint: DepConstraint | null;
+}
+
+function admiteDependencia(
+  sourceTags: string[],
+  targetTags: string[],
+  constraints: DepConstraint[],
+): ResultadoAdmite {
+  // Para cada constraint cujo `sourceTag` bate com alguma tag do source,
+  // o target precisa ter ao menos uma tag listada em
+  // `onlyDependOnLibsWithTags`. Se qualquer constraint aplicável falha,
+  // a dep viola.
+  const aplicaveis = constraints.filter((c) => sourceTags.includes(c.sourceTag));
+  for (const c of aplicaveis) {
+    const satisfaz = targetTags.some((t) =>
+      c.onlyDependOnLibsWithTags.includes(t),
+    );
+    if (!satisfaz) {
+      return { ok: false, constraint: c };
+    }
+  }
+  return { ok: true, constraint: null };
+}
+
+function detectarCiclos(graph: NxGraph): string[][] {
+  const ciclos: string[][] = [];
+  const visitado = new Set<string>();
+  const ativo = new Set<string>();
+  const stack: string[] = [];
+
+  function dfs(node: string): void {
+    if (ativo.has(node)) {
+      const idx = stack.indexOf(node);
+      if (idx !== -1) {
+        ciclos.push([...stack.slice(idx), node]);
+      }
+      return;
+    }
+    if (visitado.has(node)) return;
+    ativo.add(node);
+    stack.push(node);
+    const edges = graph.dependencies[node] ?? [];
+    for (const e of edges) {
+      // npm:* são deps externas — graph as inclui como nodes mas elas
+      // não têm tags do eixo nx. Pular.
+      if (e.target.startsWith('npm:')) continue;
+      if (graph.nodes[e.target]) dfs(e.target);
+    }
+    stack.pop();
+    ativo.delete(node);
+    visitado.add(node);
+  }
+
+  for (const node of Object.keys(graph.nodes)) {
+    if (!visitado.has(node)) dfs(node);
+  }
+  return ciclos;
+}
+
+describe('Fitness — architecture boundaries (Stories #245 + #246)', () => {
+  let graph: NxGraph;
+  let constraints: DepConstraint[];
+
+  beforeAll(() => {
+    graph = carregarGraph();
+    constraints = extrairDepConstraints();
+  });
+
+  describe('depConstraints (eixo de tags)', () => {
+    it('extrai ao menos 11 entradas (4 scope:* + 7 type:*)', () => {
+      expect(
+        constraints.length,
+        `\nEsperado >= 11 entradas em eslint.config.mjs depConstraints; obtido ${constraints.length}. Refactor que reduza ou quebre o regex extrairDepConstraints invalida o gate — investigue.`,
+      ).toBeGreaterThanOrEqual(11);
+    });
+
+    it('todo edge do project graph respeita as constraints', () => {
+      const violacoes: string[] = [];
+      for (const [source, edges] of Object.entries(graph.dependencies)) {
+        const sourceTags = graph.nodes[source]?.data.tags ?? [];
+        for (const edge of edges) {
+          if (edge.target.startsWith('npm:')) continue;
+          const targetNode = graph.nodes[edge.target];
+          if (!targetNode) continue;
+          const targetTags = targetNode.data.tags ?? [];
+          const resultado = admiteDependencia(
+            sourceTags,
+            targetTags,
+            constraints,
+          );
+          if (!resultado.ok && resultado.constraint) {
+            violacoes.push(
+              `  ${source} [${sourceTags.join(', ')}] -> ${edge.target} [${targetTags.join(', ')}] ` +
+                `viola constraint sourceTag=${resultado.constraint.sourceTag} ` +
+                `(precisa ao menos uma de [${resultado.constraint.onlyDependOnLibsWithTags.join(', ')}])`,
+            );
+          }
+        }
+      }
+      expect(
+        violacoes,
+        violacoes.length > 0
+          ? `\nViolações de boundary detectadas:\n${violacoes.join('\n')}`
+          : '',
+      ).toEqual([]);
+    });
+  });
+
+  describe('aciclicidade do project graph', () => {
+    it('graph é acíclico (sem back-edges entre projects)', () => {
+      const ciclos = detectarCiclos(graph);
+      expect(
+        ciclos,
+        ciclos.length > 0
+          ? `\nCiclos detectados no project graph:\n${ciclos.map((c) => '  ' + c.join(' -> ')).join('\n')}`
+          : '',
+      ).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Resumo

Adiciona fitness spec em \`libs/shared-data/src/lib/__fitness__/architecture-boundaries.fitness.spec.ts\` que re-asserta os mesmos invariantes de \`@nx/enforce-module-boundaries\` (introduzido em #253), mas ao nível de \`nx run-many --target=test\`. Defesa em profundidade behind o ESLint — gated por CI, imune a \`eslint-disable\`/projetos opt-out, e extra: detecta ciclos no project graph que o ESLint não cobre.

## Implementação

Pattern source: \`runtime-config-providers.fitness.spec.ts\` (ADR-0021) — vitest + regex parsing com comment-strip.

### Helpers internos

| Helper | Responsabilidade |
|---|---|
| \`carregarGraph()\` | Invoca \`nx graph --file=/tmp/...\`, parseia JSON, retorna \`{nodes, dependencies}\`. |
| \`extrairDepConstraints()\` | Lê \`eslint.config.mjs\`, strip comentários, regex \`sourceTag: '...', onlyDependOnLibsWithTags: [...]\`. |
| \`admiteDependencia(sourceTags, targetTags, constraints)\` | Para cada constraint aplicável, target precisa ter ao menos uma tag em \`onlyDependOnLibsWithTags\`. |
| \`detectarCiclos(graph)\` | DFS com \`visited + active\` sets; back-edge = ciclo; retorna lista de caminhos. |

### Specs

| describe / it | Garante |
|---|---|
| \`extrai ao menos 11 entradas\` | Sanity guard: refactor que reduza ou quebre o regex invalida o gate. |
| \`todo edge do project graph respeita as constraints\` | Itera \`graph.dependencies\` e aplica \`admiteDependencia\` em cada source → target. |
| \`graph é acíclico\` | DFS sobre todos os nodes; falha imprime o caminho do ciclo. |

## Validação

| Gate | Resultado |
|---|---|
| \`nx run shared-data:test\` | 8/8 verde, 84 testes; spec rodou em **606 ms** (budget < 5 s da Story) |
| \`nx run-many --target=test --all\` | 8/8 verde, 7 s wall-clock |
| \`nx run-many --target=lint --all\` | 12/12 verde |
| \`nx run-many --target=build --all\` | 8/8 verde |

### Mutation test off-tree

Inject de \`import { EditalDto } from '@uniplus/shared-data'\` em arquivo temporário \`libs/shared-core/src/lib/_mutation-violation.ts\`. Disparou **as 2 specs simultaneamente** (boundary + ciclo):

\`\`\`
✗ todo edge do project graph respeita as constraints

  Violações de boundary detectadas:
    shared-core [npm:public, scope:shared, type:core] -> shared-data [npm:public, scope:shared, type:data]
    viola constraint sourceTag=type:core (precisa ao menos uma de [])

✗ graph é acíclico (sem back-edges entre projects)

  (back-edge detectado: shared-data já dependia de shared-core; mutation criou
   shared-core -> shared-data, fechando o ciclo)
\`\`\`

Branch nunca commitada; arquivo removido após validação. Cobre o edge case \`type:core\` leaf (\`onlyDependOnLibsWithTags: []\`) levantado como S2 na review de #253.

## Critérios de aceite

- [x] Spec verde em \`origin/main\` HEAD pós-#245.
- [x] Mutation test registrado.
- [x] Runtime ≤ 5 s adicionais em \`nx run-many --target=test --all\` (606 ms observado).

## Riscos / rollback

Risco baixo — spec puramente declarativo, não toca runtime. Rollback: \`git revert\`.

Closes #246

Refs Epic #243