### PR TITLE
fix(shared-ui): divide template do form-field por type='number' para ativar NumberValueAccessor

### DIFF
--- a/apps/selecao/src/app/features/editais/editais-create.page.spec.ts
+++ b/apps/selecao/src/app/features/editais/editais-create.page.spec.ts
@@ -232,4 +232,50 @@ describe('EditaisCreatePage', () => {
 
     controller.expectOne(`${BASE}/api/editais`).flush('id', { status: 201, statusText: 'Created' });
   });
+
+  // Cobre o caminho real do usuário: preencher inputs via DOM (input event)
+  // em vez de form.setValue(...). O setValue() bypassa ControlValueAccessor
+  // e mascara o bug runtime — esse teste falha sem o fix em FormFieldComponent
+  // (ramo estatico type="number" para ativar NumberValueAccessor). Sem fix,
+  // tipoProcesso/numeroEdital/anoEdital sairiam no body como string e o
+  // backend retornaria 400 (issue #374, validado via Playwright real).
+  it('submit via DOM (NumberValueAccessor): body envia campos numericos como number, nao string', () => {
+    const numericInputs = fixture.nativeElement.querySelectorAll('input[type="number"]') as NodeListOf<HTMLInputElement>;
+    expect(numericInputs.length).toBe(4);
+
+    const [numeroEditalInput, anoEditalInput, tipoProcessoInput, maximoOpcoesInput] = numericInputs;
+    const tituloInput = fixture.nativeElement.querySelector('input[type="text"]') as HTMLInputElement;
+
+    numeroEditalInput.value = '42';
+    numeroEditalInput.dispatchEvent(new Event('input'));
+    anoEditalInput.value = '2026';
+    anoEditalInput.dispatchEvent(new Event('input'));
+    tituloInput.value = 'PSE 2026';
+    tituloInput.dispatchEvent(new Event('input'));
+    tipoProcessoInput.value = '1';
+    tipoProcessoInput.dispatchEvent(new Event('input'));
+    maximoOpcoesInput.value = '2';
+    maximoOpcoesInput.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    component['enviar']();
+
+    const req = controller.expectOne(`${BASE}/api/editais`);
+    expect(req.request.body).toEqual({
+      numeroEdital: 42,
+      anoEdital: 2026,
+      titulo: 'PSE 2026',
+      tipoProcesso: 1,
+      maximoOpcoesCurso: 2,
+    });
+    // Strict type check explícito: cada campo numerico tem que ser number,
+    // nao string. typeof === 'number' garante que NumberValueAccessor
+    // coergiu via FormFieldComponent (issue #374).
+    expect(typeof req.request.body.numeroEdital).toBe('number');
+    expect(typeof req.request.body.anoEdital).toBe('number');
+    expect(typeof req.request.body.tipoProcesso).toBe('number');
+    expect(typeof req.request.body.maximoOpcoesCurso).toBe('number');
+
+    req.flush('019e1a15-c374-7ae4-8f21-91e782f8f910', { status: 201, statusText: 'Created' });
+  });
 });

--- a/libs/shared-ui/src/lib/components/form-field/form-field.spec.ts
+++ b/libs/shared-ui/src/lib/components/form-field/form-field.spec.ts
@@ -173,6 +173,60 @@ describe('FormFieldComponent', () => {
     expect(control.dirty).toBe(true);
   });
 
