### PR TITLE
fix(nginx): remover 'unsafe-inline' de style-src no CSP (#360)

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -49,8 +49,10 @@ server {
         # com a CSP global após hardening do issue #360. CSP3 split: blocos
         # <style> bloqueados (style-src-elem 'self'); atributos style="..."
         # permitidos (style-src-attr 'unsafe-inline') porque Angular renderiza
-        # bindings [style.X] como atributo inline.
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src-elem 'self'; style-src-attr 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src *; frame-src *; frame-ancestors 'self';" always;
+        # bindings [style.X] como atributo inline. `style-src` legacy mantido
+        # como fallback para browsers CSP2 (sem -elem/-attr) — sem ele, esses
+        # browsers caem no `default-src 'self'` que bloqueia inline styles.
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; style-src-elem 'self'; style-src-attr 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src *; frame-src *; frame-ancestors 'self';" always;
         try_files $uri =404;
     }
 
@@ -76,6 +78,9 @@ server {
     # build-time substitution que viola o invariante "imagem única por app".
     #
     # CSP3 split em `style-src` (#360):
+    # - `style-src 'self' 'unsafe-inline'`: legacy fallback para browsers CSP2
+    #   (sem -elem/-attr). Sem ele, esses browsers caem no default-src 'self'
+    #   que bloqueia atributos style="..." (Codex P2 PR #362).
     # - `style-src-elem 'self'`: bloqueia <style> blocks e <link rel=stylesheet>
     #   externos não-self. Beasties desativado em #358 / v0.1.1 deixou de
     #   injetar <style> inline. Estilização agora vem de `styles-*.css`
@@ -84,8 +89,9 @@ server {
     #   elementos HTML. Necessário para Angular [style.X] bindings (e.g.,
     #   `data-table.ts:42` tem [style.width]). Risco menor que <style> block
     #   injetado: atributo só afeta o próprio elemento, não regras globais.
-    # - `style-src` legacy: omitido — browsers usam style-src-elem/attr
-    #   diretamente quando ambos estão presentes (CSP3 fallback OK em browsers
-    #   antigos que ignoram diretivas desconhecidas).
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src-elem 'self'; style-src-attr 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src *; frame-src *; frame-ancestors 'self';" always;
+    #
+    # Browsers CSP3 (Chrome 75+/Firefox 75+/Safari 15.4+) honram -elem/-attr
+    # e ignoram `style-src` legacy → hardening efetivo. Browsers CSP2 caem no
+    # legacy → comportamento equivalente ao pré-#360 (funcional, sem hardening).
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; style-src-elem 'self'; style-src-attr 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src *; frame-src *; frame-ancestors 'self';" always;
 }

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -45,10 +45,12 @@ server {
         add_header X-XSS-Protection "1; mode=block" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
-        # `style-src 'self'` (sem unsafe-inline) — silent-check-sso.html é
-        # template estático sem inline styles; alinha com a CSP global após
-        # hardening do issue #360.
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src *; frame-src *; frame-ancestors 'self';" always;
+        # silent-check-sso.html é template estático sem inline styles; alinha
+        # com a CSP global após hardening do issue #360. CSP3 split: blocos
+        # <style> bloqueados (style-src-elem 'self'); atributos style="..."
+        # permitidos (style-src-attr 'unsafe-inline') porque Angular renderiza
+        # bindings [style.X] como atributo inline.
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src-elem 'self'; style-src-attr 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src *; frame-src *; frame-ancestors 'self';" always;
         try_files $uri =404;
     }
 
@@ -72,10 +74,18 @@ server {
     # `connect-src *` é necessário porque a URL real de Keycloak e API vem do
     # ConfigMap em runtime (não embutida na imagem — ADR-0020); apertar exige
     # build-time substitution que viola o invariante "imagem única por app".
-    # `style-src 'self'` (sem unsafe-inline) — habilitado em #360 após o build
-    # parar de injetar `<style>` inline (Beasties desativado em #358 / v0.1.1).
-    # Toda estilização vem de `styles-*.css` externo + Tailwind utility classes.
-    # Validação: smoke browser nas 3 SPAs deve ter console DevTools 0 erros CSP
-    # (incluindo navegação por overlays PrimeNG: dropdowns, dialogs, calendars).
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src *; frame-src *; frame-ancestors 'self';" always;
+    #
+    # CSP3 split em `style-src` (#360):
+    # - `style-src-elem 'self'`: bloqueia <style> blocks e <link rel=stylesheet>
+    #   externos não-self. Beasties desativado em #358 / v0.1.1 deixou de
+    #   injetar <style> inline. Estilização agora vem de `styles-*.css`
+    #   externo + Tailwind utility classes.
+    # - `style-src-attr 'unsafe-inline'`: permite atributos style="..." em
+    #   elementos HTML. Necessário para Angular [style.X] bindings (e.g.,
+    #   `data-table.ts:42` tem [style.width]). Risco menor que <style> block
+    #   injetado: atributo só afeta o próprio elemento, não regras globais.
+    # - `style-src` legacy: omitido — browsers usam style-src-elem/attr
+    #   diretamente quando ambos estão presentes (CSP3 fallback OK em browsers
+    #   antigos que ignoram diretivas desconhecidas).
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src-elem 'self'; style-src-attr 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src *; frame-src *; frame-ancestors 'self';" always;
 }

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -45,7 +45,10 @@ server {
         add_header X-XSS-Protection "1; mode=block" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src *; frame-src *; frame-ancestors 'self';" always;
+        # `style-src 'self'` (sem unsafe-inline) — silent-check-sso.html é
+        # template estático sem inline styles; alinha com a CSP global após
+        # hardening do issue #360.
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src *; frame-src *; frame-ancestors 'self';" always;
         try_files $uri =404;
     }
 
@@ -69,5 +72,10 @@ server {
     # `connect-src *` é necessário porque a URL real de Keycloak e API vem do
     # ConfigMap em runtime (não embutida na imagem — ADR-0020); apertar exige
     # build-time substitution que viola o invariante "imagem única por app".
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src *; frame-src *; frame-ancestors 'self';" always;
+    # `style-src 'self'` (sem unsafe-inline) — habilitado em #360 após o build
+    # parar de injetar `<style>` inline (Beasties desativado em #358 / v0.1.1).
+    # Toda estilização vem de `styles-*.css` externo + Tailwind utility classes.
+    # Validação: smoke browser nas 3 SPAs deve ter console DevTools 0 erros CSP
+    # (incluindo navegação por overlays PrimeNG: dropdowns, dialogs, calendars).
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src *; frame-src *; frame-ancestors 'self';" always;
 }


### PR DESCRIPTION
## Resumo

Closes #360. Hardening do CSP do nginx das 3 SPAs Uni+: \`style-src\` deixa de aceitar \`'unsafe-inline'\`. Mudança encapsulada em 1 arquivo (\`docker/nginx.conf\`), 2 declarações (server-level + location \`silent-check-sso.html\`).

## Por que agora

PR #359 (v0.1.1, closes #358) desabilitou \`optimization.styles.inlineCritical\` no build de produção, eliminando os \`<style>\` blocks inline que o Beasties extraía. O \`'unsafe-inline'\` em \`style-src\` virou puramente permissivo, sem nenhum payload legítimo.

## Auditoria do source (uniplus-web)

\`\`\`bash
# Zero ocorrências de cada padrão de risco:
grep -rn 'styles:\\s*\\[' apps/{portal,selecao,ingresso} libs --include="*.ts"  # 0
grep -rnE 'encapsulation:\\s*ViewEncapsulation\\.None' apps libs --include="*.ts"  # 0
grep -rnE "createElement\\(.style.\\)|insertAdjacentHTML.*<style" ...  # 0
\`\`\`

Toda estilização vem de \`styles-<hash>.css\` externo + Tailwind utility classes em \`class=\"...\"\` (não \`style=\"...\"\`).

## Risco residual

PrimeNG 21.1.4 está em uso em modo unstyled + PassThrough (ADR-018). Em alguns componentes (overlays: dropdown, calendar, dialog, autocomplete), PrimeNG pode injetar \`<style>\` em runtime via JS para posicionamento dinâmico (FloatingUI/Popper).

Se isso quebrar pós-deploy, opções (em ordem de preferência, declaradas no issue #360):

1. Mover styles dinâmicos para classe utilitária Tailwind via JS (mais limpo)
2. Adicionar \`'unsafe-hashes' 'sha256-...'\` para os styles específicos
3. Rollback documentando a necessidade

## Validação local

\`\`\`bash
docker run --rm -v "\$PWD/docker/nginx.conf:/etc/nginx/conf.d/default.conf:ro" \\
  nginxinc/nginx-unprivileged:alpine nginx -t
# nginx: the configuration file /etc/nginx/nginx.conf test is successful
\`\`\`

CI build (próximo step) também valida sintaxe e build das imagens.

## Test plan

- [ ] CI green (build das 3 imagens com novo nginx.conf)
- [ ] Tag \`v0.1.2\` + workflow Publish Images success
- [ ] Bump em \`uniplus-infra/apps/uniplus-web/values.yaml\` para \`v0.1.2\`
- [ ] ArgoCD reconcilia + rolling restart
- [ ] **Smoke browser ampliado** — não só load home, mas:
  - portal → /processos → clicar nos 4 links de navegação (Processos / Acompanhamento / Documentos / Meu Perfil) — força componentes PrimeNG a renderizar
  - selecao + ingresso: tela de login Keycloak (servida pelo Keycloak, não pelo nginx das SPAs — fora do escopo deste CSP)
  - **Console DevTools 0 erros CSP** em todas as navegações
- [ ] Lighthouse Best Practices score sobe (CSP estrita pontua)

## Plano de rollback

Reverter o commit em uniplus-web + tag v0.1.3 com nginx.conf restaurado (ou bump v0.1.0 → v0.1.1 mantém anterior — porém v0.1.1 já tem o build limpo). Alternativa: temporariamente bump em uniplus-infra para uma tag que tenha o nginx anterior.

## Refs

- #358 (PR #359 / v0.1.1) — pré-requisito que eliminou \`<style>\` inline
- ADR-0020 — runtime config via ConfigMap (não embutida na imagem)
- ADR-018 — PrimeNG unstyled + PassThrough
- OWASP CSP Cheat Sheet
- Padrão Digital de Governo / Portaria SEI-MCOM 540/2020