### PR TITLE
feat(apps): NotificationHost + Edital toasts em 5xx

### DIFF
--- a/apps/ingresso/src/app/app.ts
+++ b/apps/ingresso/src/app/app.ts
@@ -1,14 +1,21 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { AuthErrorBannerComponent, LoginErrorBannerComponent } from '@uniplus/shared-auth';
+import { NotificationHostComponent } from '@uniplus/shared-ui';
 
 @Component({
   selector: 'ing-root',
   standalone: true,
-  imports: [RouterOutlet, AuthErrorBannerComponent, LoginErrorBannerComponent],
+  imports: [
+    RouterOutlet,
+    AuthErrorBannerComponent,
+    LoginErrorBannerComponent,
+    NotificationHostComponent,
+  ],
   template: `
     <auth-error-banner />
     <auth-login-error-banner />
+    <ui-notification-host />
     <router-outlet />
   `,
 })

--- a/apps/portal/src/app/app.ts
+++ b/apps/portal/src/app/app.ts
@@ -1,14 +1,21 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { AuthErrorBannerComponent, LoginErrorBannerComponent } from '@uniplus/shared-auth';
+import { NotificationHostComponent } from '@uniplus/shared-ui';
 
 @Component({
   selector: 'ptl-root',
   standalone: true,
-  imports: [RouterOutlet, AuthErrorBannerComponent, LoginErrorBannerComponent],
+  imports: [
+    RouterOutlet,
+    AuthErrorBannerComponent,
+    LoginErrorBannerComponent,
+    NotificationHostComponent,
+  ],
   template: `
     <auth-error-banner />
     <auth-login-error-banner />
+    <ui-notification-host />
     <router-outlet />
   `,
 })

--- a/apps/selecao/src/app/app.ts
+++ b/apps/selecao/src/app/app.ts
@@ -1,14 +1,21 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { AuthErrorBannerComponent, LoginErrorBannerComponent } from '@uniplus/shared-auth';
+import { NotificationHostComponent } from '@uniplus/shared-ui';
 
 @Component({
   selector: 'sel-root',
   standalone: true,
-  imports: [RouterOutlet, AuthErrorBannerComponent, LoginErrorBannerComponent],
+  imports: [
+    RouterOutlet,
+    AuthErrorBannerComponent,
+    LoginErrorBannerComponent,
+    NotificationHostComponent,
+  ],
   template: `
     <auth-error-banner />
     <auth-login-error-banner />
+    <ui-notification-host />
     <router-outlet />
   `,
 })

