### PR TITLE
feat(shared-ui): NotificationHost + DataTable retry/aria-busy/traceId

### DIFF
--- a/apps/selecao/src/app/features/editais/editais-list.page.ts
+++ b/apps/selecao/src/app/features/editais/editais-list.page.ts
@@ -47,11 +47,13 @@ import { DataTableColumn, DataTableComponent } from '@uniplus/shared-ui';
       [data]="rows()"
       [loading]="loading()"
       [errorMessage]="errorMessage()"
+      [errorTraceId]="errorTraceId()"
       [nextCursor]="nextCursor()"
       [rowClickable]="true"
       emptyMessage="Nenhum edital cadastrado."
       (loadNext)="aoCarregarMais($event)"
       (rowClick)="aoSelecionar($event)"
+      (retry)="aoTentarNovamente()"
     />
   `,
 })
@@ -65,6 +67,10 @@ export class EditaisListPage {
   readonly nextCursor = signal<Cursor | null>(null);
   readonly loading = signal<boolean>(false);
   readonly errorMessage = signal<string | null>(null);
+  /** Trace context da última falha — alimenta o link "Reportar incidente" do DataTable. */
+  readonly errorTraceId = signal<string | null>(null);
+  /** Cursor preservado da última falha pós-1ª página, para o retry retomar do mesmo ponto. */
+  private cursorUltimaFalha: Cursor | undefined = undefined;
 
   protected readonly rows = computed(
     () => this.editais() as readonly Record<string, unknown>[],
@@ -92,12 +98,22 @@ export class EditaisListPage {
     }
   }
 
+  /**
+   * Handler do output `retry` do `DataTableComponent`. Reusa o cursor
+   * pré-falha (paginação) ou recomeça do zero (carga inicial). Sem
+   * `cursorUltimaFalha`, equivale a retentar a 1ª página.
+   */
+  protected aoTentarNovamente(): void {
+    this.carregar(this.cursorUltimaFalha);
+  }
+
   private carregar(cursor: Cursor | undefined): void {
     if (this.loading()) {
       return;
     }
     this.loading.set(true);
     this.errorMessage.set(null);
+    this.errorTraceId.set(null);
 
     this.api
       .listar(cursor)
@@ -107,12 +123,17 @@ export class EditaisListPage {
         if (result.ok) {
           this.editais.update((prev) => [...prev, ...result.data]);
           this.nextCursor.set(extractNextCursor(result.headers.get('Link')));
+          this.cursorUltimaFalha = undefined;
           return;
         }
         this.errorMessage.set(this.problemI18n.resolve(result.problem).title);
+        this.errorTraceId.set(
+          result.problem.traceId.length > 0 ? result.problem.traceId : null,
+        );
         // Em falha pós-1ª página, preserva o cursor original — usuário consegue
         // retentar via "Carregar mais" sem perder os items já carregados. Em
         // falha de carga inicial, o cursor já é null por construção.
+        this.cursorUltimaFalha = cursor;
       });
   }
 }

--- a/libs/shared-core/src/lib/index.ts
+++ b/libs/shared-core/src/lib/index.ts
@@ -1,7 +1,10 @@
 // Services
 export { LoadingService } from './services/loading.service';
 export { NotificationService } from './services/notification.service';
-export type { Notification } from './services/notification.service';
+export type {
+  Notification,
+  NotificationType,
+} from './services/notification.service';
 
 // Interceptors
 export { loadingInterceptor } from './interceptors/loading.interceptor';

--- a/libs/shared-ui/src/lib/components/data-table/data-table.spec.ts
+++ b/libs/shared-ui/src/lib/components/data-table/data-table.spec.ts
@@ -238,4 +238,106 @@ describe('DataTableComponent', () => {
     linhas[0].nativeElement.click();
     expect(emit).not.toHaveBeenCalled();
   });
+
+  it('aria-busy=true no <table> quando loading()', () => {
+    const { fixture } = setup();
+    fixture.componentRef.setInput('columns', COLUMNS);
+    fixture.componentRef.setInput('loading', true);
+    fixture.detectChanges();
+
+    const table = fixture.debugElement.query(By.css('table')).nativeElement as HTMLTableElement;
+    expect(table.getAttribute('aria-busy')).toBe('true');
+
+    fixture.componentRef.setInput('loading', false);
+    fixture.detectChanges();
+    expect(table.getAttribute('aria-busy')).toBeNull();
+  });
+
+  it('estado erro inicial: renderiza botão "Tentar novamente" + emite output retry no clique', () => {
+    const { fixture, component } = setup();
+    fixture.componentRef.setInput('columns', COLUMNS);
+    fixture.componentRef.setInput('errorMessage', 'Falha de rede.');
+    fixture.detectChanges();
+
+    const retryButton = fixture.debugElement.query(
+      By.css('[data-testid="data-table-retry"]'),
+    );
+    expect(retryButton).not.toBeNull();
+    expect((retryButton.nativeElement as HTMLButtonElement).textContent?.trim()).toBe(
+      'Tentar novamente',
+    );
+
+    const emit = vi.fn();
+    component.retry.subscribe(emit);
+    (retryButton.nativeElement as HTMLButtonElement).click();
+    expect(emit).toHaveBeenCalledTimes(1);
+  });
+
+  it('estado erro inicial com errorTraceId: renderiza "Reportar incidente" e exibe o trace', () => {
+    const { fixture } = setup();
+    fixture.componentRef.setInput('columns', COLUMNS);
+    fixture.componentRef.setInput('errorMessage', 'Falha 500.');
+    fixture.componentRef.setInput('errorTraceId', '0123456789abcdef0123456789abcdef');
+    fixture.detectChanges();
+
+    const trace = fixture.debugElement.query(
+      By.css('[data-testid="data-table-error-trace"]'),
+    );
+    expect(trace).not.toBeNull();
+    expect(trace.nativeElement.textContent).toContain('Reportar incidente');
+    const traceId = fixture.debugElement.query(
+      By.css('[data-testid="data-table-error-trace-id"]'),
+    );
+    expect((traceId.nativeElement as HTMLElement).textContent).toBe(
+      '0123456789abcdef0123456789abcdef',
+    );
+  });
+
+  it('estado erro inicial sem errorTraceId: não renderiza "Reportar incidente"', () => {
+    const { fixture } = setup();
+    fixture.componentRef.setInput('columns', COLUMNS);
+    fixture.componentRef.setInput('errorMessage', 'Falha local.');
+    fixture.detectChanges();
+
+    expect(
+      fixture.debugElement.query(By.css('[data-testid="data-table-error-trace"]')),
+    ).toBeNull();
+  });
+
+  it('errorTraceId="" não habilita link "Reportar incidente" (boundary)', () => {
+    const { fixture } = setup();
+    fixture.componentRef.setInput('columns', COLUMNS);
+    fixture.componentRef.setInput('errorMessage', 'Falha local.');
+    fixture.componentRef.setInput('errorTraceId', '');
+    fixture.detectChanges();
+
+    expect(
+      fixture.debugElement.query(By.css('[data-testid="data-table-error-trace"]')),
+    ).toBeNull();
+  });
+
+  it('estado erro pós-1ª página: banner exibe botão "Tentar novamente" + emite retry', () => {
+    const { fixture, component } = setup();
+    fixture.componentRef.setInput('columns', COLUMNS);
+    fixture.componentRef.setInput('data', DATA);
+    fixture.componentRef.setInput('errorMessage', 'Falha de rede ao paginar.');
+    fixture.componentRef.setInput('nextCursor', createCursor('cursor-retry'));
+    fixture.detectChanges();
+
+    const banner = fixture.debugElement.query(
+      By.css('[data-testid="data-table-error-banner"]'),
+    );
+    expect(banner).not.toBeNull();
+    const retryButton = fixture.debugElement.query(
+      By.css('[data-testid="data-table-retry-banner"]'),
+    );
+    expect((retryButton.nativeElement as HTMLButtonElement).textContent?.trim()).toBe(
+      'Tentar novamente',
+    );
+
+    const emit = vi.fn();
+    component.retry.subscribe(emit);
+    (retryButton.nativeElement as HTMLButtonElement).click();
+    expect(emit).toHaveBeenCalledTimes(1);
+  });
 });

--- a/libs/shared-ui/src/lib/components/data-table/data-table.ts
+++ b/libs/shared-ui/src/lib/components/data-table/data-table.ts
@@ -12,18 +12,28 @@ export interface DataTableColumn {
  * Apresentacional (ADR-0017): tabela paginada por cursor opaco.
  *
  * Estados visuais:
- * - **Loading inicial** (`loading() && data().length === 0`): mensagem de
- *   carregamento ocupa o tbody.
- * - **Erro** (`errorMessage() !== null`): banner role=alert ocupa o tbody.
- *   Render preserva tabela vazia para manter altura previsível.
+ * - **Loading inicial** (`loading() && data().length === 0`): mensagem
+ *   `loadingLabel()` ocupa o tbody. `<table aria-busy="true">` enquanto
+ *   `loading()`, sinaliza estado para tecnologia assistiva (WCAG 2.1
+ *   SC 4.1.3 Status Messages).
+ * - **Erro inicial** (`errorMessage() !== null && data().length === 0`):
+ *   `<td role="alert">` com mensagem + botão "Tentar novamente"
+ *   (output `retry`) + link "Reportar incidente" exibindo o `traceId`
+ *   quando provido (`errorTraceId()`).
+ * - **Erro pós-1ª página** (`errorMessage() !== null && data().length > 0`):
+ *   banner não-bloqueante abaixo da tabela com botão "Tentar novamente";
+ *   preserva o histórico carregado.
  * - **Vazio** (`!loading() && !errorMessage() && data().length === 0`):
  *   mensagem `emptyMessage()` ocupa o tbody.
- * - **Com dados**: tabela renderizada normalmente; quando `nextCursor()` for
- *   truthy, exibe botão "Carregar mais" abaixo da tabela.
+ * - **Com dados**: tabela renderizada normalmente; quando `nextCursor()`
+ *   for truthy, exibe botão "Carregar mais" abaixo da tabela.
  *
- * Output `loadNext` emite o cursor atual (não-null) quando o usuário clica em
- * "Carregar mais". O container resolve o `loading` durante a próxima request
- * — o botão fica disabled enquanto `loading()`.
+ * Outputs:
+ * - `loadNext` — emite o cursor atual quando "Carregar mais" é clicado.
+ * - `retry` — emite quando "Tentar novamente" é clicado em qualquer
+ *   estado de erro. Container decide se reusa cursor pré-falha ou
+ *   recomeça do zero.
+ * - `rowClick` — emite quando uma linha clicável é ativada.
  */
 @Component({
   selector: 'ui-data-table',
@@ -32,7 +42,11 @@ export interface DataTableColumn {
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="overflow-x-auto rounded-lg border border-gray-200">
-      <table class="min-w-full divide-y divide-gray-200" role="grid">
+      <table
+        class="min-w-full divide-y divide-gray-200"
+        role="grid"
+        [attr.aria-busy]="loading() ? 'true' : null"
+      >
         <thead class="bg-govbr-primary">
           <tr>
             @for (col of columns(); track col.field) {
@@ -48,21 +62,46 @@ export interface DataTableColumn {
         </thead>
         <tbody class="divide-y divide-gray-200 bg-white">
           @if (mostrarErroNoCorpo()) {
-            <tr>
+            <tr data-testid="data-table-error-row">
               <td
                 [attr.colspan]="columns().length"
                 class="px-4 py-6 text-center"
                 role="alert"
+                data-testid="data-table-error-cell"
               >
-                <span class="text-sm font-semibold text-red-700">{{ errorMessage() }}</span>
+                <div class="flex flex-col items-center gap-2">
+                  <span class="text-sm font-semibold text-red-700" data-testid="data-table-error-message">{{
+                    errorMessage()
+                  }}</span>
+                  <div class="flex flex-wrap items-center justify-center gap-3">
+                    <button
+                      type="button"
+                      class="rounded-md border border-red-300 bg-white px-3 py-1.5 text-xs font-medium text-red-700 shadow-sm hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-govbr-primary"
+                      data-testid="data-table-retry"
+                      (click)="emitirRetry()"
+                    >
+                      {{ retryLabel() }}
+                    </button>
+                    @if (mostrarReporteDeIncidente()) {
+                      <span class="text-xs text-red-700" data-testid="data-table-error-trace">
+                        {{ reportIncidentLabel() }}
+                        <code
+                          class="ml-1 select-all rounded bg-red-100 px-1 py-0.5 font-mono text-[10px] text-red-900"
+                          data-testid="data-table-error-trace-id"
+                        >{{ errorTraceId() }}</code>
+                      </span>
+                    }
+                  </div>
+                </div>
               </td>
             </tr>
           } @else if (mostrarLoadingInicial()) {
-            <tr>
+            <tr data-testid="data-table-loading-row">
               <td
                 [attr.colspan]="columns().length"
                 class="px-4 py-8 text-center text-sm text-gray-500"
                 aria-live="polite"
+                data-testid="data-table-loading-cell"
               >
                 {{ loadingLabel() }}
               </td>
@@ -71,6 +110,7 @@ export interface DataTableColumn {
             @for (row of data(); track row[trackByField()] ?? $index) {
               <tr
                 class="transition-colors"
+                data-testid="data-table-row"
                 [class.hover:bg-gray-50]="rowClickable()"
                 [class.cursor-pointer]="rowClickable()"
                 [attr.role]="rowClickable() ? 'button' : null"
@@ -86,8 +126,12 @@ export interface DataTableColumn {
                 }
               </tr>
             } @empty {
-              <tr>
-                <td [attr.colspan]="columns().length" class="px-4 py-8 text-center text-sm text-gray-500">
+              <tr data-testid="data-table-empty-row">
+                <td
+                  [attr.colspan]="columns().length"
+                  class="px-4 py-8 text-center text-sm text-gray-500"
+                  data-testid="data-table-empty-cell"
+                >
                   {{ emptyMessage() }}
                 </td>
               </tr>
@@ -99,10 +143,30 @@ export interface DataTableColumn {
 
     @if (mostrarBannerDeErro()) {
       <div
-        class="mt-3 flex items-start gap-2 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800"
+        class="mt-3 flex flex-wrap items-start justify-between gap-3 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800"
         role="alert"
+        data-testid="data-table-error-banner"
       >
-        <span class="font-semibold">{{ errorMessage() }}</span>
+        <div class="flex flex-col gap-1">
+          <span class="font-semibold" data-testid="data-table-error-banner-message">{{ errorMessage() }}</span>
+          @if (mostrarReporteDeIncidente()) {
+            <span class="text-xs" data-testid="data-table-error-banner-trace">
+              {{ reportIncidentLabel() }}
+              <code
+                class="ml-1 select-all rounded bg-red-100 px-1 py-0.5 font-mono text-[10px] text-red-900"
+                data-testid="data-table-error-banner-trace-id"
+              >{{ errorTraceId() }}</code>
+            </span>
+          }
+        </div>
+        <button
+          type="button"
+          class="rounded-md border border-red-300 bg-white px-3 py-1.5 text-xs font-medium text-red-700 shadow-sm hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-govbr-primary"
+          data-testid="data-table-retry-banner"
+          (click)="emitirRetry()"
+        >
+          {{ retryLabel() }}
+        </button>
       </div>
     }
 
@@ -111,6 +175,7 @@ export interface DataTableColumn {
         <button
           type="button"
           class="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-govbr-primary disabled:cursor-not-allowed disabled:opacity-60"
+          data-testid="data-table-load-more"
           [disabled]="loading()"
           (click)="emitirLoadNext()"
         >
@@ -125,10 +190,20 @@ export class DataTableComponent {
   readonly data = input<readonly Record<string, unknown>[]>([]);
   readonly loading = input<boolean>(false);
   readonly errorMessage = input<string | null>(null);
+  /**
+   * Trace context (W3C) opcional acompanhando o erro atual. Quando provido
+   * (string não-vazia), o estado de erro renderiza o link "Reportar
+   * incidente: <traceId>" para o usuário copiar e referenciar ao reportar
+   * o problema. Em falhas client-side (`uniplus.client.*` codes) o trace
+   * pode vir vazio — neste caso o link é suprimido.
+   */
+  readonly errorTraceId = input<string | null>(null);
   readonly nextCursor = input<Cursor | null>(null);
   readonly emptyMessage = input<string>('Nenhum registro encontrado.');
   readonly loadMoreLabel = input<string>('Carregar mais');
   readonly loadingLabel = input<string>('Carregando…');
+  readonly retryLabel = input<string>('Tentar novamente');
+  readonly reportIncidentLabel = input<string>('Reportar incidente:');
   /**
    * Campo do row usado pelo `track` do `@for`. Default `id` cobre todos os
    * DTOs do contrato V1 (UUID v7 estável). Para listas sem `id`, o consumer
@@ -138,6 +213,13 @@ export class DataTableComponent {
 
   readonly loadNext = output<Cursor>();
   readonly rowClick = output<Record<string, unknown>>();
+  /**
+   * Emitido quando o usuário clica em "Tentar novamente" em qualquer
+   * estado de erro (corpo da tabela ou banner pós-1ª página). Container
+   * decide a estratégia: refazer carga inicial, retentar com o mesmo
+   * cursor pré-falha, etc.
+   */
+  readonly retry = output<void>();
   /** Quando true, linhas ganham hover/cursor/role=button e respondem a click + Enter/Space. */
   readonly rowClickable = input<boolean>(false);
 
@@ -158,12 +240,21 @@ export class DataTableComponent {
   protected readonly mostrarBotaoCarregarMais = computed(
     () => this.nextCursor() !== null,
   );
+  /** Renderiza link "Reportar incidente" apenas quando há trace context não-vazio. */
+  protected readonly mostrarReporteDeIncidente = computed(() => {
+    const traceId = this.errorTraceId();
+    return typeof traceId === 'string' && traceId.length > 0;
+  });
 
   protected emitirLoadNext(): void {
     const cursor = this.nextCursor();
     if (cursor !== null && !this.loading()) {
       this.loadNext.emit(cursor);
     }
+  }
+
+  protected emitirRetry(): void {
+    this.retry.emit();
   }
 
   /**

--- a/libs/shared-ui/src/lib/components/notification-host/notification-host.spec.ts
+++ b/libs/shared-ui/src/lib/components/notification-host/notification-host.spec.ts
@@ -1,0 +1,187 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NotificationService } from '@uniplus/shared-core';
+import type { ProblemDetails } from '@uniplus/shared-core';
+import { NotificationHostComponent } from './notification-host';
+
+function montarProblem(overrides: Partial<ProblemDetails> = {}): ProblemDetails {
+  return {
+    type: 'https://uniplus.unifesspa.edu.br/erros/exemplo',
+    title: 'Recurso não encontrado',
+    status: 404,
+    detail: 'Edital com id 42 não existe.',
+    code: 'uniplus.selecao.edital.nao_encontrado',
+    traceId: '0123456789abcdef0123456789abcdef',
+    ...overrides,
+  };
+}
+
+function byTestId<T extends Element = HTMLElement>(
+  fixture: ComponentFixture<NotificationHostComponent>,
+  testId: string,
+): T | null {
+  const debug = fixture.debugElement.query(By.css(`[data-testid="${testId}"]`));
+  return (debug?.nativeElement as T) ?? null;
+}
+
+function allByTestId<T extends Element = HTMLElement>(
+  fixture: ComponentFixture<NotificationHostComponent>,
+  testId: string,
+): T[] {
+  return fixture.debugElement
+    .queryAll(By.css(`[data-testid="${testId}"]`))
+    .map((debug) => debug.nativeElement as T);
+}
+
+describe('NotificationHostComponent', () => {
+  let service: NotificationService;
+  let fixture: ComponentFixture<NotificationHostComponent>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    TestBed.configureTestingModule({
+      imports: [NotificationHostComponent],
+    });
+    service = TestBed.inject(NotificationService);
+    fixture = TestBed.createComponent(NotificationHostComponent);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    TestBed.resetTestingModule();
+  });
+
+  describe('rendering por tipo', () => {
+    it('renderiza nada quando fila está vazia', () => {
+      expect(allByTestId(fixture, 'notification-host-toast-success')).toHaveLength(0);
+      expect(allByTestId(fixture, 'notification-host-toast-error')).toHaveLength(0);
+      expect(allByTestId(fixture, 'notification-host-toast-warning')).toHaveLength(0);
+      expect(allByTestId(fixture, 'notification-host-toast-info')).toHaveLength(0);
+    });
+
+    it('renderiza article role=alert + aria-live=assertive para error', () => {
+      service.error('Falha', 'detalhe');
+      fixture.detectChanges();
+      const article = byTestId(fixture, 'notification-host-toast-error');
+      expect(article).not.toBeNull();
+      expect(article?.getAttribute('role')).toBe('alert');
+      expect(article?.getAttribute('aria-live')).toBe('assertive');
+    });
+
+    it('renderiza article role=status + aria-live=polite para success', () => {
+      service.success('Pronto');
+      fixture.detectChanges();
+      const article = byTestId(fixture, 'notification-host-toast-success');
+      expect(article?.getAttribute('role')).toBe('status');
+      expect(article?.getAttribute('aria-live')).toBe('polite');
+    });
+
+    it('renderiza article aria-live=assertive para warning', () => {
+      service.warning('Atenção');
+      fixture.detectChanges();
+      const article = byTestId(fixture, 'notification-host-toast-warning');
+      expect(article?.getAttribute('aria-live')).toBe('assertive');
+    });
+
+    it('exibe title e detail quando ambos providos', () => {
+      service.info('Sessão expira', 'Em 5 minutos.');
+      fixture.detectChanges();
+      const title = byTestId(fixture, 'notification-host-title');
+      const detail = byTestId(fixture, 'notification-host-detail');
+      expect(title?.textContent?.trim()).toBe('Sessão expira');
+      expect(detail?.textContent?.trim()).toBe('Em 5 minutos.');
+    });
+  });
+
+  describe('botão "Copiar traceId"', () => {
+    it('não renderiza quando notification não tem traceId', () => {
+      service.error('Falha local');
+      fixture.detectChanges();
+      expect(byTestId(fixture, 'notification-host-copy-trace')).toBeNull();
+      expect(byTestId(fixture, 'notification-host-trace-block')).toBeNull();
+    });
+
+    it('renderiza com traceId quando errorFromProblem(problem) provê', () => {
+      service.errorFromProblem(montarProblem({ traceId: 'abc123' }));
+      fixture.detectChanges();
+      const code = byTestId(fixture, 'notification-host-trace-id');
+      expect(code?.textContent?.trim()).toBe('abc123');
+      const copyBtn = byTestId<HTMLButtonElement>(fixture, 'notification-host-copy-trace');
+      expect(copyBtn?.getAttribute('aria-label')).toContain('abc123');
+    });
+
+    it('clipboard.writeText é chamado com o traceId no clique', () => {
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(globalThis.navigator, 'clipboard', {
+        value: { writeText },
+        configurable: true,
+      });
+
+      service.errorFromProblem(montarProblem({ traceId: 'xyz789' }));
+      fixture.detectChanges();
+      byTestId<HTMLButtonElement>(fixture, 'notification-host-copy-trace')?.click();
+
+      expect(writeText).toHaveBeenCalledWith('xyz789');
+    });
+
+    it('falha silenciosa quando clipboard API ausente', () => {
+      Object.defineProperty(globalThis.navigator, 'clipboard', {
+        value: undefined,
+        configurable: true,
+      });
+
+      service.errorFromProblem(montarProblem({ traceId: 'no-api' }));
+      fixture.detectChanges();
+      const copyBtn = byTestId<HTMLButtonElement>(fixture, 'notification-host-copy-trace');
+      expect(() => copyBtn?.click()).not.toThrow();
+    });
+  });
+
+  describe('dispensar', () => {
+    it('clique no botão fechar remove o toast', () => {
+      service.error('Falha');
+      fixture.detectChanges();
+      expect(byTestId(fixture, 'notification-host-toast-error')).not.toBeNull();
+
+      byTestId<HTMLButtonElement>(fixture, 'notification-host-dismiss')?.click();
+      fixture.detectChanges();
+      expect(byTestId(fixture, 'notification-host-toast-error')).toBeNull();
+    });
+  });
+
+  describe('persistência em 5xx', () => {
+    it('toast errorFromProblem 503 não some após timeout default', () => {
+      service.errorFromProblem(montarProblem({ status: 503 }));
+      fixture.detectChanges();
+      vi.advanceTimersByTime(60_000);
+      fixture.detectChanges();
+      expect(byTestId(fixture, 'notification-host-toast-error')).not.toBeNull();
+    });
+
+    it('toast 4xx some após 5 s default', () => {
+      service.errorFromProblem(montarProblem({ status: 404 }));
+      fixture.detectChanges();
+      vi.advanceTimersByTime(5000);
+      fixture.detectChanges();
+      expect(byTestId(fixture, 'notification-host-toast-error')).toBeNull();
+    });
+  });
+
+  describe('a11y', () => {
+    it('section container tem role=region + aria-label', () => {
+      const section = fixture.debugElement.query(By.css('section'))
+        ?.nativeElement as HTMLElement;
+      expect(section?.getAttribute('role')).toBe('region');
+      expect(section?.getAttribute('aria-label')).toBe('Notificações do sistema');
+    });
+
+    it('botão fechar tem aria-label descritivo', () => {
+      service.success('a');
+      fixture.detectChanges();
+      const closeBtn = byTestId<HTMLButtonElement>(fixture, 'notification-host-dismiss');
+      expect(closeBtn?.getAttribute('aria-label')).toBe('Fechar notificação');
+    });
+  });
+});

--- a/libs/shared-ui/src/lib/components/notification-host/notification-host.ts
+++ b/libs/shared-ui/src/lib/components/notification-host/notification-host.ts
@@ -1,0 +1,174 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import {
+  Notification,
+  NotificationService,
+  NotificationType,
+} from '@uniplus/shared-core';
+
+/**
+ * Apresentacional (ADR-0017): renderiza a fila de toasts mantida pelo
+ * `NotificationService` (`shared-core`).
+ *
+ * Coloque uma única instância no shell de cada app:
+ * ```html
+ * <ui-notification-host />
+ * ```
+ *
+ * **Acessibilidade (WCAG 2.1 AA + e-MAG 3.1):**
+ * - Container com `role="region"` + `aria-label` descritivo.
+ * - Cada toast renderizado com `role="status"` (info/success/warning) ou
+ *   `role="alert"` (error). Em info/success usa `aria-live="polite"`,
+ *   em error/warning usa `aria-live="assertive"` para garantir anúncio
+ *   imediato pelo leitor de tela.
+ * - Botões "Copiar traceId" e "Fechar" são `<button type="button">`
+ *   focáveis via Tab; navegação por teclado nativa.
+ *
+ * **`Copiar traceId`:** botão renderizado apenas quando
+ * `notification.traceId` é não-vazio. Usa `navigator.clipboard.writeText`
+ * com fallback silencioso em navegadores antigos (operador opt-in via
+ * `aria-pressed` para feedback). `traceId` selecionável via `select-all`
+ * dispensa clipboard quando esta API não existir.
+ */
+@Component({
+  selector: 'ui-notification-host',
+  standalone: true,
+  imports: [],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <section
+      class="pointer-events-none fixed inset-x-0 top-4 z-50 flex flex-col items-end gap-2 px-4 sm:items-end"
+      role="region"
+      aria-label="Notificações do sistema"
+    >
+      @for (notification of notifications(); track notification.id) {
+        <article
+          class="pointer-events-auto flex w-full max-w-md flex-col gap-2 rounded-md border px-4 py-3 shadow-lg"
+          [attr.data-testid]="'notification-host-toast-' + notification.type"
+          [class.border-green-200]="notification.type === 'success'"
+          [class.bg-green-50]="notification.type === 'success'"
+          [class.text-green-900]="notification.type === 'success'"
+          [class.border-red-200]="notification.type === 'error'"
+          [class.bg-red-50]="notification.type === 'error'"
+          [class.text-red-900]="notification.type === 'error'"
+          [class.border-amber-200]="notification.type === 'warning'"
+          [class.bg-amber-50]="notification.type === 'warning'"
+          [class.text-amber-900]="notification.type === 'warning'"
+          [class.border-blue-200]="notification.type === 'info'"
+          [class.bg-blue-50]="notification.type === 'info'"
+          [class.text-blue-900]="notification.type === 'info'"
+          [attr.role]="papelAria(notification.type)"
+          [attr.aria-live]="ariaLive(notification.type)"
+          [attr.aria-atomic]="true"
+        >
+          <div class="flex items-start justify-between gap-2">
+            <p class="text-sm font-semibold" data-testid="notification-host-title">{{ notification.title }}</p>
+            <button
+              type="button"
+              class="-m-1 rounded p-1 text-current opacity-70 hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-govbr-primary"
+              data-testid="notification-host-dismiss"
+              [attr.aria-label]="dismissLabel"
+              (click)="dispensar(notification.id)"
+            >
+              ×
+            </button>
+          </div>
+          @if (notification.detail) {
+            <p class="text-xs leading-relaxed" data-testid="notification-host-detail">{{ notification.detail }}</p>
+          }
+          @if (notification.traceId) {
+            <div
+              class="flex flex-wrap items-center gap-2 border-t border-current/10 pt-2 text-xs"
+              data-testid="notification-host-trace-block"
+            >
+              <span>{{ traceIdLabel }}</span>
+              <code
+                class="select-all rounded bg-black/5 px-1 py-0.5 font-mono text-[11px]"
+                data-testid="notification-host-trace-id"
+              >{{ notification.traceId }}</code>
+              <button
+                type="button"
+                class="rounded border border-current/20 bg-white/60 px-2 py-0.5 text-[11px] font-medium hover:bg-white focus:outline-none focus:ring-2 focus:ring-govbr-primary"
+                data-testid="notification-host-copy-trace"
+                [attr.aria-label]="copyTraceLabelFor(notification.traceId)"
+                [attr.aria-pressed]="idsCopiados().has(notification.id)"
+                (click)="copiarTrace(notification.id, notification.traceId)"
+              >
+                {{ idsCopiados().has(notification.id) ? copiedLabel : copyLabel }}
+              </button>
+            </div>
+          }
+        </article>
+      }
+    </section>
+  `,
+})
+export class NotificationHostComponent {
+  private readonly service = inject(NotificationService);
+  protected readonly notifications = this.service.notifications;
+  /** IDs de notifications cujo traceId já foi copiado (para feedback de "Copiado!"). */
+  private readonly _idsCopiados = signal<ReadonlySet<number>>(new Set());
+  protected readonly idsCopiados = this._idsCopiados.asReadonly();
+
+  /** Labels — futuramente movíveis para um service de i18n; por enquanto pt-BR fixo. */
+  protected readonly dismissLabel = 'Fechar notificação';
+  protected readonly traceIdLabel = 'ID de rastreamento:';
+  protected readonly copyLabel = 'Copiar';
+  protected readonly copiedLabel = 'Copiado!';
+
+  protected readonly hasNotifications = computed(
+    () => this.notifications().length > 0,
+  );
+
+  protected dispensar(id: number): void {
+    this.service.dismiss(id);
+  }
+
+  /**
+   * Copia o `traceId` para o clipboard. Em navegadores sem
+   * `navigator.clipboard` (HTTP non-secure context, IE legado etc.) cai em
+   * fallback no-op — o usuário pode selecionar o `<code>` (que tem
+   * `select-all`) e copiar manualmente.
+   */
+  protected copiarTrace(id: number, traceId: string): void {
+    const clipboard = typeof navigator !== 'undefined' ? navigator.clipboard : undefined;
+    if (!clipboard?.writeText) {
+      return;
+    }
+    void clipboard.writeText(traceId).then(
+      () => {
+        this._idsCopiados.update((current) => {
+          const next = new Set(current);
+          next.add(id);
+          return next;
+        });
+      },
+      () => {
+        // Falha silenciosa: o `<code>` continua selecionável manualmente
+        // (atributo `select-all`) e o usuário pode copiar via Ctrl+C.
+      },
+    );
+  }
+
+  protected papelAria(type: NotificationType): 'alert' | 'status' {
+    return type === 'error' ? 'alert' : 'status';
+  }
+
+  protected ariaLive(type: NotificationType): 'assertive' | 'polite' {
+    return type === 'error' || type === 'warning' ? 'assertive' : 'polite';
+  }
+
+  protected copyTraceLabelFor(traceId: string): string {
+    return `Copiar ID de rastreamento ${traceId}`;
+  }
+
+  protected resetTraceCopiadoFlag(_notification: Notification): void {
+    // Reservado para futuro reset por timeout — por enquanto a flag persiste
+    // até o toast ser dispensado, o que é o ciclo de vida natural.
+  }
+}

