### PR TITLE
ci(security): migrar CodeQL action para v4 (Node 24 runtime)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,12 +59,12 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Resumo

Resolve issue #370. Migra `github/codeql-action/{init,analyze}` de `@v3` para `@v4` no workflow CodeQL — o Node 20 runtime do v3 está deprecado pelo GitHub e em vias de remoção. Sem migração, quando o Node 20 for forçado para remoção, o workflow falha silently e a aba Security para de receber resultados em PRs e pushes para main até intervenção manual.

## Contexto

Finding original do Codex no PR irmão `unifesspa-edu-br/uniplus-api#391`. A fix análoga já foi aplicada e mergeada no `uniplus-api/codeql.yml` (sha `b8e358e`). Este PR fecha o débito de 2 linhas no `uniplus-web/codeql.yml` que mergeou antes do finding em #369.

## Mudança

```diff
- uses: github/codeql-action/init@v3
+ uses: github/codeql-action/init@v4

- uses: github/codeql-action/analyze@v4
+ uses: github/codeql-action/analyze@v4
```

## Plano de teste

- [x] `yamllint` passa
- [ ] CI: workflow será executado neste próprio PR; `Analyze (javascript-typescript)` deve seguir verde como na execução anterior

Closes #370