--- a/apps/selecao/src/app/features/editais/editais-create.page.ts
+++ b/apps/selecao/src/app/features/editais/editais-create.page.ts
@@ -14,6 +14,7 @@ import {
 } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import {
+  NotificationService,
   ProblemDetails,
   ProblemI18nService,
   ProblemValidationError,
@@ -127,6 +128,7 @@ interface CriarEditalForm {
 export class EditaisCreatePage {
   private readonly api = inject(EditaisApi);
   private readonly problemI18n = inject(ProblemI18nService);
+  private readonly notifications = inject(NotificationService);
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
 
@@ -212,7 +214,13 @@ export class EditaisCreatePage {
       this.aplicarErrosDeValidacao(problem.errors);
       return;
     }
-    this.errorMessage.set(this.problemI18n.resolve(problem).title);
+    const mensagem = this.problemI18n.resolve(problem).title;
+    this.errorMessage.set(mensagem);
+    // 5xx vira toast persistente em paralelo ao banner local — usuário
+    // copia o `traceId` para reportar incidente.
+    if (problem.status >= 500) {
+      this.notifications.errorFromProblem(problem, { title: mensagem });
+    }
   }
 
   private aplicarErrosDeValidacao(

--- a/apps/selecao/src/app/features/editais/editais-detail.page.ts
+++ b/apps/selecao/src/app/features/editais/editais-detail.page.ts
@@ -12,6 +12,7 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import {
+  NotificationService,
   ProblemI18nService,
   idempotencyKey,
   useApiResource,
@@ -149,6 +150,7 @@ export class EditaisDetailPage {
 
   private readonly api = inject(EditaisApi);
   private readonly problemI18n = inject(ProblemI18nService);
+  private readonly notifications = inject(NotificationService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly basePath = inject(SELECAO_BASE_PATH);
 
@@ -215,6 +217,19 @@ export class EditaisDetailPage {
         this.mensagemSucesso.set(null);
       });
     });
+
+    // 5xx no GET → toast persistente em paralelo ao banner local. Disparado
+    // só quando o `problem` muda (mesmo problem repetido em re-renders não
+    // duplica toast). 4xx mantém apenas o banner inline.
+    effect(() => {
+      const problem = this.editalResource.problem();
+      if (problem && problem.status >= 500) {
+        const titulo = this.problemI18n.resolve(problem).title;
+        untracked(() => {
+          this.notifications.errorFromProblem(problem, { title: titulo });
+        });
+      }
+    });
   }
 
   protected abrirConfirmacao(): void {
@@ -249,7 +264,13 @@ export class EditaisDetailPage {
           this.editalResource.reload();
           return;
         }
-        this.publishErrorMessage.set(this.problemI18n.resolve(result.problem).title);
+        const mensagem = this.problemI18n.resolve(result.problem).title;
+        this.publishErrorMessage.set(mensagem);
+        // 5xx no POST publicar também vira toast persistente — usuário
+        // copia o `traceId` para reportar incidente sem sair da página.
+        if (result.problem.status >= 500) {
+          this.notifications.errorFromProblem(result.problem, { title: mensagem });
+        }
       });
   }
 }

--- a/apps/selecao/src/app/features/editais/editais-list.page.spec.ts
+++ b/apps/selecao/src/app/features/editais/editais-list.page.spec.ts
@@ -7,7 +7,11 @@ import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideRouter } from '@angular/router';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { apiResultInterceptor, buildVendorMimeAccept } from '@uniplus/shared-core';
+import {
+  NotificationService,
+  apiResultInterceptor,
+  buildVendorMimeAccept,
+} from '@uniplus/shared-core';
 import { EditalDto, SELECAO_BASE_PATH } from '@uniplus/shared-data';
 import { EditaisListPage } from './editais-list.page';
 