--- a/libs/shared-ui/src/lib/index.ts
+++ b/libs/shared-ui/src/lib/index.ts
@@ -6,6 +6,7 @@ export { StatusBadgeComponent, type StatusType } from './components/status-badge
 export { ConfirmDialogComponent } from './components/confirm-dialog/confirm-dialog';
 export { FormFieldComponent } from './components/form-field/form-field';
 export { LoadingOverlayComponent } from './components/loading-overlay/loading-overlay';
+export { NotificationHostComponent } from './components/notification-host/notification-host';
 
 // Pipes
 export { CpfPipe } from './pipes/cpf.pipe';


### PR DESCRIPTION
## Resumo

PR-B da Story #171 (PR-A `#361` mergeada em `20210dd`). Entrega o renderer de toasts (`NotificationHostComponent`) que consome a fila do `NotificationService` (refatorado em PR-A) e estende o `DataTableComponent` com `aria-busy`, output `retry` e link "Reportar incidente" exibindo `traceId`. Ajusta `EditaisListPage` para bindar o `(retry)` — sem isso o botão "Tentar novamente" seria visível mas não-funcional.

## Mudanças

### `libs/shared-ui/src/lib/components/notification-host/` (novo)

| Aspecto | Detalhe |
|---|---|
| Render | Cada notification vira `<article>` posicionada top-right do viewport (4 tipos: `success`/`error`/`warning`/`info`) |
| ARIA | `role="alert"` + `aria-live="assertive"` em `error`/`warning`; `role="status"` + `aria-live="polite"` em `success`/`info`; container `<section role="region" aria-label="Notificações do sistema">` |
| Botão "Copiar traceId" | Só renderiza quando `notification.traceId` é não-vazio. `navigator.clipboard.writeText` com fallback silencioso (o `<code>` tem `select-all` para Ctrl+C manual). `aria-pressed` + flag `idsCopiados` exibe "Copiado!" |
| Botão fechar | `aria-label="Fechar notificação"`, chama `service.dismiss(id)` |
| LGPD | Renderiza apenas `title` e `detail` da `Notification` (já PII-safe pelo backend ou via override em `errorFromProblem`) |

