### PR TITLE
ci(publish): habilita manifest list multi-arch (amd64+arm64) no GHCR

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -21,6 +21,14 @@ name: Publish Images
 #   - ghcr.io/<owner>/uniplus-portal
 #   - ghcr.io/<owner>/uniplus-web-selecao
 #   - ghcr.io/<owner>/uniplus-web-ingresso
+#
+# Multi-arch: cada tag acima é publicada como manifest list cobrindo
+#   - linux/amd64  (cluster legacy GRU/E5)
+#   - linux/arm64  (cluster IAD/A1 ARM Ampere, Epic uniplus-infra#317)
+# O smoke runtime (non-root + /health.json) roda apenas no build amd64 —
+# `nginxinc/nginx-unprivileged` é multi-arch e as invariantes validadas
+# (usuário não-root, nginx servindo health) são idênticas em ambas
+# arquiteturas, então emular arm64 só repete o mesmo cheque com overhead.
 
 on:
   push:
@@ -107,6 +115,16 @@ jobs:
           fi
           echo "✓ Tag aponta para commit em main: $TAG_COMMIT"
 
+      - name: Set up QEMU
+        # Habilita cross-build linux/arm64 no runner amd64 do GitHub
+        # Actions registrando os binfmt_misc handlers para emulação
+        # user-mode. Buildx delega para QEMU quando a plataforma alvo
+        # não bate com a do runner. Smoke roda em amd64 (nativo); push
+        # multi-arch usa esta capability para compilar o layer arm64.
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -159,14 +177,22 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile.${{ matrix.module }}
+          # Smoke fica amd64 apenas: o `load: true` do buildx só funciona
+          # com uma plataforma por vez (carrega no daemon Docker local
+          # para `docker run`). As invariantes que o smoke valida
+          # (usuário não-root, /health.json responde 200 com {"status":"ok"})
+          # são idênticas entre arquiteturas — repetir com arm64 emulado
+          # via QEMU não acrescenta cobertura, só overhead.
           platforms: linux/amd64
           push: false
           load: true
           tags: smoke/${{ matrix.image }}:ci
-          # Cache scoped por módulo: builds independentes não invalidam cache
-          # uns dos outros (cada Dockerfile copia dist/apps/<module>/ separado).
-          cache-from: type=gha,scope=${{ matrix.module }}
-          cache-to: type=gha,scope=${{ matrix.module }},mode=max
+          # Cache scoped por módulo + arch amd64: builds independentes
+          # não invalidam cache uns dos outros, e o cache amd64 deste
+          # smoke é reaproveitado integralmente pelo layer amd64 do
+          # push multi-arch a seguir.
+          cache-from: type=gha,scope=${{ matrix.module }}-amd64
+          cache-to: type=gha,scope=${{ matrix.module }}-amd64,mode=max
 
       - name: Smoke test — non-root + /health.json
         # Smoke runtime cobre os dois critérios de aceite da Story #217 que
