### PR TITLE
feat(tools): Nx generator @uniplus/workspace:feature-lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "@types/supertest": "^6.0.3",
         "@types/uuid": "^10.0.0",
         "@typescript-eslint/utils": "^8.40.0",
+        "@uniplus/workspace": "file:tools/workspace-generators/uniplus-workspace",
         "@vitest/coverage-v8": "4.0.9",
         "@vitest/ui": "4.0.9",
         "angular-eslint": "21.3.1",
@@ -12504,6 +12505,10 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@uniplus/workspace": {
+      "resolved": "tools/workspace-generators/uniplus-workspace",
+      "link": true
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.11.1",
@@ -28499,6 +28504,14 @@
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.0.tgz",
       "integrity": "sha512-LqLPpIQANebrlxY6jKcYKdgN5DTXyyHAKnnWWjE5pPfEQ4n7j5zn7mOEEpwNZVKGqx3kKKmvplEmoBrvpgROTA==",
       "license": "MIT"
+    },
+    "tools/workspace-generators/uniplus-workspace": {
+      "name": "@uniplus/workspace",
+      "version": "0.0.1",
+      "dev": true,
+      "peerDependencies": {
+        "@nx/devkit": ">=22.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "zone.js": "0.16.0"
   },
   "devDependencies": {
+    "@uniplus/workspace": "file:tools/workspace-generators/uniplus-workspace",
     "@analogjs/vite-plugin-angular": "2.2.0",
     "@analogjs/vitest-angular": "2.2.0",
     "@angular-devkit/core": "21.2.5",

--- a/tools/workspace-generators/uniplus-workspace/README.md
+++ b/tools/workspace-generators/uniplus-workspace/README.md
@@ -1,0 +1,45 @@
+# `@uniplus/workspace`
+
+Workspace generators locais do Uni+ — usados para fabricar feature libs taggeadas dentro do monorepo Nx.
+
+## Disponível
+
+### `feature-lib`
+
+Cria uma feature lib em `libs/<scope>/<name>/` com:
+
+- `project.json` taggeada `["scope:<scope>", "type:<type>"]`.
+- Builder `@nx/angular:ng-packagr-lite` (uniformidade com `shared-*`, conforme [ADR-0021](../../../docs/adrs/0021-runtime-config-via-token.md), Onda 1).
+- `vite.config.mts` + `tsconfig.spec.json` com Vitest + `@analogjs/vite-plugin-angular` (paridade com `shared-utils`).
+- `src/index.ts` (barrel) + `src/lib/<name>.ts` (placeholder) + `src/test-setup.ts`.
+- Path mapping `@uniplus/<scope>-<name>` registrado em `tsconfig.base.json`.
+
+#### Uso
+
+```bash
+npx nx g @uniplus/workspace:feature-lib <scope>/<name> --type=<feature|ui|data-access>
+```
+
+Exemplos:
+
+```bash
+npx nx g @uniplus/workspace:feature-lib selecao/feature-editais-detail --type=feature
+npx nx g @uniplus/workspace:feature-lib portal/data-access-inscricoes --type=data-access
+```
+
+#### Validações
+
+- `<scope>` ∈ `{selecao, ingresso, portal}`. Outros valores são rejeitados pelo generator com mensagem listando os scopes válidos.
+- `<type>` ∈ `{feature, ui, data-access}`. Validado pelo schema `enum` antes do factory rodar.
+
+#### Tags emitidas
+
+| `--type` | Tags do `project.json` gerado |
+|---|---|
+| `feature` | `["scope:<scope>", "type:feature"]` |
+| `ui` | `["scope:<scope>", "type:ui"]` |
+| `data-access` | `["scope:<scope>", "type:data-access"]` |
+
+#### Builder em V1
+
+Uniformidade com `shared-*` — todos `@nx/angular:ng-packagr-lite`. `@nx/js:tsc` para `--type=data-access` puro fica para V2 / Onda 2 (ADR-0021 *Roadmap V2*).

--- a/tools/workspace-generators/uniplus-workspace/generators.json
+++ b/tools/workspace-generators/uniplus-workspace/generators.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "name": "@uniplus/workspace",
+  "version": "0.0.1",
+  "generators": {
+    "feature-lib": {
+      "factory": "./src/generators/feature-lib/generator",
+      "schema": "./src/generators/feature-lib/schema.json",
+      "description": "Cria uma feature lib taggeada [scope:<scope>, type:<type>] em libs/<scope>/<name>/."
+    }
+  }
+}

--- a/tools/workspace-generators/uniplus-workspace/package.json
+++ b/tools/workspace-generators/uniplus-workspace/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@uniplus/workspace",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Workspace generators do Uni+ — feature-lib taggeada para scopes da plataforma.",
+  "generators": "./generators.json",
+  "main": "./src/index.js",
+  "type": "commonjs",
+  "peerDependencies": {
+    "@nx/devkit": ">=22.0.0"
+  }
+}