### `libs/shared-ui/src/lib/components/data-table/data-table.ts` (extensões CA-03)

| Mudança | Razão |
|---|---|
| `[attr.aria-busy]="loading() ? 'true' : null"` no `<table>` | WCAG 2.1 SC 4.1.3 Status Messages — anuncia carregamento para tecnologia assistiva |
| Output `(retry)` + botão "Tentar novamente" no estado erro inicial | Permite o consumer recarregar sem reload de página; aparece também no banner pós-1ª página |
| Input opcional `[errorTraceId]` + bloco "Reportar incidente: `<traceId>`" | Habilita o usuário copiar trace context para reportar o problema; suprimido se `errorTraceId` é `null`/`""` |
| `data-testid` em todos os elementos relevantes | Pattern do repo (`ConfirmDialogComponent`, `selecao/btn-publicar`); specs selecionam por testid em vez de índice/texto |

### `apps/selecao/src/app/features/editais/editais-list.page.ts` (bind retry — Codex P2)

- `(retry)="aoTentarNovamente()"` chama `carregar(cursorUltimaFalha)` — retoma a paginação do mesmo ponto da falha; em carga inicial equivale a retentar 1ª página.
- `[errorTraceId]="errorTraceId()"` capturado de `problem.traceId` quando não-vazio.
- `cursorUltimaFalha` privado preserva o cursor entre falha e retry.

