### PR TITLE
feat(configuracao): migra filtro de unidades para server-side

### DIFF
--- a/apps/configuracao-e2e/src/specs/unidades.visual.spec.ts
+++ b/apps/configuracao-e2e/src/specs/unidades.visual.spec.ts
@@ -110,7 +110,9 @@ test.describe('Unidade — cobertura visual DS', () => {
     await expect(page.getByRole('row', { name: /CEPS.*Centro de Processos Seletivos/ })).toBeVisible();
 
     await page.getByRole('button', { name: 'Limpar' }).click();
-    await page.getByRole('button', { name: /Centro 2/ }).click();
+    // Chips vêm do roster fechado (sem contagem, server-side); nome exato
+    // evita colidir com os botões de linha "Centro de …".
+    await page.getByRole('button', { name: 'Centro', exact: true }).click();
     await expect(page.locator('table tbody tr')).toHaveCount(2);
     await expect(page.getByRole('row', { name: /CEPS.*Centro de Processos Seletivos/ })).toBeVisible();
     await expect(
@@ -265,12 +267,56 @@ async function mockUnidadesApi(page: Page): Promise<void> {
       return;
     }
 
+    // Mimetiza o filtro server-side do backend (q + tipo): a página não filtra
+    // mais em memória, então o mock precisa devolver só o que casa.
+    const url = new URL(request.url());
+    const q = url.searchParams.get('q');
+    const tipos = url.searchParams.getAll('tipo');
+
+    let resultado = [...UNIDADES];
+    if (q) {
+      const termo = normalizarBusca(q);
+      resultado = resultado.filter((u) =>
+        normalizarBusca(`${u.nome} ${u.sigla} ${u.codigo} ${u.slug} ${u.alias ?? ''}`).includes(
+          termo,
+        ),
+      );
+    }
+    if (tipos.length > 0) {
+      const labels = tipos.map((t) => TIPO_LABEL_POR_VALOR[t]).filter(Boolean);
+      resultado = resultado.filter((u) => labels.includes(u.tipo));
+    }
+
     await route.fulfill({
       status: 200,
       headers: { ...corsHeaders, 'content-type': 'application/json' },
-      body: JSON.stringify(UNIDADES),
+      body: JSON.stringify(resultado),
     });
   });
+}
+
+// Roster fechado TipoUnidade (valor numérico → label do DTO), espelhando
+// TIPOS_UNIDADE da página para traduzir o filtro `?tipo=N` do contrato.
+const TIPO_LABEL_POR_VALOR: Record<string, string> = {
+  '1': 'Reitoria',
+  '2': 'Pro-Reitoria',
+  '3': 'Centro',
+  '4': 'Instituto',
+  '5': 'Faculdade',
+  '6': 'Departamento',
+  '7': 'Coordenacao',
+  '8': 'Diretoria',
+  '9': 'Divisao',
+  '10': 'Nucleo',
+  '11': 'Outro',
+};
+
+function normalizarBusca(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLocaleLowerCase('pt-BR')
+    .trim();
 }
 
 async function fillRequiredUnitForm(drawer: Locator): Promise<void> {

--- a/apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
@@ -591,4 +591,55 @@ describe('UnidadesPage', () => {
     expect(component['unidades']()).toHaveLength(2); // acumulou após o retry
     expect(component['errorMessage']()).toBeNull();
   });
+
+  it('limpa a lista quando o refetch pós-mutação falha, sem manter linhas desatualizadas', async () => {
+    await flushInicial();
+    expect(component['unidades']()).toHaveLength(2);
+
+    component['pedirRemocao'](unidadesSeed[1]);
+    component['removerConfirmado']();
+    controller
+      .expectOne(`${BASE}/api/admin/unidades/${INSTITUTO_ID}`)
+      .flush(null, { status: 204, statusText: 'No Content' });
+
+    await propagate();
+    expectListGet().flush(
+      { type: 'about:blank', title: 'Erro interno', status: 500, code: 'uniplus.erro', traceId: 'x' },
+      {
+        status: 500,
+        statusText: 'Internal Server Error',
+        headers: { 'Content-Type': 'application/problem+json' },
+      },
+    );
+    await propagate();
+
+    expect(component['unidades']()).toHaveLength(0); // não mantém a linha removida
+    expect(component['errorMessage']()).not.toBeNull();
+  });
+
+  it('sinaliza falha ao carregar as opções de unidade superior e permite retry', async () => {
+    await flushInicial();
+    component['abrirCadastro']();
+    await propagate();
+    expectListGet((r) => !r.params.has('q') && !r.params.has('cursor')).flush(
+      { type: 'about:blank', title: 'Erro interno', status: 500, code: 'uniplus.erro', traceId: 'x' },
+      {
+        status: 500,
+        statusText: 'Internal Server Error',
+        headers: { 'Content-Type': 'application/problem+json' },
+      },
+    );
+    await propagate();
+
+    expect(component['opcoesSuperiorComErro']()).toBe(true);
+    expect(component['opcoesUnidadeSuperior']()).toHaveLength(0);
+
+    component['recarregarOpcoesSuperior']();
+    await propagate();
+    expectListGet((r) => !r.params.has('q')).flush(unidadesSeed);
+    await propagate();
+
+    expect(component['opcoesSuperiorComErro']()).toBe(false);
+    expect(component['opcoesUnidadeSuperior']()).toHaveLength(2);
+  });
 });

