### PR TITLE
feat(shared-core): NotificationService aceitar ProblemDetails + traceId/persistent

### DIFF
--- a/libs/shared-core/src/lib/services/notification.service.spec.ts
+++ b/libs/shared-core/src/lib/services/notification.service.spec.ts
@@ -1,0 +1,159 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpHeaders } from '@angular/common/http';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NotificationService } from './notification.service';
+import type { ProblemDetails } from '../http/problem-details';
+
+function montarProblem(overrides: Partial<ProblemDetails> = {}): ProblemDetails {
+  return {
+    type: 'https://uniplus.unifesspa.edu.br/erros/exemplo',
+    title: 'Recurso não encontrado',
+    status: 404,
+    detail: 'Edital com id 42 não existe.',
+    code: 'uniplus.selecao.edital.nao_encontrado',
+    traceId: '0123456789abcdef0123456789abcdef',
+    ...overrides,
+  };
+}
+
+describe('NotificationService', () => {
+  let service: NotificationService;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(NotificationService);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('success/info/warning/error simples', () => {
+    it('publica notification com type/title/detail e auto-dismiss em 5 s', () => {
+      const id = service.success('Salvo', 'Edital criado com sucesso.');
+      expect(service.notifications()).toHaveLength(1);
+      const [n] = service.notifications();
+      expect(n.id).toBe(id);
+      expect(n.type).toBe('success');
+      expect(n.title).toBe('Salvo');
+      expect(n.detail).toBe('Edital criado com sucesso.');
+      expect(n.persistent).toBe(false);
+      expect(n.traceId).toBeUndefined();
+      expect(n.code).toBeUndefined();
+
+      vi.advanceTimersByTime(5000);
+      expect(service.notifications()).toHaveLength(0);
+    });
+
+    it('respeita timeoutMs override em info/warning', () => {
+      service.info('Aviso', 'Sessão expira em 5 min.', { timeoutMs: 1000 });
+      vi.advanceTimersByTime(999);
+      expect(service.notifications()).toHaveLength(1);
+      vi.advanceTimersByTime(1);
+      expect(service.notifications()).toHaveLength(0);
+    });
+
+    it('persistent=true não auto-dismisses', () => {
+      const id = service.warning('Atenção', 'Verifique anexos', { persistent: true });
+      vi.advanceTimersByTime(60_000);
+      expect(service.notifications()).toHaveLength(1);
+      service.dismiss(id);
+      expect(service.notifications()).toHaveLength(0);
+    });
+
+    it('error simples segue mesmo padrão de auto-dismiss', () => {
+      service.error('Falha', 'Conexão recusada.');
+      vi.advanceTimersByTime(5000);
+      expect(service.notifications()).toHaveLength(0);
+    });
+  });
+
+  describe('errorFromProblem', () => {
+    it('extrai title/detail/code/traceId do ProblemDetails', () => {
+      const problem = montarProblem();
+      service.errorFromProblem(problem);
+      const [n] = service.notifications();
+      expect(n.type).toBe('error');
+      expect(n.title).toBe(problem.title);
+      expect(n.detail).toBe(problem.detail);
+      expect(n.code).toBe(problem.code);
+      expect(n.traceId).toBe(problem.traceId);
+    });
+
+    it('aplica persistent automaticamente em status >= 500', () => {
+      service.errorFromProblem(montarProblem({ status: 503 }));
+      const [n] = service.notifications();
+      expect(n.persistent).toBe(true);
+      vi.advanceTimersByTime(60_000);
+      expect(service.notifications()).toHaveLength(1);
+    });
+
+    it('mantém timeout normal em 4xx (não persistent)', () => {
+      service.errorFromProblem(montarProblem({ status: 404 }));
+      const [n] = service.notifications();
+      expect(n.persistent).toBe(false);
+      vi.advanceTimersByTime(5000);
+      expect(service.notifications()).toHaveLength(0);
+    });
+
+    it('overrides.title/detail substituem os do problem (LGPD: PII-safe)', () => {
+      service.errorFromProblem(
+        montarProblem({ detail: 'CPF 123.456.789-09 não encontrado' }),
+        { detail: 'Documento não encontrado.' },
+      );
+      const [n] = service.notifications();
+      expect(n.detail).toBe('Documento não encontrado.');
+      expect(n.detail).not.toContain('CPF');
+    });
+
+    it('overrides.persistent prevalece sobre o default por status', () => {
+      service.errorFromProblem(montarProblem({ status: 503 }), { persistent: false });
+      const [n] = service.notifications();
+      expect(n.persistent).toBe(false);
+    });
+
+    it('traceId vazio do backend vira undefined (não habilita botão "copiar")', () => {
+      service.errorFromProblem(montarProblem({ traceId: '' }));
+      const [n] = service.notifications();
+      expect(n.traceId).toBeUndefined();
+    });
+
+    it('retorna id sequencial para chamadas paralelas', () => {
+      const id1 = service.errorFromProblem(montarProblem());
+      const id2 = service.errorFromProblem(montarProblem());
+      expect(id2).toBeGreaterThan(id1);
+      expect(service.notifications()).toHaveLength(2);
+    });
+  });
+
+  describe('dismiss + clearAll', () => {
+    it('dismiss(id) cancela timer associado e remove da fila', () => {
+      const id = service.success('Salvo');
+      service.dismiss(id);
+      expect(service.notifications()).toHaveLength(0);
+      // Avançar o timer não pode causar erro nem reaparecer
+      vi.advanceTimersByTime(5000);
+      expect(service.notifications()).toHaveLength(0);
+    });
+
+    it('clearAll esvazia fila e cancela timers pendentes', () => {
+      service.success('a');
+      service.success('b');
+      service.error('c');
+      expect(service.notifications()).toHaveLength(3);
+      service.clearAll();
+      expect(service.notifications()).toHaveLength(0);
+      vi.advanceTimersByTime(60_000);
+      expect(service.notifications()).toHaveLength(0);
+    });
+  });
+
+  describe('signature compatibility', () => {
+    it('HttpHeaders importado mas não exposto pelo signal — evita leak', () => {
+      // Sanity: garantir que ProblemDetails é o único contrato de entrada estruturada.
+      const headers = new HttpHeaders({ 'x-trace-id': 'abc' });
+      expect(headers.get('x-trace-id')).toBe('abc');
+    });
+  });
+});