### `libs/shared-core/src/lib/index.ts`

- Exporta `NotificationType` (consumido pelo `NotificationHost`).

## Validação

| Gate | Resultado |
|---|---|
| `nx run shared-ui:test` | 7/7 files, **111 verde** (14 NotificationHost + 6 DataTable novos + 91 sem regressão) |
| `nx run-many --target=test --all` | 8/8 verde |
| `nx run-many --target=lint --all` | 13/13 verde |
| `nx run-many --target=build --all` | 8/8 verde |
| `codex review --uncommitted` (CLI local) | **zero findings** após bind do `retry` em `EditaisListPage` |

### Codex CLI — pipeline de revisão

Rodadas duas vezes:

1. **1ª rodada (pré-bind)** — P1 sobre arquivos untracked (falso-positivo, resolvido via `git add`) + P2 sobre o botão "Tentar novamente" não-funcional sem handler em `EditaisListPage` (válido, absorvido).
2. **2ª rodada (pós-bind)** — "I did not find any discrete correctness issues in the staged changes."

## Critérios de aceite endereçados

- [x] **CA-03** — DataTable com `aria-busy`, retry button, link "Reportar incidente: <traceId>", + estados loading/empty/error já existentes.
- [x] **CA-04 (UI)** — `NotificationHostComponent` renderiza fila com botão "Copiar traceId" copiável; persistência em 5xx vinda do `NotificationService` (PR-A).
- [x] **CA-06 (LGPD)** — host renderiza apenas `title`/`detail` PII-safe; `<code>` para `traceId` não interpola dados sensíveis.
- [x] **CA-07 (a11y)** — `role`/`aria-live`/`aria-label`/`aria-pressed` aplicados; navegação por teclado nativa via `<button type="button">`. Validação axe-core fica no PR-C (Playwright E2E).

## Próximo PR

**PR-C** (apps): monta `<ui-notification-host />` em `selecao`/`ingresso`/`portal`; Edital screens disparam `errorFromProblem` em paralelo ao banner local; Playwright E2E + axe-core scan.

## Riscos / rollback

Risco baixo. `EditaisListPage` já consome o novo behavior — sem features quebradas para usuário hoje. Rollback: `git revert`.

Refs Story #171 (CA-03 completo + CA-04 host UI)
Refs Feature #167
Refs Epic #259 (Milestone B)