### PR TITLE
fix(build): desabilitar inlineCritical para conformar CSP estrita (#358)

### DIFF
--- a/apps/ingresso/project.json
+++ b/apps/ingresso/project.json
@@ -36,7 +36,15 @@
               "maximumError": "8kb"
             }
           ],
-          "outputHashing": "all"
+          "outputHashing": "all",
+          "optimization": {
+            "scripts": true,
+            "fonts": true,
+            "styles": {
+              "minify": true,
+              "inlineCritical": false
+            }
+          }
         },
         "development": {
           "optimization": false,

--- a/apps/portal/project.json
+++ b/apps/portal/project.json
@@ -36,7 +36,15 @@
               "maximumError": "8kb"
             }
           ],
-          "outputHashing": "all"
+          "outputHashing": "all",
+          "optimization": {
+            "scripts": true,
+            "fonts": true,
+            "styles": {
+              "minify": true,
+              "inlineCritical": false
+            }
+          }
         },
         "development": {
           "optimization": false,

--- a/apps/selecao/project.json
+++ b/apps/selecao/project.json
@@ -36,7 +36,15 @@
               "maximumError": "8kb"
             }
           ],
-          "outputHashing": "all"
+          "outputHashing": "all",
+          "optimization": {
+            "scripts": true,
+            "fonts": true,
+            "styles": {
+              "minify": true,
+              "inlineCritical": false
+            }
+          }
         },
         "development": {
           "optimization": false,


### PR DESCRIPTION
## Resumo

Closes #358. Smoke E2E pós-deploy standalone (uniplus-infra#171) expôs erro CSP recorrente nas 3 SPAs:

\`\`\`
[ERROR] Executing inline event handler violates 'script-src 'self''
@ portal.standalone.portaluni.com.br/:8
\`\`\`

## Causa

\`@angular/build:application\` injeta por padrão um \`<link rel="stylesheet" media="print" onload="this.media='all'">\` no index.html como otimização de async-loading de CSS crítico (Beasties). O \`onload\` é um inline event handler que viola a CSP \`script-src 'self'\` configurada em \`docker/nginx.conf:72\`.

## Fix

Desabilitar \`optimization.styles.inlineCritical\` na configuração de produção das 3 apps:

\`\`\`json
"optimization": {
  "scripts": true,
  "fonts": true,
  "styles": {
    "minify": true,
    "inlineCritical": false
  }
}
\`\`\`

Mantém minificação e demais otimizações; só remove a inserção do \`<link onload>\`.

## Trade-off

| Item | Antes | Depois |
|---|---|---|
| FCP em conexão lenta | melhor (CSS crítico inline + async load do bundle) | +50–100ms estimado |
| CSP | violava \`script-src 'self'\` | passa limpa |
| Aderência ao Padrão Digital de Governo | parcial (CSP relaxada exigida) | total (sem \`unsafe-inline\`/\`unsafe-hashes\`) |
| Robustez | hash do handler quebra a cada bump Angular | independente de versão |

Para SPAs administrativas como Uni+ (autarquia federal, usuário autenticado, sem SEO público), o ganho marginal de FCP não justifica afrouxar CSP.

## Validação local

\`\`\`bash
nx run-many -t build --projects=portal,selecao,ingresso --configuration=production
grep -c "onload\\|media=\\\"print\\\"" dist/apps/*/browser/index.html
# → 0 ocorrências em todos os 3
\`\`\`

\`index.html\` resultante:

\`\`\`html
<link rel="stylesheet" href="styles-K5LF5KO5.css">
\`\`\`

Sem \`media="print" onload\`, sem inline event handler.

## Plano de rollback

Reverter o commit. Os 3 builds voltam ao comportamento anterior (\`inlineCritical: true\` default).

## Test plan

- [ ] CI: lint + build production limpos nas 3 apps
- [ ] Após bump de imagens GHCR (\`v0.1.1\`) e atualização de tags em uniplus-infra: smoke browser pós-deploy
- [ ] Console DevTools: 0 erros CSP em \`https://{portal,selecao,ingresso}.standalone.portaluni.com.br\`