### PR TITLE
docs(ci-publish-images): seção GitOps para deploy em cluster

### DIFF
--- a/docs/ci-publish-images.md
+++ b/docs/ci-publish-images.md
@@ -76,6 +76,58 @@ docker pull ghcr.io/unifesspa-edu-br/uniplus-web-selecao:v0.1.0
 docker pull ghcr.io/unifesspa-edu-br/uniplus-web-ingresso:v0.1.0
 ```
 
+## Como sair de "imagem publicada" para "rodando em cluster"
+
+`publish-images.yml` **publica** a imagem no GHCR. **Não deploya.** A
+fonte de verdade GitOps que decide qual versão roda em cada cluster é o
+repositório [`unifesspa-edu-br/uniplus-infra`](https://github.com/unifesspa-edu-br/uniplus-infra).
+O desacoplamento é deliberado — invariante registrado na
+[ADR-0020](adrs/0020-registry-ghcr-e-tagging.md): a imagem é idêntica em
+todos os ambientes; só o `ConfigMap` injetado em runtime
+([#84](https://github.com/unifesspa-edu-br/uniplus-web/issues/84)) muda.
+
+Fluxo completo entre tag e cluster (exemplo concreto `v0.1.2`):
+
+| Etapa | Onde | Quem | Tempo típico |
+|---|---|---|---|
+| Tag git semver | `uniplus-web` | dev | < 1 min |
+| Workflow `Publish Images` | `uniplus-web` Actions | CI | ~4 min |
+| 3 imagens em GHCR | `ghcr.io/unifesspa-edu-br/uniplus-{portal,web-selecao,web-ingresso}` | CI | parte do anterior |
+| PR de bump em `values.yaml` | `uniplus-infra/apps/uniplus-web/values.yaml` | dev/agente | ~1 min |
+| Codex AI review + CI | `uniplus-infra` | bot | ~5 min |
+| Merge do PR | `uniplus-infra` | dev | < 1 min |
+| ArgoCD reconcile | cluster | argocd (auto, poll ~3 min) | até 3 min |
+| Rolling restart dos pods | cluster | kubernetes | 1–2 min |
+| **Total tag → servindo em prod** | — | — | **15–20 min** |
+
+Snippet típico do PR de bump (`uniplus-infra`):
+
+```diff
+# apps/uniplus-web/values.yaml — repetir em cada um dos 3 apps:
+    portal:
+      image: uniplus-portal
+-     tag: v0.1.1
++     tag: v0.1.2
+```
+
+### Por que o gate manual
+
+- **Auditabilidade:** `git log` no `uniplus-infra` mostra exatamente quando
+  cada versão entrou em produção, por quem e com qual revisão.
+- **Rollback:** `git revert <commit-bump>` no `uniplus-infra` desfaz o
+  deploy sem precisar tocar imagens nem registry.
+- **Hotfix barato:** subir uma versão urgente custa um PR de ~10 linhas
+  (bump da tag), revisado e CI-validado, em vez de deploy não testado.
+
+### Quando automatizar
+
+Quando releases passarem a acontecer várias vezes por dia, vale plugar
+[`argocd-image-updater`](https://argocd-image-updater.readthedocs.io/) ou
+Renovate — ambos **abrem o PR de bump automaticamente** ao detectar nova
+tag no GHCR, mas o merge continua passando por CI + Codex + revisão
+humana. Hoje (2026-05) o volume de releases não justifica a automação;
+fica registrado como follow-up.
+
 ## Follow-ups deferidos
 
 - **SBOM e attestation cosign keyless via OIDC** — registrados em backlog,


### PR DESCRIPTION
## Resumo

Adiciona ao `docs/ci-publish-images.md` a seção que cobre o lado **consumo** das imagens publicadas (o doc atual cobre só o lado publish). Documenta explicitamente que `publish-images.yml` publica no GHCR mas não deploya — o gate é o repositório `unifesspa-edu-br/uniplus-infra` (GitOps via ArgoCD).

A confusão que motivou a issue era real: ao criar tag `v0.1.2`, parecia razoável assumir deploy automático. Não é — o `values.yaml` em `uniplus-infra` precisa ser bumped por PR. Esse passo manual é deliberado (auditabilidade + rollback + hotfix barato), mas só agora está documentado.

## O que mudou

- Nova seção `## Como sair de "imagem publicada" para "rodando em cluster"`, posicionada entre **Pull público** e **Follow-ups deferidos**.
- Tabela com 8 etapas (tag → workflow → GHCR → PR bump → Codex/CI → merge → ArgoCD reconcile → rolling restart) e tempos típicos. Total tag→prod: 15–20 min.
- Snippet `diff` mostrando o bump em `apps/uniplus-web/values.yaml`.
- Subseção **Por que o gate manual** (auditabilidade, rollback, hotfix).
- Subseção **Quando automatizar** menciona `argocd-image-updater` e Renovate como follow-up — não hoje.
- Link reverso para [ADR-0020](docs/adrs/0020-registry-ghcr-e-tagging.md) e referência cruzada à issue [#84](https://github.com/unifesspa-edu-br/uniplus-web/issues/84) (runtime config via `ConfigMap`).

Diff: +52 linhas, 0 removidas.

## Critérios da issue

- [x] Seção adicionada ao arquivo existente (sem criar arquivo separado)
- [x] Tabela de etapas com tempos
- [x] Snippet do PR de bump (formato `diff` em vez de `yaml`+marcação manual — mais legível)
- [x] Link reverso para ADR-0020
- [x] `argocd-image-updater` mencionado como follow-up futuro

## Codex CLI local

`codex review --uncommitted` indisponível: cota OpenAI esgotada até 12/05/2026 (`ERROR: You've hit your usage limit`). Self-review manual cobriu:

- Conformidade com critérios da issue (todos os 5 atendidos).
- Estilo consistente com o restante do doc (tabela compacta, tom factual em pt-BR, links absolutos para refs externas).
- Ausência de PII, secrets ou referências a `.compozy/`/CLAUDE.md.
- Posicionamento natural na hierarquia do doc (consumo segue publicação).

Codex AI bot e revisão humana cross-account permanecem como gates do PR.

## Plano de teste

- [ ] CI verde (lint sem efeito real — sem código tocado; `codegen-drift-check` no-op).
- [ ] Render do markdown na UI do GitHub: tabela, snippet `diff`, links e seções aninhadas legíveis.
- [ ] Approve cross-account (jf2s).

Closes #364