+  // Garante que o ramo estatico type="number" do template ativa o
+  // NumberValueAccessor do Angular Reactive Forms (selector estatico
+  // 'input[type=number][formControl]'). Sem essa cobertura, refactors
+  // futuros que tentem fundir os ramos de novo em um [type] dinamico
+  // regridem para DefaultValueAccessor entregando string ao FormControl<number>
+  // — exatamente o bug runtime identificado na issue #374 (criar edital
+  // via SPA falhava com 400 porque tipoProcesso chegava ao backend como
+  // string e quebrava o binding do enum integer).
+  it('type="number": NumberValueAccessor entrega valor como number ao FormControl<number>', () => {
+    const control = new FormControl<number | null>(null);
+    fixture.componentRef.setInput('control', control);
+    fixture.componentRef.setInput('type', 'number');
+    fixture.detectChanges();
+
+    const input = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+    expect(input.type).toBe('number');
+
+    input.value = '42';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    expect(typeof control.value).toBe('number');
+    expect(control.value).toBe(42);
+  });
+
+  it('type="number": input vazio entrega null ao FormControl<number | null> (semantica do NumberValueAccessor)', () => {
+    const control = new FormControl<number | null>(42);
+    fixture.componentRef.setInput('control', control);
+    fixture.componentRef.setInput('type', 'number');
+    fixture.detectChanges();
+
+    const input = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+    input.value = '';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    expect(control.value).toBeNull();
+  });
+
+  it('type="text": DefaultValueAccessor entrega string mesmo quando usuario digita digitos', () => {
+    const control = new FormControl<string>('');
+    fixture.componentRef.setInput('control', control);
+    fixture.componentRef.setInput('type', 'text');
+    fixture.detectChanges();
+
+    const input = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+    input.value = '42';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    expect(typeof control.value).toBe('string');
+    expect(control.value).toBe('42');
+  });
+
   // Documenta a API: defaults dos inputs opcionais. Como signals nunca
   // são nulos (sempre objetos), checar `.toBeTruthy()` direto seria trivial;
   // chamar como função (`input()`) verifica o valor default real.

--- a/libs/shared-ui/src/lib/components/form-field/form-field.ts
+++ b/libs/shared-ui/src/lib/components/form-field/form-field.ts
@@ -35,17 +35,38 @@ let formFieldIdSeed = 0;
     <label [for]="inputId" class="mb-1 block text-sm font-medium text-gray-700">
       {{ label() }}
     </label>
