### PR TITLE
ci(security): adicionar workflow CodeQL SAST para TypeScript / JavaScript

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,8 +10,19 @@ name: CodeQL
 on:
   push:
     branches: [main]
+    # paths-ignore evita execução em PRs/pushes docs-only (sem código TS/JS
+    # alterado, CodeQL não acrescenta sinal). O schedule semanal abaixo
+    # cobre drift acidental.
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.github/ISSUE_TEMPLATE/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.github/ISSUE_TEMPLATE/**'
   schedule:
     # Segunda-feira 03:45 UTC (= 00:45 BRT). Defasado 15min do api/codeql.yml
     # para evitar concorrência por runners do GitHub Actions na mesma janela.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,59 @@
+name: CodeQL
+
+# Análise estática de segurança (SAST) do código TypeScript/JavaScript do
+# monorepo Nx (apps Selecao, Ingresso, Portal + libs shared-*). Resultados
+# alimentam a aba Security do GitHub via upload SARIF do passo `analyze`.
+# Issue uniplus-api#23: adoção de CodeQL como gate inicial não bloqueante
+# (alerta); elevação para required check fica para fase futura quando a
+# baseline de findings estiver triada.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Segunda-feira 03:45 UTC (= 00:45 BRT). Defasado 15min do api/codeql.yml
+    # para evitar concorrência por runners do GitHub Actions na mesma janela.
+    - cron: '45 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # build-mode none para JS/TS: CodeQL analisa o source diretamente,
+          # sem precisar transpilar. Mais rápido que `autobuild` e suficiente
+          # para as queries default de segurança.
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Resumo

- Adiciona `.github/workflows/codeql.yml` para análise estática (SAST) do código TS/JS do monorepo Nx (apps Selecao, Ingresso, Portal + libs `shared-*`) — atende metade da issue [`unifesspa-edu-br/uniplus-api#23`](https://github.com/unifesspa-edu-br/uniplus-api/issues/23) (a outra metade é o PR irmão em `uniplus-api` que cobre C#).
- Resultados publicados automaticamente na aba **Security** do repositório via upload SARIF da action `github/codeql-action/analyze`.

## Triggers

- `push` → main
- `pull_request` → main
- `schedule` semanal (segunda 03:45 UTC — defasado 15min do `uniplus-api/codeql.yml` para evitar concorrência por runners)
- `workflow_dispatch` (re-run manual)

## Decisões

- **`build-mode: none`**: CodeQL analisa o source TS/JS diretamente sem precisar transpilar — mais rápido que `autobuild` e suficiente para as queries default de segurança.
- **Linguagem**: `javascript-typescript` (single language, cobre ambos via mesma análise).
- **Permissions mínimas**: `actions:read`, `contents:read`, `security-events:write`.
- **Concurrency**: cancela PRs em re-push.
- **Gate não bloqueante**: alinhado com critério da issue ("alerta, não bloqueante inicialmente").

## Plano de teste

- [x] `yamllint` passa (estilo limpo)
- [x] YAML parse válido
- [ ] CI: workflow será executado neste próprio PR; resultado visível na aba Checks e na aba Security após análise

Refs `unifesspa-edu-br/uniplus-api#23` (issue cross-repo; fechamento manual quando o PR irmão `uniplus-api/feature/23-codeql-sast` também mergear)