@@ -218,20 +244,33 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile.${{ matrix.module }}
-          platforms: linux/amd64
+          # Manifest list multi-arch: ArgoCD em cluster amd64 (GRU/E5)
+          # ou arm64 (IAD/A1) puxa o layer correto automaticamente do
+          # mesmo `ghcr.io/.../${{ matrix.image }}:vX.Y.Z`. Layer amd64
+          # reusa cache integral do step smoke; layer arm64 compila via
+          # QEMU emulation (~2-3x mais lento que nativo, aceitável para
+          # release explícito em tag).
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          # Reusa o cache do build_local — segundo build é praticamente
-          # instantâneo (apenas resolve manifest e push das layers já em cache).
-          cache-from: type=gha,scope=${{ matrix.module }}
+          # Cache amd64 vem do smoke (cache-to amd64-only); cache arm64
+          # é populado neste push e fica disponível para releases futuras
+          # do mesmo módulo. Scopes separados por arch evitam invalidação
+          # cruzada quando só uma arquitetura tem mudança de base image.
+          cache-from: |
+            type=gha,scope=${{ matrix.module }}-amd64
+            type=gha,scope=${{ matrix.module }}-arm64
+          cache-to: type=gha,scope=${{ matrix.module }}-arm64,mode=max
 
       - name: Resumo
         if: always()
         run: |
           echo "### Publish: \`${{ matrix.image }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Tags publicadas:**" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Plataformas:** \`linux/amd64\`, \`linux/arm64\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Tags publicadas (manifest list multi-arch):**" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           echo "${{ steps.meta.outputs.tags }}" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/docs/adrs/0020-registry-ghcr-e-tagging.md
+++ b/docs/adrs/0020-registry-ghcr-e-tagging.md
@@ -11,6 +11,19 @@ informed:
 
 # ADR-0020: GitHub Container Registry e estratégia de tagging das imagens da `uniplus-web`
 
+> **Emenda de 2026-05-17 — multi-arch (`linux/arm64`) habilitado**
+>
+> A decisão original limita publicação a `linux/amd64` (seção "Resultado da decisão") e lista "Sem multi-arch ARM" nas consequências negativas. A clausula é revisitada agora porque a Epic [`unifesspa-edu-br/uniplus-infra#317`](https://github.com/unifesspa-edu-br/uniplus-infra/issues/317) provisiona o lab Uni+ em `us-ashburn-1` sobre `VM.Standard.A1.Flex` (ARM Ampere) — alvo de migração do lab atual `standalone` (`sa-saopaulo-1`/E5 AMD) antes do trial OCI expirar em 2026-06-03.
+>
+> **O que muda:**
+>
+> - `publish-images.yml` passa a produzir manifest list multi-arch (`linux/amd64,linux/arm64`) por release. ArgoCD em cluster amd64 ou arm64 consome a mesma tag `vX.Y.Z`; o daemon Docker resolve o digest correto pela plataforma do nó.
+> - Smoke test runtime (non-root + `/health.json`) permanece em `linux/amd64` apenas: as invariantes validadas (usuário não-root, nginx servindo `/health.json` com `{"status":"ok"}`) são idênticas entre arquiteturas. `nginxinc/nginx-unprivileged` é imagem multi-arch nativa, então emular arm64 via QEMU só repete o mesmo cheque com overhead.
+> - Layer arm64 é compilado via QEMU emulation no runner amd64 do GitHub Actions (`docker/setup-qemu-action` registra os handlers `binfmt_misc`). Custo: ~2–3× mais lento por release. Aceitável porque o trigger continua sendo tag explícita (release raro, não rolling tag).
+> - O Dockerfile não muda — `node:22-alpine` (build) e `nginxinc/nginx-unprivileged:1.27-alpine` (runtime) já são multi-arch; o `npm ci` + `npx nx build` é puro JS arch-neutral.
+>
+> **O que permanece válido:** registry (GHCR), naming `uniplus-portal` / `uniplus-web-{selecao,ingresso}`, estratégia lockstep semver, gates de validação (formato semver, tag em commit em `main`), smoke runtime pré-push com hardening da [#4](https://github.com/unifesspa-edu-br/uniplus-web/issues/4) verificado. A emenda toca apenas a cláusula de plataformas.
+
 ## Contexto e enunciado do problema
 
 A Fase 5 do plano de deploy (cluster standalone) está bloqueada porque as imagens dos três frontends (`uniplus-portal`, `uniplus-web-selecao`, `uniplus-web-ingresso`) ainda não são publicadas em um registry acessível pelo cluster. Os Dockerfiles existem (`docker/Dockerfile.portal`, `docker/Dockerfile.selecao`, `docker/Dockerfile.ingresso`) e o pipeline de lint/test/build/E2E já é verde via Nx Cloud — mas não há workflow de publish, não há convenção de naming nem política de tagging.


### PR DESCRIPTION
## Resumo

Adapta `.github/workflows/publish-images.yml` para produzir manifest list multi-arch (`linux/amd64,linux/arm64`) por release no GHCR e emenda a ADR-0020 documentando que o gatilho da cláusula "linux/amd64 apenas" disparou: a Epic `unifesspa-edu-br/uniplus-infra#317` provisiona cluster ARM destino (`us-ashburn-1` sobre `VM.Standard.A1.Flex`) antes do trial OCI expirar em 2026-06-03.

Equivale ao PR `unifesspa-edu-br/uniplus-api#525` que aplica a mesma mudança no lado backend. Atende Story `unifesspa-edu-br/uniplus-infra#339` (S2.2 — buildx multi-arch no CI do uniplus-web), cobrindo os 3 services hoje publicados:

- `uniplus-portal`
- `uniplus-web-selecao`
- `uniplus-web-ingresso`

## O que muda

### `publish-images.yml` (+48 / −9)

| Step | Mudança |
|---|---|
| Header docstring | Documenta multi-arch e por que smoke fica em amd64 |
| **NOVO**: Set up QEMU | `docker/setup-qemu-action@v3` com `platforms: arm64` antes do `setup-buildx-action`. Registra binfmt_misc handlers para emulação user-mode da arch não-nativa do runner |
| Build local (smoke) | Permanece `linux/amd64` (`load: true` exige single platform). Cache scope passa a `${{ matrix.module }}-amd64` |
| Smoke test runtime | Sem mudança — `docker run` + `curl /health.json` validam non-root + nginx servindo `{"status":"ok"}`. Invariantes idênticas entre arquiteturas, então não vale repetir em arm64 emulado |
| Push para GHCR | `platforms: linux/amd64,linux/arm64`. Layer amd64 reusa cache do smoke; layer arm64 compila sob QEMU. Cache scopes separados por arch |
| Resumo | Linha extra mostrando `Plataformas: linux/amd64, linux/arm64` |

### `docs/adrs/0020-registry-ghcr-e-tagging.md` (+13 / 0)

- Status frontmatter mantém `accepted` bare (enum estrito do `tools/adr-lint/validate.sh`)
- Bloco "Emenda de 2026-05-17" no topo descrevendo:
  - **Trigger**: cluster ARM via `uniplus-infra#317`
  - **O que muda**: workflow + smoke amd64-only + emulação QEMU + cache scopes
  - **O que permanece**: registry GHCR, naming, lockstep semver, gates, smoke runtime pré-push, hardening da #4

Texto histórico do corpo (`Multi-arch limitado a linux/amd64 neste momento` na seção "Resultado da decisão" e `Sem multi-arch ARM` nas consequências) permanece como contexto da decisão original — superado pela emenda no topo.

## Validação local

```bash
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/publish-images.yml'))"   # YAML OK
yamllint .github/workflows/publish-images.yml                                              # exit=0
bash tools/adr-lint/validate.sh docs/adrs                                                  # 22 ADR(s) sem erros
```

Pré-revisão via `/up-coder-revisar` (qwen2.5-coder:14b + uniplus-rag): **LIMPO**.

7 cenários cruzados manualmente (idênticos ao PR uniplus-api#525, padrão validado lá):
- `setup-qemu-action@v3` com `platforms: arm64` — uso padrão ✓
- Ordem `setup-qemu` → `setup-buildx` — obrigatória ✓
- Cache scopes `${{ matrix.module }}-amd64` / `-arm64` — pattern recomendado p/ multi-arch ✓
- `cache-from: |` com 2 linhas — sintaxe válida em `docker/build-push-action@v5` ✓
- `load: true` + single platform amd64 — limitação do daemon Docker ✓
- Push multi-arch com `setup-qemu` só `arm64` — amd64 é nativo do runner ✓
- Tom da emenda ADR — trigger + o-que-muda + o-que-permanece ✓

## Como confirmar pós-merge

1. Próxima tag `v*.*.*` em commit em main dispara o workflow
2. `gh run watch` mostra:
   - Smoke amd64 passando como antes (sem regressão)
   - Push final consumindo ~2-3× mais tempo no layer arm64 (QEMU)
3. `docker manifest inspect ghcr.io/unifesspa-edu-br/uniplus-portal:vX.Y.Z` deve listar 2 entries amd64 + arm64
4. ArgoCD em cluster amd64 ou arm64 puxa o digest correto automaticamente

## Notas

- Não toca em Dockerfiles — `node:22-alpine` e `nginxinc/nginx-unprivileged:1.27-alpine` já são multi-arch; `npm ci` + `nx build` puramente JS
- Mantém hardening da #4 intacto (smoke continua validando non-root)
- Runtime config via ConfigMap (#84 / ADR-0021) sem mudança — independe de arch

Refs unifesspa-edu-br/uniplus-infra#317
Refs unifesspa-edu-br/uniplus-infra#339