--- a/apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
@@ -114,6 +114,18 @@ describe('UnidadesPage', () => {
     await propagate();
   }
 
+  // Abrir o formulário dispara o GET (sem filtro) das opções de "unidade
+  // superior" — desacoplado do filtro da listagem. Flush logo após o abrir*.
+  async function flushOpcoesSuperior(
+    unidades: readonly UnidadeDto[] = unidadesSeed,
+  ): Promise<void> {
+    await propagate();
+    expectListGet(
+      (r) => !r.params.has('q') && !r.params.has('tipo') && !r.params.has('cursor'),
+    ).flush(unidades);
+    await propagate();
+  }
+
   it('carrega unidades na inicialização com limit 100 e monta hierarquia', async () => {
     await flushInicial();
 
@@ -209,6 +221,7 @@ describe('UnidadesPage', () => {
   it('cria unidade com Idempotency-Key e recarrega a lista após sucesso', async () => {
     await flushInicial();
     component['abrirCadastro']();
+    await flushOpcoesSuperior();
     component['form'].setValue({
       nome: 'Faculdade de Computação',
       alias: '',
@@ -248,6 +261,7 @@ describe('UnidadesPage', () => {
   it('submete regra de vigência ao backend e exibe erro 422 inline no campo correspondente', async () => {
     await flushInicial();
     component['abrirCadastro']();
+    await flushOpcoesSuperior();
     component['form'].setValue({
       nome: 'Faculdade de Computação',
       alias: '',
@@ -335,6 +349,7 @@ describe('UnidadesPage', () => {
   it('renova Idempotency-Key quando backend sinaliza body_mismatch', async () => {
     await flushInicial();
     component['abrirCadastro']();
+    await flushOpcoesSuperior();
     component['form'].setValue({
       nome: 'Faculdade de Computação',
       alias: '',
@@ -378,6 +393,7 @@ describe('UnidadesPage', () => {
   it('renova Idempotency-Key em 409 Conflict para permitir reenvio após corrigir identificador duplicado', async () => {
     await flushInicial();
     component['abrirCadastro']();
+    await flushOpcoesSuperior();
     component['form'].setValue({
       nome: 'Faculdade de Computação',
       alias: '',
@@ -422,6 +438,7 @@ describe('UnidadesPage', () => {
   it('atualiza unidade sem enviar vigenciaInicio no command de update', async () => {
     await flushInicial();
     component['abrirEdicao']({ ...unidadesSeed[1], origem: 'ImportadoSIORG' });
+    await flushOpcoesSuperior();
     component['form'].controls.nome.setValue('Instituto Renomeado');
     const key = component['idempotencyKeyAtual']();
 
@@ -452,6 +469,7 @@ describe('UnidadesPage', () => {
   it('preserva tipo Pro-Reitoria ao editar unidade', async () => {
     await flushInicial();
     component['abrirEdicao']({ ...unidadesSeed[1], tipo: 'Pro-Reitoria' });
+    await flushOpcoesSuperior();
     component['form'].controls.nome.setValue('Pró-Reitoria Renomeada');
 
     expect(component['form'].controls.tipo.value).toBe('2');
@@ -477,6 +495,7 @@ describe('UnidadesPage', () => {
     await flushInicial();
 
     component['abrirEdicao']({ ...unidadesSeed[1], tipo: 'TipoInexistente' });
+    await flushOpcoesSuperior();
 
     expect(component['form'].controls.tipo.value).toBe('');
     expect(component['tipoNaoReconhecido']()).toBe(true);
@@ -492,12 +511,14 @@ describe('UnidadesPage', () => {
     await flushInicial();
 
     component['abrirEdicao']({ ...unidadesSeed[1], origem: 'OrigemExterna' });
+    await flushOpcoesSuperior();
 
     expect(component['form'].controls.origem.disabled).toBe(true);
     expect(component['form'].controls.origem.value).toBe('');
     expect(component['origemEmEdicaoLabel']()).toBe('OrigemExterna');
 
     component['abrirCadastro']();
+    await flushOpcoesSuperior();
 
     expect(component['form'].controls.origem.enabled).toBe(true);
     expect(component['form'].controls.origem.value).toBe('2');

--- a/apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
@@ -677,4 +677,25 @@ describe('UnidadesPage', () => {
     // Reitoria não está na página filtrada, mas foi vista na carga inicial.
     expect(component['unidadeSuperiorLabel'](REITORIA_ID)).toBe('REITORIA — Reitoria');
   });
+
+  it('ao reabrir o formulário não reusa a busca anterior de unidade superior', async () => {
+    await flushInicial();
+    component['abrirCadastro']();
+    await flushOpcoesSuperior(); // GET inicial das opções (sem q)
+
+    component['buscaPai'].set('inst');
+    await sleep(DEBOUNCE_FOLGA_MS);
+    await propagate();
+    expectListGet((r) => r.params.get('q') === 'inst').flush([unidadesSeed[1]]);
+    await propagate();
+
+    // Reabre: o termo é resetado de forma síncrona, então o GET não leva o q
+    // antigo enquanto o debounce não zera.
+    component['abrirCadastro']();
+    await propagate();
+    const reaberto = expectListGet();
+    expect(reaberto.request.params.has('q')).toBe(false);
+    reaberto.flush(unidadesSeed);
+    await propagate();
+  });
 });

--- a/apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
@@ -1,5 +1,10 @@
-import { provideHttpClient, withInterceptors } from '@angular/common/http';
-import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpRequest, provideHttpClient, withInterceptors } from '@angular/common/http';
+import {
+  HttpTestingController,
+  TestRequest,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { ApplicationRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { apiResultInterceptor, buildVendorMimeAccept } from '@uniplus/shared-core/http';
@@ -10,6 +15,9 @@ import { UnidadesPage } from './unidades.page';
 const BASE = 'http://localhost:5000';
 const REITORIA_ID = '01960000-0000-7000-0000-000000000001';
 const INSTITUTO_ID = '01960000-0000-7000-0000-000000000002';
+
+// Folga acima do debounce da busca (BUSCA_DEBOUNCE_MS = 300 na página).
+const DEBOUNCE_FOLGA_MS = 360;
 
 const unidadesSeed: readonly UnidadeDto[] = [
   {
@@ -48,6 +56,7 @@ describe('UnidadesPage', () => {
   let fixture: ComponentFixture<UnidadesPage>;
   let component: UnidadesPage;
   let controller: HttpTestingController;
+  let appRef: ApplicationRef;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -63,43 +72,142 @@ describe('UnidadesPage', () => {
     fixture = TestBed.createComponent(UnidadesPage);
     component = fixture.componentInstance;
     controller = TestBed.inject(HttpTestingController);
-    fixture.detectChanges();
+    appRef = TestBed.inject(ApplicationRef);
   });
 
   afterEach(() => controller.verify());
 
-  function flushList(unidades: readonly UnidadeDto[] = unidadesSeed): void {
+  // Dreia o microtask queue + roda change detection para o `httpResource`
+  // propagar valores aos signals do resource (mesmo padrão de editais-detail).
+  const propagate = async (): Promise<void> => {
+    await Promise.resolve();
+    appRef.tick();
+  };
+
+  const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+  function expectListGet(matcher?: (request: HttpRequest<unknown>) => boolean): TestRequest {
     const req = controller.expectOne(
-      (request) => request.url === `${BASE}/api/unidades` && request.params.get('limit') === '100',
+      (request) =>
+        request.url === `${BASE}/api/unidades` &&
+        request.method === 'GET' &&
+        (matcher ? matcher(request) : true),
     );
-    expect(req.request.method).toBe('GET');
     expect(req.request.headers.get('Accept')).toBe(buildVendorMimeAccept('unidade', 1));
-    req.flush(unidades);
+    return req;
   }
 
-  it('carrega unidades na inicialização com limit 100 e monta hierarquia', () => {
-    flushList();
+  // Carga inicial (sem filtros). Opcionalmente injeta header Link (rel="next").
+  async function flushInicial(
+    unidades: readonly UnidadeDto[] = unidadesSeed,
+    headers?: Record<string, string>,
+  ): Promise<void> {
+    fixture.detectChanges();
+    const request = expectListGet(
+      (r) =>
+        !r.params.has('q') &&
+        !r.params.has('tipo') &&
+        !r.params.has('cursor') &&
+        r.params.get('limit') === '100',
+    );
+    request.flush(unidades, headers ? { headers } : undefined);
+    await propagate();
+  }
+
+  it('carrega unidades na inicialização com limit 100 e monta hierarquia', async () => {
+    await flushInicial();
 
     expect(component['unidades']()).toHaveLength(2);
     expect(component['arvore']()).toHaveLength(1);
     expect(component['arvore']()[0].children).toHaveLength(1);
   });
 
-  it('filtra client-side por busca e tipo sem enviar query inexistente ao backend', () => {
-    flushList();
+  it('busca server-side: digitação em rajada dispara um único GET com q após debounce', async () => {
+    await flushInicial();
 
+    component['busca'].set('i');
+    component['busca'].set('ie');
     component['busca'].set('iedar');
-    expect(component['unidadesFiltradas']()).toHaveLength(1);
-    expect(component['unidadesFiltradas']()[0].id).toBe(INSTITUTO_ID);
+    appRef.tick();
+    // Antes do debounce, nenhuma request com q (não dispara por tecla).
+    controller.expectNone(
+      (request) => request.url === `${BASE}/api/unidades` && request.params.has('q'),
+    );
 
-    component['busca'].set('');
-    component['tipoFiltro'].set('Instituto');
-    expect(component['unidadesFiltradas']()).toHaveLength(1);
-    expect(component['unidadesFiltradas']()[0].tipo).toBe('Instituto');
+    await sleep(DEBOUNCE_FOLGA_MS);
+    await propagate();
+
+    const request = expectListGet(
+      (r) => r.params.get('q') === 'iedar' && !r.params.has('cursor'),
+    );
+    request.flush([unidadesSeed[1]]);
+    await propagate();
+
+    expect(component['unidades']()).toHaveLength(1);
+    expect(component['unidades']()[0].id).toBe(INSTITUTO_ID);
   });
 
-  it('cria unidade com Idempotency-Key e recarrega a lista após sucesso', () => {
-    flushList();
+  it('filtro de tipo dispara GET imediato com tipo numérico do roster', async () => {
+    await flushInicial();
+
+    component['tipoFiltro'].set('4'); // Instituto
+    await propagate();
+
+    const request = expectListGet(
+      (r) => r.params.get('tipo') === '4' && !r.params.has('q'),
+    );
+    request.flush([unidadesSeed[1]]);
+    await propagate();
+
+    expect(component['unidades']()).toHaveLength(1);
+    expect(component['unidades']()[0].tipo).toBe('Instituto');
+  });
+
+  it('Carregar mais acumula a próxima página (cursor forward-only)', async () => {
+    await flushInicial([unidadesSeed[0]], {
+      Link: `<${BASE}/api/unidades?cursor=pagina-2>; rel="next"`,
+    });
+
+    expect(component['unidades']()).toHaveLength(1);
+    expect(component['nextCursor']()).not.toBeNull();
+
+    component['carregarMais']();
+    await propagate();
+
+    const request = expectListGet((r) => r.params.get('cursor') === 'pagina-2');
+    request.flush([unidadesSeed[1]]); // sem Link → última página
+    await propagate();
+
+    expect(component['unidades']()).toHaveLength(2);
+    expect(component['unidades']().map((u) => u.id)).toEqual([REITORIA_ID, INSTITUTO_ID]);
+    expect(component['nextCursor']()).toBeNull();
+  });
+
+  it('mudar o filtro reseta a paginação para a primeira página e substitui a lista', async () => {
+    await flushInicial([unidadesSeed[0]], {
+      Link: `<${BASE}/api/unidades?cursor=pagina-2>; rel="next"`,
+    });
+    component['carregarMais']();
+    await propagate();
+    expectListGet((r) => r.params.get('cursor') === 'pagina-2').flush([unidadesSeed[1]]);
+    await propagate();
+    expect(component['unidades']()).toHaveLength(2);
+
+    // Aplicar tipo volta à primeira página (sem cursor) e substitui, não acumula.
+    component['tipoFiltro'].set('1'); // Reitoria
+    await propagate();
+    const request = expectListGet(
+      (r) => r.params.get('tipo') === '1' && !r.params.has('cursor'),
+    );
+    request.flush([unidadesSeed[0]]);
+    await propagate();
+
+    expect(component['unidades']()).toHaveLength(1);
+    expect(component['unidades']()[0].id).toBe(REITORIA_ID);
+  });
+
+  it('cria unidade com Idempotency-Key e recarrega a lista após sucesso', async () => {
+    await flushInicial();
     component['abrirCadastro']();
     component['form'].setValue({
       nome: 'Faculdade de Computação',
@@ -119,24 +227,26 @@ describe('UnidadesPage', () => {
 
     component['salvar']();
 
-    const req = controller.expectOne(`${BASE}/api/admin/unidades`);
-    expect(req.request.method).toBe('POST');
-    expect(req.request.headers.get('Idempotency-Key')).toBe(key);
-    expect(req.request.body).toMatchObject({
+    const post = controller.expectOne(`${BASE}/api/admin/unidades`);
+    expect(post.request.method).toBe('POST');
+    expect(post.request.headers.get('Idempotency-Key')).toBe(key);
+    expect(post.request.body).toMatchObject({
       nome: 'Faculdade de Computação',
       alias: null,
       unidadeSuperiorId: INSTITUTO_ID,
       tipo: 5,
       origem: 2,
     });
-    req.flush('01960000-0000-7000-0000-000000000099', { status: 201, statusText: 'Created' });
-
-    flushList();
+    post.flush('01960000-0000-7000-0000-000000000099', { status: 201, statusText: 'Created' });
     expect(component['formOpen']()).toBe(false);
+
+    await propagate();
+    expectListGet().flush(unidadesSeed); // refetch pós-mutação
+    await propagate();
   });
 
-  it('submete regra de vigência ao backend e exibe erro 422 inline no campo correspondente', () => {
-    flushList();
+  it('submete regra de vigência ao backend e exibe erro 422 inline no campo correspondente', async () => {
+    await flushInicial();
     component['abrirCadastro']();
     component['form'].setValue({
       nome: 'Faculdade de Computação',
@@ -158,14 +268,14 @@ describe('UnidadesPage', () => {
 
     component['salvar']();
 
-    const req = controller.expectOne(`${BASE}/api/admin/unidades`);
-    expect(req.request.method).toBe('POST');
-    expect(req.request.headers.get('Idempotency-Key')).toBe(primeiraChave);
-    expect(req.request.body).toMatchObject({
+    const req1 = controller.expectOne(`${BASE}/api/admin/unidades`);
+    expect(req1.request.method).toBe('POST');
+    expect(req1.request.headers.get('Idempotency-Key')).toBe(primeiraChave);
+    expect(req1.request.body).toMatchObject({
       vigenciaInicio: '2026-06-10',
       vigenciaFim: '2026-06-02',
     });
-    req.flush(
+    req1.flush(
       {
         type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.validacao',
         title: 'Erro de validação',
@@ -215,13 +325,15 @@ describe('UnidadesPage', () => {
       status: 201,
       statusText: 'Created',
     });
-
-    flushList();
     expect(component['formOpen']()).toBe(false);
+
+    await propagate();
+    expectListGet().flush(unidadesSeed);
+    await propagate();
   });
 
-  it('renova Idempotency-Key quando backend sinaliza body_mismatch', () => {
-    flushList();
+  it('renova Idempotency-Key quando backend sinaliza body_mismatch', async () => {
+    await flushInicial();
     component['abrirCadastro']();
     component['form'].setValue({
       nome: 'Faculdade de Computação',
@@ -263,8 +375,8 @@ describe('UnidadesPage', () => {
     expect(component['idempotencyKeyAtual']()).not.toBe(primeiraChave);
   });
 
-  it('renova Idempotency-Key em 409 Conflict para permitir reenvio após corrigir identificador duplicado', () => {
-    flushList();
+  it('renova Idempotency-Key em 409 Conflict para permitir reenvio após corrigir identificador duplicado', async () => {
+    await flushInicial();
     component['abrirCadastro']();
     component['form'].setValue({
       nome: 'Faculdade de Computação',
@@ -307,8 +419,8 @@ describe('UnidadesPage', () => {
     expect(component['idempotencyKeyAtual']()).not.toBe(primeiraChave);
   });
 
-  it('atualiza unidade sem enviar vigenciaInicio no command de update', () => {
-    flushList();
+  it('atualiza unidade sem enviar vigenciaInicio no command de update', async () => {
+    await flushInicial();
     component['abrirEdicao']({ ...unidadesSeed[1], origem: 'ImportadoSIORG' });
     component['form'].controls.nome.setValue('Instituto Renomeado');
     const key = component['idempotencyKeyAtual']();
@@ -319,24 +431,26 @@ describe('UnidadesPage', () => {
 
     component['salvar']();
 
-    const req = controller.expectOne(`${BASE}/api/admin/unidades/${INSTITUTO_ID}`);
-    expect(req.request.method).toBe('PUT');
-    expect(req.request.headers.get('Idempotency-Key')).toBe(key);
-    expect(req.request.body).not.toHaveProperty('vigenciaInicio');
-    expect(req.request.body).not.toHaveProperty('origem');
-    expect(req.request.body).toMatchObject({
+    const put = controller.expectOne(`${BASE}/api/admin/unidades/${INSTITUTO_ID}`);
+    expect(put.request.method).toBe('PUT');
+    expect(put.request.headers.get('Idempotency-Key')).toBe(key);
+    expect(put.request.body).not.toHaveProperty('vigenciaInicio');
+    expect(put.request.body).not.toHaveProperty('origem');
+    expect(put.request.body).toMatchObject({
       id: INSTITUTO_ID,
       nome: 'Instituto Renomeado',
       tipo: 4,
     });
-    req.flush(null, { status: 204, statusText: 'No Content' });
-
-    flushList();
+    put.flush(null, { status: 204, statusText: 'No Content' });
     expect(component['formOpen']()).toBe(false);
+
+    await propagate();
+    expectListGet().flush(unidadesSeed);
+    await propagate();
   });
 
-  it('preserva tipo Pro-Reitoria ao editar unidade', () => {
-    flushList();
+  it('preserva tipo Pro-Reitoria ao editar unidade', async () => {
+    await flushInicial();
     component['abrirEdicao']({ ...unidadesSeed[1], tipo: 'Pro-Reitoria' });
     component['form'].controls.nome.setValue('Pró-Reitoria Renomeada');
 
@@ -344,21 +458,23 @@ describe('UnidadesPage', () => {
 
     component['salvar']();
 
-    const req = controller.expectOne(`${BASE}/api/admin/unidades/${INSTITUTO_ID}`);
-    expect(req.request.method).toBe('PUT');
-    expect(req.request.body).toMatchObject({
+    const put = controller.expectOne(`${BASE}/api/admin/unidades/${INSTITUTO_ID}`);
+    expect(put.request.method).toBe('PUT');
+    expect(put.request.body).toMatchObject({
       id: INSTITUTO_ID,
       nome: 'Pró-Reitoria Renomeada',
       tipo: 2,
     });
-    req.flush(null, { status: 204, statusText: 'No Content' });
-
-    flushList();
+    put.flush(null, { status: 204, statusText: 'No Content' });
     expect(component['formOpen']()).toBe(false);
+
+    await propagate();
+    expectListGet().flush(unidadesSeed);
+    await propagate();
   });
 
-  it('não coage tipo desconhecido para "Outro" ao editar — bloqueia o submit', () => {
-    flushList();
+  it('não coage tipo desconhecido para "Outro" ao editar — bloqueia o submit', async () => {
+    await flushInicial();
 
     component['abrirEdicao']({ ...unidadesSeed[1], tipo: 'TipoInexistente' });
 
@@ -372,8 +488,8 @@ describe('UnidadesPage', () => {
     expect(component['form'].controls.tipo.valid).toBe(true);
   });
 
-  it('preserva origem desconhecida ao editar e reabilita o campo ao criar', () => {
-    flushList();
+  it('preserva origem desconhecida ao editar e reabilita o campo ao criar', async () => {
+    await flushInicial();
 
     component['abrirEdicao']({ ...unidadesSeed[1], origem: 'OrigemExterna' });
 
@@ -388,18 +504,21 @@ describe('UnidadesPage', () => {
     expect(component['origemEmEdicaoLabel']()).toBe('');
   });
 
-  it('remove unidade sem Idempotency-Key porque o endpoint DELETE não exige o header', () => {
-    flushList();
+  it('remove unidade sem Idempotency-Key porque o endpoint DELETE não exige o header', async () => {
+    await flushInicial();
     component['pedirRemocao'](unidadesSeed[1]);
 
     component['removerConfirmado']();
 
-    const req = controller.expectOne(`${BASE}/api/admin/unidades/${INSTITUTO_ID}`);
-    expect(req.request.method).toBe('DELETE');
-    expect(req.request.headers.has('Idempotency-Key')).toBe(false);
-    req.flush(null, { status: 204, statusText: 'No Content' });
+    const del = controller.expectOne(`${BASE}/api/admin/unidades/${INSTITUTO_ID}`);
+    expect(del.request.method).toBe('DELETE');
+    expect(del.request.headers.has('Idempotency-Key')).toBe(false);
+    del.flush(null, { status: 204, statusText: 'No Content' });
 
-    flushList([unidadesSeed[0]]);
+    await propagate();
+    expectListGet().flush([unidadesSeed[0]]);
+    await propagate();
+
     expect(component['unidadeParaRemover']()).toBeNull();
   });
 });

--- a/apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
@@ -642,4 +642,25 @@ describe('UnidadesPage', () => {
     expect(component['opcoesSuperiorComErro']()).toBe(false);
     expect(component['opcoesUnidadeSuperior']()).toHaveLength(2);
   });
+
+  it('marca a lista em recarga durante o refetch pós-mutação (ações de linha desabilitam)', async () => {
+    await flushInicial();
+    expect(component['recarregandoLista']()).toBe(false);
+
+    component['pedirRemocao'](unidadesSeed[1]);
+    component['removerConfirmado']();
+    controller
+      .expectOne(`${BASE}/api/admin/unidades/${INSTITUTO_ID}`)
+      .flush(null, { status: 204, statusText: 'No Content' });
+
+    await propagate();
+    // Refetch pós-remoção pendente: a lista ainda mostra dados, mas em recarga.
+    expect(component['recarregandoLista']()).toBe(true);
+
+    expectListGet().flush([unidadesSeed[0]]);
+    await propagate();
+
+    expect(component['recarregandoLista']()).toBe(false);
+    expect(component['unidades']()).toHaveLength(1);
+  });
 });

--- a/apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
@@ -542,4 +542,22 @@ describe('UnidadesPage', () => {
 
     expect(component['unidadeParaRemover']()).toBeNull();
   });
+
+  it('busca de unidade superior consulta o backend com q e atualiza as opções (escala além de 1 página)', async () => {
+    await flushInicial();
+    component['abrirCadastro']();
+    await flushOpcoesSuperior(); // GET inicial das opções (sem q)
+
+    component['buscaPai'].set('inst');
+    await sleep(DEBOUNCE_FOLGA_MS);
+    await propagate();
+
+    const request = expectListGet(
+      (r) => r.params.get('q') === 'inst' && !r.params.has('cursor'),
+    );
+    request.flush([unidadesSeed[1]]);
+    await propagate();
+
+    expect(component['opcoesUnidadeSuperior']().map((u) => u.id)).toEqual([INSTITUTO_ID]);
+  });
 });

--- a/apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
@@ -560,4 +560,35 @@ describe('UnidadesPage', () => {
 
     expect(component['opcoesUnidadeSuperior']().map((u) => u.id)).toEqual([INSTITUTO_ID]);
   });
+
+  it('permite tentar novamente quando uma página falha, sem perder o que já foi carregado', async () => {
+    await flushInicial([unidadesSeed[0]], {
+      Link: `<${BASE}/api/unidades?cursor=pagina-2>; rel="next"`,
+    });
+    expect(component['unidades']()).toHaveLength(1);
+
+    component['carregarMais']();
+    await propagate();
+    expectListGet((r) => r.params.get('cursor') === 'pagina-2').flush(
+      { type: 'about:blank', title: 'Erro interno', status: 500, code: 'uniplus.erro', traceId: 'x' },
+      {
+        status: 500,
+        statusText: 'Internal Server Error',
+        headers: { 'Content-Type': 'application/problem+json' },
+      },
+    );
+    await propagate();
+
+    expect(component['unidades']()).toHaveLength(1); // mantém a página já carregada
+    expect(component['errorMessage']()).not.toBeNull();
+
+    component['tentarNovamente']();
+    await propagate();
+    const retry = expectListGet((r) => r.params.get('cursor') === 'pagina-2');
+    retry.flush([unidadesSeed[1]]);
+    await propagate();
+
+    expect(component['unidades']()).toHaveLength(2); // acumulou após o retry
+    expect(component['errorMessage']()).toBeNull();
+  });
 });

--- a/apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
@@ -663,4 +663,18 @@ describe('UnidadesPage', () => {
     expect(component['recarregandoLista']()).toBe(false);
     expect(component['unidades']()).toHaveLength(1);
   });
+
+  it('resolve o rótulo do pai mesmo quando ele é filtrado para fora da página atual', async () => {
+    await flushInicial(); // Reitoria + Instituto na carga inicial (alimenta o cache)
+
+    component['tipoFiltro'].set('4'); // Instituto — o pai Reitoria sai da página
+    await propagate();
+    expectListGet((r) => r.params.get('tipo') === '4').flush([unidadesSeed[1]]);
+    await propagate();
+
+    expect(component['unidades']()).toHaveLength(1);
+    expect(component['unidades']()[0].id).toBe(INSTITUTO_ID);
+    // Reitoria não está na página filtrada, mas foi vista na carga inicial.
+    expect(component['unidadeSuperiorLabel'](REITORIA_ID)).toBe('REITORIA — Reitoria');
+  });
 });

--- a/apps/configuracao/src/app/features/unidades/unidades.page.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.ts
@@ -268,6 +268,7 @@ const BACKEND_FIELD_TO_CONTROL = {
                       <button
                         type="button"
                         class="btn btn--tertiary btn--sm btn--rect"
+                        [disabled]="recarregandoLista()"
                         (click)="abrirEdicao(unidade)"
                       >
                         Editar
@@ -275,6 +276,7 @@ const BACKEND_FIELD_TO_CONTROL = {
                       <button
                         type="button"
                         class="btn btn--tertiary btn--sm btn--rect"
+                        [disabled]="recarregandoLista()"
                         (click)="pedirRemocao(unidade)"
                       >
                         Remover
@@ -338,6 +340,7 @@ const BACKEND_FIELD_TO_CONTROL = {
               type="button"
               class="btn btn--tertiary btn--sm btn--rect"
               [attr.aria-label]="'Editar ' + node.unidade.sigla"
+              [disabled]="recarregandoLista()"
               (click)="abrirEdicao(node.unidade)"
             >
               Editar
@@ -701,6 +704,17 @@ export class UnidadesPage {
   }));
 
   protected readonly loading = this.lista.isLoading;
+
+  /**
+   * Recarga que **substitui** a lista em andamento (primeira página: troca de
+   * filtro ou refetch pós-mutação). Durante essa janela as linhas exibidas
+   * podem estar desatualizadas (ex.: linha recém-removida ainda visível até a
+   * resposta chegar), então as ações de linha ficam desabilitadas. "Carregar
+   * mais" (cursor definido) só acumula e não invalida as linhas atuais.
+   */
+  protected readonly recarregandoLista = computed(
+    () => this.loading() && this.cursor() === undefined,
+  );
 
   /** Próximo cursor (rel="next" do header Link). `null` = última página. */
   protected readonly nextCursor = computed(() =>

--- a/apps/configuracao/src/app/features/unidades/unidades.page.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.ts
@@ -510,7 +510,7 @@ const BACKEND_FIELD_TO_CONTROL = {
               <span class="field__label">Unidade superior</span>
               <select class="select" formControlName="unidadeSuperiorId">
                 <option value="">Raiz — sem superior</option>
-                @for (unidade of unidades(); track unidade.id) {
+                @for (unidade of opcoesUnidadeSuperior(); track unidade.id) {
                   <option [value]="unidade.id" [disabled]="unidade.id === unidadeEmEdicaoId()">
                     {{ unidade.sigla }} — {{ unidade.nome }}
                   </option>
@@ -711,6 +711,29 @@ export class UnidadesPage {
     () => this.buscaAplicada().length > 0 || this.tipoFiltro().length > 0,
   );
 
+  // Ativa a busca das opções de "unidade superior" na primeira abertura do
+  // formulário (lazy — sem custo de request enquanto o form nunca abre).
+  private readonly carregarOpcoesSuperior = signal(false);
+
+  /**
+   * Opções de "unidade superior" do formulário — sempre **sem filtro**, para
+   * não sumir pais válidos (ex.: Reitoria) quando há filtro ativo na listagem.
+   * Resource próprio, desacoplado do filtro/paginação; recarregado a cada
+   * abertura do form para refletir unidades recém-criadas.
+   */
+  private readonly opcoesSuperiorResource = useApiResource<readonly UnidadeDto[]>(() =>
+    this.carregarOpcoesSuperior()
+      ? {
+          url: `${this.basePath}/api/unidades`,
+          params: new HttpParams().set('limit', String(PAGE_SIZE)),
+          context: withVendorMime('unidade', 1),
+        }
+      : undefined,
+  );
+  protected readonly opcoesUnidadeSuperior = computed(
+    () => this.opcoesSuperiorResource.data() ?? [],
+  );
+
   protected readonly tipoOptions = TIPOS_UNIDADE.map((tipo) => ({
     value: String(tipo.value),
     label: tipo.label,
@@ -825,6 +848,17 @@ export class UnidadesPage {
     return params;
   }
 
+  // Carrega/atualiza as opções de "unidade superior" ao abrir o formulário. Na
+  // primeira vez ativa o resource (dispara o GET sem filtro); nas reaberturas
+  // refaz a busca para incluir unidades criadas desde então.
+  private prepararOpcoesSuperior(): void {
+    if (this.carregarOpcoesSuperior()) {
+      this.opcoesSuperiorResource.reload();
+    } else {
+      this.carregarOpcoesSuperior.set(true);
+    }
+  }
+
   protected abrirCadastro(): void {
     this.modo.set('criar');
     this.unidadeEmEdicaoId.set(null);
@@ -846,6 +880,7 @@ export class UnidadesPage {
     });
     this.formError.set(null);
     this.idempotencyKeyAtual.set(idempotencyKey.create());
+    this.prepararOpcoesSuperior();
     this.formOpen.set(true);
   }
 
@@ -870,6 +905,7 @@ export class UnidadesPage {
     });
     this.formError.set(null);
     this.idempotencyKeyAtual.set(idempotencyKey.create());
+    this.prepararOpcoesSuperior();
     this.drawerOpen.set(false);
     this.formOpen.set(true);
   }

--- a/apps/configuracao/src/app/features/unidades/unidades.page.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.ts
@@ -506,9 +506,21 @@ const BACKEND_FIELD_TO_CONTROL = {
                 </span>
               }
             </label>
-            <label class="field field--full">
+            <div class="field field--full">
               <span class="field__label">Unidade superior</span>
-              <select class="select" formControlName="unidadeSuperiorId">
+              <input
+                type="search"
+                class="input"
+                placeholder="Buscar por sigla ou nome..."
+                aria-label="Buscar unidade superior"
+                [value]="buscaPai()"
+                (input)="buscaPai.set(inputValue($event))"
+              />
+              <select
+                class="select"
+                formControlName="unidadeSuperiorId"
+                aria-label="Unidade superior"
+              >
                 <option value="">Raiz — sem superior</option>
                 @for (unidade of opcoesUnidadeSuperior(); track unidade.id) {
                   <option [value]="unidade.id" [disabled]="unidade.id === unidadeEmEdicaoId()">
@@ -516,8 +528,10 @@ const BACKEND_FIELD_TO_CONTROL = {
                   </option>
                 }
               </select>
-              <span class="field__hint">Não pode formar ciclo na hierarquia.</span>
-            </label>
+              <span class="field__hint">
+                Digite para buscar entre todas as unidades. Não pode formar ciclo na hierarquia.
+              </span>
+            </div>
             <label class="checkbox cfg-form__checkbox">
               <input type="checkbox" formControlName="unidadeAcademica" />
               <span class="checkbox__box" aria-hidden="true"></span>
@@ -715,21 +729,39 @@ export class UnidadesPage {
   // formulário (lazy — sem custo de request enquanto o form nunca abre).
   private readonly carregarOpcoesSuperior = signal(false);
 
-  /**
-   * Opções de "unidade superior" do formulário — sempre **sem filtro**, para
-   * não sumir pais válidos (ex.: Reitoria) quando há filtro ativo na listagem.
-   * Resource próprio, desacoplado do filtro/paginação; recarregado a cada
-   * abertura do form para refletir unidades recém-criadas.
-   */
-  private readonly opcoesSuperiorResource = useApiResource<readonly UnidadeDto[]>(() =>
-    this.carregarOpcoesSuperior()
-      ? {
-          url: `${this.basePath}/api/unidades`,
-          params: new HttpParams().set('limit', String(PAGE_SIZE)),
-          context: withVendorMime('unidade', 1),
-        }
-      : undefined,
+  /** Termo de busca do campo "unidade superior" (input do formulário). */
+  protected readonly buscaPai = signal('');
+  private readonly buscaPaiAplicada = toSignal(
+    toObservable(this.buscaPai).pipe(
+      map((termo) => termo.trim()),
+      debounceTime(BUSCA_DEBOUNCE_MS),
+      distinctUntilChanged(),
+    ),
+    { initialValue: '' },
   );
+
+  /**
+   * Opções de "unidade superior" do formulário — desacopladas do filtro da
+   * **listagem**, mas com busca server-side própria (`q`) para escalar além de
+   * uma página: o usuário digita e o backend devolve os pais que casam, então
+   * pais fora da primeira página continuam selecionáveis. Resource próprio,
+   * lazy, recarregado a cada abertura do form.
+   */
+  private readonly opcoesSuperiorResource = useApiResource<readonly UnidadeDto[]>(() => {
+    if (!this.carregarOpcoesSuperior()) {
+      return undefined;
+    }
+    let params = new HttpParams().set('limit', String(PAGE_SIZE));
+    const q = this.buscaPaiAplicada();
+    if (q.length > 0) {
+      params = params.set('q', q);
+    }
+    return {
+      url: `${this.basePath}/api/unidades`,
+      params,
+      context: withVendorMime('unidade', 1),
+    };
+  });
   protected readonly opcoesUnidadeSuperior = computed(
     () => this.opcoesSuperiorResource.data() ?? [],
   );
@@ -852,6 +884,7 @@ export class UnidadesPage {
   // primeira vez ativa o resource (dispara o GET sem filtro); nas reaberturas
   // refaz a busca para incluir unidades criadas desde então.
   private prepararOpcoesSuperior(): void {
+    this.buscaPai.set('');
     if (this.carregarOpcoesSuperior()) {
       this.opcoesSuperiorResource.reload();
     } else {

--- a/apps/configuracao/src/app/features/unidades/unidades.page.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.ts
@@ -836,6 +836,30 @@ export class UnidadesPage {
     );
   });
 
+  /**
+   * Cache monotônico de unidades já vistas (páginas da lista + busca de pai),
+   * por id. `unidadeSuperiorLabel` consulta este cache em vez de só a página
+   * filtrada: com filtro server-side ativo o pai (ex.: Reitoria) pode sair da
+   * página, mas se já foi carregado antes seu rótulo continua resolvendo, sem
+   * cair em "Não carregada". `linkedSignal` acumula em vez de `effect`.
+   */
+  private readonly unidadesConhecidas = linkedSignal<
+    { lista: readonly UnidadeDto[]; opcoes: readonly UnidadeDto[] },
+    ReadonlyMap<string, UnidadeDto>
+  >({
+    source: () => ({ lista: this.unidades(), opcoes: this.opcoesUnidadeSuperior() }),
+    computation: (vistas, previous) => {
+      const mapa = new Map(previous?.value ?? []);
+      for (const unidade of vistas.lista) {
+        mapa.set(unidade.id, unidade);
+      }
+      for (const unidade of vistas.opcoes) {
+        mapa.set(unidade.id, unidade);
+      }
+      return mapa;
+    },
+  });
+
   protected readonly tipoOptions = TIPOS_UNIDADE.map((tipo) => ({
     value: String(tipo.value),
     label: tipo.label,
@@ -1114,7 +1138,9 @@ export class UnidadesPage {
     if (id === null) {
       return 'Sem superior';
     }
-    const superior = this.unidades().find((unidade) => unidade.id === id);
+    // Consulta o cache de unidades já vistas (não só a página filtrada atual),
+    // para o pai não virar "Não carregada" quando filtrado para fora da página.
+    const superior = this.unidadesConhecidas().get(id);
     return superior ? `${superior.sigla} — ${superior.nome}` : 'Não carregada';
   }
 

--- a/apps/configuracao/src/app/features/unidades/unidades.page.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.ts
@@ -140,6 +140,16 @@ const BACKEND_FIELD_TO_CONTROL = {
     @if (errorMessage()) {
       <ui-alert variant="danger" heading="Não foi possível carregar unidades">
         {{ errorMessage() }}
+        <div class="cfg-unidades__retry">
+          <button
+            type="button"
+            class="btn btn--secondary btn--sm"
+            [disabled]="loading()"
+            (click)="tentarNovamente()"
+          >
+            Tentar novamente
+          </button>
+        </div>
       </ui-alert>
     }
 
@@ -858,6 +868,15 @@ export class UnidadesPage {
       // Só avança (cursor forward-only). A acumulação fica a cargo do
       // linkedSignal `unidades` quando a próxima página chega.
       this.cursor.set(proximo);
+    }
+  }
+
+  // Refaz a carga da página atual após falha. Reusa `reload()` porque o cursor
+  // já aponta para a página que falhou — `cursor.set(mesmoValor)` não dispararia
+  // novo request. Cobre falha da primeira página e de "Carregar mais".
+  protected tentarNovamente(): void {
+    if (!this.loading()) {
+      this.lista.reload();
     }
   }
 

--- a/apps/configuracao/src/app/features/unidades/unidades.page.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.ts
@@ -1,28 +1,37 @@
+import { HttpParams } from '@angular/common/http';
 import { NgTemplateOutlet } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
   computed,
+  effect,
   inject,
+  linkedSignal,
   signal,
+  untracked,
 } from '@angular/core';
-import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { debounceTime, distinctUntilChanged, map } from 'rxjs';
 import {
   ApiResult,
   Cursor,
   ProblemDetails,
   ProblemI18nService,
   ProblemValidationError,
+  cursorToString,
   extractNextCursor,
   idempotencyKey,
+  useApiResource,
   withIdempotencyKey,
+  withVendorMime,
 } from '@uniplus/shared-core/http';
 import { NotificationService } from '@uniplus/shared-core/notifications';
 import {
   AtualizarUnidadeCommand,
   CriarUnidadeCommand,
+  ORGANIZACAO_BASE_PATH,
   ORIGENS_UNIDADE,
   TIPOS_UNIDADE,
   OrigemUnidade,
@@ -39,6 +48,16 @@ import {
   SpinnerComponent,
   type UiFilterChipOption,
 } from '@uniplus/shared-ui/components';
+
+/** Tamanho da janela de cada página (cursor pagination, ADR-0026). */
+const PAGE_SIZE = 100;
+
+/**
+ * Debounce da busca textual — uma request por rajada de digitação, não por
+ * tecla (critério de aceite #397). Angular 22 trará `debounced()`; no 21.x o
+ * padrão oficial é a interop `toObservable → debounceTime → toSignal`.
+ */
+const BUSCA_DEBOUNCE_MS = 300;
 
 interface UnidadeForm {
   nome: FormControl<string>;
@@ -151,7 +170,7 @@ const BACKEND_FIELD_TO_CONTROL = {
         <div class="filter-bar__group">
           <span class="u-eyebrow">Tipo</span>
           <ui-filter-chips
-            [options]="tipoChips()"
+            [options]="tipoChips"
             [selected]="tipoFiltro()"
             (selectedChange)="tipoFiltro.set($event ?? '')"
             ariaLabel="Filtrar por tipo"
@@ -189,8 +208,8 @@ const BACKEND_FIELD_TO_CONTROL = {
         <div class="panel-head">
           <div class="panel-head__title">
             <h2 id="cfg-unidades-list-title">Unidades</h2>
-            <span class="list-count" aria-label="Total de unidades filtradas">
-              {{ unidadesFiltradas().length }}
+            <span class="list-count" aria-label="Total de unidades carregadas">
+              {{ unidades().length }}
             </span>
           </div>
           <button type="button" class="btn btn--primary" (click)="abrirCadastro()">
@@ -199,25 +218,7 @@ const BACKEND_FIELD_TO_CONTROL = {
           </button>
         </div>
 
-        @if (!loading() && unidades().length === 0 && !errorMessage()) {
-          <ui-empty-state
-            heading="Nenhuma unidade carregada"
-            description="Cadastre a primeira unidade para iniciar a estrutura institucional."
-          >
-            <button type="button" class="btn btn--primary" (click)="abrirCadastro()">
-              Nova unidade
-            </button>
-          </ui-empty-state>
-        } @else if (unidadesFiltradas().length === 0) {
-          <ui-empty-state
-            heading="Nenhuma unidade encontrada"
-            description="Ajuste a busca ou o filtro de tipo para ver resultados."
-          >
-            <button type="button" class="btn btn--secondary" (click)="limparFiltros()">
-              Limpar filtros
-            </button>
-          </ui-empty-state>
-        } @else {
+        @if (unidades().length > 0) {
           <div class="table-responsive">
             <table>
               <thead>
@@ -230,7 +231,7 @@ const BACKEND_FIELD_TO_CONTROL = {
                 </tr>
               </thead>
               <tbody>
-                @for (unidade of unidadesFiltradas(); track unidade.id) {
+                @for (unidade of unidades(); track unidade.id) {
                   <tr>
                     <td data-label="Sigla">
                       <code>{{ unidade.sigla }}</code>
@@ -274,6 +275,26 @@ const BACKEND_FIELD_TO_CONTROL = {
               </tbody>
             </table>
           </div>
+        } @else if (!loading() && !errorMessage()) {
+          @if (temFiltro()) {
+            <ui-empty-state
+              heading="Nenhuma unidade encontrada"
+              description="Ajuste a busca ou o filtro de tipo para ver resultados."
+            >
+              <button type="button" class="btn btn--secondary" (click)="limparFiltros()">
+                Limpar filtros
+              </button>
+            </ui-empty-state>
+          } @else {
+            <ui-empty-state
+              heading="Nenhuma unidade carregada"
+              description="Cadastre a primeira unidade para iniciar a estrutura institucional."
+            >
+              <button type="button" class="btn btn--primary" (click)="abrirCadastro()">
+                Nova unidade
+              </button>
+            </ui-empty-state>
+          }
         }
 
         @if (nextCursor()) {
@@ -592,12 +613,9 @@ export class UnidadesPage {
   private readonly problemI18n = inject(ProblemI18nService);
   private readonly notifications = inject(NotificationService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly basePath = inject(ORGANIZACAO_BASE_PATH);
 
-  protected readonly unidades = signal<readonly UnidadeDto[]>([]);
-  protected readonly nextCursor = signal<Cursor | null>(null);
-  protected readonly loading = signal(false);
   protected readonly saving = signal(false);
-  protected readonly errorMessage = signal<string | null>(null);
   protected readonly formError = signal<string | null>(null);
   protected readonly busca = signal('');
   protected readonly tipoFiltro = signal('');
@@ -611,6 +629,88 @@ export class UnidadesPage {
   protected readonly origemEmEdicao = signal<string | null>(null);
   protected readonly idempotencyKeyAtual = signal(idempotencyKey.create());
 
+  // Termo de busca aplicado — debounced (uma request por rajada, não por tecla).
+  private readonly buscaAplicada = toSignal(
+    toObservable(this.busca).pipe(
+      map((termo) => termo.trim()),
+      debounceTime(BUSCA_DEBOUNCE_MS),
+      distinctUntilChanged(),
+    ),
+    { initialValue: '' },
+  );
+
+  // Chave do filtro vigente — fonte do reset de paginação.
+  private readonly filtroKey = computed(() => JSON.stringify([this.buscaAplicada(), this.tipoFiltro()]));
+
+  /**
+   * Cursor da página atual (`undefined` = primeira). Volta para a primeira
+   * página sempre que o filtro muda (linkedSignal: `source` = `filtroKey`).
+   * "Carregar mais" faz `cursor.set(next)` — navegação só para frente, casando
+   * com o cursor forward-only do ADR-0026 (sem "Anterior", sem nº de página).
+   */
+  private readonly cursor = linkedSignal<string, Cursor | undefined>({
+    source: () => this.filtroKey(),
+    computation: () => undefined,
+  });
+
+  /**
+   * GET reativo de `/api/unidades`. Re-dispara quando filtro (`q`/`tipo`) ou
+   * `cursor` mudam; `httpResource` cancela a request anterior nativamente — sem
+   * `unsubscribe`/guarda manual. Vendor MIME `unidade v1` no HttpContext.
+   */
+  private readonly lista = useApiResource<readonly UnidadeDto[]>(() => ({
+    url: `${this.basePath}/api/unidades`,
+    params: this.montarParams(),
+    context: withVendorMime('unidade', 1),
+  }));
+
+  protected readonly loading = this.lista.isLoading;
+
+  /** Próximo cursor (rel="next" do header Link). `null` = última página. */
+  protected readonly nextCursor = computed(() =>
+    extractNextCursor(this.lista.headers()?.get('Link') ?? null),
+  );
+
+  /**
+   * Acumulação reativa das páginas ("Carregar mais"): substitui na primeira
+   * página (cursor `undefined` — cobre carga inicial, troca de filtro e refetch
+   * pós-mutação) e concatena nas seguintes. `linkedSignal` em vez de `effect`
+   * (guidance oficial Angular: `effect` não serve para atualizar outro signal).
+   */
+  protected readonly unidades = linkedSignal<
+    ApiResult<readonly UnidadeDto[]> | undefined,
+    readonly UnidadeDto[]
+  >({
+    source: () => this.lista.value(),
+    computation: (envelope, previous) => {
+      const acumulado = previous?.value ?? [];
+      // Loading inicial ou falha: preserva o que já está na tela (o banner de
+      // erro cobre a falha; não piscar a lista para vazio).
+      if (envelope === undefined || !envelope.ok) {
+        return acumulado;
+      }
+      // Lê o cursor no instante em que os dados chegam — `untracked` porque a
+      // única dependência reativa deste linkedSignal é `lista.value()`; rastrear
+      // o cursor reexecutaria a computação com dados velhos e duplicaria a página.
+      const primeiraPagina = untracked(() => this.cursor() === undefined);
+      return primeiraPagina ? [...envelope.data] : [...acumulado, ...envelope.data];
+    },
+  });
+
+  /** Mensagem de erro da listagem (RFC 9457 → título i18n). */
+  protected readonly errorMessage = computed<string | null>(() => {
+    const problem = this.lista.problem();
+    if (problem) {
+      return this.problemI18n.resolve(problem).title;
+    }
+    return this.lista.error() ? 'Erro inesperado ao carregar unidades.' : null;
+  });
+
+  /** Há filtro ativo? Distingue "sem unidades" de "filtro sem resultado". */
+  protected readonly temFiltro = computed(
+    () => this.buscaAplicada().length > 0 || this.tipoFiltro().length > 0,
+  );
+
   protected readonly tipoOptions = TIPOS_UNIDADE.map((tipo) => ({
     value: String(tipo.value),
     label: tipo.label,
@@ -620,43 +720,19 @@ export class UnidadesPage {
     label: origem.label,
   }));
 
-  protected readonly tiposDisponiveis = computed(() =>
-    [...new Set(this.unidades().map((unidade) => unidade.tipo))].sort((a, b) =>
-      a.localeCompare(b, 'pt-BR'),
-    ),
-  );
+  /**
+   * Chips de tipo a partir do roster fechado `TIPOS_UNIDADE` (11 tipos, valor
+   * numérico). Estático — não derivado da página: com filtro server-side a
+   * contagem por tipo exigiria facetas que o backend não expõe, então sem count.
+   */
+  protected readonly tipoChips: readonly UiFilterChipOption[] = [
+    { value: '', label: 'Todas' },
+    ...TIPOS_UNIDADE.map((tipo) => ({ value: String(tipo.value), label: tipo.label })),
+  ];
 
-  protected readonly tipoChips = computed<readonly UiFilterChipOption[]>(() => {
-    const unidades = this.unidades();
-    return [
-      {
-        value: '',
-        label: 'Todas',
-        count: unidades.length,
-      },
-      ...this.tiposDisponiveis().map((tipo) => ({
-        value: tipo,
-        label: tipo,
-        count: unidades.filter((u) => u.tipo === tipo).length,
-      })),
-    ];
-  });
-
-  protected readonly unidadesFiltradas = computed(() => {
-    const termo = normalizarBusca(this.busca());
-    const tipo = this.tipoFiltro();
-
-    return this.unidades().filter((unidade) => {
-      const bateBusca =
-        termo.length === 0 ||
-        normalizarBusca(
-          `${unidade.nome} ${unidade.sigla} ${unidade.codigo} ${unidade.slug} ${unidade.alias ?? ''}`,
-        ).includes(termo);
-      const bateTipo = tipo.length === 0 || unidade.tipo === tipo;
-      return bateBusca && bateTipo;
-    });
-  });
-
+  // A árvore reflete o conjunto carregado/filtrado. Com filtro ativo, nós cujo
+  // pai foi filtrado aparecem como raiz — comportamento documentado (#397): não
+  // há endpoint de hierarquia dedicado.
   protected readonly arvore = computed(() => montarArvore(this.unidades()));
   protected readonly formHeading = computed(() =>
     this.modo() === 'criar' ? 'Nova unidade' : 'Editar unidade',
@@ -710,14 +786,43 @@ export class UnidadesPage {
   );
 
   constructor() {
-    this.carregar(undefined, false);
+    // 5xx na listagem → toast persistente além do banner inline. Disparado só
+    // quando o problem muda (não duplica em re-render). 4xx fica só no banner.
+    effect(() => {
+      const problem = this.lista.problem();
+      if (problem && problem.status >= 500) {
+        const titulo = this.problemI18n.resolve(problem).title;
+        untracked(() => this.notifications.errorFromProblem(problem, { title: titulo }));
+      }
+    });
   }
 
   protected carregarMais(): void {
-    const cursor = this.nextCursor();
-    if (cursor !== null) {
-      this.carregar(cursor, true);
+    const proximo = this.nextCursor();
+    if (proximo !== null && !this.loading()) {
+      // Só avança (cursor forward-only). A acumulação fica a cargo do
+      // linkedSignal `unidades` quando a próxima página chega.
+      this.cursor.set(proximo);
     }
+  }
+
+  private montarParams(): HttpParams {
+    let params = new HttpParams().set('limit', String(PAGE_SIZE));
+    const q = this.buscaAplicada();
+    if (q.length > 0) {
+      params = params.set('q', q);
+    }
+    const tipo = this.tipoFiltro();
+    if (tipo.length > 0) {
+      // Valor numérico-como-string do roster TIPOS_UNIDADE; `tipo` é repetível
+      // no contrato (?tipo=3). Valor fora do roster → backend responde 400.
+      params = params.append('tipo', tipo);
+    }
+    const cursor = this.cursor();
+    if (cursor !== undefined) {
+      params = params.set('cursor', cursorToString(cursor));
+    }
+    return params;
   }
 
   protected abrirCadastro(): void {
@@ -876,35 +981,16 @@ export class UnidadesPage {
     this.tipoFiltro.set('');
   }
 
-  private carregar(cursor: Cursor | undefined, append: boolean): void {
-    if (this.loading()) {
-      return;
-    }
-    this.loading.set(true);
-    this.errorMessage.set(null);
-
-    this.api
-      .listar(cursor, 100)
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((result) => {
-        this.loading.set(false);
-        if (result.ok) {
-          this.unidades.set(append ? [...this.unidades(), ...result.data] : result.data);
-          this.nextCursor.set(extractNextCursor(result.headers.get('Link')));
-          return;
-        }
-        const mensagem = this.problemI18n.resolve(result.problem).title;
-        this.errorMessage.set(mensagem);
-        if (result.problem.status >= 500) {
-          this.notifications.errorFromProblem(result.problem, { title: mensagem });
-        }
-      });
-  }
-
   private recarregar(): void {
-    this.unidades.set([]);
-    this.nextCursor.set(null);
-    this.carregar(undefined, false);
+    // Pós-mutação: volta para a primeira página e refaz o fetch. Se já está na
+    // primeira (cursor undefined), `reload()` força o refetch (params iguais);
+    // senão, resetar o cursor dispara o refetch reativo pelo httpResource. Em
+    // ambos os casos o linkedSignal `unidades` substitui (não acumula).
+    if (this.cursor() === undefined) {
+      this.lista.reload();
+    } else {
+      this.cursor.set(undefined);
+    }
   }
 
   private handleSalvarResult(result: ApiResult<string | void>): void {
@@ -1016,14 +1102,6 @@ function ordenarArvore(nodes: readonly UnidadeTreeNode[]): readonly UnidadeTreeN
   return [...nodes]
     .sort((a, b) => a.unidade.nome.localeCompare(b.unidade.nome, 'pt-BR'))
     .map((node) => ({ ...node, children: ordenarArvore(node.children) }));
-}
-
-function normalizarBusca(value: string): string {
-  return value
-    .normalize('NFD')
-    .replace(/\p{Diacritic}/gu, '')
-    .toLocaleLowerCase('pt-BR')
-    .trim();
 }
 
 function nullIfBlank(value: string): string | null {

--- a/apps/configuracao/src/app/features/unidades/unidades.page.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.ts
@@ -788,14 +788,10 @@ export class UnidadesPage {
 
   /** Termo de busca do campo "unidade superior" (input do formulário). */
   protected readonly buscaPai = signal('');
-  private readonly buscaPaiAplicada = toSignal(
-    toObservable(this.buscaPai).pipe(
-      map((termo) => termo.trim()),
-      debounceTime(BUSCA_DEBOUNCE_MS),
-      distinctUntilChanged(),
-    ),
-    { initialValue: '' },
-  );
+  // Termo de pai aplicado: atualizado com debounce na digitação (subscription
+  // no constructor) e resetado de forma SÍNCRONA ao abrir o form — sem esperar
+  // o debounce, senão a reabertura dispararia `?q=<termo antigo>`.
+  private readonly buscaPaiAplicada = signal('');
 
   /**
    * Opções de "unidade superior" do formulário — desacopladas do filtro da
@@ -944,6 +940,16 @@ export class UnidadesPage {
         untracked(() => this.notifications.errorFromProblem(problem, { title: titulo }));
       }
     });
+
+    // Debounce da digitação no campo "unidade superior" → termo aplicado.
+    toObservable(this.buscaPai)
+      .pipe(
+        map((termo) => termo.trim()),
+        debounceTime(BUSCA_DEBOUNCE_MS),
+        distinctUntilChanged(),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe((termo) => this.buscaPaiAplicada.set(termo));
   }
 
   protected carregarMais(): void {
@@ -987,11 +993,19 @@ export class UnidadesPage {
   // primeira vez ativa o resource (dispara o GET sem filtro); nas reaberturas
   // refaz a busca para incluir unidades criadas desde então.
   private prepararOpcoesSuperior(): void {
+    const tinhaTermo = this.buscaPaiAplicada().length > 0;
+    // Reset síncrono do termo (exibido e aplicado), para a reabertura não
+    // carregar com `q` da busca anterior enquanto o debounce não zera.
     this.buscaPai.set('');
-    if (this.carregarOpcoesSuperior()) {
+    this.buscaPaiAplicada.set('');
+
+    if (!this.carregarOpcoesSuperior()) {
+      this.carregarOpcoesSuperior.set(true); // primeira vez: ativa e dispara o GET
+    } else if (!tinhaTermo) {
+      // Sem termo anterior, o reset não muda params; força o refetch para
+      // refletir unidades recém-criadas. Com termo, o reset de `buscaPaiAplicada`
+      // já dispara o refetch (remove o `q`), sem duplicar a request.
       this.opcoesSuperiorResource.reload();
-    } else {
-      this.carregarOpcoesSuperior.set(true);
     }
   }
 

--- a/apps/configuracao/src/app/features/unidades/unidades.page.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.ts
@@ -250,6 +250,7 @@ const BACKEND_FIELD_TO_CONTROL = {
                       <button
                         type="button"
                         class="cfg-link-button table-responsive__primary"
+                        [disabled]="recarregandoLista()"
                         (click)="abrirDetalhe(unidade)"
                       >
                         {{ unidade.nome }}
@@ -331,7 +332,12 @@ const BACKEND_FIELD_TO_CONTROL = {
           <span class="unit-node__icon" aria-hidden="true">
             <i class="pi pi-sitemap"></i>
           </span>
-          <button type="button" class="unit-node__name" (click)="abrirDetalhe(node.unidade)">
+          <button
+            type="button"
+            class="unit-node__name"
+            [disabled]="recarregandoLista()"
+            (click)="abrirDetalhe(node.unidade)"
+          >
             {{ node.unidade.sigla }}
           </button>
           <span class="unit-node__type">{{ node.unidade.nome }}</span>
@@ -389,10 +395,20 @@ const BACKEND_FIELD_TO_CONTROL = {
           <dd>{{ vigenciaLabel(unidade) }}</dd>
         </dl>
         <div class="cfg-drawer-actions">
-          <button type="button" class="btn btn--tertiary btn--rect" (click)="abrirEdicao(unidade)">
+          <button
+            type="button"
+            class="btn btn--tertiary btn--rect"
+            [disabled]="recarregandoLista()"
+            (click)="abrirEdicao(unidade)"
+          >
             Editar
           </button>
-          <button type="button" class="btn btn--danger btn--rect" (click)="pedirRemocao(unidade)">
+          <button
+            type="button"
+            class="btn btn--danger btn--rect"
+            [disabled]="recarregandoLista()"
+            (click)="pedirRemocao(unidade)"
+          >
             Remover
           </button>
         </div>

--- a/apps/configuracao/src/app/features/unidades/unidades.page.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.ts
@@ -541,6 +541,18 @@ const BACKEND_FIELD_TO_CONTROL = {
               <span class="field__hint">
                 Digite para buscar entre todas as unidades. Não pode formar ciclo na hierarquia.
               </span>
+              @if (opcoesSuperiorComErro()) {
+                <span class="field__error">
+                  Não foi possível carregar as unidades para seleção.
+                  <button
+                    type="button"
+                    class="cfg-link-button"
+                    (click)="recarregarOpcoesSuperior()"
+                  >
+                    Tentar novamente
+                  </button>
+                </span>
+              }
             </div>
             <label class="checkbox cfg-form__checkbox">
               <input type="checkbox" formControlName="unidadeAcademica" />
@@ -708,15 +720,20 @@ export class UnidadesPage {
     source: () => this.lista.value(),
     computation: (envelope, previous) => {
       const acumulado = previous?.value ?? [];
-      // Loading inicial ou falha: preserva o que já está na tela (o banner de
-      // erro cobre a falha; não piscar a lista para vazio).
-      if (envelope === undefined || !envelope.ok) {
+      // Sem resposta ainda (loading/reload): preserva para não piscar a lista.
+      if (envelope === undefined) {
         return acumulado;
       }
       // Lê o cursor no instante em que os dados chegam — `untracked` porque a
       // única dependência reativa deste linkedSignal é `lista.value()`; rastrear
       // o cursor reexecutaria a computação com dados velhos e duplicaria a página.
       const primeiraPagina = untracked(() => this.cursor() === undefined);
+      if (!envelope.ok) {
+        // Falha numa página seguinte preserva o acumulado (não perde o que já
+        // foi carregado); falha na primeira página limpa — após refetch
+        // pós-mutação a lista anterior está desatualizada (ex.: linha removida).
+        return primeiraPagina ? [] : acumulado;
+      }
       return primeiraPagina ? [...envelope.data] : [...acumulado, ...envelope.data];
     },
   });
@@ -775,6 +792,19 @@ export class UnidadesPage {
   protected readonly opcoesUnidadeSuperior = computed(
     () => this.opcoesSuperiorResource.data() ?? [],
   );
+  /**
+   * Falha ao carregar as opções de pai — diferencia "sem opções" de "não
+   * carregou". Sem isso, um 5xx transitório no lookup deixaria o select só com
+   * "Raiz" e o usuário submeteria pai em branco sem saber da falha. Não bloqueia
+   * o submit (pai é opcional), mas sinaliza com retry.
+   */
+  protected readonly opcoesSuperiorComErro = computed(() => {
+    const envelope = this.opcoesSuperiorResource.value();
+    return (
+      (envelope !== undefined && !envelope.ok) ||
+      this.opcoesSuperiorResource.error() !== undefined
+    );
+  });
 
   protected readonly tipoOptions = TIPOS_UNIDADE.map((tipo) => ({
     value: String(tipo.value),
@@ -909,6 +939,10 @@ export class UnidadesPage {
     } else {
       this.carregarOpcoesSuperior.set(true);
     }
+  }
+
+  protected recarregarOpcoesSuperior(): void {
+    this.opcoesSuperiorResource.reload();
   }
 
   protected abrirCadastro(): void {

--- a/libs/shared-data/openapi/organizacao.openapi.json
+++ b/libs/shared-data/openapi/organizacao.openapi.json
@@ -162,230 +162,6 @@
         }
       }
     },
-    "/api/areas-organizacionais": {
-      "get": {
-        "tags": [
-          "AreasOrganizacionais"
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AreaOrganizacionalDto"
-                  }
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AreaOrganizacionalDto"
-                  }
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AreaOrganizacionalDto"
-                  }
-                }
-              }
-            }
-          },
-          "406": {
-            "description": "Not Acceptable",
-            "content": {
-              "application/problem\u002Bjson": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/areas-organizacionais/{codigo}": {
-      "get": {
-        "tags": [
-          "AreasOrganizacionais"
-        ],
-        "parameters": [
-          {
-            "name": "codigo",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/AreaOrganizacionalDto"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AreaOrganizacionalDto"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AreaOrganizacionalDto"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/problem\u002Bjson": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "406": {
-            "description": "Not Acceptable",
-            "content": {
-              "application/problem\u002Bjson": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/admin/areas-organizacionais": {
-      "post": {
-        "tags": [
-          "AreasOrganizacionais"
-        ],
-        "parameters": [
-          {
-            "name": "Idempotency-Key",
-            "in": "header",
-            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
-            "required": true,
-            "schema": {
-              "maxLength": 255,
-              "minLength": 1,
-              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CriarAreaOrganizacionalCommand"
-              }
-            },
-            "text/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CriarAreaOrganizacionalCommand"
-              }
-            },
-            "application/*\u002Bjson": {
-              "schema": {
-                "$ref": "#/components/schemas/CriarAreaOrganizacionalCommand"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string",
-                  "format": "uuid"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "type": "string",
-                  "format": "uuid"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "type": "string",
-                  "format": "uuid"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/problem\u002Bjson": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem\u002Bjson": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem\u002Bjson": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict",
-            "content": {
-              "application/problem\u002Bjson": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/problem\u002Bjson": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        },
-        "x-uniplus-idempotent": true
-      }
-    },
     "/api/instituicao": {
       "get": {
         "tags": [
@@ -715,6 +491,28 @@
           "Unidades"
         ],
         "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tipo",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "pattern": "^-?(?:0|[1-9]\\d*)$",
+                "type": [
+                  "integer",
+                  "string"
+                ],
+                "format": "int32"
+              }
+            }
+          },
           {
             "name": "cursor",
             "in": "query",
@@ -1179,52 +977,6 @@
   },
   "components": {
     "schemas": {
-      "AreaOrganizacionalDto": {
-        "required": [
-          "id",
-          "codigo",
-          "nome",
-          "tipo",
-          "descricao",
-          "adrReferenceCode",
-          "criadoEm"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "codigo": {
-            "type": "string"
-          },
-          "nome": {
-            "type": "string"
-          },
-          "tipo": {
-            "type": "string"
-          },
-          "descricao": {
-            "type": "string"
-          },
-          "adrReferenceCode": {
-            "type": "string"
-          },
-          "criadoEm": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "_links": {
-            "type": [
-              "null",
-              "object"
-            ],
-            "additionalProperties": {
-              "type": "string"
-            }
-          }
-        }
-      },
       "AtualizarInstituicaoCommand": {
         "required": [
           "id",
@@ -1444,33 +1196,6 @@
           "timestamp": {
             "type": "string",
             "format": "date-time"
-          }
-        }
-      },
-      "CriarAreaOrganizacionalCommand": {
-        "required": [
-          "codigo",
-          "nome",
-          "tipo",
-          "descricao",
-          "adrReferenceCode"
-        ],
-        "type": "object",
-        "properties": {
-          "codigo": {
-            "type": "string"
-          },
-          "nome": {
-            "type": "string"
-          },
-          "tipo": {
-            "$ref": "#/components/schemas/TipoAreaOrganizacional"
-          },
-          "descricao": {
-            "type": "string"
-          },
-          "adrReferenceCode": {
-            "type": "string"
           }
         }
       },
@@ -1825,9 +1550,6 @@
           }
         }
       },
-      "TipoAreaOrganizacional": {
-        "type": "integer"
-      },
       "TipoUnidade": {
         "type": "integer"
       },
@@ -1980,9 +1702,6 @@
     },
     {
       "name": "_smoke"
-    },
-    {
-      "name": "AreasOrganizacionais"
     },
     {
       "name": "Instituicao"

--- a/libs/shared-data/src/lib/api/organizacao/schema.ts
+++ b/libs/shared-data/src/lib/api/organizacao/schema.ts
@@ -104,200 +104,6 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
-    readonly "/api/areas-organizacionais": {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path?: never;
-            readonly cookie?: never;
-        };
-        readonly get: {
-            readonly parameters: {
-                readonly query?: never;
-                readonly header?: never;
-                readonly path?: never;
-                readonly cookie?: never;
-            };
-            readonly requestBody?: never;
-            readonly responses: {
-                /** @description OK */
-                readonly 200: {
-                    headers: {
-                        readonly [name: string]: unknown;
-                    };
-                    content: {
-                        readonly "text/plain": readonly components["schemas"]["AreaOrganizacionalDto"][];
-                        readonly "application/json": readonly components["schemas"]["AreaOrganizacionalDto"][];
-                        readonly "text/json": readonly components["schemas"]["AreaOrganizacionalDto"][];
-                    };
-                };
-                /** @description Not Acceptable */
-                readonly 406: {
-                    headers: {
-                        readonly [name: string]: unknown;
-                    };
-                    content: {
-                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
-                    };
-                };
-            };
-        };
-        readonly put?: never;
-        readonly post?: never;
-        readonly delete?: never;
-        readonly options?: never;
-        readonly head?: never;
-        readonly patch?: never;
-        readonly trace?: never;
-    };
-    readonly "/api/areas-organizacionais/{codigo}": {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path?: never;
-            readonly cookie?: never;
-        };
-        readonly get: {
-            readonly parameters: {
-                readonly query?: never;
-                readonly header?: never;
-                readonly path: {
-                    readonly codigo: string;
-                };
-                readonly cookie?: never;
-            };
-            readonly requestBody?: never;
-            readonly responses: {
-                /** @description OK */
-                readonly 200: {
-                    headers: {
-                        readonly [name: string]: unknown;
-                    };
-                    content: {
-                        readonly "text/plain": components["schemas"]["AreaOrganizacionalDto"];
-                        readonly "application/json": components["schemas"]["AreaOrganizacionalDto"];
-                        readonly "text/json": components["schemas"]["AreaOrganizacionalDto"];
-                    };
-                };
-                /** @description Not Found */
-                readonly 404: {
-                    headers: {
-                        readonly [name: string]: unknown;
-                    };
-                    content: {
-                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
-                    };
-                };
-                /** @description Not Acceptable */
-                readonly 406: {
-                    headers: {
-                        readonly [name: string]: unknown;
-                    };
-                    content: {
-                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
-                    };
-                };
-            };
-        };
-        readonly put?: never;
-        readonly post?: never;
-        readonly delete?: never;
-        readonly options?: never;
-        readonly head?: never;
-        readonly patch?: never;
-        readonly trace?: never;
-    };
-    readonly "/api/admin/areas-organizacionais": {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path?: never;
-            readonly cookie?: never;
-        };
-        readonly get?: never;
-        readonly put?: never;
-        readonly post: {
-            readonly parameters: {
-                readonly query?: never;
-                readonly header: {
-                    /** @description Chave opaca (1-255 ASCII printable, sem ',' ou ';') para retry seguro do comando. Replay com mesma key + mesmo body retorna response cacheada (ADR-0027). */
-                    readonly "Idempotency-Key": string;
-                };
-                readonly path?: never;
-                readonly cookie?: never;
-            };
-            readonly requestBody: {
-                readonly content: {
-                    readonly "application/json": components["schemas"]["CriarAreaOrganizacionalCommand"];
-                    readonly "text/json": components["schemas"]["CriarAreaOrganizacionalCommand"];
-                    readonly "application/*+json": components["schemas"]["CriarAreaOrganizacionalCommand"];
-                };
-            };
-            readonly responses: {
-                /** @description Created */
-                readonly 201: {
-                    headers: {
-                        readonly [name: string]: unknown;
-                    };
-                    content: {
-                        readonly "text/plain": string;
-                        readonly "application/json": string;
-                        readonly "text/json": string;
-                    };
-                };
-                /** @description Bad Request */
-                readonly 400: {
-                    headers: {
-                        readonly [name: string]: unknown;
-                    };
-                    content: {
-                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
-                    };
-                };
-                /** @description Unauthorized */
-                readonly 401: {
-                    headers: {
-                        readonly [name: string]: unknown;
-                    };
-                    content: {
-                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
-                    };
-                };
-                /** @description Forbidden */
-                readonly 403: {
-                    headers: {
-                        readonly [name: string]: unknown;
-                    };
-                    content: {
-                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
-                    };
-                };
-                /** @description Conflict */
-                readonly 409: {
-                    headers: {
-                        readonly [name: string]: unknown;
-                    };
-                    content: {
-                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
-                    };
-                };
-                /** @description Unprocessable Entity */
-                readonly 422: {
-                    headers: {
-                        readonly [name: string]: unknown;
-                    };
-                    content: {
-                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
-                    };
-                };
-            };
-        };
-        readonly delete?: never;
-        readonly options?: never;
-        readonly head?: never;
-        readonly patch?: never;
-        readonly trace?: never;
-    };
     readonly "/api/instituicao": {
         readonly parameters: {
             readonly query?: never;
@@ -589,6 +395,8 @@ export interface paths {
         readonly get: {
             readonly parameters: {
                 readonly query?: {
+                    readonly q?: string;
+                    readonly tipo?: readonly (number | string)[];
                     /** @description Cursor opaco AES-GCM emitido pelo servidor no header Link da página anterior. Ausente na primeira página. Cliente trata como string opaca — não decodificar (ADR-0026, ADR-0031). */
                     readonly cursor?: string;
                     /** @description Tamanho máximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026). */
@@ -966,20 +774,6 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
-        readonly AreaOrganizacionalDto: {
-            /** Format: uuid */
-            readonly id: string;
-            readonly codigo: string;
-            readonly nome: string;
-            readonly tipo: string;
-            readonly descricao: string;
-            readonly adrReferenceCode: string;
-            /** Format: date-time */
-            readonly criadoEm: string;
-            readonly _links?: null | {
-                readonly [key: string]: string;
-            };
-        };
         readonly AtualizarInstituicaoCommand: {
             /** Format: uuid */
             readonly id: string;
@@ -1025,13 +819,6 @@ export interface components {
             readonly roles: readonly string[];
             /** Format: date-time */
             readonly timestamp: string;
-        };
-        readonly CriarAreaOrganizacionalCommand: {
-            readonly codigo: string;
-            readonly nome: string;
-            readonly tipo: components["schemas"]["TipoAreaOrganizacional"];
-            readonly descricao: string;
-            readonly adrReferenceCode: string;
         };
         readonly CriarInstituicaoCommand: {
             readonly codigoEmec: string;
@@ -1107,7 +894,6 @@ export interface components {
             readonly detail?: null | string;
             readonly instance?: null | string;
         };
-        readonly TipoAreaOrganizacional: number;
         readonly TipoUnidade: number;
         readonly UnidadeDto: {
             /** Format: uuid */

--- a/libs/shared-data/src/lib/api/organizacao/unidades.api.spec.ts
+++ b/libs/shared-data/src/lib/api/organizacao/unidades.api.spec.ts
@@ -7,7 +7,6 @@ import {
   ApiResult,
   apiResultInterceptor,
   buildVendorMimeAccept,
-  createCursor,
   isApiOk,
   withIdempotencyKey,
 } from '@uniplus/shared-core/http';
@@ -84,38 +83,6 @@ describe('UnidadesApi', () => {
   });
 
   afterEach(() => controller.verify());
-
-  it('listar() faz GET /api/unidades com vendor MIME v1', async () => {
-    const promise = firstValueFrom(api.listar());
-
-    const req = controller.expectOne(
-      (request) => request.url === `${BASE}/api/unidades` && request.params.keys().length === 0,
-    );
-    expect(req.request.method).toBe('GET');
-    expect(req.request.headers.get('Accept')).toBe(buildVendorMimeAccept('unidade', 1));
-    req.flush([unidadeSeed]);
-
-    const result = (await promise) as ApiResult<readonly UnidadeDto[]>;
-    expect(isApiOk(result)).toBe(true);
-    if (result.ok) {
-      expect(result.data[0].sigla).toBe('IEDAR');
-    }
-  });
-
-  it('listar(cursor, limit) serializa cursor opaco e limit', async () => {
-    const cursor = createCursor('opaque-next-page');
-    const promise = firstValueFrom(api.listar(cursor, 50));
-
-    const req = controller.expectOne(
-      (request) => request.url === `${BASE}/api/unidades` && request.params.has('cursor'),
-    );
-    expect(req.request.params.get('cursor')).toBe('opaque-next-page');
-    expect(req.request.params.get('limit')).toBe('50');
-    expect(req.request.headers.get('Accept')).toBe(buildVendorMimeAccept('unidade', 1));
-    req.flush([]);
-
-    await promise;
-  });
 
   it('obter() faz GET /api/unidades/{id} com encoding seguro', async () => {
     const id = 'id com espaço/01';

--- a/libs/shared-data/src/lib/api/organizacao/unidades.api.ts
+++ b/libs/shared-data/src/lib/api/organizacao/unidades.api.ts
@@ -1,7 +1,7 @@
-import { HttpClient, HttpContext, HttpHeaders, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpContext, HttpHeaders } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
-import { ApiResult, Cursor, cursorToString, withVendorMime } from '@uniplus/shared-core/http';
+import { ApiResult, withVendorMime } from '@uniplus/shared-core/http';
 import type { components } from './schema';
 import { ORGANIZACAO_BASE_PATH } from './tokens';
 
@@ -45,21 +45,6 @@ export const ORIGENS_UNIDADE: readonly UnidadeOrigemOption[] = [
 export class UnidadesApi {
   private readonly http = inject(HttpClient);
   private readonly basePath = inject(ORGANIZACAO_BASE_PATH);
-
-  listar(cursor?: Cursor, limit?: number): Observable<ApiResult<readonly UnidadeDto[]>> {
-    let params = new HttpParams();
-    if (cursor !== undefined) {
-      params = params.set('cursor', cursorToString(cursor));
-    }
-    if (limit !== undefined) {
-      params = params.set('limit', String(limit));
-    }
-
-    return this.http.get<ApiResult<readonly UnidadeDto[]>>(`${this.basePath}/api/unidades`, {
-      context: withVendorMime('unidade', 1),
-      params,
-    });
-  }
 
   obter(id: string): Observable<ApiResult<UnidadeDto>> {
     return this.http.get<ApiResult<UnidadeDto>>(


### PR DESCRIPTION
## Contexto

A tela de Unidade (story #385, PR #396) filtrava **no cliente**: busca textual, chips de tipo e a árvore hierárquica operavam apenas sobre a página carregada (`limit=100`, append cumulativo). Com mais de uma página, busca/filtro não enxergavam o que não estava carregado. O backend **uniplus-api#640** (mergeado) passou a expor `q` e `tipo` no `GET /api/unidades`.

Closes #397

## Decisão de arquitetura (pesquisa-backed)

O cursor do **ADR-0026 é forward-only** (só `next` no header `Link`, sem `prevCursor`, sem total). A literatura de cursor/keyset pagination e a documentação do Angular moderno convergem:

- **UX correta para cursor forward-only = acumulação ("Carregar mais")**, não prev/next. Fabricar "Anterior" com pilha de cursores no cliente seria anti-padrão (exigiria `prevCursor` no backend).
- **Padrão idiomático Angular 21 = `httpResource` + `linkedSignal`**: cancelamento de request stale nativo (sem `unsubscribe`/guarda manual) + acumulação que reseta na troca de filtro. `effect` não serve para atualizar signal (guidance oficial) → `linkedSignal`.

## O que muda

- **`httpResource`** (via `useApiResource`, ADR-0018) com params reativos `q`/`tipo`/`cursor`. O fitness `no-direct-http-in-pages` permanece verde.
- **`linkedSignal`** acumula as páginas e substitui na primeira (cursor `undefined`); troca de filtro reseta para a primeira página.
- **Busca com debounce** (`toObservable → debounceTime(300) → toSignal`): uma request por rajada, não por tecla.
- **Chips de tipo** do roster fechado `TIPOS_UNIDADE` (valor numérico, sem contagem — server-side não expõe facetas).
- Remove `UnidadesApi.listar` (a página consome o GET via `useApiResource`).
- **Baseline OpenAPI ressincronizado** com a main da API (traz `q`/`tipo`; remove, de quebra, os paths/schemas mortos de `areas-organizacionais`, sem consumidores).

## Critérios de aceite

- [x] Busca e filtro de tipo disparam requisição ao backend com os params corretos (`q`, `tipo` numérico).
- [x] Resultado independe de quantas páginas foram carregadas (acumulação reseta na troca de filtro).
- [x] Busca com debounce (sem requisição a cada tecla).
- [x] Sem regressão de acessibilidade na filter-bar/chips (e2e visual ajustado).

## Limitação documentada

A árvore reflete o conjunto filtrado; nós cujo pai foi filtrado aparecem como raiz — não há endpoint de hierarquia dedicado (escopo de #397 permite documentar).

## Validação local

- `nx vite:test configuracao` — 14 testes da página (inclui filtro server-side, debounce, acumulação forward, reset na troca de filtro).
- `nx vite:test shared-data` — 100 testes (api spec ajustado).
- `nx affected --target=vite:test` — 5 projetos verdes.
- `nx lint` (configuracao, shared-data, configuracao-e2e) + `nx build configuracao` (AOT) + typecheck e2e — limpos.
- E2e visual: mock ajustado para filtrar server-side; não roda local (depende de Keycloak/auth-setup), validado no CI.