### PR TITLE
feat(web): adota navegação prev/next nas listas paginadas

### DIFF
--- a/apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
@@ -175,41 +175,73 @@ describe('UnidadesPage', () => {
     expect(component['unidades']()[0].tipo).toBe('Instituto');
   });
 
-  it('Carregar mais acumula a próxima página (cursor forward-only)', async () => {
+  it('navega Próximo/Anterior por substituição, com direction casado e sem limit (ADR-0089)', async () => {
     await flushInicial([unidadesSeed[0]], {
-      Link: `<${BASE}/api/unidades?cursor=pagina-2>; rel="next"`,
+      Link: `<${BASE}/api/unidades?cursor=pagina-2&direction=next>; rel="next"`,
     });
 
     expect(component['unidades']()).toHaveLength(1);
     expect(component['nextCursor']()).not.toBeNull();
+    expect(component['prevCursor']()).toBeNull();
 
-    component['carregarMais']();
+    // Próximo: envia cursor + direction=next, sem limit; substitui a lista.
+    component['proximaPagina']();
     await propagate();
 
-    const request = expectListGet((r) => r.params.get('cursor') === 'pagina-2');
-    request.flush([unidadesSeed[1]]); // sem Link → última página
+    const reqNext = expectListGet(
+      (r) =>
+        r.params.get('cursor') === 'pagina-2' &&
+        r.params.get('direction') === 'next' &&
+        !r.params.has('limit'),
+    );
+    reqNext.flush([unidadesSeed[1]], {
+      headers: { Link: `<${BASE}/api/unidades?cursor=pagina-1&direction=prev>; rel="prev"` },
+    });
     await propagate();
 
-    expect(component['unidades']()).toHaveLength(2);
-    expect(component['unidades']().map((u) => u.id)).toEqual([REITORIA_ID, INSTITUTO_ID]);
+    // Substituição: a página 2 troca a 1 (1 item, não 2).
+    expect(component['unidades']()).toHaveLength(1);
+    expect(component['unidades']()[0].id).toBe(INSTITUTO_ID);
+    expect(component['prevCursor']()).not.toBeNull();
     expect(component['nextCursor']()).toBeNull();
+
+    // Anterior: envia cursor + direction=prev, sem limit; substitui de volta.
+    component['paginaAnterior']();
+    await propagate();
+
+    const reqPrev = expectListGet(
+      (r) =>
+        r.params.get('cursor') === 'pagina-1' &&
+        r.params.get('direction') === 'prev' &&
+        !r.params.has('limit'),
+    );
+    reqPrev.flush([unidadesSeed[0]]);
+    await propagate();
+
+    expect(component['unidades']()).toHaveLength(1);
+    expect(component['unidades']()[0].id).toBe(REITORIA_ID);
   });
 
   it('mudar o filtro reseta a paginação para a primeira página e substitui a lista', async () => {
     await flushInicial([unidadesSeed[0]], {
-      Link: `<${BASE}/api/unidades?cursor=pagina-2>; rel="next"`,
+      Link: `<${BASE}/api/unidades?cursor=pagina-2&direction=next>; rel="next"`,
     });
-    component['carregarMais']();
+    component['proximaPagina']();
     await propagate();
     expectListGet((r) => r.params.get('cursor') === 'pagina-2').flush([unidadesSeed[1]]);
     await propagate();
-    expect(component['unidades']()).toHaveLength(2);
+    expect(component['unidades']()).toHaveLength(1);
+    expect(component['unidades']()[0].id).toBe(INSTITUTO_ID);
 
-    // Aplicar tipo volta à primeira página (sem cursor) e substitui, não acumula.
+    // Aplicar tipo volta à primeira página (sem cursor, com limit) e substitui.
     component['tipoFiltro'].set('1'); // Reitoria
     await propagate();
     const request = expectListGet(
-      (r) => r.params.get('tipo') === '1' && !r.params.has('cursor'),
+      (r) =>
+        r.params.get('tipo') === '1' &&
+        !r.params.has('cursor') &&
+        !r.params.has('direction') &&
+        r.params.get('limit') === '100',
     );
     request.flush([unidadesSeed[0]]);
     await propagate();
@@ -561,13 +593,13 @@ describe('UnidadesPage', () => {
     expect(component['opcoesUnidadeSuperior']().map((u) => u.id)).toEqual([INSTITUTO_ID]);
   });
 
-  it('permite tentar novamente quando uma página falha, sem perder o que já foi carregado', async () => {
+  it('permite tentar novamente quando a navegação falha, preservando a página atual', async () => {
     await flushInicial([unidadesSeed[0]], {
-      Link: `<${BASE}/api/unidades?cursor=pagina-2>; rel="next"`,
+      Link: `<${BASE}/api/unidades?cursor=pagina-2&direction=next>; rel="next"`,
     });
     expect(component['unidades']()).toHaveLength(1);
 
-    component['carregarMais']();
+    component['proximaPagina']();
     await propagate();
     expectListGet((r) => r.params.get('cursor') === 'pagina-2').flush(
       { type: 'about:blank', title: 'Erro interno', status: 500, code: 'uniplus.erro', traceId: 'x' },
@@ -579,7 +611,7 @@ describe('UnidadesPage', () => {
     );
     await propagate();
 
-    expect(component['unidades']()).toHaveLength(1); // mantém a página já carregada
+    expect(component['unidades']()).toHaveLength(1); // preserva a página atual
     expect(component['errorMessage']()).not.toBeNull();
 
     component['tentarNovamente']();
@@ -588,7 +620,9 @@ describe('UnidadesPage', () => {
     retry.flush([unidadesSeed[1]]);
     await propagate();
 
-    expect(component['unidades']()).toHaveLength(2); // acumulou após o retry
+    // Substitui a lista pela página recém-carregada (sem acumular).
+    expect(component['unidades']()).toHaveLength(1);
+    expect(component['unidades']()[0].id).toBe(INSTITUTO_ID);
     expect(component['errorMessage']()).toBeNull();
   });
 

--- a/apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
@@ -613,6 +613,9 @@ describe('UnidadesPage', () => {
 
     expect(component['unidades']()).toHaveLength(1); // preserva a página atual
     expect(component['errorMessage']()).not.toBeNull();
+    // Cursores preservados na falha (resposta de erro não traz Link): o pager
+    // não some, o usuário continua podendo navegar a partir da página exibida.
+    expect(component['nextCursor']()).toBe('pagina-2');
 
     component['tentarNovamente']();
     await propagate();

--- a/apps/configuracao/src/app/features/unidades/unidades.page.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.ts
@@ -737,15 +737,42 @@ export class UnidadesPage {
    */
   protected readonly recarregandoLista = computed(() => this.loading());
 
+  /**
+   * Cursores de navegação (prev/next) da página em exibição. `linkedSignal` em
+   * vez de `computed(headers())` para **preservar** os cursores quando uma
+   * navegação falha: em erro o `apiResultInterceptor` devolve os headers da
+   * resposta de erro (sem `Link`), então ler `headers()` direto zeraria o pager
+   * — o usuário perderia prev/next enquanto `unidades` ainda mostra a página
+   * preservada. Espelha o `unidades`: sucesso extrai do `Link`; erro na 1ª
+   * página zera (a lista também é limpa); erro em navegação ou loading preserva.
+   */
+  private readonly cursores = linkedSignal<
+    ApiResult<readonly UnidadeDto[]> | undefined,
+    { readonly prev: Cursor | null; readonly next: Cursor | null }
+  >({
+    source: () => this.lista.value(),
+    computation: (envelope, previous) => {
+      const atual = previous?.value ?? { prev: null, next: null };
+      // Sem resposta ainda (loading/reload): preserva para não piscar o pager.
+      if (envelope === undefined) {
+        return atual;
+      }
+      const primeiraPagina = untracked(() => this.pagina() === undefined);
+      if (!envelope.ok) {
+        // Erro na 1ª página zera (a lista é limpa); erro em navegação preserva
+        // os cursores da página atual para o usuário continuar navegando.
+        return primeiraPagina ? { prev: null, next: null } : atual;
+      }
+      const link = untracked(() => this.lista.headers()?.get('Link') ?? null);
+      return { prev: extractPrevCursor(link), next: extractNextCursor(link) };
+    },
+  });
+
   /** Cursor da página anterior (rel="prev" do header Link). `null` = primeira página. */
-  protected readonly prevCursor = computed(() =>
-    extractPrevCursor(this.lista.headers()?.get('Link') ?? null),
-  );
+  protected readonly prevCursor = computed(() => this.cursores().prev);
 
   /** Próximo cursor (rel="next" do header Link). `null` = última página. */
-  protected readonly nextCursor = computed(() =>
-    extractNextCursor(this.lista.headers()?.get('Link') ?? null),
-  );
+  protected readonly nextCursor = computed(() => this.cursores().next);
 
   /**
    * Lista reativa por **substituição** (navegação prev/next, ADR-0089): cada

--- a/apps/configuracao/src/app/features/unidades/unidades.page.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.ts
@@ -17,11 +17,13 @@ import { debounceTime, distinctUntilChanged, map } from 'rxjs';
 import {
   ApiResult,
   Cursor,
+  PaginationDirection,
   ProblemDetails,
   ProblemI18nService,
   ProblemValidationError,
   cursorToString,
   extractNextCursor,
+  extractPrevCursor,
   idempotencyKey,
   useApiResource,
   withIdempotencyKey,
@@ -45,6 +47,7 @@ import {
   DrawerComponent,
   EmptyStateComponent,
   FilterChipsComponent,
+  PagerComponent,
   SpinnerComponent,
   type UiFilterChipOption,
 } from '@uniplus/shared-ui/components';
@@ -112,6 +115,7 @@ const BACKEND_FIELD_TO_CONTROL = {
     EmptyStateComponent,
     FilterChipsComponent,
     NgTemplateOutlet,
+    PagerComponent,
     SpinnerComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -310,18 +314,16 @@ const BACKEND_FIELD_TO_CONTROL = {
           }
         }
 
-        @if (nextCursor()) {
-          <nav class="pager" aria-label="Carregar mais unidades">
-            <button
-              class="btn btn--secondary"
-              type="button"
-              [disabled]="loading()"
-              (click)="carregarMais()"
-            >
-              Carregar mais
-              <i class="pi pi-angle-down btn__icon" aria-hidden="true"></i>
-            </button>
-          </nav>
+        @if (prevCursor() !== null || nextCursor() !== null) {
+          <ui-pager
+            statusText="Navegação por páginas"
+            navigationLabel="Paginação de unidades"
+            [hasPrevious]="prevCursor() !== null"
+            [hasNext]="nextCursor() !== null"
+            [isDisabled]="loading()"
+            (previous)="paginaAnterior()"
+            (next)="proximaPagina()"
+          />
         }
       </section>
     </div>
@@ -698,12 +700,17 @@ export class UnidadesPage {
   private readonly filtroKey = computed(() => JSON.stringify([this.buscaAplicada(), this.tipoFiltro()]));
 
   /**
-   * Cursor da página atual (`undefined` = primeira). Volta para a primeira
-   * página sempre que o filtro muda (linkedSignal: `source` = `filtroKey`).
-   * "Carregar mais" faz `cursor.set(next)` — navegação só para frente, casando
-   * com o cursor forward-only do ADR-0026 (sem "Anterior", sem nº de página).
+   * Página de navegação atual (`undefined` = primeira). Volta para a primeira
+   * sempre que o filtro muda (linkedSignal: `source` = `filtroKey`). "Anterior"/
+   * "Próximo" fazem `pagina.set({ cursor, direction })` com o cursor opaco do
+   * header `Link` e a direção casada (`'prev'`/`'next'`) — navegação por
+   * substituição sobre o cursor bidirecional (ADR-0089 do `uniplus-api`); o
+   * cliente não mantém pilha de cursores.
    */
-  private readonly cursor = linkedSignal<string, Cursor | undefined>({
+  private readonly pagina = linkedSignal<
+    string,
+    { readonly cursor: Cursor; readonly direction: PaginationDirection } | undefined
+  >({
     source: () => this.filtroKey(),
     computation: () => undefined,
   });
@@ -722,14 +729,17 @@ export class UnidadesPage {
   protected readonly loading = this.lista.isLoading;
 
   /**
-   * Recarga que **substitui** a lista em andamento (primeira página: troca de
-   * filtro ou refetch pós-mutação). Durante essa janela as linhas exibidas
-   * podem estar desatualizadas (ex.: linha recém-removida ainda visível até a
-   * resposta chegar), então as ações de linha ficam desabilitadas. "Carregar
-   * mais" (cursor definido) só acumula e não invalida as linhas atuais.
+   * Recarga que **substitui** a lista em andamento. Com navegação prev/next por
+   * substituição, toda carga troca as linhas exibidas (troca de filtro, refetch
+   * pós-mutação, ou navegação de página) — durante essa janela as linhas podem
+   * estar desatualizadas (ex.: linha recém-removida ainda visível até a resposta
+   * chegar), então as ações de linha ficam desabilitadas.
    */
-  protected readonly recarregandoLista = computed(
-    () => this.loading() && this.cursor() === undefined,
+  protected readonly recarregandoLista = computed(() => this.loading());
+
+  /** Cursor da página anterior (rel="prev" do header Link). `null` = primeira página. */
+  protected readonly prevCursor = computed(() =>
+    extractPrevCursor(this.lista.headers()?.get('Link') ?? null),
   );
 
   /** Próximo cursor (rel="next" do header Link). `null` = última página. */
@@ -738,9 +748,8 @@ export class UnidadesPage {
   );
 
   /**
-   * Acumulação reativa das páginas ("Carregar mais"): substitui na primeira
-   * página (cursor `undefined` — cobre carga inicial, troca de filtro e refetch
-   * pós-mutação) e concatena nas seguintes. `linkedSignal` em vez de `effect`
+   * Lista reativa por **substituição** (navegação prev/next, ADR-0089): cada
+   * página troca a anterior — sem acumular. `linkedSignal` em vez de `effect`
    * (guidance oficial Angular: `effect` não serve para atualizar outro signal).
    */
   protected readonly unidades = linkedSignal<
@@ -749,22 +758,23 @@ export class UnidadesPage {
   >({
     source: () => this.lista.value(),
     computation: (envelope, previous) => {
-      const acumulado = previous?.value ?? [];
+      const atual = previous?.value ?? [];
       // Sem resposta ainda (loading/reload): preserva para não piscar a lista.
       if (envelope === undefined) {
-        return acumulado;
+        return atual;
       }
-      // Lê o cursor no instante em que os dados chegam — `untracked` porque a
+      // Lê a página no instante em que os dados chegam — `untracked` porque a
       // única dependência reativa deste linkedSignal é `lista.value()`; rastrear
-      // o cursor reexecutaria a computação com dados velhos e duplicaria a página.
-      const primeiraPagina = untracked(() => this.cursor() === undefined);
+      // `pagina` reexecutaria a computação com dados velhos.
+      const primeiraPagina = untracked(() => this.pagina() === undefined);
       if (!envelope.ok) {
-        // Falha numa página seguinte preserva o acumulado (não perde o que já
-        // foi carregado); falha na primeira página limpa — após refetch
-        // pós-mutação a lista anterior está desatualizada (ex.: linha removida).
-        return primeiraPagina ? [] : acumulado;
+        // Falha na primeira página (troca de filtro / refetch pós-mutação) limpa
+        // — a lista anterior pode estar desatualizada (ex.: linha removida).
+        // Falha em navegação (cursor definido) preserva a página atual para o
+        // usuário não perder o contexto; o retry (banner) refaz a mesma página.
+        return primeiraPagina ? [] : atual;
       }
-      return primeiraPagina ? [...envelope.data] : [...acumulado, ...envelope.data];
+      return [...envelope.data];
     },
   });
 
@@ -952,18 +962,23 @@ export class UnidadesPage {
       .subscribe((termo) => this.buscaPaiAplicada.set(termo));
   }
 
-  protected carregarMais(): void {
+  protected proximaPagina(): void {
     const proximo = this.nextCursor();
     if (proximo !== null && !this.loading()) {
-      // Só avança (cursor forward-only). A acumulação fica a cargo do
-      // linkedSignal `unidades` quando a próxima página chega.
-      this.cursor.set(proximo);
+      this.pagina.set({ cursor: proximo, direction: 'next' });
     }
   }
 
-  // Refaz a carga da página atual após falha. Reusa `reload()` porque o cursor
-  // já aponta para a página que falhou — `cursor.set(mesmoValor)` não dispararia
-  // novo request. Cobre falha da primeira página e de "Carregar mais".
+  protected paginaAnterior(): void {
+    const anterior = this.prevCursor();
+    if (anterior !== null && !this.loading()) {
+      this.pagina.set({ cursor: anterior, direction: 'prev' });
+    }
+  }
+
+  // Refaz a carga da página atual após falha. Reusa `reload()` porque `pagina`
+  // já aponta para a página que falhou — `pagina.set(mesmoValor)` não dispararia
+  // novo request. Cobre falha da primeira página e de navegação prev/next.
   protected tentarNovamente(): void {
     if (!this.loading()) {
       this.lista.reload();
@@ -971,7 +986,7 @@ export class UnidadesPage {
   }
 
   private montarParams(): HttpParams {
-    let params = new HttpParams().set('limit', String(PAGE_SIZE));
+    let params = new HttpParams();
     const q = this.buscaAplicada();
     if (q.length > 0) {
       params = params.set('q', q);
@@ -982,9 +997,16 @@ export class UnidadesPage {
       // no contrato (?tipo=3). Valor fora do roster → backend responde 400.
       params = params.append('tipo', tipo);
     }
-    const cursor = this.cursor();
-    if (cursor !== undefined) {
-      params = params.set('cursor', cursorToString(cursor));
+    const pagina = this.pagina();
+    if (pagina === undefined) {
+      // Primeira página: define a janela; sem cursor/direction (o servidor
+      // coage para 'next').
+      params = params.set('limit', String(PAGE_SIZE));
+    } else {
+      // Navegação: o cursor opaco carrega a janela e a direção cifrada; envia
+      // `direction` casado ao cursor (ADR-0089) e omite `limit`.
+      params = params.set('cursor', cursorToString(pagina.cursor));
+      params = params.set('direction', pagina.direction);
     }
     return params;
   }
@@ -1175,13 +1197,13 @@ export class UnidadesPage {
 
   private recarregar(): void {
     // Pós-mutação: volta para a primeira página e refaz o fetch. Se já está na
-    // primeira (cursor undefined), `reload()` força o refetch (params iguais);
-    // senão, resetar o cursor dispara o refetch reativo pelo httpResource. Em
-    // ambos os casos o linkedSignal `unidades` substitui (não acumula).
-    if (this.cursor() === undefined) {
+    // primeira (`pagina` undefined), `reload()` força o refetch (params iguais);
+    // senão, resetar `pagina` dispara o refetch reativo pelo httpResource. Em
+    // ambos os casos o linkedSignal `unidades` substitui a lista.
+    if (this.pagina() === undefined) {
       this.lista.reload();
     } else {
-      this.cursor.set(undefined);
+      this.pagina.set(undefined);
     }
   }
 

--- a/apps/selecao/src/app/features/editais/editais-list.page.spec.ts
+++ b/apps/selecao/src/app/features/editais/editais-list.page.spec.ts
@@ -68,25 +68,28 @@ describe('EditaisListPage', () => {
     expect(component.editais()).toHaveLength(2);
   });
 
-  it('extrai nextCursor do header Link rel="next" da resposta de sucesso', () => {
+  it('extrai prev/next cursors do header Link da resposta de sucesso', () => {
     fixture.detectChanges();
 
     const req = controller.expectOne(`${BASE}/api/editais`);
     req.flush([editalSeed('40')], {
       headers: {
-        Link: '<https://api/editais?cursor=opaque-next-page>; rel="next"',
+        Link:
+          '<https://api/editais?cursor=opaque-prev&direction=prev>; rel="prev", ' +
+          '<https://api/editais?cursor=opaque-next-page&direction=next>; rel="next"',
       },
     });
 
+    expect(component.prevCursor()).toBe('opaque-prev');
     expect(component.nextCursor()).toBe('opaque-next-page');
   });
 
-  it('paginação acumula items da próxima página e atualiza o cursor', () => {
+  it('navegação "Próximo" substitui a página, envia direction=next e atualiza cursores', () => {
     fixture.detectChanges();
 
     controller.expectOne(`${BASE}/api/editais`).flush([editalSeed('40')], {
       headers: {
-        Link: '<https://api/editais?cursor=cursor-pagina-2>; rel="next"',
+        Link: '<https://api/editais?cursor=cursor-pagina-2&direction=next>; rel="next"',
       },
     });
 
@@ -96,25 +99,80 @@ describe('EditaisListPage', () => {
       throw new Error('Cursor da página 2 não foi extraído.');
     }
 
-    component['aoCarregarMais'](cursorPagina2);
+    component['aoProxima'](cursorPagina2);
 
     const req = controller.expectOne(
       (request) =>
-        request.url === `${BASE}/api/editais` && request.params.get('cursor') === 'cursor-pagina-2',
+        request.url === `${BASE}/api/editais` &&
+        request.params.get('cursor') === 'cursor-pagina-2' &&
+        request.params.get('direction') === 'next',
     );
     req.flush([editalSeed('41'), editalSeed('42')], {
       headers: {
-        Link: '<https://api/editais?cursor=cursor-pagina-3>; rel="next"',
+        Link:
+          '<https://api/editais?cursor=cursor-pagina-1&direction=prev>; rel="prev", ' +
+          '<https://api/editais?cursor=cursor-pagina-3&direction=next>; rel="next"',
       },
     });
 
-    expect(component.editais()).toHaveLength(3);
-    expect(component.editais()[0].numeroEdital).toBe('040/2026');
-    expect(component.editais()[2].numeroEdital).toBe('042/2026');
+    // Substituição (ADR-0089): a página 2 troca a 1 — 2 items, não 3.
+    expect(component.editais()).toHaveLength(2);
+    expect(component.editais()[0].numeroEdital).toBe('041/2026');
+    expect(component.editais()[1].numeroEdital).toBe('042/2026');
+    expect(component.prevCursor()).toBe('cursor-pagina-1');
     expect(component.nextCursor()).toBe('cursor-pagina-3');
   });
 
-  it('última página (sem rel="next") zera o nextCursor', () => {
+  it('navegação "Anterior" envia direction=prev e substitui a página', () => {
+    fixture.detectChanges();
+
+    // 1ª página com next disponível
+    controller.expectOne(`${BASE}/api/editais`).flush([editalSeed('43')], {
+      headers: {
+        Link: '<https://api/editais?cursor=c2&direction=next>; rel="next"',
+      },
+    });
+    const cursorProximo = component.nextCursor();
+    if (!cursorProximo) {
+      throw new Error('Cursor "next" não foi extraído.');
+    }
+    component['aoProxima'](cursorProximo);
+    controller
+      .expectOne((request) => request.params.get('cursor') === 'c2')
+      .flush([editalSeed('44')], {
+        headers: {
+          Link: '<https://api/editais?cursor=c1&direction=prev>; rel="prev"',
+        },
+      });
+
+    const cursorAnterior = component.prevCursor();
+    if (cursorAnterior === null) {
+      throw new Error('Cursor "prev" não foi extraído.');
+    }
+    expect(cursorAnterior).toBe('c1');
+    component['aoAnterior'](cursorAnterior);
+
+    const req = controller.expectOne(
+      (request) =>
+        request.params.get('cursor') === 'c1' && request.params.get('direction') === 'prev',
+    );
+    req.flush([editalSeed('43')]);
+
+    expect(component.editais()).toHaveLength(1);
+    expect(component.editais()[0].numeroEdital).toBe('043/2026');
+  });
+
+  it('1ª página não envia direction (servidor coage para next)', () => {
+    fixture.detectChanges();
+
+    const req = controller.expectOne(
+      (request) => request.url === `${BASE}/api/editais` && !request.params.has('cursor'),
+    );
+    expect(req.request.params.has('direction')).toBe(false);
+    req.flush([editalSeed('40')]);
+  });
+
+  it('última página (sem rel="prev"/"next") zera os cursores', () => {
     fixture.detectChanges();
 
     controller.expectOne(`${BASE}/api/editais`).flush([editalSeed('40')], {
@@ -123,6 +181,7 @@ describe('EditaisListPage', () => {
       },
     });
 
+    expect(component.prevCursor()).toBeNull();
     expect(component.nextCursor()).toBeNull();
   });
 
@@ -150,13 +209,13 @@ describe('EditaisListPage', () => {
     expect(component.editais()).toEqual([]);
   });
 
-  it('falha 4xx em load-more preserva cursor e items já carregados (retry possível)', () => {
+  it('falha em navegação preserva a página atual e seus cursores (retry possível)', () => {
     fixture.detectChanges();
 
     // 1ª página OK: ganha cursor para a próxima
     controller.expectOne(`${BASE}/api/editais`).flush([editalSeed('40')], {
       headers: {
-        Link: '<https://api/editais?cursor=cursor-retry>; rel="next"',
+        Link: '<https://api/editais?cursor=cursor-retry&direction=next>; rel="next"',
       },
     });
 
@@ -168,7 +227,7 @@ describe('EditaisListPage', () => {
     }
 
     // 2ª página falha
-    component['aoCarregarMais'](cursorRetry);
+    component['aoProxima'](cursorRetry);
     controller
       .expectOne((request) => request.params.get('cursor') === 'cursor-retry')
       .flush(
@@ -188,9 +247,20 @@ describe('EditaisListPage', () => {
 
     expect(component.errorMessage()).toBe('Falha temporária do servidor');
     expect(component.loading()).toBe(false);
-    // Items da 1ª página preservados; cursor mantido para retry.
+    // Página atual (1) preservada; cursor mantido para o retry refazer.
     expect(component.editais()).toHaveLength(1);
     expect(component.nextCursor()).toBe('cursor-retry');
+
+    // Retry refaz exatamente a navegação que falhou (mesmo cursor + direction).
+    component['aoTentarNovamente']();
+    const retry = controller.expectOne(
+      (request) =>
+        request.params.get('cursor') === 'cursor-retry' &&
+        request.params.get('direction') === 'next',
+    );
+    retry.flush([editalSeed('41'), editalSeed('42')]);
+    expect(component.editais()).toHaveLength(2);
+    expect(component.errorMessage()).toBeNull();
   });
 
   it('renderiza ui-data-table com dados e header correto após carga inicial', () => {

--- a/apps/selecao/src/app/features/editais/editais-list.page.ts
+++ b/apps/selecao/src/app/features/editais/editais-list.page.ts
@@ -8,7 +8,13 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router, RouterLink } from '@angular/router';
-import { Cursor, ProblemI18nService, extractNextCursor } from '@uniplus/shared-core/http';
+import {
+  Cursor,
+  PaginationDirection,
+  ProblemI18nService,
+  extractNextCursor,
+  extractPrevCursor,
+} from '@uniplus/shared-core/http';
 import { NotificationService } from '@uniplus/shared-core/notifications';
 import { EditaisApi, EditalDto } from '@uniplus/shared-data/selecao';
 import {
@@ -18,11 +24,14 @@ import {
 } from '@uniplus/shared-ui/components';
 
 /**
- * Container (ADR-0017) da feature Editais — lista paginada por cursor opaco.
+ * Container (ADR-0017) da feature Editais — lista paginada por cursor opaco
+ * bidirecional (ADR-0089 do `uniplus-api`).
  *
- * Carga inicial dispara via constructor (1ª página, sem cursor). Paginação
- * incremental via output `loadNext` do `DataTableComponent`. Erro 4xx/5xx é
- * resolvido em mensagem pt-BR via `ProblemI18nService.resolve(problem).title`.
+ * Carga inicial dispara via constructor (1ª página, sem cursor/direção).
+ * Navegação **Anterior / Próximo por substituição** via outputs `loadPrev`/
+ * `loadNext` do `DataTableComponent`: cada página troca a anterior (sem
+ * acumular). Erro 4xx/5xx é resolvido em mensagem pt-BR via
+ * `ProblemI18nService.resolve(problem).title`.
  */
 @Component({
   selector: 'sel-editais-list-page',
@@ -40,11 +49,13 @@ import {
       [isLoading]="loading()"
       [errorMessage]="errorMessage()"
       [errorTraceId]="errorTraceId()"
+      [prevCursor]="prevCursor()"
       [nextCursor]="nextCursor()"
       [rowClickable]="true"
       pageStatusLabel="Lista paginada por cursor"
       emptyMessage="Nenhum edital cadastrado."
-      (loadNext)="aoCarregarMais($event)"
+      (loadPrev)="aoAnterior($event)"
+      (loadNext)="aoProxima($event)"
       (rowClick)="aoSelecionar($event)"
       (retry)="aoTentarNovamente()"
     />
@@ -58,13 +69,17 @@ export class EditaisListPage {
   private readonly router = inject(Router);
 
   readonly editais = signal<readonly EditalDto[]>([]);
+  readonly prevCursor = signal<Cursor | null>(null);
   readonly nextCursor = signal<Cursor | null>(null);
   readonly loading = signal<boolean>(false);
   readonly errorMessage = signal<string | null>(null);
   /** Trace context da última falha — alimenta o link "Reportar incidente" do DataTable. */
   readonly errorTraceId = signal<string | null>(null);
-  /** Cursor preservado da última falha pós-1ª página, para o retry retomar do mesmo ponto. */
-  private cursorUltimaFalha: Cursor | undefined = undefined;
+  /**
+   * Requisição preservada da última falha, para o retry refazer exatamente a
+   * mesma navegação (1ª página, próximo ou anterior). Vazia em sucesso.
+   */
+  private ultimaRequisicao: { cursor?: Cursor; direction?: PaginationDirection } = {};
 
   protected readonly rows = computed(() => this.editais() as readonly Record<string, unknown>[]);
 
@@ -76,11 +91,15 @@ export class EditaisListPage {
   ];
 
   constructor() {
-    this.carregar(undefined);
+    this.carregar(undefined, undefined);
   }
 
-  protected aoCarregarMais(cursor: Cursor): void {
-    this.carregar(cursor);
+  protected aoProxima(cursor: Cursor): void {
+    this.carregar(cursor, 'next');
+  }
+
+  protected aoAnterior(cursor: Cursor): void {
+    this.carregar(cursor, 'prev');
   }
 
   protected aoSelecionar(row: Record<string, unknown>): void {
@@ -91,15 +110,15 @@ export class EditaisListPage {
   }
 
   /**
-   * Handler do output `retry` do `DataTableComponent`. Reusa o cursor
-   * pré-falha (paginação) ou recomeça do zero (carga inicial). Sem
-   * `cursorUltimaFalha`, equivale a retentar a 1ª página.
+   * Handler do output `retry` do `DataTableComponent`. Refaz a navegação que
+   * falhou (1ª página, próximo ou anterior); sem `ultimaRequisicao`, equivale
+   * a recarregar a 1ª página.
    */
   protected aoTentarNovamente(): void {
-    this.carregar(this.cursorUltimaFalha);
+    this.carregar(this.ultimaRequisicao.cursor, this.ultimaRequisicao.direction);
   }
 
-  private carregar(cursor: Cursor | undefined): void {
+  private carregar(cursor: Cursor | undefined, direction: PaginationDirection | undefined): void {
     if (this.loading()) {
       return;
     }
@@ -108,14 +127,18 @@ export class EditaisListPage {
     this.errorTraceId.set(null);
 
     this.api
-      .listar(cursor)
+      .listar(cursor, direction)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((result) => {
         this.loading.set(false);
         if (result.ok) {
-          this.editais.update((prev) => [...prev, ...result.data]);
-          this.nextCursor.set(extractNextCursor(result.headers.get('Link')));
-          this.cursorUltimaFalha = undefined;
+          // Substituição (ADR-0089): cada página troca a anterior — sem
+          // acumular. Os cursores prev/next vêm do header Link da resposta.
+          this.editais.set([...result.data]);
+          const link = result.headers.get('Link');
+          this.prevCursor.set(extractPrevCursor(link));
+          this.nextCursor.set(extractNextCursor(link));
+          this.ultimaRequisicao = {};
           return;
         }
         const mensagem = this.problemI18n.resolve(result.problem).title;
@@ -127,10 +150,9 @@ export class EditaisListPage {
         if (result.problem.status >= 500) {
           this.notifications.errorFromProblem(result.problem, { title: mensagem });
         }
-        // Em falha pós-1ª página, preserva o cursor original — usuário consegue
-        // retentar via "Carregar mais" sem perder os items já carregados. Em
-        // falha de carga inicial, o cursor já é null por construção.
-        this.cursorUltimaFalha = cursor;
+        // Falha de navegação preserva a página atual e seus cursores (o usuário
+        // não perde o contexto); guarda a requisição para o retry refazê-la.
+        this.ultimaRequisicao = { cursor, direction };
       });
   }
 }

--- a/libs/shared-core/src/lib/http/index.ts
+++ b/libs/shared-core/src/lib/http/index.ts
@@ -25,8 +25,8 @@ export {
 export { parseLink } from './link-header';
 export type { ParsedLink } from './link-header';
 
-export { createCursor, cursorToString, extractNextCursor } from './pagination';
-export type { Cursor } from './pagination';
+export { createCursor, cursorToString, extractNextCursor, extractPrevCursor } from './pagination';
+export type { Cursor, PaginationDirection } from './pagination';
 
 export { CLIENT_PROBLEM_CODES } from './problem-details';
 export type {

--- a/libs/shared-core/src/lib/http/pagination.spec.ts
+++ b/libs/shared-core/src/lib/http/pagination.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createCursor, cursorToString, extractNextCursor } from './pagination';
+import { createCursor, cursorToString, extractNextCursor, extractPrevCursor } from './pagination';
 
 function extractRequiredNextCursor(linkHeader: string): string {
   const next = extractNextCursor(linkHeader);
@@ -7,6 +7,14 @@ function extractRequiredNextCursor(linkHeader: string): string {
     throw new Error(`Esperava cursor no Link header: ${linkHeader}`);
   }
   return cursorToString(next);
+}
+
+function extractRequiredPrevCursor(linkHeader: string): string {
+  const prev = extractPrevCursor(linkHeader);
+  if (prev === null) {
+    throw new Error(`Esperava cursor "prev" no Link header: ${linkHeader}`);
+  }
+  return cursorToString(prev);
 }
 
 describe('Cursor branded type (ADR-0015)', () => {
@@ -116,6 +124,69 @@ describe('extractNextCursor — header Link → próximo cursor opaco', () => {
     it('ignora hash fragment na URI (#...)', () => {
       const linkHeader = '<https://api/x?cursor=ABC#section>; rel="next"';
       expect(extractRequiredNextCursor(linkHeader)).toBe('ABC');
+    });
+  });
+});
+
+describe('extractPrevCursor — header Link → cursor da página anterior (ADR-0089)', () => {
+  describe('caminhos felizes', () => {
+    it('rel="prev" com cursor= no query string retorna Cursor', () => {
+      const linkHeader = '<https://api/x?cursor=PREV1&direction=prev>; rel="prev"';
+      expect(extractRequiredPrevCursor(linkHeader)).toBe('PREV1');
+    });
+
+    it('extrai cursor de prev preservando os filtros na URI (q/tipo)', () => {
+      const linkHeader =
+        '<https://api/unidades?q=ceps&tipo=3&cursor=PREV2&direction=prev>; rel="prev"';
+      expect(extractRequiredPrevCursor(linkHeader)).toBe('PREV2');
+    });
+
+    it('rel="prev" + rel="next": extrai independentemente cada cursor', () => {
+      const linkHeader =
+        '<https://api/x?cursor=P&direction=prev>; rel="prev", ' +
+        '<https://api/x?cursor=N&direction=next>; rel="next"';
+      expect(extractRequiredPrevCursor(linkHeader)).toBe('P');
+      expect(extractRequiredNextCursor(linkHeader)).toBe('N');
+    });
+
+    it('decodifica percent-encoding do valor do cursor de prev', () => {
+      const linkHeader = '<https://api/x?cursor=ab%3Dcd%3D&direction=prev>; rel="prev"';
+      expect(extractRequiredPrevCursor(linkHeader)).toBe('ab=cd=');
+    });
+  });
+
+  describe('retorna null em casos legítimos', () => {
+    it('header null/undefined/vazio', () => {
+      expect(extractPrevCursor(null)).toBeNull();
+      expect(extractPrevCursor(undefined)).toBeNull();
+      expect(extractPrevCursor('')).toBeNull();
+    });
+
+    it('primeira página: só rel="next", sem rel="prev"', () => {
+      const linkHeader = '<https://api/x?cursor=N&direction=next>; rel="next"';
+      expect(extractPrevCursor(linkHeader)).toBeNull();
+    });
+
+    it('header só com rel="self"', () => {
+      const linkHeader = '<https://api/x>; rel="self"';
+      expect(extractPrevCursor(linkHeader)).toBeNull();
+    });
+  });
+
+  describe('retorna null em formas defensivas', () => {
+    it('rel="prev" sem query string', () => {
+      const linkHeader = '<https://api/x>; rel="prev"';
+      expect(extractPrevCursor(linkHeader)).toBeNull();
+    });
+
+    it('rel="prev" com query string mas sem cursor=', () => {
+      const linkHeader = '<https://api/x?direction=prev>; rel="prev"';
+      expect(extractPrevCursor(linkHeader)).toBeNull();
+    });
+
+    it('rel="prev" com cursor= vazio', () => {
+      const linkHeader = '<https://api/x?cursor=&direction=prev>; rel="prev"';
+      expect(extractPrevCursor(linkHeader)).toBeNull();
     });
   });
 });

--- a/libs/shared-core/src/lib/http/pagination.ts
+++ b/libs/shared-core/src/lib/http/pagination.ts
@@ -54,7 +54,21 @@ export function cursorToString(cursor: Cursor): string {
 }
 
 /**
- * Extrai o cursor da próxima página do header `Link`. Retorna `null` quando:
+ * Direção de navegação da paginação por cursor bidirecional (ADR-0089 do
+ * `uniplus-api`). É o valor literal do query param `direction` que o cliente
+ * envia junto ao cursor — `'next'` para avançar, `'prev'` para retroceder.
+ *
+ * O servidor cifra a direção dentro do próprio cursor e rejeita no boundary
+ * um `direction` que divirja do cifrado (anti-adulteração), então o cliente
+ * deve enviar a direção que casa com o cursor seguido: `extractNextCursor`
+ * pareia com `'next'`, `extractPrevCursor` com `'prev'`. Na primeira página
+ * (sem cursor) o param é omitido — o servidor coage para `'next'`.
+ */
+export type PaginationDirection = 'next' | 'prev';
+
+/**
+ * Extrai o cursor da próxima página do header `Link` (`rel="next"`). Retorna
+ * `null` quando:
  *
  * - header é `null`, `undefined` ou string vazia;
  * - header não tem entrada `rel="next"`;
@@ -66,12 +80,37 @@ export function cursorToString(cursor: Cursor): string {
  * - endpoint não-paginado retornando outros rels (ex.: `rel="related"`).
  */
 export function extractNextCursor(linkHeader: string | null | undefined): Cursor | null {
+  return extractCursorForRel(linkHeader, 'next');
+}
+
+/**
+ * Extrai o cursor da página anterior do header `Link` (`rel="prev"`).
+ * Simétrico a {@link extractNextCursor} — retorna `null` quando o header está
+ * ausente/vazio, não tem `rel="prev"`, ou o `rel="prev"` não carrega
+ * `cursor=`.
+ *
+ * `null` é o caso legítimo da **primeira página**: o servidor não emite
+ * `rel="prev"` quando não há âncora anterior (ADR-0089 do `uniplus-api`).
+ */
+export function extractPrevCursor(linkHeader: string | null | undefined): Cursor | null {
+  return extractCursorForRel(linkHeader, 'prev');
+}
+
+/**
+ * Resolve o cursor opaco de um `rel` específico do header `Link`. Núcleo
+ * comum a {@link extractNextCursor}/{@link extractPrevCursor}: parseia o
+ * header, localiza o link-value do `rel` e extrai o query param `cursor=`.
+ */
+function extractCursorForRel(
+  linkHeader: string | null | undefined,
+  rel: 'next' | 'prev',
+): Cursor | null {
   const links = parseLink(linkHeader);
-  const next = links.get('next');
-  if (next === undefined) {
+  const link = links.get(rel);
+  if (link === undefined) {
     return null;
   }
-  const cursorValue = extractCursorParam(next.uri);
+  const cursorValue = extractCursorParam(link.uri);
   if (cursorValue === null) {
     return null;
   }

--- a/libs/shared-data/src/lib/api/selecao/editais.api.spec.ts
+++ b/libs/shared-data/src/lib/api/selecao/editais.api.spec.ts
@@ -81,30 +81,45 @@ describe('EditaisApi', () => {
     await promise;
   });
 
-  it('listar(cursor, limit) anexa cursor + limit como query params', async () => {
+  it('listar(cursor, "next") anexa cursor + direction=next (ADR-0089)', async () => {
     const cursor = createCursor('next-page-cursor');
 
-    const promise = firstValueFrom(api.listar(cursor, 25));
+    const promise = firstValueFrom(api.listar(cursor, 'next'));
 
     const req = controller.expectOne(
       (request) => request.url === `${BASE}/api/editais` && request.params.has('cursor'),
     );
     expect(req.request.params.get('cursor')).toBe('next-page-cursor');
-    expect(req.request.params.get('limit')).toBe('25');
+    expect(req.request.params.get('direction')).toBe('next');
     expect(req.request.headers.get('Accept')).toBe(buildVendorMimeAccept('edital', 1));
     req.flush([]);
 
     await promise;
   });
 
-  it('listar(undefined, limit) anexa apenas limit como query param', async () => {
-    const promise = firstValueFrom(api.listar(undefined, 10));
+  it('listar(cursor, "prev") anexa cursor + direction=prev', async () => {
+    const cursor = createCursor('prev-page-cursor');
+
+    const promise = firstValueFrom(api.listar(cursor, 'prev'));
 
     const req = controller.expectOne(
-      (request) => request.url === `${BASE}/api/editais` && request.params.has('limit'),
+      (request) => request.url === `${BASE}/api/editais` && request.params.has('cursor'),
+    );
+    expect(req.request.params.get('cursor')).toBe('prev-page-cursor');
+    expect(req.request.params.get('direction')).toBe('prev');
+    req.flush([]);
+
+    await promise;
+  });
+
+  it('listar(undefined, "next") não envia direction sem cursor (1ª página)', async () => {
+    const promise = firstValueFrom(api.listar(undefined, 'next'));
+
+    const req = controller.expectOne(
+      (request) => request.url === `${BASE}/api/editais` && request.params.keys().length === 0,
     );
     expect(req.request.params.has('cursor')).toBe(false);
-    expect(req.request.params.get('limit')).toBe('10');
+    expect(req.request.params.has('direction')).toBe(false);
     req.flush([]);
 
     await promise;

--- a/libs/shared-data/src/lib/api/selecao/editais.api.ts
+++ b/libs/shared-data/src/lib/api/selecao/editais.api.ts
@@ -5,6 +5,7 @@ import {
   ApiResult,
   Cursor,
   IDEMPOTENCY_KEY_TOKEN,
+  PaginationDirection,
   cursorToString,
   withVendorMime,
 } from '@uniplus/shared-core/http';
@@ -42,25 +43,34 @@ export class EditaisApi {
   private readonly basePath = inject(SELECAO_BASE_PATH);
 
   /**
-   * GET `/api/editais` — lista paginada por cursor opaco (ADR-0026 + ADR-0031
-   * do `uniplus-api`; consumer client-side via ADR-0015).
+   * GET `/api/editais` — lista paginada por cursor opaco bidirecional
+   * (ADR-0026 + ADR-0031 + ADR-0089 do `uniplus-api`; consumer client-side
+   * via ADR-0015).
    *
    * Parâmetros opcionais:
-   * - `cursor`: cursor opaco emitido pelo servidor no header `Link rel="next"`
-   *   da página anterior. Ausente na 1ª página.
-   * - `limit`: tamanho máximo da janela. Ausente => default do servidor.
+   * - `cursor`: cursor opaco emitido pelo servidor no header `Link` (`rel="next"`
+   *   ou `rel="prev"`) da página atual. Ausente na 1ª página.
+   * - `direction`: `'next'` (avançar) ou `'prev'` (retroceder). Acompanha o
+   *   `cursor` e deve casar com a direção que ele cifra — o servidor rejeita
+   *   divergência (anti-adulteração, ADR-0089). Omitido na 1ª página (o
+   *   servidor coage para `'next'`).
    *
    * O cursor é serializado no query param `cursor=`; o cliente nunca decifra
-   * o conteúdo (ADR-0031 do backend). Use `extractNextCursor(result.headers
-   * .get('Link'))` para obter o próximo cursor a partir do header de resposta.
+   * o conteúdo (ADR-0031 do backend). Use `extractNextCursor`/`extractPrevCursor`
+   * sobre `result.headers.get('Link')` para obter os cursores de navegação.
    */
-  listar(cursor?: Cursor, limit?: number): Observable<ApiResult<readonly EditalDto[]>> {
+  listar(
+    cursor?: Cursor,
+    direction?: PaginationDirection,
+  ): Observable<ApiResult<readonly EditalDto[]>> {
     let params = new HttpParams();
     if (cursor !== undefined) {
       params = params.set('cursor', cursorToString(cursor));
-    }
-    if (limit !== undefined) {
-      params = params.set('limit', String(limit));
+      // `direction` só faz sentido com cursor: o servidor o valida contra a
+      // direção cifrada no cursor. Sem cursor (1ª página), é omitido.
+      if (direction !== undefined) {
+        params = params.set('direction', direction);
+      }
     }
     return this.http.get<ApiResult<readonly EditalDto[]>>(`${this.basePath}/api/editais`, {
       context: withVendorMime('edital', 1),

--- a/libs/shared-ui/src/lib/components/data-table/data-table.spec.ts
+++ b/libs/shared-ui/src/lib/components/data-table/data-table.spec.ts
@@ -289,6 +289,31 @@ describe('DataTableComponent', () => {
     expect(emit).not.toHaveBeenCalled();
   });
 
+  it('durante isLoading as linhas não são clicáveis mesmo com rowClickable=true (substituição)', () => {
+    const { fixture, component } = setup();
+    fixture.componentRef.setInput('columns', COLUMNS);
+    fixture.componentRef.setInput('records', DATA);
+    fixture.componentRef.setInput('rowClickable', true);
+    fixture.componentRef.setInput('isLoading', true);
+    fixture.detectChanges();
+
+    const linhas = fixture.debugElement.queryAll(By.css('tbody tr'));
+    // Linhas da página anterior preservadas, mas não clicáveis durante a recarga.
+    expect(linhas[0].nativeElement.getAttribute('tabindex')).toBeNull();
+    expect(linhas[0].nativeElement.classList).not.toContain('table-responsive__row--clickable');
+
+    const emit = vi.fn();
+    component.rowClick.subscribe(emit);
+    linhas[0].nativeElement.click();
+    expect(emit).not.toHaveBeenCalled();
+
+    // Ao terminar a recarga, as linhas voltam a ser clicáveis.
+    fixture.componentRef.setInput('isLoading', false);
+    fixture.detectChanges();
+    linhas[0].nativeElement.click();
+    expect(emit).toHaveBeenCalledWith(DATA[0]);
+  });
+
   it('aria-busy=true no <table> quando isLoading()', () => {
     const { fixture } = setup();
     fixture.componentRef.setInput('columns', COLUMNS);

--- a/libs/shared-ui/src/lib/components/data-table/data-table.spec.ts
+++ b/libs/shared-ui/src/lib/components/data-table/data-table.spec.ts
@@ -99,7 +99,7 @@ describe('DataTableComponent', () => {
     expect(alertaTbody.nativeElement.textContent).toContain('Falha ao carregar editais.');
   });
 
-  it('em erro com records carregados: linhas preservadas + banner de erro fora do tbody + botão "Carregar mais" disponível', () => {
+  it('em erro com records carregados: linhas preservadas + banner de erro fora do tbody + paginação disponível', () => {
     const { fixture } = setup();
     fixture.componentRef.setInput('columns', COLUMNS);
     fixture.componentRef.setInput('records', DATA);
@@ -117,41 +117,66 @@ describe('DataTableComponent', () => {
     expect(banners.length).toBe(1);
     expect(banners[0].nativeElement.textContent).toContain('Falha de rede ao paginar.');
 
-    const botao = fixture.debugElement.query(By.css('button')).nativeElement as HTMLButtonElement;
-    expect(botao).toBeTruthy();
-    expect(botao.disabled).toBe(false);
+    // A barra de paginação segue disponível em erro pós-1ª página: o "Próximo"
+    // permite retentar a navegação (isLoading=false → botão habilitado).
+    const proximo = fixture.debugElement.query(By.css('[data-pager="next"]'))
+      .nativeElement as HTMLButtonElement;
+    expect(proximo).toBeTruthy();
+    expect(proximo.disabled).toBe(false);
   });
 
-  it('botão "Carregar mais" só aparece quando nextCursor está populado', () => {
+  it('barra de paginação só aparece quando há cursor (prev ou next)', () => {
     const { fixture } = setup();
     fixture.componentRef.setInput('columns', COLUMNS);
     fixture.componentRef.setInput('records', DATA);
     fixture.detectChanges();
 
-    expect(fixture.debugElement.query(By.css('button'))).toBeNull();
+    expect(fixture.debugElement.query(By.css('[data-pager]'))).toBeNull();
 
     fixture.componentRef.setInput('nextCursor', createCursor('proximo-cursor'));
     fixture.detectChanges();
 
-    const botao = fixture.debugElement.query(By.css('button')).nativeElement as HTMLButtonElement;
-    expect(botao.textContent?.trim()).toBe('Carregar mais');
-    expect(botao.disabled).toBe(false);
+    const proximo = fixture.debugElement.query(By.css('[data-pager="next"]'))
+      .nativeElement as HTMLButtonElement;
+    const anterior = fixture.debugElement.query(By.css('[data-pager="prev"]'))
+      .nativeElement as HTMLButtonElement;
+    expect(proximo.textContent?.trim()).toBe('Próximo');
+    expect(proximo.disabled).toBe(false);
+    // Primeira página: sem prevCursor, "Anterior" fica desabilitado.
+    expect(anterior.disabled).toBe(true);
   });
 
-  it('botão "Carregar mais" troca rótulo para loadingLabel e fica disabled durante loading', () => {
+  it('Anterior habilita quando prevCursor está populado', () => {
     const { fixture } = setup();
     fixture.componentRef.setInput('columns', COLUMNS);
     fixture.componentRef.setInput('records', DATA);
-    fixture.componentRef.setInput('nextCursor', createCursor('proximo-cursor'));
+    fixture.componentRef.setInput('prevCursor', createCursor('cursor-anterior'));
+    fixture.componentRef.setInput('nextCursor', createCursor('cursor-proximo'));
+    fixture.detectChanges();
+
+    const anterior = fixture.debugElement.query(By.css('[data-pager="prev"]'))
+      .nativeElement as HTMLButtonElement;
+    expect(anterior.disabled).toBe(false);
+  });
+
+  it('botões Anterior/Próximo ficam disabled durante loading', () => {
+    const { fixture } = setup();
+    fixture.componentRef.setInput('columns', COLUMNS);
+    fixture.componentRef.setInput('records', DATA);
+    fixture.componentRef.setInput('prevCursor', createCursor('cursor-anterior'));
+    fixture.componentRef.setInput('nextCursor', createCursor('cursor-proximo'));
     fixture.componentRef.setInput('isLoading', true);
     fixture.detectChanges();
 
-    const botao = fixture.debugElement.query(By.css('button')).nativeElement as HTMLButtonElement;
-    expect(botao.disabled).toBe(true);
-    expect(botao.textContent?.trim()).toBe('Carregando…');
+    const anterior = fixture.debugElement.query(By.css('[data-pager="prev"]'))
+      .nativeElement as HTMLButtonElement;
+    const proximo = fixture.debugElement.query(By.css('[data-pager="next"]'))
+      .nativeElement as HTMLButtonElement;
+    expect(anterior.disabled).toBe(true);
+    expect(proximo.disabled).toBe(true);
   });
 
-  it('clicar em "Carregar mais" emite output loadNext com o cursor atual', () => {
+  it('clicar em "Próximo" emite output loadNext com o nextCursor', () => {
     const { fixture, component } = setup();
     const cursor = createCursor('cursor-pagina-2');
     fixture.componentRef.setInput('columns', COLUMNS);
@@ -162,14 +187,35 @@ describe('DataTableComponent', () => {
     const emit = vi.fn();
     component.loadNext.subscribe(emit);
 
-    const botao = fixture.debugElement.query(By.css('button')).nativeElement as HTMLButtonElement;
-    botao.click();
+    const proximo = fixture.debugElement.query(By.css('[data-pager="next"]'))
+      .nativeElement as HTMLButtonElement;
+    proximo.click();
 
     expect(emit).toHaveBeenCalledTimes(1);
     expect(emit).toHaveBeenCalledWith(cursor);
   });
 
-  it('clicar no botão durante loading não emite loadNext (guarda interna)', () => {
+  it('clicar em "Anterior" emite output loadPrev com o prevCursor', () => {
+    const { fixture, component } = setup();
+    const cursor = createCursor('cursor-pagina-1');
+    fixture.componentRef.setInput('columns', COLUMNS);
+    fixture.componentRef.setInput('records', DATA);
+    fixture.componentRef.setInput('prevCursor', cursor);
+    fixture.componentRef.setInput('nextCursor', createCursor('cursor-pagina-3'));
+    fixture.detectChanges();
+
+    const emit = vi.fn();
+    component.loadPrev.subscribe(emit);
+
+    const anterior = fixture.debugElement.query(By.css('[data-pager="prev"]'))
+      .nativeElement as HTMLButtonElement;
+    anterior.click();
+
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(emit).toHaveBeenCalledWith(cursor);
+  });
+
+  it('clicar em "Próximo" durante loading não emite loadNext (botão disabled)', () => {
     const { fixture, component } = setup();
     fixture.componentRef.setInput('columns', COLUMNS);
     fixture.componentRef.setInput('records', DATA);
@@ -180,8 +226,9 @@ describe('DataTableComponent', () => {
     const emit = vi.fn();
     component.loadNext.subscribe(emit);
 
-    const botao = fixture.debugElement.query(By.css('button')).nativeElement as HTMLButtonElement;
-    botao.click();
+    const proximo = fixture.debugElement.query(By.css('[data-pager="next"]'))
+      .nativeElement as HTMLButtonElement;
+    proximo.click();
 
     expect(emit).not.toHaveBeenCalled();
   });

--- a/libs/shared-ui/src/lib/components/data-table/data-table.ts
+++ b/libs/shared-ui/src/lib/components/data-table/data-table.ts
@@ -119,8 +119,8 @@ export interface UiDataTableColumn {
             @for (row of records(); track row[trackByField()] ?? $index) {
               <tr
                 data-testid="data-table-row"
-                [class.table-responsive__row--clickable]="rowClickable()"
-                [attr.tabindex]="rowClickable() ? 0 : null"
+                [class.table-responsive__row--clickable]="linhasClicaveis()"
+                [attr.tabindex]="linhasClicaveis() ? 0 : null"
                 (click)="ativarLinha(row)"
                 (keydown.enter)="ativarLinha(row, $event)"
                 (keydown.space)="ativarLinha(row, $event)"
@@ -261,6 +261,16 @@ export class DataTableComponent {
     return typeof traceId === 'string' && traceId.length > 0;
   });
 
+  /**
+   * Linhas clicáveis apenas quando habilitado **e** fora de recarga. Com
+   * paginação por substituição (ADR-0089) as linhas exibidas durante o
+   * `isLoading()` são da página anterior e podem navegar para um item prestes a
+   * sair; gatear no componente evita que cada container precise lembrar disso.
+   */
+  protected readonly linhasClicaveis = computed(
+    () => this.rowClickable() && !this.isLoading(),
+  );
+
   protected emitirLoadNext(): void {
     const cursor = this.nextCursor();
     if (cursor !== null && !this.isLoading()) {
@@ -285,7 +295,7 @@ export class DataTableComponent {
    * rola a página, e Enter pode submeter forms ancestrais.
    */
   protected ativarLinha(row: Record<string, unknown>, event?: Event): void {
-    if (!this.rowClickable()) {
+    if (!this.linhasClicaveis()) {
       return;
     }
     event?.preventDefault();

--- a/libs/shared-ui/src/lib/components/data-table/data-table.ts
+++ b/libs/shared-ui/src/lib/components/data-table/data-table.ts
@@ -1,5 +1,6 @@
 import { Component, ChangeDetectionStrategy, computed, input, output } from '@angular/core';
 import type { Cursor } from '@uniplus/shared-core/http';
+import { PagerComponent } from '../pager/pager';
 
 export interface UiDataTableColumn {
   field: string;
@@ -27,20 +28,29 @@ export interface UiDataTableColumn {
  *   preserva o histórico carregado.
  * - **Vazio** (`!isLoading() && !errorMessage() && records().length === 0`):
  *   mensagem `emptyMessage()` ocupa o tbody.
- * - **Com dados**: tabela renderizada normalmente; quando `nextCursor()`
- *   for truthy, exibe botão "Carregar mais" abaixo da tabela.
+ * - **Com dados**: tabela renderizada normalmente; quando há cursor de
+ *   navegação (`prevCursor()` e/ou `nextCursor()`), exibe a barra de
+ *   paginação **Anterior / Próximo** (`ui-pager`) abaixo da tabela.
+ *
+ * Navegação por **substituição** (ADR-0089 do `uniplus-api`, cursor
+ * bidirecional): cada página substitui a anterior — o container troca
+ * `records()` a cada `loadPrev`/`loadNext`. O componente é apresentacional
+ * (ADR-0017): só reflete os cursores que o container fornece e emite o
+ * cursor seguido; quem decide substituir/preservar e enviar a direção
+ * casada ao cursor é o container.
  *
  * Outputs:
- * - `loadNext` — emite o cursor atual quando "Carregar mais" é clicado.
+ * - `loadNext` — emite `nextCursor()` quando "Próximo" é clicado.
+ * - `loadPrev` — emite `prevCursor()` quando "Anterior" é clicado.
  * - `retry` — emite quando "Tentar novamente" é clicado em qualquer
- *   estado de erro. Container decide se reusa cursor pré-falha ou
+ *   estado de erro. Container decide se reusa o cursor pré-falha ou
  *   recomeça do zero.
  * - `rowClick` — emite quando uma linha clicável é ativada.
  */
 @Component({
   selector: 'ui-data-table',
   standalone: true,
-  imports: [],
+  imports: [PagerComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="table-responsive">
@@ -170,20 +180,16 @@ export interface UiDataTableColumn {
       </div>
     }
 
-    @if (mostrarBotaoCarregarMais()) {
-      <nav class="pager" aria-label="Paginação">
-        <span class="pager__status" aria-live="polite">{{ pageStatusLabel() }}</span>
-        <button
-          type="button"
-          class="pager__btn"
-          data-pager="next"
-          data-testid="data-table-load-more"
-          [disabled]="isLoading()"
-          (click)="emitirLoadNext()"
-        >
-          {{ isLoading() ? loadingLabel() : loadMoreLabel() }}
-        </button>
-      </nav>
+    @if (mostrarPaginacao()) {
+      <ui-pager
+        [statusText]="pageStatusLabel()"
+        navigationLabel="Paginação"
+        [hasPrevious]="prevCursor() !== null"
+        [hasNext]="nextCursor() !== null"
+        [isDisabled]="isLoading()"
+        (previous)="emitirLoadPrev()"
+        (next)="emitirLoadNext()"
+      />
     }
   `,
 })
@@ -200,9 +206,11 @@ export class DataTableComponent {
    * pode vir vazio — neste caso o link é suprimido.
    */
   readonly errorTraceId = input<string | null>(null);
+  /** Cursor da página anterior (`rel="prev"`); `null` na primeira página. */
+  readonly prevCursor = input<Cursor | null>(null);
+  /** Cursor da próxima página (`rel="next"`); `null` na última página. */
   readonly nextCursor = input<Cursor | null>(null);
   readonly emptyMessage = input<string>('Nenhum registro encontrado.');
-  readonly loadMoreLabel = input<string>('Carregar mais');
   readonly loadingLabel = input<string>('Carregando…');
   readonly retryLabel = input<string>('Tentar novamente');
   readonly reportIncidentLabel = input<string>('Reportar incidente:');
@@ -215,6 +223,7 @@ export class DataTableComponent {
   readonly trackByField = input<string>('id');
 
   readonly loadNext = output<Cursor>();
+  readonly loadPrev = output<Cursor>();
   readonly rowClick = output<Record<string, unknown>>();
   /**
    * Emitido quando o usuário clica em "Tentar novamente" em qualquer
@@ -238,8 +247,14 @@ export class DataTableComponent {
   protected readonly mostrarLoadingInicial = computed(
     () => this.isLoading() && this.errorMessage() === null && this.records().length === 0,
   );
-  /** Botão segue disponível mesmo em erro pós-1ª página, para permitir retry. */
-  protected readonly mostrarBotaoCarregarMais = computed(() => this.nextCursor() !== null);
+  /**
+   * Barra de paginação visível quando há ao menos um cursor de navegação
+   * (anterior ou próximo). Segue disponível em erro pós-1ª página, permitindo
+   * retentar a navegação além do botão "Tentar novamente" do banner.
+   */
+  protected readonly mostrarPaginacao = computed(
+    () => this.prevCursor() !== null || this.nextCursor() !== null,
+  );
   /** Renderiza link "Reportar incidente" apenas quando há trace context não-vazio. */
   protected readonly mostrarReporteDeIncidente = computed(() => {
     const traceId = this.errorTraceId();
@@ -250,6 +265,13 @@ export class DataTableComponent {
     const cursor = this.nextCursor();
     if (cursor !== null && !this.isLoading()) {
       this.loadNext.emit(cursor);
+    }
+  }
+
+  protected emitirLoadPrev(): void {
+    const cursor = this.prevCursor();
+    if (cursor !== null && !this.isLoading()) {
+      this.loadPrev.emit(cursor);
     }
   }
 

--- a/libs/shared-ui/src/lib/components/pager/pager.spec.ts
+++ b/libs/shared-ui/src/lib/components/pager/pager.spec.ts
@@ -1,0 +1,72 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { PagerComponent } from './pager';
+
+describe('PagerComponent (Anterior / Próximo)', () => {
+  let fixture: ComponentFixture<PagerComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [PagerComponent] });
+    fixture = TestBed.createComponent(PagerComponent);
+  });
+
+  function botao(rel: 'prev' | 'next'): HTMLButtonElement {
+    return fixture.debugElement.query(By.css(`[data-pager="${rel}"]`))
+      .nativeElement as HTMLButtonElement;
+  }
+
+  it('por padrão ambos os botões ficam desabilitados (sem páginas)', () => {
+    fixture.detectChanges();
+    expect(botao('prev').disabled).toBe(true);
+    expect(botao('next').disabled).toBe(true);
+  });
+
+  it('habilita Anterior/Próximo conforme hasPrevious/hasNext', () => {
+    fixture.componentRef.setInput('hasPrevious', true);
+    fixture.componentRef.setInput('hasNext', false);
+    fixture.detectChanges();
+
+    expect(botao('prev').disabled).toBe(false);
+    expect(botao('next').disabled).toBe(true);
+  });
+
+  it('isDisabled desabilita ambos mesmo com páginas disponíveis (recarga)', () => {
+    fixture.componentRef.setInput('hasPrevious', true);
+    fixture.componentRef.setInput('hasNext', true);
+    fixture.componentRef.setInput('isDisabled', true);
+    fixture.detectChanges();
+
+    expect(botao('prev').disabled).toBe(true);
+    expect(botao('next').disabled).toBe(true);
+  });
+
+  it('clicar em Anterior/Próximo emite os outputs correspondentes', () => {
+    fixture.componentRef.setInput('hasPrevious', true);
+    fixture.componentRef.setInput('hasNext', true);
+    fixture.detectChanges();
+
+    const previous = vi.fn();
+    const next = vi.fn();
+    fixture.componentInstance.previous.subscribe(previous);
+    fixture.componentInstance.next.subscribe(next);
+
+    botao('prev').click();
+    botao('next').click();
+
+    expect(previous).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('expõe statusText e navigationLabel acessíveis', () => {
+    fixture.componentRef.setInput('statusText', 'Página 2');
+    fixture.componentRef.setInput('navigationLabel', 'Paginação de unidades');
+    fixture.detectChanges();
+
+    const nav = fixture.debugElement.query(By.css('nav')).nativeElement as HTMLElement;
+    expect(nav.getAttribute('aria-label')).toBe('Paginação de unidades');
+    expect(fixture.debugElement.query(By.css('.pager__status')).nativeElement.textContent).toContain(
+      'Página 2',
+    );
+  });
+});


### PR DESCRIPTION
## Resumo

- Adota **navegação Anterior / Próximo (prev/next) por substituição** como padrão das listas paginadas, encerrando a montagem interina de "Carregar mais" (acumulação forward) entregue no #399.
- Habilitado pelo cursor bidirecional do backend (unifesspa-edu-br/uniplus-api#656, ADR-0089): o header `Link` passa a emitir `rel="prev"` além de `rel="next"`, com o param `direction` vinculado ao cursor.
- Cliente **não** mantém pilha de cursores — o servidor fornece `prev`/`next` a cada página.

Closes #401

## Mudanças (por camada)

### `shared-core` — helpers (`dd2ebeb`)
- `extractPrevCursor` (simétrico a `extractNextCursor`, núcleo comum extraído) e tipo `PaginationDirection` (`'next' | 'prev'`).

### `shared-ui` — data-table + pager (`bf80711`)
- `data-table` troca o botão "Carregar mais" pela barra **Anterior/Próximo**, reusando o `PagerComponent` (`ui-pager`) que existia mas não estava conectado a nenhuma tela.
- Novos: input `prevCursor`, output `loadPrev`. Spec do `ui-pager` (antes sem cobertura).

### `selecao` — editais (`611d6c1`)
- `EditaisApi.listar` ganha `direction`; o container deixa de acumular (substitui a página) e relê prev/next do header `Link`. Retry refaz exatamente a navegação que falhou.

### `configuracao` — unidades (`0e0baf3`)
- Migra a montagem interina do #399: `linkedSignal` substitui (não acumula); `montarParams` envia `cursor`+`direction` na navegação. Invariantes de erro do #399 preservadas.

## Contrato cliente ↔ backend (ADR-0089)

- **1ª página:** sem `cursor`/`direction` (o servidor coage para `next`).
- **Navegação:** envia `cursor` + `direction` casado à direção cifrada no cursor (o backend rejeita divergência); `limit` é omitido (o cursor carrega a janela).

## Invariantes de erro preservadas (#399)

- Retry da página via `reload()`/`retry`; ações de linha desabilitadas durante recarga substitutiva (tabela, hierarquia, drawer); seletor de unidade superior com resource próprio; cache monotônico de rótulos; reset síncrono da busca.

## Testes / validação local

`nx lint` + `nx vite:test` + `nx build` verdes nos projetos afetados:

| Projeto | Testes |
|---|---|
| shared-core | 134 |
| shared-ui | 136 |
| shared-data | 101 |
| selecao | 43 |
| configuracao | 23 |

## Checklist

- [x] Build sem erros (apps + libs dependentes)
- [x] Testes passando
- [x] Lint sem warnings