--- a/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/eslint.config.mjs__tmpl__
+++ b/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/eslint.config.mjs__tmpl__
@@ -1,0 +1,22 @@
+import nx from '@nx/eslint-plugin';
+import baseConfig from '../../../eslint.config.mjs';
+
+export default [
+  ...nx.configs['flat/angular'],
+  ...nx.configs['flat/angular-template'],
+  ...baseConfig,
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          ignoredFiles: ['{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}'],
+        },
+      ],
+    },
+    languageOptions: {
+      parser: await import('jsonc-eslint-parser'),
+    },
+  },
+];

--- a/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/ng-package.json__tmpl__
+++ b/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/ng-package.json__tmpl__
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../../dist/<%= projectRoot %>",
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/package.json__tmpl__
+++ b/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/package.json__tmpl__
@@ -1,0 +1,10 @@
+{
+  "name": "<%= importPath %>",
+  "version": "0.0.1",
+  "peerDependencies": {
+    "vite": "^7.0.0",
+    "@analogjs/vite-plugin-angular": ">=2.0.0",
+    "@nx/vite": ">=22.0.0"
+  },
+  "sideEffects": false
+}

--- a/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/project.json__tmpl__
+++ b/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/project.json__tmpl__
@@ -1,5 +1,5 @@
 {
-  "name": "<%= name %>",
+  "name": "<%= projectName %>",
   "$schema": "../../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "<%= projectRoot %>/src",
   "prefix": "<%= prefix %>",

--- a/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/project.json__tmpl__
+++ b/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/project.json__tmpl__
@@ -1,0 +1,28 @@
+{
+  "name": "<%= name %>",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "<%= projectRoot %>/src",
+  "prefix": "<%= prefix %>",
+  "projectType": "library",
+  "tags": <%- tags %>,
+  "targets": {
+    "build": {
+      "executor": "@nx/angular:ng-packagr-lite",
+      "outputs": ["{workspaceRoot}/dist/{projectRoot}"],
+      "options": {
+        "project": "<%= projectRoot %>/ng-package.json",
+        "tsConfig": "<%= projectRoot %>/tsconfig.lib.json"
+      },
+      "configurations": {
+        "production": {
+          "tsConfig": "<%= projectRoot %>/tsconfig.lib.prod.json"
+        },
+        "development": {}
+      },
+      "defaultConfiguration": "production"
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    }
+  }
+}

--- a/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/src/index.ts__tmpl__
+++ b/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/src/index.ts__tmpl__
@@ -1,0 +1,1 @@
+export * from './lib';

--- a/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/src/lib/__name__.spec.ts__tmpl__
+++ b/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/src/lib/__name__.spec.ts__tmpl__
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { <%= name.replace(/-/g, '_') %>_placeholder } from './<%= name %>';
+
+describe('<%= name %> (placeholder)', () => {
+  it('exporta o identificador placeholder', () => {
+    expect(<%= name.replace(/-/g, '_') %>_placeholder).toBe('<%= projectName %>');
+  });
+});

--- a/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/src/lib/__name__.ts__tmpl__
+++ b/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/src/lib/__name__.ts__tmpl__
@@ -1,0 +1,6 @@
+/**
+ * Placeholder gerado por `@uniplus/workspace:feature-lib` (type=<%= type %>, scope=<%= scope %>).
+ *
+ * Substitua por código real assim que iniciar a implementação da feature.
+ */
+export const <%= name.replace(/-/g, '_') %>_placeholder = '<%= projectName %>';

--- a/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/src/lib/index.ts__tmpl__
+++ b/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/src/lib/index.ts__tmpl__
@@ -1,0 +1,1 @@
+export * from './<%= name %>';

--- a/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/src/test-setup.ts__tmpl__
+++ b/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/src/test-setup.ts__tmpl__
@@ -1,0 +1,5 @@
+import '@angular/compiler';
+import '@analogjs/vitest-angular/setup-snapshots';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
+
+setupTestBed({ zoneless: false });

--- a/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/tsconfig.json__tmpl__
+++ b/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/tsconfig.json__tmpl__
@@ -1,0 +1,31 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "isolatedModules": true,
+    "target": "es2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "emitDecoratorMetadata": false,
+    "module": "preserve"
+  },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/tsconfig.lib.json__tmpl__
+++ b/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/tsconfig.lib.json__tmpl__
@@ -1,0 +1,25 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx"
+  ]
+}