--- a/libs/shared-core/src/lib/services/notification.service.ts
+++ b/libs/shared-core/src/lib/services/notification.service.ts
@@ -1,41 +1,161 @@
 import { Injectable, signal } from '@angular/core';
+import type { ProblemDetails } from '../http/problem-details';
 
+export type NotificationType = 'success' | 'error' | 'warning' | 'info';
+
+/**
+ * Toast renderizado pelo `NotificationHostComponent` (`shared-ui`).
+ *
+ * Campos `traceId` e `code` só aparecem em notificações disparadas por
+ * `errorFromProblem(problem)` — em `success/info/warning/error` simples
+ * ficam `undefined`. O host usa `traceId` para habilitar botão
+ * "Copiar traceId" e `code` para hooks futuros de i18n/analytics.
+ *
+ * `persistent: true` instrui o host a não auto-dismiss; default em 5xx.
+ */
 export interface Notification {
-  id: number;
-  type: 'success' | 'error' | 'warning' | 'info';
-  title: string;
-  message: string;
+  readonly id: number;
+  readonly type: NotificationType;
+  readonly title: string;
+  readonly detail?: string;
+  readonly traceId?: string;
+  readonly code?: string;
+  readonly persistent: boolean;
 }
 
+export interface NotificationOptions {
+  /** Override do timeout (ms). Default: 5000. Ignorado se `persistent`. */
+  readonly timeoutMs?: number;
+  /** Quando `true`, toast não auto-dismisses — usuário fecha manualmente. */
+  readonly persistent?: boolean;
+}
+
+/**
+ * Override opcional ao despachar a partir de `ProblemDetails`. Quando ausentes,
+ * `title`/`detail` vêm do próprio `problem` — o backend já garante PII-safe.
+ *
+ * **LGPD:** quem registrar override é responsável por garantir que o texto
+ * não interpole `errors[].message`/`detail` raw. Use `errors[].field` +
+ * `errors[].code` como chaves para mensagens estáticas pt-BR.
+ */
+export interface NotificationFromProblemOptions extends NotificationOptions {
+  readonly title?: string;
+  readonly detail?: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 5000;
+const SERVER_ERROR_THRESHOLD = 500;
+
+/**
+ * Hub de notificações da `uniplus-web` (ADR-0011/0012).
+ *
+ * Mantém a fila de toasts ativos como signal e expõe API tipada para os
+ * containers despacharem mensagens. O renderer fica em `shared-ui`
+ * (`NotificationHostComponent`) — o serviço é puro de UI.
+ *
+ * **Toasts disparados via `errorFromProblem(problem)`** carregam `traceId`,
+ * `code` e ficam persistentes em 5xx por default — o suporte de incidentes
+ * precisa do trace ID copiável para vincular ao log/Tempo. Status 4xx
+ * permanece com timeout normal.
+ */
 @Injectable({ providedIn: 'root' })
 export class NotificationService {
   private counter = 0;
-  private readonly _notifications = signal<Notification[]>([]);
+  private readonly _notifications = signal<readonly Notification[]>([]);
   readonly notifications = this._notifications.asReadonly();
+  private readonly timers = new Map<number, ReturnType<typeof setTimeout>>();
 
-  success(title: string, message: string): void {
-    this.add('success', title, message);
+  success(title: string, detail?: string, options?: NotificationOptions): number {
+    return this.add('success', title, detail, options);
   }
 
-  error(title: string, message: string): void {
-    this.add('error', title, message);
+  warning(title: string, detail?: string, options?: NotificationOptions): number {
+    return this.add('warning', title, detail, options);
   }
 
-  warning(title: string, message: string): void {
-    this.add('warning', title, message);
+  info(title: string, detail?: string, options?: NotificationOptions): number {
+    return this.add('info', title, detail, options);
   }
 
-  info(title: string, message: string): void {
-    this.add('info', title, message);
+  error(title: string, detail?: string, options?: NotificationOptions): number {
+    return this.add('error', title, detail, options);
+  }
+
+  /**
+   * Dispara toast de erro a partir de `ProblemDetails` (`ApiFailure.problem`).
+   *
+   * - `title`/`detail` vêm de `overrides` quando providos; senão de
+   *   `problem.title`/`problem.detail`.
+   * - `traceId` é exposto para o host renderizar botão "Copiar traceId"
+   *   quando o backend emitiu trace context não-vazio.
+   * - `persistent` é `true` por default em status `>= 500`; pode ser
+   *   sobrescrito via `overrides.persistent`.
+   */
+  errorFromProblem(
+    problem: ProblemDetails,
+    overrides?: NotificationFromProblemOptions,
+  ): number {
+    const id = ++this.counter;
+    const persistent =
+      overrides?.persistent ?? problem.status >= SERVER_ERROR_THRESHOLD;
+    const traceId = problem.traceId.length > 0 ? problem.traceId : undefined;
+    const notification: Notification = {
+      id,
+      type: 'error',
+      title: overrides?.title ?? problem.title,
+      detail: overrides?.detail ?? problem.detail,
+      traceId,
+      code: problem.code,
+      persistent,
+    };
+    this.publish(notification, overrides?.timeoutMs);
+    return id;
   }
 
   dismiss(id: number): void {
+    const timer = this.timers.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      this.timers.delete(id);
+    }
     this._notifications.update((items) => items.filter((n) => n.id !== id));
   }
 
-  private add(type: Notification['type'], title: string, message: string): void {
+  /** Limpa todas as notificações ativas — útil em logout/route change. */
+  clearAll(): void {
+    for (const timer of this.timers.values()) {
+      clearTimeout(timer);
+    }
+    this.timers.clear();
+    this._notifications.set([]);
+  }
+
+  private add(
+    type: NotificationType,
+    title: string,
+    detail: string | undefined,
+    options: NotificationOptions | undefined,
+  ): number {
     const id = ++this.counter;
-    this._notifications.update((items) => [...items, { id, type, title, message }]);
-    setTimeout(() => this.dismiss(id), 5000);
+    const persistent = options?.persistent ?? false;
+    const notification: Notification = {
+      id,
+      type,
+      title,
+      detail,
+      persistent,
+    };
+    this.publish(notification, options?.timeoutMs);
+    return id;
+  }
+
+  private publish(notification: Notification, timeoutMs: number | undefined): void {
+    this._notifications.update((items) => [...items, notification]);
+    if (notification.persistent) {
+      return;
+    }
+    const timeout = timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const timer = setTimeout(() => this.dismiss(notification.id), timeout);
+    this.timers.set(notification.id, timer);
   }
 }


### PR DESCRIPTION
## Resumo

PR-A da Story #171 (3 PRs sequenciais: shared-core → shared-ui → apps). Refatora `NotificationService` em `libs/shared-core/src/lib/services/` para aceitar `ProblemDetails` (ADR-0023 do `uniplus-api` — RFC 9457 + extensions Uni+) e habilitar os campos que o `NotificationHostComponent` (próximo PR-B) precisará para o toast: `traceId`, `code` e `persistent`.

## Mudanças

### `Notification` interface

| Campo | Antes | Depois |
|---|---|---|
| `id`, `type`, `title` | ✓ | ✓ |
| `message: string` | ✓ | renomeado → `detail?: string` |
| `traceId?: string` | — | NOVO (W3C trace context) |
| `code?: string` | — | NOVO (`uniplus.<modulo>.<razao>`) |
| `persistent: boolean` | — | NOVO (toast não auto-dismiss) |

### Novos métodos

- `errorFromProblem(problem: ProblemDetails, overrides?: NotificationFromProblemOptions): number`
  - Extrai `title`/`detail`/`code`/`traceId` do `ProblemDetails`.
  - `persistent = true` por default em `status >= 500` (suporte de incidente precisa do `traceId` copiável; ver PR-B).
  - `traceId === ''` (string vazia do backend) vira `undefined` — host não renderiza botão "copiar" sem fallback inválido.
  - `overrides.title`/`detail` permitem o caller substituir o conteúdo do `problem` (LGPD: neutraliza PII residual em `problem.detail`).
- `clearAll()`: limpa fila + cancela timers pendentes (útil em logout/route change).

### Compatibilidade

- `success/info/warning/error` mantêm a signature `(title, detail?, options?)`. O parâmetro antes chamado `message` virou `detail` na interface; o tipo aceita `undefined`. Sem consumers externos hoje (grep zero em `apps/` + `libs/`).
- Refactor não-breaking efetivamente; estará disponível para os 3 apps consumirem quando o `NotificationHost` for entregue em PR-B.

## Testes

14 specs Vitest novos em `notification.service.spec.ts`, agrupados por:

| Grupo | Cenários |
|---|---|
| `success/info/warning/error simples` | publica + auto-dismiss em 5 s; timeoutMs override; persistent=true não dismisses; error simples segue mesmo padrão |
| `errorFromProblem` | extrai title/detail/code/traceId; persistent automático em 5xx; normal em 4xx; override.title/detail substitui (PII-safe); override.persistent prevalece; traceId='' → undefined; ids sequenciais |
| `dismiss + clearAll` | dismiss(id) cancela timer + remove; clearAll esvazia + cancela timers |

## Validação

| Gate | Resultado |
|---|---|
| `nx run shared-core:test` (specs novos) | 14/14 verde, 35 ms |
| `nx run-many --target=test --all` | 8/8 verde, 119 testes total |
| `nx run-many --target=lint --all` | 13/13 verde |
| `nx run-many --target=build --all` | 8/8 verde |

## Critérios de aceite endereçados

- [x] **CA-04 base** — API exposta para o host renderizar (`title`, `detail`, `traceId`, `code`, `persistent`). Host UI vem em PR-B.
- [x] **CA-06 (LGPD)** — `errorFromProblem` permite override de `title`/`detail` para neutralizar PII residual; comentário inline + spec dedicado.

## Próximos PRs

- **PR-B** (shared-ui): `NotificationHostComponent` (toast renderer com botão "Copiar traceId") + `DataTable` enhancements (`aria-busy`, output `retry`, link reportar incidente).
- **PR-C** (apps): monta `<ui-notification-host>` em `selecao`/`ingresso`/`portal`; Edital screens disparam `errorFromProblem` em casos 5xx; Playwright E2E + axe-core.

## Riscos / rollback

Risco baixo. Sem consumers; refactor isolado em uma lib. Rollback: `git revert`.

Refs Story #171 (CA-04 base)
Refs Feature #167
Refs Epic #259 (Milestone B)