### PR TITLE
refactor(eslint): permitir type:data-access ler type:data + type:auth

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -54,8 +54,20 @@ export default [
               onlyDependOnLibsWithTags: ['type:util', 'type:core'],
             },
             {
+              // `type:data-access` admite `type:data` porque feature libs HTTP
+              // por definição consomem DTOs/schemas/InjectionToken/services de
+              // `@uniplus/shared-data` (`type:data`) — `EditalDto`, `EditaisApi`,
+              // `SELECAO_BASE_PATH`, `provideRuntimeConfig`. Sem essa entrada,
+              // devs forçariam `type:feature` (mais permissivo) e o tipo
+              // `data-access` ficaria sem uso prático. Decisão registrada em
+              // [#254](https://github.com/unifesspa-edu-br/uniplus-web/issues/254).
               sourceTag: 'type:data-access',
-              onlyDependOnLibsWithTags: ['type:util', 'type:core'],
+              onlyDependOnLibsWithTags: [
+                'type:util',
+                'type:core',
+                'type:data',
+                'type:auth',
+              ],
             },
             {
               sourceTag: 'type:util',


### PR DESCRIPTION
## Resumo

Follow-up de #253 (Story #245). A matriz literal da Story produziu `type:data-access → ['type:util', 'type:core']`, mas feature libs `type:data-access` (geradas via #256/#247) por definição consomem DTOs/schemas/InjectionToken/services de `@uniplus/shared-data` (`type:data`). Sem essa permissão, devs forçariam `type:feature` (mais permissivo) e o tipo `data-access` ficaria sem uso prático.

## Decisão (opção A da issue #254)

Adiciona `type:data` e `type:auth` em `onlyDependOnLibsWithTags` de `type:data-access`:

```diff
 {
+  // `type:data-access` admite `type:data` porque feature libs HTTP
+  // por definição consomem DTOs/schemas/InjectionToken/services de
+  // `@uniplus/shared-data` (`type:data`) — `EditalDto`, `EditaisApi`,
+  // `SELECAO_BASE_PATH`, `provideRuntimeConfig`.
   sourceTag: 'type:data-access',
-  onlyDependOnLibsWithTags: ['type:util', 'type:core'],
+  onlyDependOnLibsWithTags: [
+    'type:util',
+    'type:core',
+    'type:data',
+    'type:auth',
+  ],
 },
```

`type:auth` segue a mesma justificativa que `type:data → type:auth` (ADR-0021): feature data-access pode precisar de `UserContextService`/`AuthService` para personalizar requests por usuário autenticado.

## Validação

| Gate | Resultado |
|---|---|
| `nx run-many --target=lint --all` (workspace atual) | 13/13 verde |
| Mutation test off-tree | Boundary aceita; só warning ortogonal de `@nx/dependency-checks` (peerDeps) |

### Mutation test off-tree

```bash
$ nx g @uniplus/workspace:feature-lib selecao/data-access-mut-test --type=data-access
$ # injetado: import type { EditalDto } from '@uniplus/shared-data'
$ nx run selecao-data-access-mut-test:lint
```

Resultado: **NENHUM** erro de `@nx/enforce-module-boundaries`. Apenas warning ortogonal de `@nx/dependency-checks` sobre `@uniplus/shared-data` faltar em `peerDependencies` — esperado para libs locais não publicadas e fora do escopo desta PR. Branch nunca commitada; artifact removido + path mapping deletado de `tsconfig.base.json` antes deste commit.

## Critérios de aceite

- [x] Decisão registrada (opção A da issue) — comentário inline em `eslint.config.mjs` cita #254 + ADR-0021.
- [x] `eslint.config.mjs` ajustado: `type:data-access` agora pode importar de `type:data` e `type:auth`.
- [x] #246 (fitness spec) continua verde — re-asserta a matriz dinamicamente, sem alteração necessária.
- [x] #247 (generator) já emite `type:data-access` como tag possível; sem alteração necessária.

## Riscos / rollback

Risco baixo. Mudança apenas relaxa uma constraint para um tipo (`type:data-access`) que ainda não tem nenhuma lib real no workspace. Rollback: `git revert`.

Closes #254

Refs Epic #243