@@ -29,6 +33,7 @@ describe('EditaisListPage', () => {
   let fixture: ComponentFixture<EditaisListPage>;
   let component: EditaisListPage;
   let controller: HttpTestingController;
+  let notifications: NotificationService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -44,6 +49,8 @@ describe('EditaisListPage', () => {
     fixture = TestBed.createComponent(EditaisListPage);
     component = fixture.componentInstance;
     controller = TestBed.inject(HttpTestingController);
+    notifications = TestBed.inject(NotificationService);
+    notifications.clearAll();
   });
 
   afterEach(() => controller.verify());
@@ -188,9 +195,78 @@ describe('EditaisListPage', () => {
     const heading = fixture.debugElement.query(By.css('h2')).nativeElement as HTMLElement;
     expect(heading.textContent).toContain('Editais');
 
-    const linhas = fixture.debugElement.queryAll(By.css('tbody tr'));
+    const linhas = fixture.debugElement.queryAll(By.css('[data-testid="data-table-row"]'));
     expect(linhas.length).toBe(1);
     const cells = fixture.debugElement.queryAll(By.css('tbody td'));
     expect(cells[0].nativeElement.textContent.trim()).toBe('040/2026');
+  });
+
+  it('5xx dispara toast persistente via NotificationService (CA-04)', () => {
+    fixture.detectChanges();
+
+    controller.expectOne(`${BASE}/api/editais`).flush(
+      {
+        type: 'about:blank',
+        title: 'Falha temporária do servidor',
+        status: 503,
+        code: 'uniplus.server.indisponivel',
+        traceId: '7af92f3577b34da6a3ce929d0e0e4742',
+      },
+      {
+        status: 503,
+        statusText: 'Service Unavailable',
+        headers: { 'Content-Type': 'application/problem+json' },
+      },
+    );
+
+    expect(notifications.notifications()).toHaveLength(1);
+    const [toast] = notifications.notifications();
+    expect(toast.type).toBe('error');
+    expect(toast.title).toBe('Falha temporária do servidor');
+    expect(toast.traceId).toBe('7af92f3577b34da6a3ce929d0e0e4742');
+    expect(toast.persistent).toBe(true);
+  });
+
+  it('4xx NÃO dispara toast — apenas banner inline (CA-04)', () => {
+    fixture.detectChanges();
+
+    controller.expectOne(`${BASE}/api/editais`).flush(
+      {
+        type: 'about:blank',
+        title: 'Token inválido',
+        status: 401,
+        code: 'uniplus.auth.token_invalido',
+        traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
+      },
+      {
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: { 'Content-Type': 'application/problem+json' },
+      },
+    );
+
+    expect(component.errorMessage()).toBe('Token inválido');
+    expect(notifications.notifications()).toHaveLength(0);
+  });
+
+  it('errorTraceId é propagado ao DataTable em falha 5xx', () => {
+    fixture.detectChanges();
+
+    controller.expectOne(`${BASE}/api/editais`).flush(
+      {
+        type: 'about:blank',
+        title: 'Falha do servidor',
+        status: 502,
+        code: 'uniplus.server.gateway',
+        traceId: 'cafe1234567890abcdef1234567890ab',
+      },
+      {
+        status: 502,
+        statusText: 'Bad Gateway',
+        headers: { 'Content-Type': 'application/problem+json' },
+      },
+    );
+
+    expect(component.errorTraceId()).toBe('cafe1234567890abcdef1234567890ab');
   });
 });

--- a/apps/selecao/src/app/features/editais/editais-list.page.ts
+++ b/apps/selecao/src/app/features/editais/editais-list.page.ts
@@ -10,6 +10,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router, RouterLink } from '@angular/router';
 import {
   Cursor,
+  NotificationService,
   ProblemI18nService,
   extractNextCursor,
 } from '@uniplus/shared-core';