-    <input
-      [id]="inputId"
-      [type]="type()"
-      [formControl]="control()"
-      [attr.placeholder]="placeholder() || null"
-      [attr.min]="min() ?? null"
-      [attr.max]="max() ?? null"
-      [attr.aria-invalid]="errorMessage() ? 'true' : null"
-      [attr.aria-describedby]="describedBy()"
-      class="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-govbr-primary"
-    />
+    <!-- Ramo estatico type="number": necessario para que o NumberValueAccessor
+         do Angular Reactive Forms case com seu selector estatico
+         ('input[type=number][formControl]'). Com [type] dinamico via signal,
+         o Angular cai no DefaultValueAccessor e entrega o valor como string,
+         quebrando FormControl<number> (issue #374). Demais types continuam
+         no ramo dinamico padrao porque DefaultValueAccessor (string) eh o
+         comportamento desejado para text/email/password/etc. -->
+    @if (type() === 'number') {
+      <input
+        [id]="inputId"
+        type="number"
+        [formControl]="control()"
+        [attr.placeholder]="placeholder() || null"
+        [attr.min]="min() ?? null"
+        [attr.max]="max() ?? null"
+        [attr.aria-invalid]="errorMessage() ? 'true' : null"
+        [attr.aria-describedby]="describedBy()"
+        class="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-govbr-primary"
+      />
+    } @else {
+      <input
+        [id]="inputId"
+        [type]="type()"
+        [formControl]="control()"
+        [attr.placeholder]="placeholder() || null"
+        [attr.min]="min() ?? null"
+        [attr.max]="max() ?? null"
+        [attr.aria-invalid]="errorMessage() ? 'true' : null"
+        [attr.aria-describedby]="describedBy()"
+        class="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-govbr-primary"
+      />
+    }
     <!-- Erro e hint sempre renderizados (com [hidden]) — garantem que o ID
          existe no DOM antes que aria-describedby o referencie, evitando gap
          para leitores de tela (NVDA/JAWS) na primeira exibição de erro.


### PR DESCRIPTION
## Contexto

Validação E2E real via Playwright em `https://selecao.standalone.portaluni.com.br/editais/novo` (após uniplus-api v0.3.3 + uniplus-infra#239 destravarem CORS) revelou: criar edital via SPA falha com **HTTP 400** retornado pelo backend:

```json
{
  "errors": {
    "$.tipoProcesso": ["The JSON value could not be converted to ... CriarEditalCommand"]
  }
}
```

Request body enviado pelo frontend:
```json
{ "numeroEdital":"9999", "anoEdital":"2026", "tipoProcesso":"1", ... }
```

Todos os campos numéricos estavam serializados como **string** ao invés de **number**.

## Causa raiz

`libs/shared-ui/src/lib/components/form-field/form-field.ts:38` usava:

```html
<input [type]="type()" [formControl]="control()" ...>
```

`[type]="type()"` é property binding dinâmico (signal). Mas o selector do `NumberValueAccessor` do Angular Reactive Forms é estático:

```ts
selector: 'input[type=number][formControlName],input[type=number][formControl],input[type=number][ngModel]'
```

Selector matching no Angular é feito sobre o template estático — não casa com `[type]` dinâmico. Resultado: cai no `DefaultValueAccessor` que sempre entrega o valor como string ao `FormControl`, mesmo quando o tipo do FormControl é `number`.

O bug afetava **todos** os campos `type="number"` renderizados via `ui-form-field`, não só `tipoProcesso`. Os demais (`numeroEdital`, `anoEdital`, `maximoOpcoesCurso`) sobreviviam porque o backend aceita string-coerce no oneOf `integer | string`. Só `tipoProcesso` é enum integer estrito e rejeitava.

## Fix

Dividir o template em dois ramos:

```html
@if (type() === 'number') {
  <input type="number" [formControl]="control()" ...>
} @else {
  <input [type]="type()" [formControl]="control()" ...>
}
```

Com `type="number"` literal estático, o selector do `NumberValueAccessor` casa e o Angular coerge o valor automaticamente.

Demais types continuam no ramo dinâmico — `DefaultValueAccessor` entregando string é o comportamento desejado para `text`/`email`/`password`/etc.

## Cobertura

**`libs/shared-ui/.../form-field.spec.ts`** — 3 testes novos:
- `type="number"`: `NumberValueAccessor` entrega `typeof === 'number'` ao FormControl após DOM `input` event.
- `type="number"`: input vazio entrega `null` (semântica do NumberValueAccessor).
- `type="text"`: `DefaultValueAccessor` entrega `typeof === 'string'` mesmo digitando dígitos (preserva comportamento).

**`apps/selecao/.../editais-create.page.spec.ts`** — 1 teste E2E unit novo:
- Simula preenchimento via DOM `input` events (não `form.setValue()` — esse bypassa ControlValueAccessor e mascara o bug).
- Submete e verifica `req.request.body` tem `typeof === 'number'` em todos os 4 campos numéricos.

Testes existentes continuam passando porque usam `form.setValue(COMANDO_VALIDO)` — não exercitam o caminho do ControlValueAccessor.

## Validação local

- `npx nx vite:test shared-ui` → **114/114** verde (3 testes novos)
- `npx nx vite:test selecao` → **41/41** verde (1 teste novo)
- `npx nx affected --target=lint` → limpo
- `npx nx affected --target=build` → limpo

## Validação pós-merge esperada

Smoke E2E via Playwright em `https://selecao.standalone.portaluni.com.br/editais/novo`:

1. Login Keycloak PKCE
2. Navegar para `/editais/novo`
3. Preencher form (Número=9999, Ano=2026, Título="Smoke", Tipo=1, Máximo=1)
4. Submit
5. **Esperado**: HTTP 201, redirect para `/editais`, novo edital aparece na listagem

## Follow-ups

Nenhum — esta é a última frente da cascata pós-v0.3.0 para destravar criação de edital via UI standalone.

Closes #374
Refs unifesspa-edu-br/uniplus-api#424, unifesspa-edu-br/uniplus-api#425