### PR TITLE
refactor: publica entrypoints granulares das libs

### DIFF
--- a/apps/ingresso/src/app/app.config.ts
+++ b/apps/ingresso/src/app/app.config.ts
@@ -2,12 +2,11 @@ import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter, withComponentInputBinding } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { appRoutes } from './app.routes';
-import { loadingInterceptor } from '@uniplus/shared-core/interceptors/loading.interceptor';
-import { apiResultInterceptor } from '@uniplus/shared-core/http/api-result.interceptor';
+import { loadingInterceptor } from '@uniplus/shared-core/interceptors';
+import { apiResultInterceptor } from '@uniplus/shared-core/http';
 import { provideRuntimeConfig } from '@uniplus/shared-data/config';
-import { authErrorInterceptor } from '@uniplus/shared-auth/interceptors/auth-error.interceptor';
-import { tokenInterceptor } from '@uniplus/shared-auth/interceptors/token.interceptor';
-import { provideAuth } from '@uniplus/shared-auth/providers/auth.provider';
+import { authErrorInterceptor, tokenInterceptor } from '@uniplus/shared-auth/interceptors';
+import { provideAuth } from '@uniplus/shared-auth/bootstrap';
 
 export const appConfig: ApplicationConfig = {
   providers: [

--- a/apps/ingresso/src/app/app.routes.ts
+++ b/apps/ingresso/src/app/app.routes.ts
@@ -1,7 +1,6 @@
 import { Routes } from '@angular/router';
-import { AccessDeniedComponent } from '@uniplus/shared-auth/components/access-denied.component';
-import { authGuard } from '@uniplus/shared-auth/guards/auth.guard';
-import { roleGuard } from '@uniplus/shared-auth/guards/role.guard';
+import { AccessDeniedComponent } from '@uniplus/shared-auth/components';
+import { authGuard, roleGuard } from '@uniplus/shared-auth/guards';
 import { LayoutComponent } from './layout/layout';
 
 export const appRoutes: Routes = [
@@ -19,19 +18,23 @@ export const appRoutes: Routes = [
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
       {
         path: 'dashboard',
-        loadChildren: () => import('./features/dashboard/dashboard.routes').then((m) => m.DASHBOARD_ROUTES),
+        loadChildren: () =>
+          import('./features/dashboard/dashboard.routes').then((m) => m.DASHBOARD_ROUTES),
       },
       {
         path: 'chamadas',
-        loadChildren: () => import('./features/chamadas/chamadas.routes').then((m) => m.CHAMADAS_ROUTES),
+        loadChildren: () =>
+          import('./features/chamadas/chamadas.routes').then((m) => m.CHAMADAS_ROUTES),
       },
       {
         path: 'convocacoes',
-        loadChildren: () => import('./features/convocacoes/convocacoes.routes').then((m) => m.CONVOCACOES_ROUTES),
+        loadChildren: () =>
+          import('./features/convocacoes/convocacoes.routes').then((m) => m.CONVOCACOES_ROUTES),
       },
       {
         path: 'matriculas',
-        loadChildren: () => import('./features/matriculas/matriculas.routes').then((m) => m.MATRICULAS_ROUTES),
+        loadChildren: () =>
+          import('./features/matriculas/matriculas.routes').then((m) => m.MATRICULAS_ROUTES),
       },
     ],
   },

--- a/apps/ingresso/src/app/app.routes.ts
+++ b/apps/ingresso/src/app/app.routes.ts
@@ -1,7 +1,6 @@
 import { Routes } from '@angular/router';
 import { AccessDeniedComponent } from '@uniplus/shared-auth/components';
 import { authGuard, roleGuard } from '@uniplus/shared-auth/guards';
-import { LayoutComponent } from './layout/layout';
 
 export const appRoutes: Routes = [
   {
@@ -12,7 +11,7 @@ export const appRoutes: Routes = [
     // Backoffice Ingresso: todas as rotas exigem autenticação.
     // Roles elegíveis nesta SPA: admin, gestor.
     path: '',
-    component: LayoutComponent,
+    loadComponent: () => import('./layout/layout').then((m) => m.LayoutComponent),
     canActivate: [authGuard, roleGuard('admin', 'gestor')],
     children: [
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },

--- a/apps/ingresso/src/app/app.ts
+++ b/apps/ingresso/src/app/app.ts
@@ -1,8 +1,10 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { AuthErrorBannerComponent } from '@uniplus/shared-auth/components/auth-error-banner.component';
-import { LoginErrorBannerComponent } from '@uniplus/shared-auth/components/login-error-banner.component';
-import { NotificationHostComponent } from '@uniplus/shared-ui/components/notification-host/notification-host';
+import {
+  AuthErrorBannerComponent,
+  LoginErrorBannerComponent,
+} from '@uniplus/shared-auth/components';
+import { NotificationHostComponent } from '@uniplus/shared-ui/notifications';
 
 @Component({
   selector: 'ing-root',

--- a/apps/ingresso/src/app/features/chamadas/chamadas.ts
+++ b/apps/ingresso/src/app/features/chamadas/chamadas.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
+import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui/components';
 
 @Component({
   selector: 'ing-chamadas',
@@ -9,7 +9,10 @@ import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ui-page-header heading="Chamadas" description="Gestão de chamadas de vagas." />
-    <ui-empty-state heading="Nenhuma chamada configurada" description="As listas de chamada serão apresentadas nesta área." />
+    <ui-empty-state
+      heading="Nenhuma chamada configurada"
+      description="As listas de chamada serão apresentadas nesta área."
+    />
     <router-outlet />
   `,
 })

--- a/apps/ingresso/src/app/features/convocacoes/convocacoes.ts
+++ b/apps/ingresso/src/app/features/convocacoes/convocacoes.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
+import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui/components';
 
 @Component({
   selector: 'ing-convocacoes',
@@ -9,7 +9,10 @@ import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ui-page-header heading="Convocações" description="Convocação de candidatos aprovados." />
-    <ui-empty-state heading="Nenhuma convocação emitida" description="As convocações publicadas serão exibidas nesta tela." />
+    <ui-empty-state
+      heading="Nenhuma convocação emitida"
+      description="As convocações publicadas serão exibidas nesta tela."
+    />
     <router-outlet />
   `,
 })

--- a/apps/ingresso/src/app/features/dashboard/dashboard.ts
+++ b/apps/ingresso/src/app/features/dashboard/dashboard.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
+import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui/components';
 
 @Component({
   selector: 'ing-dashboard',
@@ -9,7 +9,10 @@ import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ui-page-header heading="Dashboard" description="Painel administrativo do módulo Ingresso." />
-    <ui-empty-state heading="Painel em preparação" description="Indicadores de ingresso e matrícula serão exibidos aqui." />
+    <ui-empty-state
+      heading="Painel em preparação"
+      description="Indicadores de ingresso e matrícula serão exibidos aqui."
+    />
     <router-outlet />
   `,
 })

--- a/apps/ingresso/src/app/features/matriculas/matriculas.ts
+++ b/apps/ingresso/src/app/features/matriculas/matriculas.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
+import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui/components';
 
 @Component({
   selector: 'ing-matriculas',
@@ -9,7 +9,10 @@ import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ui-page-header heading="Matrículas" description="Efetivação de matrículas." />
-    <ui-empty-state heading="Nenhuma matrícula pendente" description="As etapas de efetivação aparecerão nesta área." />
+    <ui-empty-state
+      heading="Nenhuma matrícula pendente"
+      description="As etapas de efetivação aparecerão nesta área."
+    />
     <router-outlet />
   `,
 })

--- a/apps/ingresso/src/app/layout/layout.ts
+++ b/apps/ingresso/src/app/layout/layout.ts
@@ -1,7 +1,7 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { UserHeaderInfoComponent } from '@uniplus/shared-auth/components/user-header-info.component';
-import { AppShellComponent, type UiShellNavItem } from '@uniplus/shared-ui/components/app-shell/app-shell';
+import { UserHeaderInfoComponent } from '@uniplus/shared-auth/components';
+import { AppShellComponent, type UiShellNavItem } from '@uniplus/shared-ui/shell';
 
 @Component({
   selector: 'ing-layout',

--- a/apps/portal/src/app/app.config.ts
+++ b/apps/portal/src/app/app.config.ts
@@ -2,12 +2,11 @@ import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter, withComponentInputBinding } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { appRoutes } from './app.routes';
-import { loadingInterceptor } from '@uniplus/shared-core/interceptors/loading.interceptor';
-import { apiResultInterceptor } from '@uniplus/shared-core/http/api-result.interceptor';
+import { loadingInterceptor } from '@uniplus/shared-core/interceptors';
+import { apiResultInterceptor } from '@uniplus/shared-core/http';
 import { provideRuntimeConfig } from '@uniplus/shared-data/config';
-import { authErrorInterceptor } from '@uniplus/shared-auth/interceptors/auth-error.interceptor';
-import { tokenInterceptor } from '@uniplus/shared-auth/interceptors/token.interceptor';
-import { provideAuth } from '@uniplus/shared-auth/providers/auth.provider';
+import { authErrorInterceptor, tokenInterceptor } from '@uniplus/shared-auth/interceptors';
+import { provideAuth } from '@uniplus/shared-auth/bootstrap';
 
 export const appConfig: ApplicationConfig = {
   providers: [

--- a/apps/portal/src/app/app.routes.ts
+++ b/apps/portal/src/app/app.routes.ts
@@ -1,7 +1,6 @@
 import { Routes } from '@angular/router';
 import { AccessDeniedComponent } from '@uniplus/shared-auth/components';
 import { authGuard } from '@uniplus/shared-auth/guards';
-import { LayoutComponent } from './layout/layout';
 
 export const appRoutes: Routes = [
   {
@@ -10,7 +9,7 @@ export const appRoutes: Routes = [
   },
   {
     path: '',
-    component: LayoutComponent,
+    loadComponent: () => import('./layout/layout').then((m) => m.LayoutComponent),
     children: [
       { path: '', redirectTo: 'processos', pathMatch: 'full' },
       {

--- a/apps/portal/src/app/app.routes.ts
+++ b/apps/portal/src/app/app.routes.ts
@@ -1,6 +1,6 @@
 import { Routes } from '@angular/router';
-import { AccessDeniedComponent } from '@uniplus/shared-auth/components/access-denied.component';
-import { authGuard } from '@uniplus/shared-auth/guards/auth.guard';
+import { AccessDeniedComponent } from '@uniplus/shared-auth/components';
+import { authGuard } from '@uniplus/shared-auth/guards';
 import { LayoutComponent } from './layout/layout';
 
 export const appRoutes: Routes = [
@@ -16,28 +16,35 @@ export const appRoutes: Routes = [
       {
         // Consulta pública de processos seletivos — sem autenticação.
         path: 'processos',
-        loadChildren: () => import('./features/processos/processos.routes').then((m) => m.PROCESSOS_ROUTES),
+        loadChildren: () =>
+          import('./features/processos/processos.routes').then((m) => m.PROCESSOS_ROUTES),
       },
       {
         // Áreas autenticadas do candidato — exigem authGuard.
         path: 'inscricao',
         canActivate: [authGuard],
-        loadChildren: () => import('./features/inscricao/inscricao.routes').then((m) => m.INSCRICAO_ROUTES),
+        loadChildren: () =>
+          import('./features/inscricao/inscricao.routes').then((m) => m.INSCRICAO_ROUTES),
       },
       {
         path: 'acompanhamento',
         canActivate: [authGuard],
-        loadChildren: () => import('./features/acompanhamento/acompanhamento.routes').then((m) => m.ACOMPANHAMENTO_ROUTES),
+        loadChildren: () =>
+          import('./features/acompanhamento/acompanhamento.routes').then(
+            (m) => m.ACOMPANHAMENTO_ROUTES,
+          ),
       },
       {
         path: 'recursos',
         canActivate: [authGuard],
-        loadChildren: () => import('./features/recursos/recursos.routes').then((m) => m.RECURSOS_ROUTES),
+        loadChildren: () =>
+          import('./features/recursos/recursos.routes').then((m) => m.RECURSOS_ROUTES),
       },
       {
         path: 'documentos',
         canActivate: [authGuard],
-        loadChildren: () => import('./features/documentos/documentos.routes').then((m) => m.DOCUMENTOS_ROUTES),
+        loadChildren: () =>
+          import('./features/documentos/documentos.routes').then((m) => m.DOCUMENTOS_ROUTES),
       },
       {
         path: 'perfil',

--- a/apps/portal/src/app/app.ts
+++ b/apps/portal/src/app/app.ts
@@ -1,8 +1,10 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { AuthErrorBannerComponent } from '@uniplus/shared-auth/components/auth-error-banner.component';
-import { LoginErrorBannerComponent } from '@uniplus/shared-auth/components/login-error-banner.component';
-import { NotificationHostComponent } from '@uniplus/shared-ui/components/notification-host/notification-host';
+import {
+  AuthErrorBannerComponent,
+  LoginErrorBannerComponent,
+} from '@uniplus/shared-auth/components';
+import { NotificationHostComponent } from '@uniplus/shared-ui/notifications';
 
 @Component({
   selector: 'ptl-root',

--- a/apps/portal/src/app/features/acompanhamento/acompanhamento.ts
+++ b/apps/portal/src/app/features/acompanhamento/acompanhamento.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
+import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui/components';
 
 @Component({
   selector: 'ptl-acompanhamento',
@@ -8,8 +8,14 @@ import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
   imports: [RouterOutlet, EmptyStateComponent, PageHeaderComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <ui-page-header heading="Acompanhamento" description="Acompanhe o status da sua inscrição e resultados." />
-    <ui-empty-state heading="Nenhum acompanhamento disponível" description="Quando houver inscrição ativa, o andamento será mostrado aqui." />
+    <ui-page-header
+      heading="Acompanhamento"
+      description="Acompanhe o status da sua inscrição e resultados."
+    />
+    <ui-empty-state
+      heading="Nenhum acompanhamento disponível"
+      description="Quando houver inscrição ativa, o andamento será mostrado aqui."
+    />
     <router-outlet />
   `,
 })

--- a/apps/portal/src/app/features/documentos/documentos.ts
+++ b/apps/portal/src/app/features/documentos/documentos.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
+import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui/components';
 
 @Component({
   selector: 'ptl-documentos',
@@ -8,8 +8,14 @@ import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
   imports: [RouterOutlet, EmptyStateComponent, PageHeaderComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <ui-page-header heading="Documentos" description="Upload e gestão de documentos comprobatórios." />
-    <ui-empty-state heading="Nenhum documento solicitado" description="As pendências documentais serão listadas nesta tela." />
+    <ui-page-header
+      heading="Documentos"
+      description="Upload e gestão de documentos comprobatórios."
+    />
+    <ui-empty-state
+      heading="Nenhum documento solicitado"
+      description="As pendências documentais serão listadas nesta tela."
+    />
     <router-outlet />
   `,
 })

--- a/apps/portal/src/app/features/inscricao/inscricao.ts
+++ b/apps/portal/src/app/features/inscricao/inscricao.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
+import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui/components';
 
 @Component({
   selector: 'ptl-inscricao',
@@ -9,7 +9,10 @@ import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ui-page-header heading="Inscrição" description="Formulário de inscrição do candidato." />
-    <ui-empty-state heading="Escolha um processo seletivo" description="A inscrição começa pela lista de processos disponíveis." />
+    <ui-empty-state
+      heading="Escolha um processo seletivo"
+      description="A inscrição começa pela lista de processos disponíveis."
+    />
     <router-outlet />
   `,
 })

--- a/apps/portal/src/app/features/perfil/perfil.ts
+++ b/apps/portal/src/app/features/perfil/perfil.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
+import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui/components';
 
 @Component({
   selector: 'ptl-perfil',
@@ -9,7 +9,10 @@ import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ui-page-header heading="Meu Perfil" description="Dados pessoais e informações de contato." />
-    <ui-empty-state heading="Perfil em preparação" description="Os dados da conta autenticada serão exibidos nesta área." />
+    <ui-empty-state
+      heading="Perfil em preparação"
+      description="Os dados da conta autenticada serão exibidos nesta área."
+    />
     <router-outlet />
   `,
 })

--- a/apps/portal/src/app/features/processos/processos.ts
+++ b/apps/portal/src/app/features/processos/processos.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
+import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui/components';
 
 @Component({
   selector: 'ptl-processos',
@@ -8,8 +8,14 @@ import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
   imports: [RouterOutlet, EmptyStateComponent, PageHeaderComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <ui-page-header heading="Processos Seletivos" description="Lista de processos seletivos abertos para inscrição." />
-    <ui-empty-state heading="Nenhum processo aberto" description="Os editais disponíveis para inscrição serão listados aqui." />
+    <ui-page-header
+      heading="Processos Seletivos"
+      description="Lista de processos seletivos abertos para inscrição."
+    />
+    <ui-empty-state
+      heading="Nenhum processo aberto"
+      description="Os editais disponíveis para inscrição serão listados aqui."
+    />
     <router-outlet />
   `,
 })

--- a/apps/portal/src/app/features/recursos/recursos.ts
+++ b/apps/portal/src/app/features/recursos/recursos.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
+import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui/components';
 
 @Component({
   selector: 'ptl-recursos',
@@ -9,7 +9,10 @@ import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ui-page-header heading="Recursos" description="Interposição de recursos administrativos." />
-    <ui-empty-state heading="Nenhum recurso disponível" description="Prazos e solicitações de recurso aparecerão nesta tela." />
+    <ui-empty-state
+      heading="Nenhum recurso disponível"
+      description="Prazos e solicitações de recurso aparecerão nesta tela."
+    />
     <router-outlet />
   `,
 })

--- a/apps/portal/src/app/layout/layout.ts
+++ b/apps/portal/src/app/layout/layout.ts
@@ -1,7 +1,7 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { UserHeaderInfoComponent } from '@uniplus/shared-auth/components/user-header-info.component';
-import { AppShellComponent, type UiShellNavItem } from '@uniplus/shared-ui/components/app-shell/app-shell';
+import { UserHeaderInfoComponent } from '@uniplus/shared-auth/components';
+import { AppShellComponent, type UiShellNavItem } from '@uniplus/shared-ui/shell';
 
 @Component({
   selector: 'ptl-layout',

--- a/apps/selecao/src/app/app.config.ts
+++ b/apps/selecao/src/app/app.config.ts
@@ -2,12 +2,11 @@ import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter, withComponentInputBinding } from '@angular/router';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { appRoutes } from './app.routes';
-import { loadingInterceptor } from '@uniplus/shared-core/interceptors/loading.interceptor';
-import { apiResultInterceptor } from '@uniplus/shared-core/http/api-result.interceptor';
+import { loadingInterceptor } from '@uniplus/shared-core/interceptors';
+import { apiResultInterceptor } from '@uniplus/shared-core/http';
 import { provideRuntimeConfig } from '@uniplus/shared-data/config';
-import { authErrorInterceptor } from '@uniplus/shared-auth/interceptors/auth-error.interceptor';
-import { tokenInterceptor } from '@uniplus/shared-auth/interceptors/token.interceptor';
-import { provideAuth } from '@uniplus/shared-auth/providers/auth.provider';
+import { authErrorInterceptor, tokenInterceptor } from '@uniplus/shared-auth/interceptors';
+import { provideAuth } from '@uniplus/shared-auth/bootstrap';
 
 export const appConfig: ApplicationConfig = {
   providers: [

--- a/apps/selecao/src/app/app.routes.ts
+++ b/apps/selecao/src/app/app.routes.ts
@@ -1,7 +1,6 @@
 import { Routes } from '@angular/router';
-import { AccessDeniedComponent } from '@uniplus/shared-auth/components/access-denied.component';
-import { authGuard } from '@uniplus/shared-auth/guards/auth.guard';
-import { roleGuard } from '@uniplus/shared-auth/guards/role.guard';
+import { AccessDeniedComponent } from '@uniplus/shared-auth/components';
+import { authGuard, roleGuard } from '@uniplus/shared-auth/guards';
 import { LayoutComponent } from './layout/layout';
 
 export const appRoutes: Routes = [
@@ -21,22 +20,26 @@ export const appRoutes: Routes = [
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
       {
         path: 'dashboard',
-        loadChildren: () => import('./features/dashboard/dashboard.routes').then((m) => m.DASHBOARD_ROUTES),
+        loadChildren: () =>
+          import('./features/dashboard/dashboard.routes').then((m) => m.DASHBOARD_ROUTES),
       },
       {
         path: 'editais',
         canActivate: [roleGuard('admin', 'gestor')],
-        loadChildren: () => import('./features/editais/editais.routes').then((m) => m.EDITAIS_ROUTES),
+        loadChildren: () =>
+          import('./features/editais/editais.routes').then((m) => m.EDITAIS_ROUTES),
       },
       {
         path: 'inscricoes',
         canActivate: [roleGuard('admin', 'gestor')],
-        loadChildren: () => import('./features/inscricoes/inscricoes.routes').then((m) => m.INSCRICOES_ROUTES),
+        loadChildren: () =>
+          import('./features/inscricoes/inscricoes.routes').then((m) => m.INSCRICOES_ROUTES),
       },
       {
         path: 'homologacao',
         canActivate: [roleGuard('admin', 'gestor', 'avaliador')],
-        loadChildren: () => import('./features/homologacao/homologacao.routes').then((m) => m.HOMOLOGACAO_ROUTES),
+        loadChildren: () =>
+          import('./features/homologacao/homologacao.routes').then((m) => m.HOMOLOGACAO_ROUTES),
       },
       {
         path: 'notas',
@@ -46,7 +49,10 @@ export const appRoutes: Routes = [
       {
         path: 'classificacao',
         canActivate: [roleGuard('admin', 'gestor')],
-        loadChildren: () => import('./features/classificacao/classificacao.routes').then((m) => m.CLASSIFICACAO_ROUTES),
+        loadChildren: () =>
+          import('./features/classificacao/classificacao.routes').then(
+            (m) => m.CLASSIFICACAO_ROUTES,
+          ),
       },
     ],
   },

--- a/apps/selecao/src/app/app.routes.ts
+++ b/apps/selecao/src/app/app.routes.ts
@@ -1,7 +1,6 @@
 import { Routes } from '@angular/router';
 import { AccessDeniedComponent } from '@uniplus/shared-auth/components';
 import { authGuard, roleGuard } from '@uniplus/shared-auth/guards';
-import { LayoutComponent } from './layout/layout';
 
 export const appRoutes: Routes = [
   {
@@ -14,7 +13,7 @@ export const appRoutes: Routes = [
     // Backoffice Seleção: todas as rotas exigem autenticação.
     // Roles elegíveis nesta SPA: admin, gestor, avaliador.
     path: '',
-    component: LayoutComponent,
+    loadComponent: () => import('./layout/layout').then((m) => m.LayoutComponent),
     canActivate: [authGuard, roleGuard('admin', 'gestor', 'avaliador')],
     children: [
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },

--- a/apps/selecao/src/app/app.ts
+++ b/apps/selecao/src/app/app.ts
@@ -1,8 +1,10 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { AuthErrorBannerComponent } from '@uniplus/shared-auth/components/auth-error-banner.component';
-import { LoginErrorBannerComponent } from '@uniplus/shared-auth/components/login-error-banner.component';
-import { NotificationHostComponent } from '@uniplus/shared-ui/components/notification-host/notification-host';
+import {
+  AuthErrorBannerComponent,
+  LoginErrorBannerComponent,
+} from '@uniplus/shared-auth/components';
+import { NotificationHostComponent } from '@uniplus/shared-ui/notifications';
 
 @Component({
   selector: 'sel-root',

--- a/apps/selecao/src/app/features/__fitness__/no-direct-http-in-pages.fitness.spec.ts
+++ b/apps/selecao/src/app/features/__fitness__/no-direct-http-in-pages.fitness.spec.ts
@@ -53,12 +53,12 @@ describe('Fitness — pages container em apps/selecao/src/app/features/', () => 
       // services em shared-data via inject(EditaisApi) etc., não fazer HTTP
       // direto. ADR-0017 container/presentational + ADR-0011/0012.
       const importsHttpClient = /import\s+\{[^}]*\bHttpClient\b[^}]*\}\s+from\s+['"]@angular\/common\/http['"]/.test(source);
-      expect(importsHttpClient).toBe(
-        false,
+      expect(
+        importsHttpClient,
         `\nArquivo: ${relativePath}\n` +
           `Pages container não devem importar HttpClient direto. Crie um service em libs/shared-data/src/lib/api/<modulo>/<recurso>.api.ts ` +
           `que retorne Observable<ApiResult<T>> e injete-o via inject(<MeuApi>) na page (ADR-0017).`,
-      );
+      ).toBe(false);
     });
 
     it('NÃO faz inject(HttpClient) (incluindo variantes com options)', () => {
@@ -66,11 +66,11 @@ describe('Fitness — pages container em apps/selecao/src/app/features/', () => 
       // `inject(HttpClient, { skipSelf: true })` etc. Vírgula OU parêntese
       // depois de HttpClient — qualquer variante de inject() do Angular DI.
       const injectsHttpClient = /inject\(\s*HttpClient\s*[,)]/.test(source);
-      expect(injectsHttpClient).toBe(
-        false,
+      expect(
+        injectsHttpClient,
         `\nArquivo: ${relativePath}\n` +
           `inject(HttpClient) na page é HTTP direto — extraia para um service em shared-data.`,
-      );
+      ).toBe(false);
     });
   });
 });

--- a/apps/selecao/src/app/features/classificacao/classificacao.ts
+++ b/apps/selecao/src/app/features/classificacao/classificacao.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
+import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui/components';
 
 @Component({
   selector: 'sel-classificacao',
@@ -9,7 +9,10 @@ import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ui-page-header heading="Classificação" description="Classificação e resultados." />
-    <ui-empty-state heading="Classificação em preparação" description="A publicação dos resultados aparecerá nesta área." />
+    <ui-empty-state
+      heading="Classificação em preparação"
+      description="A publicação dos resultados aparecerá nesta área."
+    />
     <router-outlet />
   `,
 })

--- a/apps/selecao/src/app/features/dashboard/dashboard.ts
+++ b/apps/selecao/src/app/features/dashboard/dashboard.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
+import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui/components';
 
 @Component({
   selector: 'sel-dashboard',
@@ -9,7 +9,10 @@ import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ui-page-header heading="Dashboard" description="Painel administrativo do módulo Seleção." />
-    <ui-empty-state heading="Painel em preparação" description="Os indicadores operacionais serão exibidos aqui." />
+    <ui-empty-state
+      heading="Painel em preparação"
+      description="Os indicadores operacionais serão exibidos aqui."
+    />
     <router-outlet />
   `,
 })

--- a/apps/selecao/src/app/features/editais/editais-create.page.spec.ts
+++ b/apps/selecao/src/app/features/editais/editais-create.page.spec.ts
@@ -1,13 +1,10 @@
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
-import {
-  HttpTestingController,
-  provideHttpClientTesting,
-} from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { provideRouter, Router } from '@angular/router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { apiResultInterceptor } from '@uniplus/shared-core';
-import { SELECAO_BASE_PATH } from '@uniplus/shared-data';
+import { apiResultInterceptor } from '@uniplus/shared-core/http';
+import { SELECAO_BASE_PATH } from '@uniplus/shared-data/selecao';
 import { EditaisCreatePage } from './editais-create.page';
 
 const BASE = 'http://localhost:5000';
@@ -107,7 +104,11 @@ describe('EditaisCreatePage', () => {
           { field: 'numeroEdital', code: 'GreaterThan', message: 'Número deve ser positivo.' },
         ],
       },
-      { status: 422, statusText: 'Unprocessable Entity', headers: { 'Content-Type': 'application/problem+json' } },
+      {
+        status: 422,
+        statusText: 'Unprocessable Entity',
+        headers: { 'Content-Type': 'application/problem+json' },
+      },
     );
 
     expect(component.submitting()).toBe(false);
@@ -135,7 +136,11 @@ describe('EditaisCreatePage', () => {
         traceId: 'tx',
         errors: [{ field: 'campo_inexistente', code: 'X', message: 'Y' }],
       },
-      { status: 422, statusText: 'Unprocessable Entity', headers: { 'Content-Type': 'application/problem+json' } },
+      {
+        status: 422,
+        statusText: 'Unprocessable Entity',
+        headers: { 'Content-Type': 'application/problem+json' },
+      },
     );
 
     expect(component.errorMessage()).toContain('Não foi possível mapear');
@@ -153,7 +158,11 @@ describe('EditaisCreatePage', () => {
         code: 'uniplus.selecao.edital.duplicado',
         traceId: 'tx2',
       },
-      { status: 409, statusText: 'Conflict', headers: { 'Content-Type': 'application/problem+json' } },
+      {
+        status: 409,
+        statusText: 'Conflict',
+        headers: { 'Content-Type': 'application/problem+json' },
+      },
     );
 
     expect(component.errorMessage()).toBe('Edital já existente');
@@ -174,7 +183,11 @@ describe('EditaisCreatePage', () => {
         traceId: 'tx',
         errors: [{ field: 'titulo', code: 'NotEmpty', message: 'Título é obrigatório.' }],
       },
-      { status: 422, statusText: 'Unprocessable Entity', headers: { 'Content-Type': 'application/problem+json' } },
+      {
+        status: 422,
+        statusText: 'Unprocessable Entity',
+        headers: { 'Content-Type': 'application/problem+json' },
+      },
     );
 
     expect(component.form.controls.titulo.errors).toMatchObject({
@@ -210,7 +223,11 @@ describe('EditaisCreatePage', () => {
         code: 'uniplus.selecao.edital.duplicado',
         traceId: 'tx',
       },
-      { status: 409, statusText: 'Conflict', headers: { 'Content-Type': 'application/problem+json' } },
+      {
+        status: 409,
+        statusText: 'Conflict',
+        headers: { 'Content-Type': 'application/problem+json' },
+      },
     );
 
     expect(component.idempotencyKeyAtual()).toBe(keyOriginal);
@@ -240,11 +257,15 @@ describe('EditaisCreatePage', () => {
   // tipoProcesso/numeroEdital/anoEdital sairiam no body como string e o
   // backend retornaria 400 (issue #374, validado via Playwright real).
   it('submit via DOM (NumberValueAccessor): body envia campos numericos como number, nao string', () => {
-    const numericInputs = fixture.nativeElement.querySelectorAll('input[type="number"]') as NodeListOf<HTMLInputElement>;
+    const numericInputs = fixture.nativeElement.querySelectorAll(
+      'input[type="number"]',
+    ) as NodeListOf<HTMLInputElement>;
     expect(numericInputs.length).toBe(4);
 
     const [numeroEditalInput, anoEditalInput, tipoProcessoInput, maximoOpcoesInput] = numericInputs;
-    const tituloInput = fixture.nativeElement.querySelector('input[type="text"]') as HTMLInputElement;
+    const tituloInput = fixture.nativeElement.querySelector(
+      'input[type="text"]',
+    ) as HTMLInputElement;
 
     numeroEditalInput.value = '42';
     numeroEditalInput.dispatchEvent(new Event('input'));

--- a/apps/selecao/src/app/features/editais/editais-create.page.spec.ts
+++ b/apps/selecao/src/app/features/editais/editais-create.page.spec.ts
@@ -262,7 +262,8 @@ describe('EditaisCreatePage', () => {
     ) as NodeListOf<HTMLInputElement>;
     expect(numericInputs.length).toBe(4);
 
-    const [numeroEditalInput, anoEditalInput, tipoProcessoInput, maximoOpcoesInput] = numericInputs;
+    const [numeroEditalInput, anoEditalInput, tipoProcessoInput, maximoOpcoesInput] =
+      Array.from(numericInputs);
     const tituloInput = fixture.nativeElement.querySelector(
       'input[type="text"]',
     ) as HTMLInputElement;

--- a/apps/selecao/src/app/features/editais/editais-create.page.ts
+++ b/apps/selecao/src/app/features/editais/editais-create.page.ts
@@ -1,28 +1,21 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  DestroyRef,
-  inject,
-  signal,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import {
-  FormControl,
-  FormGroup,
-  ReactiveFormsModule,
-  Validators,
-} from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import {
-  NotificationService,
   ProblemDetails,
   ProblemI18nService,
   ProblemValidationError,
   idempotencyKey,
   withIdempotencyKey,
-} from '@uniplus/shared-core';
-import { CriarEditalCommand, EditaisApi } from '@uniplus/shared-data';
-import { AlertComponent, FormFieldComponent, PageHeaderComponent } from '@uniplus/shared-ui';
+} from '@uniplus/shared-core/http';
+import { NotificationService } from '@uniplus/shared-core/notifications';
+import { CriarEditalCommand, EditaisApi } from '@uniplus/shared-data/selecao';
+import {
+  AlertComponent,
+  FormFieldComponent,
+  PageHeaderComponent,
+} from '@uniplus/shared-ui/components';
 
 /**
  * Form Reactive tipado para criação de edital.
@@ -53,7 +46,13 @@ interface CriarEditalForm {
   selector: 'sel-editais-create-page',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ReactiveFormsModule, RouterLink, AlertComponent, FormFieldComponent, PageHeaderComponent],
+  imports: [
+    ReactiveFormsModule,
+    RouterLink,
+    AlertComponent,
+    FormFieldComponent,
+    PageHeaderComponent,
+  ],
   template: `
     <ui-page-header
       heading="Novo edital"
@@ -110,12 +109,7 @@ interface CriarEditalForm {
       />
 
       <div class="ui-form-actions">
-        <a
-          routerLink="/editais"
-          class="btn btn--tertiary"
-        >
-          Cancelar
-        </a>
+        <a routerLink="/editais" class="btn btn--tertiary"> Cancelar </a>
         <button
           type="submit"
           [disabled]="submitting() || form.invalid"
@@ -229,9 +223,7 @@ export class EditaisCreatePage {
     }
   }
 
-  private aplicarErrosDeValidacao(
-    errors: ReadonlyArray<ProblemValidationError>,
-  ): void {
+  private aplicarErrosDeValidacao(errors: ReadonlyArray<ProblemValidationError>): void {
     let aplicouAlgum = false;
     for (const erro of errors) {
       const campo = erro.field as keyof CriarEditalForm;

--- a/apps/selecao/src/app/features/editais/editais-detail.page.spec.ts
+++ b/apps/selecao/src/app/features/editais/editais-detail.page.spec.ts
@@ -1,15 +1,12 @@
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
-import {
-  HttpTestingController,
-  provideHttpClientTesting,
-} from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ApplicationRef } from '@angular/core';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideRouter } from '@angular/router';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { apiResultInterceptor } from '@uniplus/shared-core';
-import { EditalDto, SELECAO_BASE_PATH } from '@uniplus/shared-data';
+import { apiResultInterceptor } from '@uniplus/shared-core/http';
+import { EditalDto, SELECAO_BASE_PATH } from '@uniplus/shared-data/selecao';
 import { EditaisDetailPage } from './editais-detail.page';
 
 const BASE = 'http://localhost:5000';
@@ -92,7 +89,11 @@ describe('EditaisDetailPage', () => {
         code: 'uniplus.selecao.edital.nao_encontrado',
         traceId: 'tx',
       },
-      { status: 404, statusText: 'Not Found', headers: { 'Content-Type': 'application/problem+json' } },
+      {
+        status: 404,
+        statusText: 'Not Found',
+        headers: { 'Content-Type': 'application/problem+json' },
+      },
     );
     await propagate();
 
@@ -188,7 +189,11 @@ describe('EditaisDetailPage', () => {
         code: 'uniplus.selecao.edital.ja_publicado',
         traceId: 'tx',
       },
-      { status: 422, statusText: 'Unprocessable Entity', headers: { 'Content-Type': 'application/problem+json' } },
+      {
+        status: 422,
+        statusText: 'Unprocessable Entity',
+        headers: { 'Content-Type': 'application/problem+json' },
+      },
     );
     await propagate();
 
@@ -263,9 +268,7 @@ describe('EditaisDetailPage', () => {
       .flush(null, { status: 204, statusText: 'No Content' });
     await propagate();
 
-    controller
-      .expectOne(`${BASE}/api/editais/${ID}`)
-      .flush(editalSeed({ status: 'Publicado' }));
+    controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Publicado' }));
     await propagate();
 
     expect(component.submitting()).toBe(false);
@@ -283,9 +286,7 @@ describe('EditaisDetailPage', () => {
       .expectOne(`${BASE}/api/editais/${ID}/publicar`)
       .flush(null, { status: 204, statusText: 'No Content' });
     await propagate();
-    controller
-      .expectOne(`${BASE}/api/editais/${ID}`)
-      .flush(editalSeed({ status: 'Publicado' }));
+    controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Publicado' }));
     await propagate();
     expect(component.mensagemSucesso()).toBe('Edital publicado com sucesso.');
 

--- a/apps/selecao/src/app/features/editais/editais-detail.page.ts
+++ b/apps/selecao/src/app/features/editais/editais-detail.page.ts
@@ -12,25 +12,21 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import {
-  NotificationService,
   ProblemI18nService,
   idempotencyKey,
   useApiResource,
   withIdempotencyKey,
   withVendorMime,
-} from '@uniplus/shared-core';
-import {
-  EditaisApi,
-  EditalDto,
-  SELECAO_BASE_PATH,
-} from '@uniplus/shared-data';
+} from '@uniplus/shared-core/http';
+import { NotificationService } from '@uniplus/shared-core/notifications';
+import { EditaisApi, EditalDto, SELECAO_BASE_PATH } from '@uniplus/shared-data/selecao';
 import {
   AlertComponent,
   CardComponent,
   ConfirmDialogComponent,
   PageHeaderComponent,
   SpinnerComponent,
-} from '@uniplus/shared-ui';
+} from '@uniplus/shared-ui/components';
 
 /**
  * Container (ADR-0017) da feature Editais — detalhe + ação Publicar.
@@ -71,13 +67,8 @@ import {
     SpinnerComponent,
   ],
   template: `
-    <ui-page-header
-      heading="Detalhes do edital"
-      [description]="editalDescription()"
-    >
-      <a uiPageActions routerLink="/editais" class="btn btn--tertiary">
-        Voltar para lista
-      </a>
+    <ui-page-header heading="Detalhes do edital" [description]="editalDescription()">
+      <a uiPageActions routerLink="/editais" class="btn btn--tertiary"> Voltar para lista </a>
     </ui-page-header>
 
     @if (errorMessage(); as msg) {

--- a/apps/selecao/src/app/features/editais/editais-list.page.spec.ts
+++ b/apps/selecao/src/app/features/editais/editais-list.page.spec.ts
@@ -1,24 +1,21 @@
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
-import {
-  HttpTestingController,
-  provideHttpClientTesting,
-} from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideRouter } from '@angular/router';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import {
-  NotificationService,
-  apiResultInterceptor,
-  buildVendorMimeAccept,
-} from '@uniplus/shared-core';
-import { EditalDto, SELECAO_BASE_PATH } from '@uniplus/shared-data';
+import { apiResultInterceptor, buildVendorMimeAccept } from '@uniplus/shared-core/http';
+import { NotificationService } from '@uniplus/shared-core/notifications';
+import { EditalDto, SELECAO_BASE_PATH } from '@uniplus/shared-data/selecao';
 import { EditaisListPage } from './editais-list.page';
 
 const BASE = 'http://localhost:5000';
 const ACCEPT = buildVendorMimeAccept('edital', 1);
 
-const editalSeed = (numero: string, id = `01960000-0000-7000-0000-0000000000${numero}`): EditalDto => ({
+const editalSeed = (
+  numero: string,
+  id = `01960000-0000-7000-0000-0000000000${numero}`,
+): EditalDto => ({
   id,
   numeroEdital: `0${numero}/2026`,
   titulo: `Edital ${numero}`,
@@ -102,7 +99,8 @@ describe('EditaisListPage', () => {
     component['aoCarregarMais'](cursorPagina2);
 
     const req = controller.expectOne(
-      (request) => request.url === `${BASE}/api/editais` && request.params.get('cursor') === 'cursor-pagina-2',
+      (request) =>
+        request.url === `${BASE}/api/editais` && request.params.get('cursor') === 'cursor-pagina-2',
     );
     req.flush([editalSeed('41'), editalSeed('42')], {
       headers: {
@@ -200,7 +198,8 @@ describe('EditaisListPage', () => {
     controller.expectOne(`${BASE}/api/editais`).flush([editalSeed('40')]);
     fixture.detectChanges();
 
-    const heading = fixture.debugElement.query(By.css('h1.page-header__title')).nativeElement as HTMLElement;
+    const heading = fixture.debugElement.query(By.css('h1.page-header__title'))
+      .nativeElement as HTMLElement;
     expect(heading.textContent).toContain('Editais');
 
     const linhas = fixture.debugElement.queryAll(By.css('[data-testid="data-table-row"]'));

--- a/apps/selecao/src/app/features/editais/editais-list.page.ts
+++ b/apps/selecao/src/app/features/editais/editais-list.page.ts
@@ -8,18 +8,14 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router, RouterLink } from '@angular/router';
-import {
-  Cursor,
-  NotificationService,
-  ProblemI18nService,
-  extractNextCursor,
-} from '@uniplus/shared-core';
-import { EditaisApi, EditalDto } from '@uniplus/shared-data';
+import { Cursor, ProblemI18nService, extractNextCursor } from '@uniplus/shared-core/http';
+import { NotificationService } from '@uniplus/shared-core/notifications';
+import { EditaisApi, EditalDto } from '@uniplus/shared-data/selecao';
 import {
   UiDataTableColumn,
   DataTableComponent,
   PageHeaderComponent,
-} from '@uniplus/shared-ui';
+} from '@uniplus/shared-ui/components';
 
 /**
  * Container (ADR-0017) da feature Editais — lista paginada por cursor opaco.
@@ -34,13 +30,8 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [DataTableComponent, PageHeaderComponent, RouterLink],
   template: `
-    <ui-page-header
-      heading="Editais"
-      description="Gestão de editais de processos seletivos."
-    >
-      <a uiPageActions routerLink="novo" class="btn">
-        Novo edital
-      </a>
+    <ui-page-header heading="Editais" description="Gestão de editais de processos seletivos.">
+      <a uiPageActions routerLink="novo" class="btn"> Novo edital </a>
     </ui-page-header>
 
     <ui-data-table
@@ -75,9 +66,7 @@ export class EditaisListPage {
   /** Cursor preservado da última falha pós-1ª página, para o retry retomar do mesmo ponto. */
   private cursorUltimaFalha: Cursor | undefined = undefined;
 
-  protected readonly rows = computed(
-    () => this.editais() as readonly Record<string, unknown>[],
-  );
+  protected readonly rows = computed(() => this.editais() as readonly Record<string, unknown>[]);
 
   protected readonly colunas: UiDataTableColumn[] = [
     { field: 'numeroEdital', header: 'Número', width: '12rem', primary: true },
@@ -131,9 +120,7 @@ export class EditaisListPage {
         }
         const mensagem = this.problemI18n.resolve(result.problem).title;
         this.errorMessage.set(mensagem);
-        this.errorTraceId.set(
-          result.problem.traceId.length > 0 ? result.problem.traceId : null,
-        );
+        this.errorTraceId.set(result.problem.traceId.length > 0 ? result.problem.traceId : null);
         // 5xx vira toast persistente em paralelo ao banner local — usuário
         // pode copiar o `traceId` para reportar incidente sem precisar
         // navegar até a tabela. 4xx mantém apenas o banner inline.

--- a/apps/selecao/src/app/features/homologacao/homologacao.ts
+++ b/apps/selecao/src/app/features/homologacao/homologacao.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
+import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui/components';
 
 @Component({
   selector: 'sel-homologacao',
@@ -9,7 +9,10 @@ import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ui-page-header heading="Homologação" description="Análise e homologação de documentos." />
-    <ui-empty-state heading="Fila de homologação vazia" description="As solicitações pendentes aparecerão nesta tela." />
+    <ui-empty-state
+      heading="Fila de homologação vazia"
+      description="As solicitações pendentes aparecerão nesta tela."
+    />
     <router-outlet />
   `,
 })

--- a/apps/selecao/src/app/features/inscricoes/inscricoes.ts
+++ b/apps/selecao/src/app/features/inscricoes/inscricoes.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
+import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui/components';
 
 @Component({
   selector: 'sel-inscricoes',
@@ -9,7 +9,10 @@ import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ui-page-header heading="Inscrições" description="Gestão de inscrições de candidatos." />
-    <ui-empty-state heading="Nenhuma inscrição selecionada" description="Use os filtros da listagem para localizar inscrições quando a integração estiver disponível." />
+    <ui-empty-state
+      heading="Nenhuma inscrição selecionada"
+      description="Use os filtros da listagem para localizar inscrições quando a integração estiver disponível."
+    />
     <router-outlet />
   `,
 })

--- a/apps/selecao/src/app/features/notas/notas.ts
+++ b/apps/selecao/src/app/features/notas/notas.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
+import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui/components';
 
 @Component({
   selector: 'sel-notas',
@@ -9,7 +9,10 @@ import { EmptyStateComponent, PageHeaderComponent } from '@uniplus/shared-ui';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <ui-page-header heading="Notas" description="Lançamento de notas por etapa." />
-    <ui-empty-state heading="Lançamento indisponível" description="As etapas avaliativas serão exibidas aqui quando configuradas." />
+    <ui-empty-state
+      heading="Lançamento indisponível"
+      description="As etapas avaliativas serão exibidas aqui quando configuradas."
+    />
     <router-outlet />
   `,
 })

--- a/apps/selecao/src/app/layout/layout.ts
+++ b/apps/selecao/src/app/layout/layout.ts
@@ -1,7 +1,7 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { UserHeaderInfoComponent } from '@uniplus/shared-auth/components/user-header-info.component';
-import { AppShellComponent, type UiShellNavItem } from '@uniplus/shared-ui/components/app-shell/app-shell';
+import { UserHeaderInfoComponent } from '@uniplus/shared-auth/components';
+import { AppShellComponent, type UiShellNavItem } from '@uniplus/shared-ui/shell';
 
 @Component({
   selector: 'sel-layout',

--- a/libs/shared-auth/bootstrap/README.md
+++ b/libs/shared-auth/bootstrap/README.md
@@ -1,0 +1,3 @@
+# @uniplus/shared-auth/bootstrap
+
+Secondary entry point of `@uniplus/shared-auth`. It can be used by importing from `@uniplus/shared-auth/bootstrap`.

--- a/libs/shared-auth/bootstrap/ng-package.json
+++ b/libs/shared-auth/bootstrap/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "../src/lib/bootstrap.ts"
+  }
+}

--- a/libs/shared-auth/bootstrap/src/index.ts
+++ b/libs/shared-auth/bootstrap/src/index.ts
@@ -1,0 +1,9 @@
+export { AuthService } from '../../src/lib/services/auth.service';
+export { UserContextService } from '../../src/lib/services/user-context.service';
+export { provideAuth } from '../../src/lib/providers/auth.provider';
+export { AUTH_ALLOWED_URLS, AUTH_CONFIG } from '../../src/lib/tokens/auth.tokens';
+export { LoginErrorCode, classifyLoginError } from '../../src/lib/models/login-error.model';
+export type { AuthConfig } from '../../src/lib/models/auth-config.model';
+export type { LoginErrorDetails } from '../../src/lib/models/login-error.model';
+export type { UniPlusTokenClaims } from '../../src/lib/models/token-claims.model';
+export type { UserProfile, UserRole } from '../../src/lib/models/user.model';

--- a/libs/shared-auth/components/README.md
+++ b/libs/shared-auth/components/README.md
@@ -1,0 +1,3 @@
+# @uniplus/shared-auth/components
+
+Secondary entry point of `@uniplus/shared-auth`. It can be used by importing from `@uniplus/shared-auth/components`.

--- a/libs/shared-auth/components/ng-package.json
+++ b/libs/shared-auth/components/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "../src/lib/components/index.ts"
+  }
+}

--- a/libs/shared-auth/components/src/index.ts
+++ b/libs/shared-auth/components/src/index.ts
@@ -1,0 +1,4 @@
+export { AccessDeniedComponent } from '../../src/lib/components/access-denied.component';
+export { AuthErrorBannerComponent } from '../../src/lib/components/auth-error-banner.component';
+export { LoginErrorBannerComponent } from '../../src/lib/components/login-error-banner.component';
+export { UserHeaderInfoComponent } from '../../src/lib/components/user-header-info.component';

--- a/libs/shared-auth/guards/README.md
+++ b/libs/shared-auth/guards/README.md
@@ -1,0 +1,3 @@
+# @uniplus/shared-auth/guards
+
+Secondary entry point of `@uniplus/shared-auth`. It can be used by importing from `@uniplus/shared-auth/guards`.

--- a/libs/shared-auth/guards/ng-package.json
+++ b/libs/shared-auth/guards/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "../src/lib/guards/index.ts"
+  }
+}

--- a/libs/shared-auth/guards/src/index.ts
+++ b/libs/shared-auth/guards/src/index.ts
@@ -1,0 +1,2 @@
+export { authGuard } from '../../src/lib/guards/auth.guard';
+export { roleGuard } from '../../src/lib/guards/role.guard';

--- a/libs/shared-auth/interceptors/README.md
+++ b/libs/shared-auth/interceptors/README.md
@@ -1,0 +1,3 @@
+# @uniplus/shared-auth/interceptors
+
+Secondary entry point of `@uniplus/shared-auth`. It can be used by importing from `@uniplus/shared-auth/interceptors`.

--- a/libs/shared-auth/interceptors/ng-package.json
+++ b/libs/shared-auth/interceptors/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "../src/lib/interceptors/index.ts"
+  }
+}

--- a/libs/shared-auth/interceptors/src/index.ts
+++ b/libs/shared-auth/interceptors/src/index.ts
@@ -1,0 +1,2 @@
+export { authErrorInterceptor } from '../../src/lib/interceptors/auth-error.interceptor';
+export { tokenInterceptor } from '../../src/lib/interceptors/token.interceptor';

--- a/libs/shared-auth/src/lib/bootstrap.ts
+++ b/libs/shared-auth/src/lib/bootstrap.ts
@@ -1,0 +1,9 @@
+export { AuthService } from './services/auth.service';
+export { UserContextService } from './services/user-context.service';
+export { provideAuth } from './providers/auth.provider';
+export { AUTH_ALLOWED_URLS, AUTH_CONFIG } from './tokens/auth.tokens';
+export { LoginErrorCode, classifyLoginError } from './models/login-error.model';
+export type { AuthConfig } from './models/auth-config.model';
+export type { LoginErrorDetails } from './models/login-error.model';
+export type { UniPlusTokenClaims } from './models/token-claims.model';
+export type { UserProfile, UserRole } from './models/user.model';

--- a/libs/shared-auth/src/lib/components/access-denied.component.ts
+++ b/libs/shared-auth/src/lib/components/access-denied.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { Router } from '@angular/router';
-import { UserContextService } from '../services/user-context.service';
+import { UserContextService } from '@uniplus/shared-auth/bootstrap';
 
 /**
  * Página de "Acesso negado" (HTTP 403). Exibida quando um usuário
@@ -17,28 +17,18 @@ import { UserContextService } from '../services/user-context.service';
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <main
-      role="main"
-      class="ui-access-denied"
-    >
+    <main role="main" class="ui-access-denied">
       <div class="empty-state empty-state--error">
         <div class="empty-state__icon" aria-hidden="true">!</div>
         <h1 class="empty-state__title">Acesso negado</h1>
-        <p class="empty-state__desc">
-          Sua conta não possui permissão para acessar esta área.
-        </p>
+        <p class="empty-state__desc">Sua conta não possui permissão para acessar esta área.</p>
         @if (user(); as profile) {
           <p class="u-caption">
-            Conectado como <strong>{{ profile.username }}</strong>.
+            Conectado como <strong>{{ profile.username }}</strong
+            >.
           </p>
         }
-        <button
-          type="button"
-          class="btn"
-          (click)="voltar()"
-        >
-          Voltar ao início
-        </button>
+        <button type="button" class="btn" (click)="voltar()">Voltar ao início</button>
       </div>
     </main>
   `,

--- a/libs/shared-auth/src/lib/components/auth-error-banner.component.ts
+++ b/libs/shared-auth/src/lib/components/auth-error-banner.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
-import { AuthService } from '../services/auth.service';
+import { AuthService } from '@uniplus/shared-auth/bootstrap';
 
 /**
  * Banner de fallback exibido quando `AuthService.init()` falha
@@ -15,19 +15,14 @@ import { AuthService } from '../services/auth.service';
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     @if (authService.initError(); as message) {
-      <div
-        role="alert"
-        aria-live="assertive"
-        class="alert alert--danger ui-auth-banner"
-      >
+      <div role="alert" aria-live="assertive" class="alert alert--danger ui-auth-banner">
         <span aria-hidden="true" class="alert__icon">!</span>
         <div class="alert__body">
           <strong class="alert__title">Serviço de autenticação indisponível</strong>
           <span class="alert__msg">{{ message }}</span>
           <span class="u-caption">
-            Você pode continuar navegando em áreas públicas. Recursos
-            protegidos ficarão indisponíveis até o restabelecimento do
-            serviço.
+            Você pode continuar navegando em áreas públicas. Recursos protegidos ficarão
+            indisponíveis até o restabelecimento do serviço.
           </span>
         </div>
       </div>

--- a/libs/shared-auth/src/lib/components/index.ts
+++ b/libs/shared-auth/src/lib/components/index.ts
@@ -1,0 +1,4 @@
+export { AccessDeniedComponent } from './access-denied.component';
+export { AuthErrorBannerComponent } from './auth-error-banner.component';
+export { LoginErrorBannerComponent } from './login-error-banner.component';
+export { UserHeaderInfoComponent } from './user-header-info.component';

--- a/libs/shared-auth/src/lib/components/login-error-banner.component.ts
+++ b/libs/shared-auth/src/lib/components/login-error-banner.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@a
 import { NavigationEnd, Router } from '@angular/router';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { filter, map, startWith } from 'rxjs/operators';
-import { LoginErrorCode, classifyLoginError } from '../models/login-error.model';
+import { LoginErrorCode, classifyLoginError } from '@uniplus/shared-auth/bootstrap';
 
 /**
  * Banner contextual exibido quando o provedor OIDC redireciona de volta à
@@ -27,10 +27,7 @@ import { LoginErrorCode, classifyLoginError } from '../models/login-error.model'
         [class.alert--danger]="isDanger()"
         [class.alert--warning]="!isDanger()"
       >
-        <span
-          aria-hidden="true"
-          class="alert__icon"
-        >
+        <span aria-hidden="true" class="alert__icon">
           {{ isDanger() ? '!' : 'i' }}
         </span>
         <div class="alert__body">

--- a/libs/shared-auth/src/lib/components/user-header-info.component.ts
+++ b/libs/shared-auth/src/lib/components/user-header-info.component.ts
@@ -7,12 +7,15 @@ import {
   inject,
   viewChild,
 } from '@angular/core';
-import { createDisclosureController } from '@uniplus/shared-core';
-import { AuthService } from '../services/auth.service';
-import { UserContextService } from '../services/user-context.service';
-import { UserRole } from '../models/user.model';
+import { createDisclosureController } from '@uniplus/shared-core/dom';
+import { AuthService, UserContextService, type UserRole } from '@uniplus/shared-auth/bootstrap';
 
-const DOMAIN_ROLES = new Set<string>(['admin', 'gestor', 'avaliador', 'candidato'] satisfies UserRole[]);
+const DOMAIN_ROLES = new Set<string>([
+  'admin',
+  'gestor',
+  'avaliador',
+  'candidato',
+] satisfies UserRole[]);
 
 /**
  * Bloco de identificação do usuário autenticado para uso em headers.
@@ -39,19 +42,30 @@ const DOMAIN_ROLES = new Set<string>(['admin', 'gestor', 'avaliador', 'candidato
           (click)="toggleMenu()"
           (keydown)="onTriggerKeydown($event)"
         >
-          <span class="user-chip__avatar" aria-hidden="true">{{ initials(userContext.displayName()) }}</span>
+          <span class="user-chip__avatar" aria-hidden="true">{{
+            initials(userContext.displayName())
+          }}</span>
           <span class="ui-user-header__text">
             <strong>{{ userContext.displayName() }}</strong>
             <span>
-            &#64;{{ profile.username }}
-            @if (domainRoles(profile.roles); as roles) {
-              @if (roles.length) {
-                · {{ roles.join(', ') }}
+              &#64;{{ profile.username }}
+              @if (domainRoles(profile.roles); as roles) {
+                @if (roles.length) {
+                  · {{ roles.join(', ') }}
+                }
               }
-            }
             </span>
           </span>
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true">
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            aria-hidden="true"
+          >
             <path d="M19 9l-7 7-7-7" />
           </svg>
         </button>
@@ -73,7 +87,13 @@ const DOMAIN_ROLES = new Set<string>(['admin', 'gestor', 'avaliador', 'candidato
               (keydown)="onMenuKeydown($event)"
               (click)="logout()"
             >
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                aria-hidden="true"
+              >
                 <path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4M16 17l5-5-5-5M21 12H9" />
               </svg>
               Sair
@@ -146,10 +166,17 @@ export class UserHeaderInfoComponent {
     const currentIndex = items.indexOf(this.document.activeElement as HTMLElement);
     const last = items.length - 1;
     const nextIndex =
-      event.key === 'Home' ? 0 :
-      event.key === 'End' ? last :
-      event.key === 'ArrowUp' ? (currentIndex <= 0 ? last : currentIndex - 1) :
-      (currentIndex >= last ? 0 : currentIndex + 1);
+      event.key === 'Home'
+        ? 0
+        : event.key === 'End'
+          ? last
+          : event.key === 'ArrowUp'
+            ? currentIndex <= 0
+              ? last
+              : currentIndex - 1
+            : currentIndex >= last
+              ? 0
+              : currentIndex + 1;
 
     items[nextIndex]?.focus();
   }

--- a/libs/shared-auth/src/lib/guards/auth.guard.ts
+++ b/libs/shared-auth/src/lib/guards/auth.guard.ts
@@ -1,6 +1,6 @@
 import { inject } from '@angular/core';
 import { CanActivateFn } from '@angular/router';
-import { AuthService } from '../services/auth.service';
+import { AuthService } from '@uniplus/shared-auth/bootstrap';
 
 export const authGuard: CanActivateFn = () => {
   const authService = inject(AuthService);

--- a/libs/shared-auth/src/lib/guards/index.ts
+++ b/libs/shared-auth/src/lib/guards/index.ts
@@ -1,0 +1,2 @@
+export { authGuard } from './auth.guard';
+export { roleGuard } from './role.guard';

--- a/libs/shared-auth/src/lib/guards/role.guard.ts
+++ b/libs/shared-auth/src/lib/guards/role.guard.ts
@@ -1,6 +1,6 @@
 import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
-import { AuthService } from '../services/auth.service';
+import { AuthService } from '@uniplus/shared-auth/bootstrap';
 
 /**
  * Guard de autorização baseado em realm roles. Distingue três cenários:

--- a/libs/shared-auth/src/lib/interceptors/auth-error.interceptor.spec.ts
+++ b/libs/shared-auth/src/lib/interceptors/auth-error.interceptor.spec.ts
@@ -1,16 +1,9 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
-import {
-  HttpTestingController,
-  provideHttpClientTesting,
-} from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { Router } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
-import {
-  ApiResult,
-  apiResultInterceptor,
-  ProblemDetails,
-} from '@uniplus/shared-core';
+import { ApiResult, apiResultInterceptor, ProblemDetails } from '@uniplus/shared-core/http';
 import { authErrorInterceptor } from './auth-error.interceptor';
 import { AuthService } from '../services/auth.service';
 
@@ -36,9 +29,7 @@ describe('authErrorInterceptor (consumindo ApiResult)', () => {
         // A ordem aqui replica a registrada nos apps:
         // authErrorInterceptor é mais externo que apiResultInterceptor,
         // portanto recebe o HttpResponse já envelopado pelo apiResult.
-        provideHttpClient(
-          withInterceptors([authErrorInterceptor, apiResultInterceptor]),
-        ),
+        provideHttpClient(withInterceptors([authErrorInterceptor, apiResultInterceptor])),
         provideHttpClientTesting(),
         { provide: AuthService, useValue: authServiceMock },
         { provide: Router, useValue: routerMock },
@@ -73,10 +64,12 @@ describe('authErrorInterceptor (consumindo ApiResult)', () => {
     const { http, httpMock, login, navigate } = setup();
 
     const promise = firstValueFrom(http.get<ApiResult<unknown>>('/api/admin'));
-    httpMock.expectOne('/api/admin').flush(
-      { ...baseProblem, code: 'uniplus.auth.forbidden', status: 403, title: 'Acesso negado' },
-      { status: 403, statusText: 'Forbidden', headers: PROBLEM_HEADERS },
-    );
+    httpMock
+      .expectOne('/api/admin')
+      .flush(
+        { ...baseProblem, code: 'uniplus.auth.forbidden', status: 403, title: 'Acesso negado' },
+        { status: 403, statusText: 'Forbidden', headers: PROBLEM_HEADERS },
+      );
 
     const result = await promise;
     expect(result.ok).toBe(false);
@@ -91,20 +84,23 @@ describe('authErrorInterceptor (consumindo ApiResult)', () => {
 
     for (const status of [500, 404]) {
       const promise = firstValueFrom(http.get<ApiResult<unknown>>(`/api/x${status}`));
-      httpMock
-        .expectOne(`/api/x${status}`)
-        .flush({ ...baseProblem, status, code: `uniplus.test.${status}` }, {
+      httpMock.expectOne(`/api/x${status}`).flush(
+        { ...baseProblem, status, code: `uniplus.test.${status}` },
+        {
           status,
           statusText: 'error',
           headers: PROBLEM_HEADERS,
-        });
+        },
+      );
       const result = await promise;
       expect(result.ok).toBe(false);
       expect(result.status).toBe(status);
     }
 
     const promise0 = firstValueFrom(http.get<ApiResult<unknown>>('/api/x0'));
-    httpMock.expectOne('/api/x0').error(new ProgressEvent('error'), { status: 0, statusText: 'Unknown' });
+    httpMock
+      .expectOne('/api/x0')
+      .error(new ProgressEvent('error'), { status: 0, statusText: 'Unknown' });
     const result0 = await promise0;
     expect(result0.ok).toBe(false);
     expect(result0.status).toBe(0);

--- a/libs/shared-auth/src/lib/interceptors/auth-error.interceptor.ts
+++ b/libs/shared-auth/src/lib/interceptors/auth-error.interceptor.ts
@@ -2,7 +2,7 @@ import { HttpInterceptorFn, HttpResponse } from '@angular/common/http';
 import { inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { tap } from 'rxjs';
-import { AuthService } from '../services/auth.service';
+import { AuthService } from '@uniplus/shared-auth/bootstrap';
 
 /**
  * Reage a respostas já envelopadas pelo `apiResultInterceptor` de

--- a/libs/shared-auth/src/lib/interceptors/index.ts
+++ b/libs/shared-auth/src/lib/interceptors/index.ts
@@ -1,0 +1,2 @@
+export { authErrorInterceptor } from './auth-error.interceptor';
+export { tokenInterceptor } from './token.interceptor';

--- a/libs/shared-auth/src/lib/interceptors/token.interceptor.ts
+++ b/libs/shared-auth/src/lib/interceptors/token.interceptor.ts
@@ -1,8 +1,7 @@
 import { HttpEvent, HttpHandlerFn, HttpInterceptorFn, HttpRequest } from '@angular/common/http';
 import { inject } from '@angular/core';
 import { Observable, defer, switchMap } from 'rxjs';
-import { AuthService } from '../services/auth.service';
-import { AUTH_ALLOWED_URLS } from '../tokens/auth.tokens';
+import { AUTH_ALLOWED_URLS, AuthService } from '@uniplus/shared-auth/bootstrap';
 
 /**
  * Interceptor que anexa `Authorization: Bearer <token>` às requisições

--- a/libs/shared-auth/tsconfig.lib.json
+++ b/libs/shared-auth/tsconfig.lib.json
@@ -7,21 +7,21 @@
     "inlineSources": true,
     "types": []
   },
-  "include": ["src/**/*.ts"],
+  "include": ["**/*.ts"],
   "exclude": [
-    "src/**/*.spec.ts",
-    "src/**/*.test.ts",
-    "src/**/*.dod.ts",
+    "**/*.spec.ts",
+    "**/*.test.ts",
+    "**/*.dod.ts",
     "vite.config.ts",
     "vite.config.mts",
     "vitest.config.ts",
     "vitest.config.mts",
-    "src/**/*.test.tsx",
-    "src/**/*.spec.tsx",
-    "src/**/*.test.js",
-    "src/**/*.spec.js",
-    "src/**/*.test.jsx",
-    "src/**/*.spec.jsx",
-    "src/test-setup.ts"
+    "**/*.test.tsx",
+    "**/*.spec.tsx",
+    "**/*.test.js",
+    "**/*.spec.js",
+    "**/*.test.jsx",
+    "**/*.spec.jsx",
+    "test-setup.ts"
   ]
 }

--- a/libs/shared-auth/tsconfig.lib.prod.json
+++ b/libs/shared-auth/tsconfig.lib.prod.json
@@ -3,7 +3,10 @@
   "compilerOptions": {
     "declarationMap": false,
     "paths": {
-      "@uniplus/shared-core": ["dist/libs/shared-core"]
+      "@uniplus/shared-auth/bootstrap": ["dist/libs/shared-auth/bootstrap"],
+      "@uniplus/shared-core": ["dist/libs/shared-core"],
+      "@uniplus/shared-core/dom": ["dist/libs/shared-core/dom"],
+      "@uniplus/shared-core/http": ["dist/libs/shared-core/http"]
     }
   },
   "angularCompilerOptions": {}

--- a/libs/shared-core/dom/README.md
+++ b/libs/shared-core/dom/README.md
@@ -1,0 +1,3 @@
+# @uniplus/shared-core/dom
+
+Secondary entry point of `@uniplus/shared-core`. It can be used by importing from `@uniplus/shared-core/dom`.

--- a/libs/shared-core/dom/ng-package.json
+++ b/libs/shared-core/dom/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "../src/lib/dom/disclosure.ts"
+  }
+}

--- a/libs/shared-core/dom/src/index.ts
+++ b/libs/shared-core/dom/src/index.ts
@@ -1,0 +1,6 @@
+export {
+  createDisclosureController,
+  type UiDisclosureController,
+  type UiDisclosureControllerOptions,
+  type UiDisclosureRef,
+} from '../../src/lib/dom/disclosure';

--- a/libs/shared-core/http/README.md
+++ b/libs/shared-core/http/README.md
@@ -1,0 +1,3 @@
+# @uniplus/shared-core/http
+
+Secondary entry point of `@uniplus/shared-core`. It can be used by importing from `@uniplus/shared-core/http`.

--- a/libs/shared-core/http/ng-package.json
+++ b/libs/shared-core/http/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "../src/lib/http/index.ts"
+  }
+}

--- a/libs/shared-core/http/src/index.ts
+++ b/libs/shared-core/http/src/index.ts
@@ -1,0 +1,1 @@
+export * from '../../src/lib/http';

--- a/libs/shared-core/interceptors/README.md
+++ b/libs/shared-core/interceptors/README.md
@@ -1,0 +1,3 @@
+# @uniplus/shared-core/interceptors
+
+Secondary entry point of `@uniplus/shared-core`. It can be used by importing from `@uniplus/shared-core/interceptors`.

--- a/libs/shared-core/interceptors/ng-package.json
+++ b/libs/shared-core/interceptors/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "../src/lib/interceptors/index.ts"
+  }
+}

--- a/libs/shared-core/interceptors/src/index.ts
+++ b/libs/shared-core/interceptors/src/index.ts
@@ -1,0 +1,2 @@
+export { loadingInterceptor } from '../../src/lib/interceptors/loading.interceptor';
+export { LoadingService } from '../../src/lib/interceptors/loading.service';

--- a/libs/shared-core/notifications/README.md
+++ b/libs/shared-core/notifications/README.md
@@ -1,0 +1,3 @@
+# @uniplus/shared-core/notifications
+
+Secondary entry point of `@uniplus/shared-core`. It can be used by importing from `@uniplus/shared-core/notifications`.

--- a/libs/shared-core/notifications/ng-package.json
+++ b/libs/shared-core/notifications/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "../src/lib/services/notification.service.ts"
+  }
+}

--- a/libs/shared-core/notifications/src/index.ts
+++ b/libs/shared-core/notifications/src/index.ts
@@ -1,0 +1,7 @@
+export {
+  NotificationService,
+  type Notification,
+  type NotificationOptions,
+  type NotificationFromProblemOptions,
+  type NotificationType,
+} from '../../src/lib/services/notification.service';

--- a/libs/shared-core/src/lib/index.ts
+++ b/libs/shared-core/src/lib/index.ts
@@ -1,10 +1,7 @@
 // Services
-export { LoadingService } from './services/loading.service';
+export { LoadingService } from './interceptors/loading.service';
 export { NotificationService } from './services/notification.service';
-export type {
-  Notification,
-  NotificationType,
-} from './services/notification.service';
+export type { Notification, NotificationType } from './services/notification.service';
 
 // Interceptors
 export { loadingInterceptor } from './interceptors/loading.interceptor';

--- a/libs/shared-core/src/lib/interceptors/index.ts
+++ b/libs/shared-core/src/lib/interceptors/index.ts
@@ -1,0 +1,2 @@
+export { loadingInterceptor } from './loading.interceptor';
+export { LoadingService } from './loading.service';

--- a/libs/shared-core/src/lib/interceptors/loading.interceptor.ts
+++ b/libs/shared-core/src/lib/interceptors/loading.interceptor.ts
@@ -1,7 +1,7 @@
 import { HttpInterceptorFn } from '@angular/common/http';
 import { inject } from '@angular/core';
 import { finalize } from 'rxjs';
-import { LoadingService } from '../services/loading.service';
+import { LoadingService } from './loading.service';
 
 export const loadingInterceptor: HttpInterceptorFn = (req, next) => {
   const loading = inject(LoadingService);

--- a/libs/shared-core/src/lib/interceptors/loading.service.ts
+++ b/libs/shared-core/src/lib/interceptors/loading.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, signal, computed } from '@angular/core';
+import { Injectable, computed, signal } from '@angular/core';
 
 @Injectable({ providedIn: 'root' })
 export class LoadingService {

--- a/libs/shared-core/src/lib/services/notification.service.ts
+++ b/libs/shared-core/src/lib/services/notification.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, signal } from '@angular/core';
-import type { ProblemDetails } from '../http/problem-details';
+import type { ProblemDetails } from '@uniplus/shared-core/http';
 
 export type NotificationType = 'success' | 'error' | 'warning' | 'info';
 
@@ -91,13 +91,9 @@ export class NotificationService {
    * - `persistent` é `true` por default em status `>= 500`; pode ser
    *   sobrescrito via `overrides.persistent`.
    */
-  errorFromProblem(
-    problem: ProblemDetails,
-    overrides?: NotificationFromProblemOptions,
-  ): number {
+  errorFromProblem(problem: ProblemDetails, overrides?: NotificationFromProblemOptions): number {
     const id = ++this.counter;
-    const persistent =
-      overrides?.persistent ?? problem.status >= SERVER_ERROR_THRESHOLD;
+    const persistent = overrides?.persistent ?? problem.status >= SERVER_ERROR_THRESHOLD;
     const traceId = problem.traceId.length > 0 ? problem.traceId : undefined;
     const notification: Notification = {
       id,

--- a/libs/shared-core/tsconfig.lib.json
+++ b/libs/shared-core/tsconfig.lib.json
@@ -7,20 +7,20 @@
     "inlineSources": true,
     "types": []
   },
-  "include": ["src/**/*.ts"],
+  "include": ["**/*.ts"],
   "exclude": [
-    "src/**/*.spec.ts",
-    "src/**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.ts",
     "vite.config.ts",
     "vite.config.mts",
     "vitest.config.ts",
     "vitest.config.mts",
-    "src/**/*.test.tsx",
-    "src/**/*.spec.tsx",
-    "src/**/*.test.js",
-    "src/**/*.spec.js",
-    "src/**/*.test.jsx",
-    "src/**/*.spec.jsx",
-    "src/test-setup.ts"
+    "**/*.test.tsx",
+    "**/*.spec.tsx",
+    "**/*.test.js",
+    "**/*.spec.js",
+    "**/*.test.jsx",
+    "**/*.spec.jsx",
+    "test-setup.ts"
   ]
 }

--- a/libs/shared-core/tsconfig.lib.prod.json
+++ b/libs/shared-core/tsconfig.lib.prod.json
@@ -1,7 +1,10 @@
 {
   "extends": "./tsconfig.lib.json",
   "compilerOptions": {
-    "declarationMap": false
+    "declarationMap": false,
+    "paths": {
+      "@uniplus/shared-core/http": ["dist/libs/shared-core/http"]
+    }
   },
   "angularCompilerOptions": {}
 }

--- a/libs/shared-data/config/README.md
+++ b/libs/shared-data/config/README.md
@@ -1,0 +1,3 @@
+# @uniplus/shared-data/config
+
+Secondary entry point of `@uniplus/shared-data`. It can be used by importing from `@uniplus/shared-data/config`.

--- a/libs/shared-data/config/ng-package.json
+++ b/libs/shared-data/config/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "../src/lib/config/index.ts"
+  }
+}

--- a/libs/shared-data/config/src/index.ts
+++ b/libs/shared-data/config/src/index.ts
@@ -1,0 +1,2 @@
+export type { AppConfig } from '../../src/lib/config';
+export { AppConfigService, provideRuntimeConfig, RUNTIME_CONFIG_PATH } from '../../src/lib/config';

--- a/libs/shared-data/ingresso/README.md
+++ b/libs/shared-data/ingresso/README.md
@@ -1,0 +1,3 @@
+# @uniplus/shared-data/ingresso
+
+Secondary entry point of `@uniplus/shared-data`. It can be used by importing from `@uniplus/shared-data/ingresso`.

--- a/libs/shared-data/ingresso/ng-package.json
+++ b/libs/shared-data/ingresso/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "../src/lib/api/ingresso/index.ts"
+  }
+}

--- a/libs/shared-data/ingresso/src/index.ts
+++ b/libs/shared-data/ingresso/src/index.ts
@@ -1,0 +1,1 @@
+export { INGRESSO_BASE_PATH } from '../../src/lib/api/ingresso/tokens';

--- a/libs/shared-data/selecao/README.md
+++ b/libs/shared-data/selecao/README.md
@@ -1,0 +1,3 @@
+# @uniplus/shared-data/selecao
+
+Secondary entry point of `@uniplus/shared-data`. It can be used by importing from `@uniplus/shared-data/selecao`.

--- a/libs/shared-data/selecao/ng-package.json
+++ b/libs/shared-data/selecao/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "../src/lib/api/selecao/index.ts"
+  }
+}

--- a/libs/shared-data/selecao/src/index.ts
+++ b/libs/shared-data/selecao/src/index.ts
@@ -1,0 +1,3 @@
+export { SELECAO_BASE_PATH } from '../../src/lib/api/selecao/tokens';
+export { EditaisApi } from '../../src/lib/api/selecao/editais.api';
+export type { CriarEditalCommand, EditalDto } from '../../src/lib/api/selecao/editais.api';

--- a/libs/shared-data/src/lib/__fitness__/public-entrypoints.fitness.spec.ts
+++ b/libs/shared-data/src/lib/__fitness__/public-entrypoints.fitness.spec.ts
@@ -1,0 +1,135 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Fitness dos contratos publicos granulares das libs Angular.
+ *
+ * O PR #378 precisou trocar root barrels por subpaths para preservar bundle.
+ * Este gate garante que os subpaths usados por apps sao secondary entrypoints
+ * reais de ng-packagr, nao aliases wildcard para `src/lib/*`.
+ */
+
+const WORKSPACE_ROOT = path.resolve(__dirname, '../../../../..');
+const APP_ROOTS = ['apps/selecao/src', 'apps/ingresso/src', 'apps/portal/src'] as const;
+
+const ENTRYPOINTS = {
+  '@uniplus/shared-ui/components': 'libs/shared-ui/components',
+  '@uniplus/shared-ui/notifications': 'libs/shared-ui/notifications',
+  '@uniplus/shared-ui/shell': 'libs/shared-ui/shell',
+  '@uniplus/shared-auth/bootstrap': 'libs/shared-auth/bootstrap',
+  '@uniplus/shared-auth/components': 'libs/shared-auth/components',
+  '@uniplus/shared-auth/guards': 'libs/shared-auth/guards',
+  '@uniplus/shared-auth/interceptors': 'libs/shared-auth/interceptors',
+  '@uniplus/shared-data/config': 'libs/shared-data/config',
+  '@uniplus/shared-data/ingresso': 'libs/shared-data/ingresso',
+  '@uniplus/shared-data/selecao': 'libs/shared-data/selecao',
+  '@uniplus/shared-core/dom': 'libs/shared-core/dom',
+  '@uniplus/shared-core/http': 'libs/shared-core/http',
+  '@uniplus/shared-core/interceptors': 'libs/shared-core/interceptors',
+  '@uniplus/shared-core/notifications': 'libs/shared-core/notifications',
+} as const;
+
+const ROOT_BARRELS = new Set([
+  '@uniplus/shared-ui',
+  '@uniplus/shared-auth',
+  '@uniplus/shared-data',
+  '@uniplus/shared-core',
+]);
+
+function listarTsFiles(root: string): string[] {
+  const arquivos: string[] = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      arquivos.push(...listarTsFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.ts')) {
+      arquivos.push(fullPath);
+    }
+  }
+  return arquivos;
+}
+
+function removerComentarios(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+}
+
+function importsUniplusShared(source: string): string[] {
+  const imports: string[] = [];
+  const semComentarios = removerComentarios(source);
+  const re = /from\s+['"](@uniplus\/shared-(?:ui|auth|data|core)(?:\/[^'"]+)?)['"]/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(semComentarios)) !== null) {
+    imports.push(match[1]);
+  }
+  return imports;
+}
+
+describe('Fitness — public secondary entrypoints das apps', () => {
+  it('todo entrypoint permitido e um secondary entrypoint ng-packagr real', () => {
+    const ausentes: string[] = [];
+
+    for (const [specifier, relativeRoot] of Object.entries(ENTRYPOINTS)) {
+      const ngPackage = path.join(WORKSPACE_ROOT, relativeRoot, 'ng-package.json');
+      const index = path.join(WORKSPACE_ROOT, relativeRoot, 'src/index.ts');
+      if (!fs.existsSync(ngPackage) || !fs.existsSync(index)) {
+        ausentes.push(`${specifier} -> ${relativeRoot}`);
+      }
+    }
+
+    expect(
+      ausentes,
+      ausentes.length > 0
+        ? `\nEntrypoints permitidos sem ng-package.json ou src/index.ts:\n${ausentes.join('\n')}`
+        : '',
+    ).toEqual([]);
+  });
+
+  it('apps importam somente entrypoints publicos granulares das libs shared-*', () => {
+    const permitidos = new Set(Object.keys(ENTRYPOINTS));
+    const violacoes: string[] = [];
+
+    for (const appRoot of APP_ROOTS) {
+      const absoluto = path.join(WORKSPACE_ROOT, appRoot);
+      for (const filePath of listarTsFiles(absoluto)) {
+        const source = fs.readFileSync(filePath, 'utf-8');
+        const relativo = path.relative(WORKSPACE_ROOT, filePath);
+
+        for (const specifier of importsUniplusShared(source)) {
+          if (ROOT_BARRELS.has(specifier)) {
+            violacoes.push(`${relativo}: usa root barrel ${specifier}`);
+            continue;
+          }
+
+          if (!permitidos.has(specifier)) {
+            violacoes.push(`${relativo}: usa subpath nao publico ${specifier}`);
+          }
+        }
+      }
+    }
+
+    expect(
+      violacoes,
+      violacoes.length > 0
+        ? `\nImports shared-* fora dos secondary entrypoints publicos:\n${violacoes.join('\n')}`
+        : '',
+    ).toEqual([]);
+  });
+
+  it('tsconfig.base.json nao expoe wildcard shared-* para src/lib/*', () => {
+    const tsconfig = JSON.parse(
+      fs.readFileSync(path.join(WORKSPACE_ROOT, 'tsconfig.base.json'), 'utf-8'),
+    ) as { compilerOptions?: { paths?: Record<string, string[]> } };
+    const paths = tsconfig.compilerOptions?.paths ?? {};
+    const wildcards = Object.entries(paths)
+      .filter(([alias]) => /^@uniplus\/shared-(ui|auth|data|core)\/\*$/.test(alias))
+      .map(([alias, values]) => `${alias} -> ${values.join(', ')}`);
+
+    expect(
+      wildcards,
+      wildcards.length > 0
+        ? `\nAliases wildcard shared-* removidos sao proibidos:\n${wildcards.join('\n')}`
+        : '',
+    ).toEqual([]);
+  });
+});

--- a/libs/shared-data/src/lib/__fitness__/runtime-config-providers.fitness.spec.ts
+++ b/libs/shared-data/src/lib/__fitness__/runtime-config-providers.fitness.spec.ts
@@ -7,10 +7,10 @@ import { describe, expect, it } from 'vitest';
  *
  * Para cada app de produção (selecao, ingresso, portal), garante que:
  *
- * 1. `app.config.ts` importa `provideRuntimeConfig` de `@uniplus/shared-data`
- *    ou subpath direto.
- * 2. `app.config.ts` importa `provideAuth` de `@uniplus/shared-auth`
- *    ou subpath direto.
+ * 1. `app.config.ts` importa `provideRuntimeConfig` de
+ *    `@uniplus/shared-data/config`.
+ * 2. `app.config.ts` importa `provideAuth` de
+ *    `@uniplus/shared-auth/bootstrap`.
  * 3. `provideRuntimeConfig()` aparece **antes** de `provideAuth()` no
  *    array `providers` — ordem é binding (Angular respeita ordem dos
  *    `APP_INITIALIZER` conforme aparecem no array; runtime-config DEVE
@@ -29,15 +29,17 @@ const APPS = ['selecao', 'ingresso', 'portal'] as const;
 
 const WORKSPACE_ROOT = path.resolve(__dirname, '../../../../..');
 
-function lerAppConfig(app: string): { conteudo: string; conteudoSemComentarios: string; relativo: string } {
+function lerAppConfig(app: string): {
+  conteudo: string;
+  conteudoSemComentarios: string;
+  relativo: string;
+} {
   const filePath = path.join(WORKSPACE_ROOT, 'apps', app, 'src/app/app.config.ts');
   const conteudo = fs.readFileSync(filePath, 'utf-8');
   // Strip comentários antes do indexOf de chamadas — caso contrário, menções
   // a `provideAuth()` em JSDoc/inline produzem falsos positivos na verificação
   // de ordem. Cobre `// linha`, `/* bloco */` e `/** JSDoc */`.
-  const conteudoSemComentarios = conteudo
-    .replace(/\/\*[\s\S]*?\*\//g, '')
-    .replace(/\/\/.*$/gm, '');
+  const conteudoSemComentarios = conteudo.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
   return {
     conteudo,
     conteudoSemComentarios,
@@ -49,16 +51,22 @@ describe('Fitness — apps app.config.ts (runtime config + auth, ADR-0021)', () 
   describe.each(APPS)('app: %s', (app) => {
     const { conteudo, conteudoSemComentarios, relativo } = lerAppConfig(app);
 
-    it('importa provideRuntimeConfig de @uniplus/shared-data ou subpath direto', () => {
-      const importou = /import\s+\{[^}]*\bprovideRuntimeConfig\b[^}]*\}\s+from\s+['"]@uniplus\/shared-data(?:\/[^'"]+)?['"]/.test(conteudo);
+    it('importa provideRuntimeConfig de @uniplus/shared-data/config', () => {
+      const importou =
+        /import\s+\{[^}]*\bprovideRuntimeConfig\b[^}]*\}\s+from\s+['"]@uniplus\/shared-data\/config['"]/.test(
+          conteudo,
+        );
       expect(
         importou,
         `\nArquivo: ${relativo}\nFalta importar provideRuntimeConfig — runtime-config.json não será carregado e AUTH_CONFIG/BASE_PATHs não terão factory.`,
       ).toBe(true);
     });
 
-    it('importa provideAuth de @uniplus/shared-auth ou subpath direto', () => {
-      const importou = /import\s+\{[^}]*\bprovideAuth\b[^}]*\}\s+from\s+['"]@uniplus\/shared-auth(?:\/[^'"]+)?['"]/.test(conteudo);
+    it('importa provideAuth de @uniplus/shared-auth/bootstrap', () => {
+      const importou =
+        /import\s+\{[^}]*\bprovideAuth\b[^}]*\}\s+from\s+['"]@uniplus\/shared-auth\/bootstrap['"]/.test(
+          conteudo,
+        );
       expect(
         importou,
         `\nArquivo: ${relativo}\nFalta importar provideAuth — provedor OIDC não será inicializado.`,
@@ -78,8 +86,14 @@ describe('Fitness — apps app.config.ts (runtime config + auth, ADR-0021)', () 
       const blocoProviders = conteudoSemComentarios.slice(inicioProviders);
       const indiceRuntime = blocoProviders.indexOf('provideRuntimeConfig(');
       const indiceAuth = blocoProviders.indexOf('provideAuth(');
-      expect(indiceRuntime, `\nArquivo: ${relativo}\nprovideRuntimeConfig() não chamado no array providers.`).toBeGreaterThan(-1);
-      expect(indiceAuth, `\nArquivo: ${relativo}\nprovideAuth() não chamado no array providers.`).toBeGreaterThan(-1);
+      expect(
+        indiceRuntime,
+        `\nArquivo: ${relativo}\nprovideRuntimeConfig() não chamado no array providers.`,
+      ).toBeGreaterThan(-1);
+      expect(
+        indiceAuth,
+        `\nArquivo: ${relativo}\nprovideAuth() não chamado no array providers.`,
+      ).toBeGreaterThan(-1);
       expect(
         indiceRuntime,
         `\nArquivo: ${relativo}\nOrdem incorreta no array providers: provideRuntimeConfig() DEVE aparecer antes de provideAuth() — caso contrário, AUTH_CONFIG não está populado quando AuthService.init é chamado.`,

--- a/libs/shared-data/src/lib/api/__fitness__/api-services.fitness.spec.ts
+++ b/libs/shared-data/src/lib/api/__fitness__/api-services.fitness.spec.ts
@@ -64,7 +64,11 @@ function listarApiFiles(root: string): string[] {
       // Skip the __fitness__ folder itself.
       if (entry.name === '__fitness__') continue;
       arquivos.push(...listarApiFiles(fullPath));
-    } else if (entry.isFile() && entry.name.endsWith('.api.ts') && !entry.name.endsWith('.spec.ts')) {
+    } else if (
+      entry.isFile() &&
+      entry.name.endsWith('.api.ts') &&
+      !entry.name.endsWith('.spec.ts')
+    ) {
       arquivos.push(fullPath);
     }
   }
@@ -87,7 +91,7 @@ describe('Fitness — services HTTP em libs/shared-data/src/lib/api/', () => {
     // recorrente em fitness baseado em regex).
     const source = rawSource
       .replace(/\/\*[\s\S]*?\*\//g, '') // /* ... */ e /** ... */
-      .replace(/\/\/.*$/gm, '');         // // linha
+      .replace(/\/\/.*$/gm, ''); // // linha
 
     it('expõe classe @Injectable', () => {
       expect(source).toMatch(/@Injectable\(\{[^}]*providedIn:\s*'root'[^}]*\}\)/);
@@ -105,7 +109,10 @@ describe('Fitness — services HTTP em libs/shared-data/src/lib/api/', () => {
 
       for (const line of lines) {
         // Linhas com `): Observable<` ou `): Promise<` em método public top-level.
-        const isMethodSignature = /^\s{2}(?!private|protected|static|constructor)\w+[^(]*\([^)]*\):\s*(Observable|Promise)</.test(line);
+        const isMethodSignature =
+          /^\s{2}(?!private|protected|static|constructor)\w+[^(]*\([^)]*\):\s*(Observable|Promise)</.test(
+            line,
+          );
         if (!isMethodSignature) continue;
 
         // Promise é proibido em service HTTP — toda chamada deve usar Observable
@@ -124,13 +131,13 @@ describe('Fitness — services HTTP em libs/shared-data/src/lib/api/', () => {
       expect(violacoes).toEqual([] as string[]);
     });
 
-    it('importa withVendorMime DE @uniplus/shared-core (regex bind import-source ADR-0016/0028)', () => {
+    it('importa withVendorMime DE @uniplus/shared-core/http (regex bind import-source ADR-0016/0028)', () => {
       // Regex única que valida `withVendorMime` está na lista de imports de
-      // `@uniplus/shared-core` — proíbe falso negativo onde o service importa
+      // `@uniplus/shared-core/http` — proíbe falso negativo onde o service importa
       // ApiResult de shared-core mas withVendorMime de outra lib qualquer.
       // Cobre imports multi-linha via [\s\S] dentro de {}.
       expect(source).toMatch(
-        /import\s+(?:type\s+)?\{[\s\S]*?\bwithVendorMime\b[\s\S]*?\}\s+from\s+['"]@uniplus\/shared-core['"]/,
+        /import\s+(?:type\s+)?\{[\s\S]*?\bwithVendorMime\b[\s\S]*?\}\s+from\s+['"]@uniplus\/shared-core\/http['"]/,
       );
     });
 

--- a/libs/shared-data/src/lib/api/ingresso/index.ts
+++ b/libs/shared-data/src/lib/api/ingresso/index.ts
@@ -1,0 +1,1 @@
+export { INGRESSO_BASE_PATH } from './tokens';

--- a/libs/shared-data/src/lib/api/selecao/editais.api.spec.ts
+++ b/libs/shared-data/src/lib/api/selecao/editais.api.spec.ts
@@ -1,8 +1,5 @@
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
-import {
-  HttpTestingController,
-  provideHttpClientTesting,
-} from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { firstValueFrom } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -13,7 +10,7 @@ import {
   createCursor,
   isApiOk,
   withIdempotencyKey,
-} from '@uniplus/shared-core';
+} from '@uniplus/shared-core/http';
 import { CriarEditalCommand, EditaisApi, EditalDto } from './editais.api';
 import { SELECAO_BASE_PATH } from './tokens';
 
@@ -141,7 +138,11 @@ describe('EditaisApi', () => {
         code: 'uniplus.selecao.edital.nao_encontrado',
         traceId: '4bf92f3577b34da6a3ce929d0e0e4736',
       },
-      { status: 404, statusText: 'Not Found', headers: { 'Content-Type': 'application/problem+json' } },
+      {
+        status: 404,
+        statusText: 'Not Found',
+        headers: { 'Content-Type': 'application/problem+json' },
+      },
     );
 
     const result = (await promise) as ApiResult<EditalDto>;
@@ -182,7 +183,9 @@ describe('EditaisApi', () => {
       expect(isApiOk(result)).toBe(true);
       if (result.ok) {
         expect(result.data).toBe('01960000-0000-7000-0000-000000000099');
-        expect(result.headers.get('Location')).toBe('/api/editais/01960000-0000-7000-0000-000000000099');
+        expect(result.headers.get('Location')).toBe(
+          '/api/editais/01960000-0000-7000-0000-000000000099',
+        );
       }
     });
 
@@ -202,7 +205,11 @@ describe('EditaisApi', () => {
             { field: 'numeroEdital', code: 'GreaterThan', message: 'Número deve ser positivo.' },
           ],
         },
-        { status: 422, statusText: 'Unprocessable Entity', headers: { 'Content-Type': 'application/problem+json' } },
+        {
+          status: 422,
+          statusText: 'Unprocessable Entity',
+          headers: { 'Content-Type': 'application/problem+json' },
+        },
       );
 
       const result = (await promise) as ApiResult<string>;
@@ -227,7 +234,11 @@ describe('EditaisApi', () => {
           code: 'uniplus.selecao.edital.duplicado',
           traceId: '4bf92f3577b34da6a3ce929d0e0e4737',
         },
-        { status: 409, statusText: 'Conflict', headers: { 'Content-Type': 'application/problem+json' } },
+        {
+          status: 409,
+          statusText: 'Conflict',
+          headers: { 'Content-Type': 'application/problem+json' },
+        },
       );
 
       const result = (await promise) as ApiResult<string>;
@@ -293,7 +304,11 @@ describe('EditaisApi', () => {
           code: 'uniplus.selecao.edital.ja_publicado',
           traceId: 'tx-publicar',
         },
-        { status: 422, statusText: 'Unprocessable Entity', headers: { 'Content-Type': 'application/problem+json' } },
+        {
+          status: 422,
+          statusText: 'Unprocessable Entity',
+          headers: { 'Content-Type': 'application/problem+json' },
+        },
       );
 
       const result = (await promise) as ApiResult<void>;

--- a/libs/shared-data/src/lib/api/selecao/editais.api.ts
+++ b/libs/shared-data/src/lib/api/selecao/editais.api.ts
@@ -1,9 +1,4 @@
-import {
-  HttpClient,
-  HttpContext,
-  HttpHeaders,
-  HttpParams,
-} from '@angular/common/http';
+import { HttpClient, HttpContext, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import {
@@ -12,7 +7,7 @@ import {
   IDEMPOTENCY_KEY_TOKEN,
   cursorToString,
   withVendorMime,
-} from '@uniplus/shared-core';
+} from '@uniplus/shared-core/http';
 import type { components } from './schema';
 import { SELECAO_BASE_PATH } from './tokens';
 
@@ -67,10 +62,10 @@ export class EditaisApi {
     if (limit !== undefined) {
       params = params.set('limit', String(limit));
     }
-    return this.http.get<ApiResult<readonly EditalDto[]>>(
-      `${this.basePath}/api/editais`,
-      { context: withVendorMime('edital', 1), params },
-    );
+    return this.http.get<ApiResult<readonly EditalDto[]>>(`${this.basePath}/api/editais`, {
+      context: withVendorMime('edital', 1),
+      params,
+    });
   }
 
   /** GET `/api/editais/{id}` — detalhe de um edital. */
@@ -101,18 +96,11 @@ export class EditaisApi {
    * JSON parse error em sucesso legítimo. Forçar JSON garante que o body
    * chega como `string` JSON-decodificada.
    */
-  criar(
-    command: CriarEditalCommand,
-    context: HttpContext,
-  ): Observable<ApiResult<string>> {
-    return this.http.post<ApiResult<string>>(
-      `${this.basePath}/api/editais`,
-      command,
-      {
-        context,
-        headers: new HttpHeaders({ Accept: 'application/json' }),
-      },
-    );
+  criar(command: CriarEditalCommand, context: HttpContext): Observable<ApiResult<string>> {
+    return this.http.post<ApiResult<string>>(`${this.basePath}/api/editais`, command, {
+      context,
+      headers: new HttpHeaders({ Accept: 'application/json' }),
+    });
   }
 
   /**
@@ -130,10 +118,7 @@ export class EditaisApi {
    */
   publicar(id: string, context: HttpContext): Observable<ApiResult<void>> {
     const idempotencyKeyValue = context.get(IDEMPOTENCY_KEY_TOKEN);
-    const ctxComposto = withVendorMime('edital', 1).set(
-      IDEMPOTENCY_KEY_TOKEN,
-      idempotencyKeyValue,
-    );
+    const ctxComposto = withVendorMime('edital', 1).set(IDEMPOTENCY_KEY_TOKEN, idempotencyKeyValue);
     return this.http.post<ApiResult<void>>(
       `${this.basePath}/api/editais/${encodeURIComponent(id)}/publicar`,
       null,

--- a/libs/shared-data/src/lib/api/selecao/index.ts
+++ b/libs/shared-data/src/lib/api/selecao/index.ts
@@ -1,0 +1,3 @@
+export { SELECAO_BASE_PATH } from './tokens';
+export { EditaisApi } from './editais.api';
+export type { CriarEditalCommand, EditalDto } from './editais.api';

--- a/libs/shared-data/src/lib/config/runtime-config.provider.ts
+++ b/libs/shared-data/src/lib/config/runtime-config.provider.ts
@@ -1,10 +1,10 @@
 import { APP_INITIALIZER, EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
 import { HttpBackend, HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
-import { AUTH_CONFIG, AuthService } from '@uniplus/shared-auth';
-import type { AuthConfig } from '@uniplus/shared-auth';
-import { SELECAO_BASE_PATH } from '../api/selecao/tokens';
-import { INGRESSO_BASE_PATH } from '../api/ingresso/tokens';
+import { AUTH_CONFIG, AuthService } from '@uniplus/shared-auth/bootstrap';
+import type { AuthConfig } from '@uniplus/shared-auth/bootstrap';
+import { INGRESSO_BASE_PATH } from '@uniplus/shared-data/ingresso';
+import { SELECAO_BASE_PATH } from '@uniplus/shared-data/selecao';
 import { AppConfigService } from './app-config.service';
 import { resolveOidcConfig, type AppConfig } from './app-config.model';
 

--- a/libs/shared-data/tsconfig.lib.json
+++ b/libs/shared-data/tsconfig.lib.json
@@ -7,20 +7,20 @@
     "inlineSources": true,
     "types": []
   },
-  "include": ["src/**/*.ts"],
+  "include": ["**/*.ts"],
   "exclude": [
-    "src/**/*.spec.ts",
-    "src/**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.ts",
     "vite.config.ts",
     "vite.config.mts",
     "vitest.config.ts",
     "vitest.config.mts",
-    "src/**/*.test.tsx",
-    "src/**/*.spec.tsx",
-    "src/**/*.test.js",
-    "src/**/*.spec.js",
-    "src/**/*.test.jsx",
-    "src/**/*.spec.jsx",
-    "src/test-setup.ts"
+    "**/*.test.tsx",
+    "**/*.spec.tsx",
+    "**/*.test.js",
+    "**/*.spec.js",
+    "**/*.test.jsx",
+    "**/*.spec.jsx",
+    "test-setup.ts"
   ]
 }

--- a/libs/shared-data/tsconfig.lib.prod.json
+++ b/libs/shared-data/tsconfig.lib.prod.json
@@ -4,7 +4,11 @@
     "declarationMap": false,
     "paths": {
       "@uniplus/shared-auth": ["dist/libs/shared-auth"],
-      "@uniplus/shared-core": ["dist/libs/shared-core"]
+      "@uniplus/shared-auth/bootstrap": ["dist/libs/shared-auth/bootstrap"],
+      "@uniplus/shared-core": ["dist/libs/shared-core"],
+      "@uniplus/shared-core/http": ["dist/libs/shared-core/http"],
+      "@uniplus/shared-data/ingresso": ["dist/libs/shared-data/ingresso"],
+      "@uniplus/shared-data/selecao": ["dist/libs/shared-data/selecao"]
     }
   },
   "angularCompilerOptions": {}

--- a/libs/shared-ui/components/README.md
+++ b/libs/shared-ui/components/README.md
@@ -1,0 +1,3 @@
+# @uniplus/shared-ui/components
+
+Secondary entry point of `@uniplus/shared-ui`. It can be used by importing from `@uniplus/shared-ui/components`.

--- a/libs/shared-ui/components/ng-package.json
+++ b/libs/shared-ui/components/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "../src/lib/components/index.ts"
+  }
+}

--- a/libs/shared-ui/components/src/index.ts
+++ b/libs/shared-ui/components/src/index.ts
@@ -1,0 +1,43 @@
+export { A11yMenuComponent } from '../../src/lib/components/a11y-menu/a11y-menu';
+export { AlertComponent, type UiAlertVariant } from '../../src/lib/components/alert/alert';
+export {
+  BreadcrumbComponent,
+  type UiBreadcrumbItem,
+} from '../../src/lib/components/breadcrumb/breadcrumb';
+export {
+  ButtonComponent,
+  type UiButtonSize,
+  type UiButtonType,
+  type UiButtonVariant,
+} from '../../src/lib/components/button/button';
+export { CardComponent } from '../../src/lib/components/card/card';
+export { CpfInputComponent } from '../../src/lib/components/cpf-input/cpf-input';
+export {
+  DataTableComponent,
+  type UiDataTableColumn,
+} from '../../src/lib/components/data-table/data-table';
+export { EmptyStateComponent } from '../../src/lib/components/empty-state/empty-state';
+export { FileUploadComponent } from '../../src/lib/components/file-upload/file-upload';
+export { ConfirmDialogComponent } from '../../src/lib/components/confirm-dialog/confirm-dialog';
+export { FormFieldComponent } from '../../src/lib/components/form-field/form-field';
+export { InstitutionalBarComponent } from '../../src/lib/components/institutional-bar/institutional-bar';
+export { IconButtonComponent } from '../../src/lib/components/icon-button/icon-button';
+export { LoadingOverlayComponent } from '../../src/lib/components/loading-overlay/loading-overlay';
+export { PageHeaderComponent } from '../../src/lib/components/page-header/page-header';
+export { PagerComponent } from '../../src/lib/components/pager/pager';
+export {
+  SegmentedComponent,
+  type UiSegmentedOption,
+} from '../../src/lib/components/segmented/segmented';
+export { SelectComponent, type UiSelectOption } from '../../src/lib/components/select/select';
+export { SkeletonComponent } from '../../src/lib/components/skeleton/skeleton';
+export { SkipLinkComponent } from '../../src/lib/components/skip-link/skip-link';
+export { SpinnerComponent } from '../../src/lib/components/spinner/spinner';
+export {
+  StatusBadgeComponent,
+  type UiStatusBadgeStatus,
+} from '../../src/lib/components/status-badge/status-badge';
+export { TagComponent, type UiTagVariant } from '../../src/lib/components/tag/tag';
+export { TextInputComponent } from '../../src/lib/components/text-input/text-input';
+export { TextareaComponent } from '../../src/lib/components/textarea/textarea';
+export { VlibrasLoaderComponent } from '../../src/lib/components/vlibras-loader/vlibras-loader';

--- a/libs/shared-ui/notifications/README.md
+++ b/libs/shared-ui/notifications/README.md
@@ -1,0 +1,3 @@
+# @uniplus/shared-ui/notifications
+
+Secondary entry point of `@uniplus/shared-ui`. It can be used by importing from `@uniplus/shared-ui/notifications`.

--- a/libs/shared-ui/notifications/ng-package.json
+++ b/libs/shared-ui/notifications/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "../src/lib/components/notification-host/notification-host.ts"
+  }
+}

--- a/libs/shared-ui/notifications/src/index.ts
+++ b/libs/shared-ui/notifications/src/index.ts
@@ -1,0 +1,1 @@
+export { NotificationHostComponent } from '../../src/lib/components/notification-host/notification-host';

--- a/libs/shared-ui/shell/README.md
+++ b/libs/shared-ui/shell/README.md
@@ -1,0 +1,3 @@
+# @uniplus/shared-ui/shell
+
+Secondary entry point of `@uniplus/shared-ui`. It can be used by importing from `@uniplus/shared-ui/shell`.

--- a/libs/shared-ui/shell/ng-package.json
+++ b/libs/shared-ui/shell/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "../src/lib/components/shell.ts"
+  }
+}

--- a/libs/shared-ui/shell/src/index.ts
+++ b/libs/shared-ui/shell/src/index.ts
@@ -1,0 +1,4 @@
+export {
+  AppShellComponent,
+  type UiShellNavItem,
+} from '../../src/lib/components/app-shell/app-shell';

--- a/libs/shared-ui/src/lib/components/a11y-menu/a11y-menu.ts
+++ b/libs/shared-ui/src/lib/components/a11y-menu/a11y-menu.ts
@@ -10,7 +10,7 @@ import {
   signal,
   viewChild,
 } from '@angular/core';
-import { createDisclosureController } from '@uniplus/shared-core';
+import { createDisclosureController } from '@uniplus/shared-core/dom';
 
 type UiTheme = 'auto' | 'light' | 'dark';
 
@@ -38,7 +38,15 @@ type UiA11yState = {
         data-a11y-menu-trigger
         (click)="toggle()"
       >
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2.25"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
           <circle cx="12" cy="4" r="2" />
           <path d="M4 8h16M12 6v14M8 12l-2 8M16 12l2 8" />
         </svg>
@@ -64,21 +72,66 @@ type UiA11yState = {
         <div class="a11y-menu__group" role="group" aria-label="Tema">
           <span class="a11y-menu__group-label">Tema</span>
           <div class="a11y-menu__options">
-            <button class="a11y-opt" type="button" data-a11y="theme" data-value="light" [attr.aria-pressed]="theme() === 'light'" (click)="setTheme('light')">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+            <button
+              class="a11y-opt"
+              type="button"
+              data-a11y="theme"
+              data-value="light"
+              [attr.aria-pressed]="theme() === 'light'"
+              (click)="setTheme('light')"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                aria-hidden="true"
+              >
                 <circle cx="12" cy="12" r="4" />
-                <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+                <path
+                  d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"
+                />
               </svg>
               Claro
             </button>
-            <button class="a11y-opt" type="button" data-a11y="theme" data-value="dark" [attr.aria-pressed]="theme() === 'dark'" (click)="setTheme('dark')">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+            <button
+              class="a11y-opt"
+              type="button"
+              data-a11y="theme"
+              data-value="dark"
+              [attr.aria-pressed]="theme() === 'dark'"
+              (click)="setTheme('dark')"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                aria-hidden="true"
+              >
                 <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
               </svg>
               Escuro
             </button>
-            <button class="a11y-opt" type="button" data-a11y="theme" data-value="auto" [attr.aria-pressed]="theme() === 'auto'" (click)="setTheme('auto')">
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <button
+              class="a11y-opt"
+              type="button"
+              data-a11y="theme"
+              data-value="auto"
+              [attr.aria-pressed]="theme() === 'auto'"
+              (click)="setTheme('auto')"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+              >
                 <rect x="2" y="3" width="20" height="14" rx="2" />
                 <path d="M8 21h8M12 17v4" />
               </svg>
@@ -89,20 +142,35 @@ type UiA11yState = {
         <div class="a11y-menu__group" role="group" aria-label="Ajustes de leitura">
           <span class="a11y-menu__group-label">Leitura</span>
           <div class="a11y-menu__options">
-            <button class="a11y-opt" type="button" data-a11y="contrast" data-value="on" [attr.aria-pressed]="contrast()" (click)="contrast.update(toggleBool)">
+            <button
+              class="a11y-opt"
+              type="button"
+              data-a11y="contrast"
+              data-value="on"
+              [attr.aria-pressed]="contrast()"
+              (click)="contrast.update(toggleBool)"
+            >
               <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                 <path d="M12 2a10 10 0 100 20V2z" />
                 <path d="M12 2a10 10 0 010 20" fill="none" stroke="currentColor" stroke-width="2" />
               </svg>
               Alto contraste
             </button>
-            <button class="a11y-opt" type="button" data-a11y="font-mode" data-value="legible" [attr.aria-pressed]="legibleFont()" (click)="legibleFont.update(toggleBool)">
+            <button
+              class="a11y-opt"
+              type="button"
+              data-a11y="font-mode"
+              data-value="legible"
+              [attr.aria-pressed]="legibleFont()"
+              (click)="legibleFont.update(toggleBool)"
+            >
               Fonte legível
             </button>
           </div>
         </div>
         <p class="a11y-menu__hint">
-          Para ampliar o texto, use o zoom do navegador (<kbd>Ctrl</kbd> <kbd>+</kbd> / <kbd>Ctrl</kbd> <kbd>-</kbd>).
+          Para ampliar o texto, use o zoom do navegador (<kbd>Ctrl</kbd> <kbd>+</kbd> /
+          <kbd>Ctrl</kbd> <kbd>-</kbd>).
         </p>
       </div>
     </div>
@@ -127,7 +195,7 @@ export class A11yMenuComponent {
   protected readonly theme = signal<UiTheme>(this.initialState.theme);
   protected readonly contrast = signal(this.initialState.contrast);
   protected readonly legibleFont = signal(this.initialState.fontMode === 'legible');
-  protected readonly effectiveTheme = computed(() => this.contrast() ? 'contrast' : this.theme());
+  protected readonly effectiveTheme = computed(() => (this.contrast() ? 'contrast' : this.theme()));
   protected readonly toggleBool = (value: boolean) => !value;
 
   constructor() {
@@ -176,7 +244,10 @@ function readState(): UiA11yState {
     if (typeof localStorage === 'undefined') return defaultState();
     const parsed = JSON.parse(localStorage.getItem(STORE_KEY) || '{}') as Partial<UiA11yState>;
     return {
-      theme: parsed.theme === 'light' || parsed.theme === 'dark' || parsed.theme === 'auto' ? parsed.theme : 'auto',
+      theme:
+        parsed.theme === 'light' || parsed.theme === 'dark' || parsed.theme === 'auto'
+          ? parsed.theme
+          : 'auto',
       contrast: parsed.contrast === true,
       fontMode: parsed.fontMode === 'legible' ? 'legible' : 'default',
     };

--- a/libs/shared-ui/src/lib/components/data-table/data-table.spec.ts
+++ b/libs/shared-ui/src/lib/components/data-table/data-table.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { createCursor } from '@uniplus/shared-core';
+import { createCursor } from '@uniplus/shared-core/http';
 import { DataTableComponent, UiDataTableColumn } from './data-table';
 
 describe('DataTableComponent', () => {
@@ -68,7 +68,8 @@ describe('DataTableComponent', () => {
   it('exibe emptyMessage padrão quando colunas e data estão vazios', () => {
     const { fixture, component } = setup();
     fixture.detectChanges();
-    const tableCellEl = fixture.debugElement.query(By.css('td')).nativeElement as HTMLTableCellElement;
+    const tableCellEl = fixture.debugElement.query(By.css('td'))
+      .nativeElement as HTMLTableCellElement;
 
     expect(component.columns().length).toBe(0);
     expect(component.emptyMessage()).toBe('Nenhum registro encontrado.');
@@ -81,7 +82,8 @@ describe('DataTableComponent', () => {
     fixture.componentRef.setInput('isLoading', true);
     fixture.detectChanges();
 
-    const cell = fixture.debugElement.query(By.css('tbody td')).nativeElement as HTMLTableCellElement;
+    const cell = fixture.debugElement.query(By.css('tbody td'))
+      .nativeElement as HTMLTableCellElement;
     expect(cell.textContent?.trim()).toBe('Carregando…');
   });
 
@@ -260,9 +262,7 @@ describe('DataTableComponent', () => {
     fixture.componentRef.setInput('errorMessage', 'Falha de rede.');
     fixture.detectChanges();
 
-    const retryButton = fixture.debugElement.query(
-      By.css('[data-testid="data-table-retry"]'),
-    );
+    const retryButton = fixture.debugElement.query(By.css('[data-testid="data-table-retry"]'));
     expect(retryButton).not.toBeNull();
     expect((retryButton.nativeElement as HTMLButtonElement).textContent?.trim()).toBe(
       'Tentar novamente',
@@ -281,14 +281,10 @@ describe('DataTableComponent', () => {
     fixture.componentRef.setInput('errorTraceId', '0123456789abcdef0123456789abcdef');
     fixture.detectChanges();
 
-    const trace = fixture.debugElement.query(
-      By.css('[data-testid="data-table-error-trace"]'),
-    );
+    const trace = fixture.debugElement.query(By.css('[data-testid="data-table-error-trace"]'));
     expect(trace).not.toBeNull();
     expect(trace.nativeElement.textContent).toContain('Reportar incidente');
-    const traceId = fixture.debugElement.query(
-      By.css('[data-testid="data-table-error-trace-id"]'),
-    );
+    const traceId = fixture.debugElement.query(By.css('[data-testid="data-table-error-trace-id"]'));
     expect((traceId.nativeElement as HTMLElement).textContent).toBe(
       '0123456789abcdef0123456789abcdef',
     );
@@ -300,9 +296,7 @@ describe('DataTableComponent', () => {
     fixture.componentRef.setInput('errorMessage', 'Falha local.');
     fixture.detectChanges();
 
-    expect(
-      fixture.debugElement.query(By.css('[data-testid="data-table-error-trace"]')),
-    ).toBeNull();
+    expect(fixture.debugElement.query(By.css('[data-testid="data-table-error-trace"]'))).toBeNull();
   });
 
   it('errorTraceId="" não habilita link "Reportar incidente" (boundary)', () => {
@@ -312,9 +306,7 @@ describe('DataTableComponent', () => {
     fixture.componentRef.setInput('errorTraceId', '');
     fixture.detectChanges();
 
-    expect(
-      fixture.debugElement.query(By.css('[data-testid="data-table-error-trace"]')),
-    ).toBeNull();
+    expect(fixture.debugElement.query(By.css('[data-testid="data-table-error-trace"]'))).toBeNull();
   });
 
   it('estado erro pós-1ª página: banner exibe botão "Tentar novamente" + emite retry', () => {
@@ -325,9 +317,7 @@ describe('DataTableComponent', () => {
     fixture.componentRef.setInput('nextCursor', createCursor('cursor-retry'));
     fixture.detectChanges();
 
-    const banner = fixture.debugElement.query(
-      By.css('[data-testid="data-table-error-banner"]'),
-    );
+    const banner = fixture.debugElement.query(By.css('[data-testid="data-table-error-banner"]'));
     expect(banner).not.toBeNull();
     const retryButton = fixture.debugElement.query(
       By.css('[data-testid="data-table-retry-banner"]'),

--- a/libs/shared-ui/src/lib/components/data-table/data-table.ts
+++ b/libs/shared-ui/src/lib/components/data-table/data-table.ts
@@ -1,5 +1,5 @@
 import { Component, ChangeDetectionStrategy, computed, input, output } from '@angular/core';
-import type { Cursor } from '@uniplus/shared-core';
+import type { Cursor } from '@uniplus/shared-core/http';
 
 export interface UiDataTableColumn {
   field: string;
@@ -44,10 +44,7 @@ export interface UiDataTableColumn {
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="table-responsive">
-      <table
-        role="grid"
-        [attr.aria-busy]="isLoading() ? 'true' : null"
-      >
+      <table role="grid" [attr.aria-busy]="isLoading() ? 'true' : null">
         <thead>
           <tr>
             @for (col of columns(); track col.field) {
@@ -72,7 +69,9 @@ export interface UiDataTableColumn {
               >
                 <div class="empty-state empty-state--error">
                   <div class="empty-state__icon" aria-hidden="true">!</div>
-                  <p class="empty-state__title" data-testid="data-table-error-message">{{ errorMessage() }}</p>
+                  <p class="empty-state__title" data-testid="data-table-error-message">
+                    {{ errorMessage() }}
+                  </p>
                   <div class="page-header__actions">
                     <button
                       type="button"
@@ -85,10 +84,9 @@ export interface UiDataTableColumn {
                     @if (mostrarReporteDeIncidente()) {
                       <span class="u-caption" data-testid="data-table-error-trace">
                         {{ reportIncidentLabel() }}
-                        <code
-                          class="ui-code"
-                          data-testid="data-table-error-trace-id"
-                        >{{ errorTraceId() }}</code>
+                        <code class="ui-code" data-testid="data-table-error-trace-id">{{
+                          errorTraceId()
+                        }}</code>
                       </span>
                     }
                   </div>
@@ -146,21 +144,18 @@ export interface UiDataTableColumn {
     </div>
 
     @if (mostrarBannerDeErro()) {
-      <div
-        class="alert alert--danger"
-        role="alert"
-        data-testid="data-table-error-banner"
-      >
+      <div class="alert alert--danger" role="alert" data-testid="data-table-error-banner">
         <span class="alert__icon" aria-hidden="true">!</span>
         <div class="alert__body">
-          <p class="alert__title" data-testid="data-table-error-banner-message">{{ errorMessage() }}</p>
+          <p class="alert__title" data-testid="data-table-error-banner-message">
+            {{ errorMessage() }}
+          </p>
           @if (mostrarReporteDeIncidente()) {
             <p class="alert__msg" data-testid="data-table-error-banner-trace">
               {{ reportIncidentLabel() }}
-              <code
-                class="ui-code"
-                data-testid="data-table-error-banner-trace-id"
-              >{{ errorTraceId() }}</code>
+              <code class="ui-code" data-testid="data-table-error-banner-trace-id">{{
+                errorTraceId()
+              }}</code>
             </p>
           }
         </div>
@@ -241,13 +236,10 @@ export class DataTableComponent {
     () => this.errorMessage() !== null && this.records().length > 0,
   );
   protected readonly mostrarLoadingInicial = computed(
-    () =>
-      this.isLoading() && this.errorMessage() === null && this.records().length === 0,
+    () => this.isLoading() && this.errorMessage() === null && this.records().length === 0,
   );
   /** Botão segue disponível mesmo em erro pós-1ª página, para permitir retry. */
-  protected readonly mostrarBotaoCarregarMais = computed(
-    () => this.nextCursor() !== null,
-  );
+  protected readonly mostrarBotaoCarregarMais = computed(() => this.nextCursor() !== null);
   /** Renderiza link "Reportar incidente" apenas quando há trace context não-vazio. */
   protected readonly mostrarReporteDeIncidente = computed(() => {
     const traceId = this.errorTraceId();

--- a/libs/shared-ui/src/lib/components/index.ts
+++ b/libs/shared-ui/src/lib/components/index.ts
@@ -1,0 +1,31 @@
+export { A11yMenuComponent } from './a11y-menu/a11y-menu';
+export { AlertComponent, type UiAlertVariant } from './alert/alert';
+export { BreadcrumbComponent, type UiBreadcrumbItem } from './breadcrumb/breadcrumb';
+export {
+  ButtonComponent,
+  type UiButtonSize,
+  type UiButtonType,
+  type UiButtonVariant,
+} from './button/button';
+export { CardComponent } from './card/card';
+export { ConfirmDialogComponent } from './confirm-dialog/confirm-dialog';
+export { CpfInputComponent } from './cpf-input/cpf-input';
+export { DataTableComponent, type UiDataTableColumn } from './data-table/data-table';
+export { EmptyStateComponent } from './empty-state/empty-state';
+export { FileUploadComponent } from './file-upload/file-upload';
+export { FormFieldComponent } from './form-field/form-field';
+export { IconButtonComponent } from './icon-button/icon-button';
+export { InstitutionalBarComponent } from './institutional-bar/institutional-bar';
+export { LoadingOverlayComponent } from './loading-overlay/loading-overlay';
+export { PageHeaderComponent } from './page-header/page-header';
+export { PagerComponent } from './pager/pager';
+export { SegmentedComponent, type UiSegmentedOption } from './segmented/segmented';
+export { SelectComponent, type UiSelectOption } from './select/select';
+export { SkeletonComponent } from './skeleton/skeleton';
+export { SkipLinkComponent } from './skip-link/skip-link';
+export { SpinnerComponent } from './spinner/spinner';
+export { StatusBadgeComponent, type UiStatusBadgeStatus } from './status-badge/status-badge';
+export { TagComponent, type UiTagVariant } from './tag/tag';
+export { TextareaComponent } from './textarea/textarea';
+export { TextInputComponent } from './text-input/text-input';
+export { VlibrasLoaderComponent } from './vlibras-loader/vlibras-loader';

--- a/libs/shared-ui/src/lib/components/notification-host/notification-host.spec.ts
+++ b/libs/shared-ui/src/lib/components/notification-host/notification-host.spec.ts
@@ -1,8 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { NotificationService } from '@uniplus/shared-core';
-import type { ProblemDetails } from '@uniplus/shared-core';
+import type { ProblemDetails } from '@uniplus/shared-core/http';
+import { NotificationService } from '@uniplus/shared-core/notifications';
 import { NotificationHostComponent } from './notification-host';
 
 function montarProblem(overrides: Partial<ProblemDetails> = {}): ProblemDetails {
@@ -171,8 +171,7 @@ describe('NotificationHostComponent', () => {
 
   describe('a11y', () => {
     it('section container tem role=region + aria-label', () => {
-      const section = fixture.debugElement.query(By.css('section'))
-        ?.nativeElement as HTMLElement;
+      const section = fixture.debugElement.query(By.css('section'))?.nativeElement as HTMLElement;
       expect(section?.getAttribute('role')).toBe('region');
       expect(section?.getAttribute('aria-label')).toBe('Notificações do sistema');
     });

--- a/libs/shared-ui/src/lib/components/notification-host/notification-host.ts
+++ b/libs/shared-ui/src/lib/components/notification-host/notification-host.ts
@@ -1,14 +1,5 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  inject,
-  signal,
-} from '@angular/core';
-import {
-  NotificationService,
-  NotificationType,
-} from '@uniplus/shared-core';
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { NotificationService, NotificationType } from '@uniplus/shared-core/notifications';
 
 /**
  * Apresentacional (ADR-0017): renderiza a fila de toasts mantida pelo
@@ -40,11 +31,7 @@ import {
   imports: [],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <section
-      class="toast-stack"
-      role="region"
-      aria-label="Notificações do sistema"
-    >
+    <section class="toast-stack" role="region" aria-label="Notificações do sistema">
       <div class="toast-region">
         @for (notification of notifications(); track notification.id) {
           <article
@@ -60,9 +47,13 @@ import {
           >
             <span class="toast__icon" aria-hidden="true">{{ iconFor(notification.type) }}</span>
             <div class="toast__body">
-              <p class="toast__title" data-testid="notification-host-title">{{ notification.title }}</p>
+              <p class="toast__title" data-testid="notification-host-title">
+                {{ notification.title }}
+              </p>
               @if (notification.detail) {
-                <p class="toast__msg" data-testid="notification-host-detail">{{ notification.detail }}</p>
+                <p class="toast__msg" data-testid="notification-host-detail">
+                  {{ notification.detail }}
+                </p>
               }
               @if (notification.traceId) {
                 <div class="ui-toast-trace" data-testid="notification-host-trace-block">
@@ -108,9 +99,7 @@ export class NotificationHostComponent {
   protected readonly copyLabel = 'Copiar';
   protected readonly copiedLabel = 'Copiado!';
 
-  protected readonly hasNotifications = computed(
-    () => this.notifications().length > 0,
-  );
+  protected readonly hasNotifications = computed(() => this.notifications().length > 0);
 
   protected dispensar(id: number): void {
     this.service.dismiss(id);
@@ -161,5 +150,4 @@ export class NotificationHostComponent {
   protected copyTraceLabelFor(traceId: string): string {
     return `Copiar ID de rastreamento ${traceId}`;
   }
-
 }

--- a/libs/shared-ui/src/lib/components/shell.ts
+++ b/libs/shared-ui/src/lib/components/shell.ts
@@ -1,0 +1,1 @@
+export { AppShellComponent, type UiShellNavItem } from './app-shell/app-shell';

--- a/libs/shared-ui/tsconfig.lib.json
+++ b/libs/shared-ui/tsconfig.lib.json
@@ -7,20 +7,20 @@
     "inlineSources": true,
     "types": []
   },
-  "include": ["src/**/*.ts"],
+  "include": ["**/*.ts"],
   "exclude": [
-    "src/**/*.spec.ts",
-    "src/**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.ts",
     "vite.config.ts",
     "vite.config.mts",
     "vitest.config.ts",
     "vitest.config.mts",
-    "src/**/*.test.tsx",
-    "src/**/*.spec.tsx",
-    "src/**/*.test.js",
-    "src/**/*.spec.js",
-    "src/**/*.test.jsx",
-    "src/**/*.spec.jsx",
-    "src/test-setup.ts"
+    "**/*.test.tsx",
+    "**/*.spec.tsx",
+    "**/*.test.js",
+    "**/*.spec.js",
+    "**/*.test.jsx",
+    "**/*.spec.jsx",
+    "test-setup.ts"
   ]
 }

--- a/libs/shared-ui/tsconfig.lib.prod.json
+++ b/libs/shared-ui/tsconfig.lib.prod.json
@@ -5,6 +5,9 @@
     "paths": {
       "@uniplus/shared-auth": ["dist/libs/shared-auth"],
       "@uniplus/shared-core": ["dist/libs/shared-core"],
+      "@uniplus/shared-core/dom": ["dist/libs/shared-core/dom"],
+      "@uniplus/shared-core/http": ["dist/libs/shared-core/http"],
+      "@uniplus/shared-core/notifications": ["dist/libs/shared-core/notifications"],
       "@uniplus/shared-data": ["dist/libs/shared-data"],
       "@uniplus/shared-utils": ["dist/libs/shared-utils"]
     }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,10 +10,7 @@
     "importHelpers": true,
     "target": "ES2022",
     "module": "ES2022",
-    "lib": [
-      "ES2022",
-      "dom"
-    ],
+    "lib": ["ES2022", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
@@ -23,40 +20,27 @@
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true,
     "paths": {
-      "@uniplus/shared-ui": [
-        "libs/shared-ui/src/index.ts"
-      ],
-      "@uniplus/shared-ui/*": [
-        "libs/shared-ui/src/lib/*"
-      ],
-      "@uniplus/shared-auth": [
-        "libs/shared-auth/src/index.ts"
-      ],
-      "@uniplus/shared-auth/*": [
-        "libs/shared-auth/src/lib/*"
-      ],
-      "@uniplus/shared-core": [
-        "libs/shared-core/src/index.ts"
-      ],
-      "@uniplus/shared-core/*": [
-        "libs/shared-core/src/lib/*"
-      ],
-      "@uniplus/shared-data": [
-        "libs/shared-data/src/index.ts"
-      ],
-      "@uniplus/shared-data/*": [
-        "libs/shared-data/src/lib/*"
-      ],
-      "@uniplus/shared-utils": [
-        "libs/shared-utils/src/index.ts"
-      ],
-      "@uniplus/shared-e2e": [
-        "libs/shared-e2e/src/index.ts"
-      ]
+      "@uniplus/shared-ui": ["libs/shared-ui/src/index.ts"],
+      "@uniplus/shared-auth": ["libs/shared-auth/src/index.ts"],
+      "@uniplus/shared-core": ["libs/shared-core/src/index.ts"],
+      "@uniplus/shared-data": ["libs/shared-data/src/index.ts"],
+      "@uniplus/shared-utils": ["libs/shared-utils/src/index.ts"],
+      "@uniplus/shared-e2e": ["libs/shared-e2e/src/index.ts"],
+      "@uniplus/shared-ui/shell": ["libs/shared-ui/shell/src/index.ts"],
+      "@uniplus/shared-ui/notifications": ["libs/shared-ui/notifications/src/index.ts"],
+      "@uniplus/shared-ui/components": ["libs/shared-ui/components/src/index.ts"],
+      "@uniplus/shared-auth/bootstrap": ["libs/shared-auth/bootstrap/src/index.ts"],
+      "@uniplus/shared-auth/guards": ["libs/shared-auth/guards/src/index.ts"],
+      "@uniplus/shared-auth/components": ["libs/shared-auth/components/src/index.ts"],
+      "@uniplus/shared-auth/interceptors": ["libs/shared-auth/interceptors/src/index.ts"],
+      "@uniplus/shared-data/config": ["libs/shared-data/config/src/index.ts"],
+      "@uniplus/shared-data/selecao": ["libs/shared-data/selecao/src/index.ts"],
+      "@uniplus/shared-core/http": ["libs/shared-core/http/src/index.ts"],
+      "@uniplus/shared-core/interceptors": ["libs/shared-core/interceptors/src/index.ts"],
+      "@uniplus/shared-core/dom": ["libs/shared-core/dom/src/index.ts"],
+      "@uniplus/shared-core/notifications": ["libs/shared-core/notifications/src/index.ts"],
+      "@uniplus/shared-data/ingresso": ["libs/shared-data/ingresso/src/index.ts"]
     }
   },
-  "exclude": [
-    "node_modules",
-    "tmp"
-  ]
+  "exclude": ["node_modules", "tmp"]
 }


### PR DESCRIPTION
Closes #379

## Contexto

O PR #378 reduziu o bundle inicial trocando imports dos root barrels por subpaths mapeados via `tsconfig.base.json`, mas ainda deixava as apps acopladas à estrutura interna das libs por meio de aliases wildcard `@uniplus/shared-*/* -> libs/shared-*/src/lib/*`.

## Mudanças

- Cria secondary entrypoints reais buildáveis por ng-packagr para os contratos granulares usados pelas apps:
  - `@uniplus/shared-ui/shell`, `@uniplus/shared-ui/notifications`, `@uniplus/shared-ui/components`
  - `@uniplus/shared-auth/bootstrap`, `@uniplus/shared-auth/components`, `@uniplus/shared-auth/guards`, `@uniplus/shared-auth/interceptors`
  - `@uniplus/shared-data/config`, `@uniplus/shared-data/selecao`, `@uniplus/shared-data/ingresso`
  - `@uniplus/shared-core/http`, `@uniplus/shared-core/interceptors`, `@uniplus/shared-core/dom`, `@uniplus/shared-core/notifications`
- Remove os aliases wildcard que expunham `src/lib/*`.
- Migra imports das apps para entrypoints públicos.
- Atualiza fitness tests para bloquear root barrels/deep imports nas apps e exigir secondary entrypoints com `ng-package.json`.
- Carrega `LayoutComponent` raiz sob demanda nas apps `selecao`, `ingresso` e `portal`.

## Bundle

Build production final:

| App | Initial raw | Transfer estimado |
| --- | ---: | ---: |
| Seleção | 445.94 kB | 115.85 kB |
| Ingresso | 424.25 kB | 108.27 kB |
| Portal | 424.33 kB | 108.23 kB |

Seleção permanece abaixo do limite de 500 kB.

## Validação

- [x] `CI=1 npx nx test shared-data`
- [x] `CI=1 npx nx test shared-ui`
- [x] `CI=1 npx nx test shared-auth`
- [x] `CI=1 npx nx test shared-core`
- [x] `npx nx run-many --target=build --projects=selecao,ingresso,portal --configuration=production --skip-nx-cache`
- [x] `npx nx run-many --target=test --projects=selecao,ingresso,portal --skip-nx-cache`
- [x] `npx nx run-many --target=typecheck --projects=selecao,ingresso,portal --skip-nx-cache`
- [x] `npx nx affected -t lint test build typecheck --base=origin/main --head=HEAD --nxBail --outputStyle=static`
- [x] `git diff --check`