### PR TITLE
ci: bypass do gate pr-author-org-member para PRs de bots

### DIFF
--- a/.github/workflows/pr-author-org-member.yml
+++ b/.github/workflows/pr-author-org-member.yml
@@ -12,21 +12,28 @@ jobs:
     name: PR author is org member
     runs-on: ubuntu-latest
     steps:
-      # Bots conhecidos do GitHub (Dependabot, GitHub Actions, Renovate)
-      # não são "members" no sentido organizacional — não passam pelo endpoint
-      # /collaborators/{login}/permission e nem aparecem em ?affiliation=outside.
-      # São agentes do próprio GitHub, autorizados a abrir PRs com as permissões
-      # do repo via secrets.GITHUB_TOKEN. Bypass explícito + nominal evita
-      # reescrever o gate semanticamente: humanos continuam sendo validados
-      # pela rota normal abaixo.
-      - name: Bypass para bots do GitHub
-        if: github.event.pull_request.user.type == 'Bot'
+      # Bots confiáveis instalados pelo Owner da org (Dependabot, GitHub Actions,
+      # Renovate) não são "members" no sentido organizacional — não passam pelo
+      # endpoint /collaborators/{login}/permission e nem aparecem em
+      # ?affiliation=outside. Operam com o GITHUB_TOKEN do repo, sem vetor de
+      # impersonation externa.
+      #
+      # Importante: whitelist NOMINAL (não `user.type == 'Bot'` genérico) — caso
+      # contrário qualquer GitHub App de terceiros instalado em qualquer momento
+      # passaria o gate. Para incluir um novo bot, adicionar o login aqui após
+      # revisão do Owner.
+      - name: Bypass para bots confiáveis do GitHub
+        if: |
+          github.event.pull_request.user.type == 'Bot' &&
+          contains(fromJSON('["dependabot[bot]", "github-actions[bot]", "renovate[bot]"]'), github.event.pull_request.user.login)
         run: |
-          echo "PR autor ${{ github.event.pull_request.user.login }} é Bot — bypass do gate org-member."
+          echo "PR autor ${{ github.event.pull_request.user.login }} é Bot confiável (whitelist) — bypass do gate org-member."
           exit 0
 
       - name: Validate author is org member with write access
-        if: github.event.pull_request.user.type != 'Bot'
+        if: |
+          github.event.pull_request.user.type != 'Bot' ||
+          !contains(fromJSON('["dependabot[bot]", "github-actions[bot]", "renovate[bot]"]'), github.event.pull_request.user.login)
         env:
           AUTHOR: ${{ github.event.pull_request.user.login }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-author-org-member.yml
+++ b/.github/workflows/pr-author-org-member.yml
@@ -12,7 +12,21 @@ jobs:
     name: PR author is org member
     runs-on: ubuntu-latest
     steps:
+      # Bots conhecidos do GitHub (Dependabot, GitHub Actions, Renovate)
+      # não são "members" no sentido organizacional — não passam pelo endpoint
+      # /collaborators/{login}/permission e nem aparecem em ?affiliation=outside.
+      # São agentes do próprio GitHub, autorizados a abrir PRs com as permissões
+      # do repo via secrets.GITHUB_TOKEN. Bypass explícito + nominal evita
+      # reescrever o gate semanticamente: humanos continuam sendo validados
+      # pela rota normal abaixo.
+      - name: Bypass para bots do GitHub
+        if: github.event.pull_request.user.type == 'Bot'
+        run: |
+          echo "PR autor ${{ github.event.pull_request.user.login }} é Bot — bypass do gate org-member."
+          exit 0
+
       - name: Validate author is org member with write access
+        if: github.event.pull_request.user.type != 'Bot'
         env:
           AUTHOR: ${{ github.event.pull_request.user.login }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Resumo

Porta o patch já aplicado em `uniplus-api` (commit [`9b0151f`](https://github.com/unifesspa-edu-br/uniplus-api/commit/9b0151f)) para manter os 3 repos da org alinhados no gate `pr-author-org-member`.

## Problema

O workflow `.github/workflows/pr-author-org-member.yml` valida `author_association` contra whitelist humana. Bots (Dependabot, GitHub Actions, Renovate) retornam 404 em `/collaborators/{login}/permission` e nem aparecem em `?affiliation=outside`. Resultado: todo PR aberto pelo bot trava no gate antes do pipeline rodar.

## Fix

Step nominal de bypass para `user.type == 'Bot'`, condicional `if: != 'Bot'` no step de validação humana — semântica preservada para humanos.

## Histórico

O bug foi observado primeiro em `uniplus-api` com a batch Dependabot de 10/05 (5 PRs `#384–#388` bloqueados, consolidados manualmente em `#395`). Issue de tracking: `unifesspa-edu-br/uniplus-api#396`. O fix foi aplicado primeiro em api (commit `9b0151f`, ~17h de 10/05); este PR replica para manter paridade entre os 3 repos.

## Validação

Sem possibilidade de validar localmente o fluxo do gate (precisa de Bot autor). YAML aceito pela syntax do GitHub Actions (mesmo formato em produção em `uniplus-api`).

Refs unifesspa-edu-br/uniplus-api#396