@@ -60,6 +61,7 @@ import { DataTableColumn, DataTableComponent } from '@uniplus/shared-ui';
 export class EditaisListPage {
   private readonly api = inject(EditaisApi);
   private readonly problemI18n = inject(ProblemI18nService);
+  private readonly notifications = inject(NotificationService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly router = inject(Router);
 
@@ -126,10 +128,17 @@ export class EditaisListPage {
           this.cursorUltimaFalha = undefined;
           return;
         }
-        this.errorMessage.set(this.problemI18n.resolve(result.problem).title);
+        const mensagem = this.problemI18n.resolve(result.problem).title;
+        this.errorMessage.set(mensagem);
         this.errorTraceId.set(
           result.problem.traceId.length > 0 ? result.problem.traceId : null,
         );
+        // 5xx vira toast persistente em paralelo ao banner local — usuário
+        // pode copiar o `traceId` para reportar incidente sem precisar
+        // navegar até a tabela. 4xx mantém apenas o banner inline.
+        if (result.problem.status >= 500) {
+          this.notifications.errorFromProblem(result.problem, { title: mensagem });
+        }
         // Em falha pós-1ª página, preserva o cursor original — usuário consegue
         // retentar via "Carregar mais" sem perder os items já carregados. Em
         // falha de carga inicial, o cursor já é null por construção.


### PR DESCRIPTION
## Resumo

PR-C (final) da Story #171. Integra o `NotificationHostComponent` (PR-B `#363`, `f7a72d9`) nos 3 apps de produção e dispara `errorFromProblem(problem)` em casos 5xx das telas de Edital, em paralelo ao banner local. PRs anteriores: PR-A `#361` (NotificationService refactor) e PR-B `#363` (NotificationHost UI + DataTable enhancements).

## Mudanças

### Apps — `<ui-notification-host />` em cada AppComponent

`apps/{selecao,ingresso,portal}/src/app/app.ts` ganham o renderer logo após os banners de auth, antes do `<router-outlet />`. Posicionamento `fixed` top-right (do componente), `pointer-events-none` no container e `pointer-events-auto` em cada toast — não bloqueia interação com o resto da app.

### `EditaisListPage`

```diff
+private readonly notifications = inject(NotificationService);
 …
-this.errorMessage.set(this.problemI18n.resolve(result.problem).title);
+const mensagem = this.problemI18n.resolve(result.problem).title;
+this.errorMessage.set(mensagem);
+if (result.problem.status >= 500) {
+  this.notifications.errorFromProblem(result.problem, { title: mensagem });
+}
```

`title` reuso do `ProblemI18nService.resolve` mantém consistência banner/toast.

### `EditaisCreatePage`

Mesmo pattern em `aplicarFalha`. 422 com `errors[]` continua só ativando `setErrors({ backend })` nos `FormControl` (sem toast).

### `EditaisDetailPage`

GET via `useApiResource` reativo: `effect()` observa `editalResource.problem()`. 5xx → `errorFromProblem` em `untracked()` (previne re-disparo em mudança de dependência reativa). POST publicar 5xx → toast em paralelo ao `publishErrorMessage`.

### Specs

3 novos em `editais-list.page.spec.ts`:

| spec | valida |
|---|---|
| `5xx dispara toast persistente via NotificationService (CA-04)` | toast com `type=error`, `title`, `traceId`, `persistent=true` |
| `4xx NÃO dispara toast — apenas banner inline (CA-04)` | `notifications.notifications()` permanece vazio em 401 |
| `errorTraceId é propagado ao DataTable em falha 5xx` | `errorTraceId()` reflete `problem.traceId` em 502 |

Spec existente "renderiza ui-data-table" refatorado para usar `data-testid="data-table-row"` (alinhado ao pattern do PR-B; substitui `queryAll('tbody tr')[index]`).

## Validação

| Gate | Resultado |
|---|---|
| `nx run selecao:test` | 5/5 files, 40 verde (3 novos + 37 sem regressão) |
| `nx run-many --target=test --all` | 8/8 verde |
| `nx run-many --target=lint --all` | 13/13 verde |
| `nx run-many --target=build --all` | 8/8 verde |
| `codex review --uncommitted` | "No actionable correctness issues were found" |

## Critérios de aceite endereçados

- [x] **CA-04** (NotificationService toast traceId) — completo, integrado nos 3 apps. Botão "Copiar traceId" entregue em PR-B.
- [x] **CA-05** (Edital 100% ApiResult) — confirmado: nenhum `try/catch` ad-hoc para `HttpErrorResponse`; failure flow só via `result.problem`.
- [x] **CA-06** (LGPD) — `title` vem de `problemI18n.resolve` (override-friendly); `errors[].message` raw nunca interpolado.
- [x] **CA-07** (a11y) — herdado do NotificationHost (PR-B): `role=alert/status`, `aria-live`, `aria-pressed`, focus ring govbr.

## Não entregue (deferido)

- **CA-08** (Playwright E2E + axe-core) — tracked em **#365**. Depende de back-end real, mock de `navigator.clipboard` + permissions, e fixture Keycloak. Os 3 PRs entregues cobrem CA-04/CA-05/CA-06/CA-07 com Vitest robusto; jornadas E2E ficam para PR dedicado.

## Riscos / rollback

Risco baixo — refactor incremental, todos os tests verdes. Rollback: `git revert`.

Closes #171

Refs Feature #167
Refs Epic #259 (Milestone B)