--- a/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/tsconfig.lib.prod.json__tmpl__
+++ b/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/tsconfig.lib.prod.json__tmpl__
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "declarationMap": false
+  },
+  "angularCompilerOptions": {}
+}

--- a/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/tsconfig.spec.json__tmpl__
+++ b/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/tsconfig.spec.json__tmpl__
@@ -1,0 +1,27 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "types": [
+      "vitest/globals",
+      "vitest/importMeta",
+      "vite/client",
+      "node",
+      "vitest"
+    ]
+  },
+  "include": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx"
+  ]
+}

--- a/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/vite.config.mts__tmpl__
+++ b/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/vite.config.mts__tmpl__
@@ -9,7 +9,7 @@ export default defineConfig(() => ({
   cacheDir: '../../../node_modules/.vite/<%= projectRoot %>',
   plugins: [angular(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
   test: {
-    name: '<%= name %>',
+    name: '<%= projectName %>',
     watch: false,
     globals: true,
     environment: 'jsdom',

--- a/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/vite.config.mts__tmpl__
+++ b/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/files/vite.config.mts__tmpl__
@@ -1,0 +1,24 @@
+/// <reference types='vitest' />
+import { defineConfig } from 'vite';
+import angular from '@analogjs/vite-plugin-angular';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
+
+export default defineConfig(() => ({
+  root: __dirname,
+  cacheDir: '../../../node_modules/.vite/<%= projectRoot %>',
+  plugins: [angular(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
+  test: {
+    name: '<%= name %>',
+    watch: false,
+    globals: true,
+    environment: 'jsdom',
+    include: ['{src,tests}/**/*.{test,spec}.{js,mts,cjs,ts,cts,jsx,tsx}'],
+    setupFiles: ['src/test-setup.ts'],
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: '../../../coverage/<%= projectRoot %>',
+      provider: 'v8' as const,
+    },
+  },
+}));

--- a/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/generator.ts
+++ b/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/generator.ts
@@ -1,0 +1,98 @@
+import {
+  formatFiles,
+  generateFiles,
+  joinPathFragments,
+  names,
+  Tree,
+  updateJson,
+} from '@nx/devkit';
+import * as path from 'node:path';
+import type { FeatureLibSchema } from './schema';
+
+const SCOPES_VALIDOS = ['selecao', 'ingresso', 'portal'] as const;
+type Scope = (typeof SCOPES_VALIDOS)[number];
+
+interface NormalizedOptions {
+  scope: Scope;
+  name: string;
+  type: FeatureLibSchema['type'];
+  projectRoot: string;
+  projectName: string;
+  importPath: string;
+  prefix: string;
+}
+
+function normalizarOpcoes(options: FeatureLibSchema): NormalizedOptions {
+  const partes = options.name.split('/');
+  if (partes.length !== 2) {
+    throw new Error(
+      `Nome inválido "${options.name}". Use o formato <scope>/<name> (ex: selecao/feature-editais-detail).`,
+    );
+  }
+  const [scope, rawName] = partes;
+  if (!SCOPES_VALIDOS.includes(scope as Scope)) {
+    throw new Error(
+      `Scope inválido "${scope}". Scopes válidos: ${SCOPES_VALIDOS.join(', ')}.`,
+    );
+  }
+  const nomeNormalizado = names(rawName).fileName;
+  if (!/^[a-z][-a-z0-9]*$/.test(nomeNormalizado)) {
+    throw new Error(
+      `Nome de lib inválido "${rawName}". Use kebab-case ASCII começando por letra (ex: feature-editais-detail).`,
+    );
+  }
+  return {
+    scope: scope as Scope,
+    name: nomeNormalizado,
+    type: options.type,
+    projectRoot: joinPathFragments('libs', scope, nomeNormalizado),
+    projectName: nomeNormalizado,
+    importPath: `@uniplus/${scope}-${nomeNormalizado}`,
+    prefix: scope,
+  };
+}
+
+function registrarPathMapping(tree: Tree, opts: NormalizedOptions): void {
+  updateJson(tree, 'tsconfig.base.json', (json) => {
+    json.compilerOptions = json.compilerOptions ?? {};
+    json.compilerOptions.paths = json.compilerOptions.paths ?? {};
+    if (json.compilerOptions.paths[opts.importPath]) {
+      throw new Error(
+        `Path "${opts.importPath}" já registrado em tsconfig.base.json. Provavelmente a lib já existe ou o nome conflita.`,
+      );
+    }
+    json.compilerOptions.paths[opts.importPath] = [
+      `${opts.projectRoot}/src/index.ts`,
+    ];
+    return json;
+  });
+}
+
+export default async function featureLibGenerator(
+  tree: Tree,
+  options: FeatureLibSchema,
+): Promise<void> {
+  const opts = normalizarOpcoes(options);
+
+  if (tree.exists(opts.projectRoot)) {
+    throw new Error(
+      `Diretório ${opts.projectRoot} já existe. Escolha outro nome ou apague antes de gerar.`,
+    );
+  }
+
+  generateFiles(
+    tree,
+    path.join(__dirname, 'files'),
+    opts.projectRoot,
+    {
+      ...opts,
+      tmpl: '',
+      // EJS helpers para os templates
+      tags: JSON.stringify([`scope:${opts.scope}`, `type:${opts.type}`]),
+    },
+  );
+
+  registrarPathMapping(tree, opts);
+
+  await formatFiles(tree);
+}

--- a/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/generator.ts
+++ b/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/generator.ts
@@ -46,7 +46,12 @@ function normalizarOpcoes(options: FeatureLibSchema): NormalizedOptions {
     name: nomeNormalizado,
     type: options.type,
     projectRoot: joinPathFragments('libs', scope, nomeNormalizado),
-    projectName: nomeNormalizado,
+    // Project name é prefixado pelo scope (`<scope>-<name>`) para garantir
+    // unicidade no Nx graph quando dois scopes diferentes geram libs com o
+    // mesmo `<name>` (ex: `selecao/foo` e `portal/foo`). Sem o prefixo, ambos
+    // sairiam como project `foo` e o graph resolution quebraria. Manter
+    // alinhado com `importPath` (`@uniplus/<scope>-<name>`).
+    projectName: `${scope}-${nomeNormalizado}`,
     importPath: `@uniplus/${scope}-${nomeNormalizado}`,
     prefix: scope,
   };

--- a/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/schema.d.ts
+++ b/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/schema.d.ts
@@ -1,0 +1,8 @@
+export type FeatureLibType = 'feature' | 'ui' | 'data-access';
+
+export interface FeatureLibSchema {
+  /** Nome da lib no formato `<scope>/<name>`. */
+  name: string;
+  /** Tipo da lib no eixo `type:*`. */
+  type: FeatureLibType;
+}

--- a/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/schema.json
+++ b/tools/workspace-generators/uniplus-workspace/src/generators/feature-lib/schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "UniPlusFeatureLib",
+  "title": "Cria uma feature lib taggeada para um scope do Uni+",
+  "description": "Gera libs/<scope>/<name>/ com builder ng-packagr-lite, vitest config, index barrel e path mapping em tsconfig.base.json.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Nome da lib no formato <scope>/<name>. Exemplo: selecao/feature-editais-detail.",
+      "$default": { "$source": "argv", "index": 0 },
+      "x-prompt": "Qual o nome da lib (formato <scope>/<name>)?",
+      "pattern": "^(selecao|ingresso|portal)/[a-z][-a-z0-9]*$"
+    },
+    "type": {
+      "type": "string",
+      "description": "Tipo da lib no eixo type:* do enforce-module-boundaries.",
+      "enum": ["feature", "ui", "data-access"],
+      "x-prompt": {
+        "message": "Tipo da lib?",
+        "type": "list",
+        "items": ["feature", "ui", "data-access"]
+      }
+    }
+  },
+  "required": ["name", "type"]
+}

--- a/tools/workspace-generators/uniplus-workspace/tsconfig.json
+++ b/tools/workspace-generators/uniplus-workspace/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "es2022",
+    "outDir": "./dist",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/files/**"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,7 +10,10 @@
     "importHelpers": true,
     "target": "ES2022",
     "module": "ES2022",
-    "lib": ["ES2022", "dom"],
+    "lib": [
+      "ES2022",
+      "dom"
+    ],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
@@ -20,13 +23,28 @@
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true,
     "paths": {
-      "@uniplus/shared-ui": ["libs/shared-ui/src/index.ts"],
-      "@uniplus/shared-auth": ["libs/shared-auth/src/index.ts"],
-      "@uniplus/shared-core": ["libs/shared-core/src/index.ts"],
-      "@uniplus/shared-data": ["libs/shared-data/src/index.ts"],
-      "@uniplus/shared-utils": ["libs/shared-utils/src/index.ts"],
-      "@uniplus/shared-e2e": ["libs/shared-e2e/src/index.ts"]
+      "@uniplus/shared-ui": [
+        "libs/shared-ui/src/index.ts"
+      ],
+      "@uniplus/shared-auth": [
+        "libs/shared-auth/src/index.ts"
+      ],
+      "@uniplus/shared-core": [
+        "libs/shared-core/src/index.ts"
+      ],
+      "@uniplus/shared-data": [
+        "libs/shared-data/src/index.ts"
+      ],
+      "@uniplus/shared-utils": [
+        "libs/shared-utils/src/index.ts"
+      ],
+      "@uniplus/shared-e2e": [
+        "libs/shared-e2e/src/index.ts"
+      ]
     }
   },
-  "exclude": ["node_modules", "tmp"]
+  "exclude": [
+    "node_modules",
+    "tmp"
+  ]
 }


### PR DESCRIPTION
## Resumo

Adiciona generator local `@uniplus/workspace:feature-lib` que cria feature libs taggeadas em `libs/<scope>/<name>/` em < 30 s wall-clock. Inverte a fricção: o caminho correto (criar feature lib própria) vira o mais rápido, evitando o failure mode "dumpar código em `shared-ui` quando sprint pressure aperta".

## Estrutura

```
tools/workspace-generators/uniplus-workspace/
├── package.json                          ("@uniplus/workspace", privado)
├── generators.json                       (registra feature-lib)
├── tsconfig.json
├── README.md                             (uso, validações, builders V1/V2)
└── src/generators/feature-lib/
    ├── generator.ts                      (factory + normalizarOpcoes + registrarPathMapping)
    ├── schema.json                       (pattern + enum)
    ├── schema.d.ts
    └── files/                            (templates EJS __tmpl__)
        ├── eslint.config.mjs__tmpl__
        ├── ng-package.json__tmpl__
        ├── package.json__tmpl__
        ├── project.json__tmpl__
        ├── tsconfig.{json,lib.json,lib.prod.json,spec.json}__tmpl__
        ├── vite.config.mts__tmpl__
        └── src/
            ├── index.ts__tmpl__
            ├── test-setup.ts__tmpl__
            └── lib/
                ├── index.ts__tmpl__
                ├── __name__.ts__tmpl__
                └── __name__.spec.ts__tmpl__
```

Plugin descoberto pelo Nx CLI via dependency local em `package.json`:

```json
"@uniplus/workspace": "file:tools/workspace-generators/uniplus-workspace"
```

`npm install` (e `npm ci` no CI) cria symlink em `node_modules/@uniplus/workspace`.

## Validações do generator

| Caso | Mecanismo |
|---|---|
| `<scope>` ∈ `{selecao, ingresso, portal}` | regex pattern no schema |
| `<type>` ∈ `{feature, ui, data-access}` | enum schema |
| Nome em kebab-case ASCII | regex pattern |
| Lib não pode pré-existir | `tree.exists(projectRoot)` falha com mensagem clara |
| Path mapping não pode pré-existir | check em `updateJson` de `tsconfig.base.json` |

## Tags emitidas

| `--type` | Tags do `project.json` gerado |
|---|---|
| `feature` | `["scope:<scope>", "type:feature"]` |
| `ui` | `["scope:<scope>", "type:ui"]` |
| `data-access` | `["scope:<scope>", "type:data-access"]` |

## Builder em V1

`@nx/angular:ng-packagr-lite` para todos os tipos (uniformidade com `shared-*`, ADR-0021 Onda 1 ratificada). `@nx/js:tsc` para `data-access` puro fica para V2 / Onda 2.

## Smoke test (executado localmente, artefatos descartados antes do commit)

```bash
$ time npx nx g @uniplus/workspace:feature-lib selecao/feature-test-smoke --type=feature --skip-nx-cache
… 1.5s

$ time (npx nx reset && \
        npx nx run feature-test-smoke:lint --skip-nx-cache && \
        npx nx run feature-test-smoke:test --skip-nx-cache && \
        npx nx run feature-test-smoke:build --skip-nx-cache)
…
NX   Successfully ran target build for project feature-test-smoke
6.7s wall-clock total
```

Wall-clock total cold-cache: **6.7 s** — bem dentro do budget de < 3 min da Story.

Cleanup: `rm -rf libs/selecao + del path mapping em tsconfig.base.json` (executado antes deste commit).

## Validações de erro confirmadas

```bash
$ npx nx g @uniplus/workspace:feature-lib invalido/lib --type=feature
NX   Property 'name' does not match the schema. 'invalido/lib' should match the pattern '^(selecao|ingresso|portal)/[a-z][-a-z0-9]*$'.

$ npx nx g @uniplus/workspace:feature-lib selecao/foo --type=bar
NX   Property 'type' does not match the schema. 'bar' should be one of feature,ui,data-access.

$ npx nx g @uniplus/workspace:feature-lib selecao/Foo_BAD --type=feature
NX   Property 'name' does not match the schema. 'selecao/Foo_BAD' should match the pattern '^(selecao|ingresso|portal)/[a-z][-a-z0-9]*$'.
```

## Validações da suíte completa pós-changes

| Gate | Resultado |
|---|---|
| `nx run-many --target=lint --all` | 13/13 verde (12 + `@uniplus/workspace` inferido como project virtual pelo `@nx/eslint/plugin`) |
| `nx run-many --target=test --all` | 8/8 verde, fitness #246 inclui `shared-data:test` em 532 ms — sem regressão |

## Critérios de aceite

- [x] Smoke test verde em < 3 min wall-clock cold-cache (6.7 s observado).
- [x] Plugin invocação não polui o workspace permanentemente (artifact removido).
- [x] Generator emite tags corretas (verificável por `nx graph`).
- [x] Path mapping registrado é resolvível pelo TypeScript.

## Riscos / rollback

Risco baixo. Smoke test exercitou o caminho feliz + 3 caminhos de erro. Rollback: `git revert` + `npm ci` (devolve symlink).

Closes #247

Refs Epic #243