### PR TITLE
feat(configuracao): cadastro de Instituição (singleton e-MEC) — tela web

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@ uniplus-ds CSS-only
 npx nx serve selecao          # porta 4200
 npx nx serve ingresso         # porta 4201
 npx nx serve portal           # porta 4202
+npx nx serve configuracao     # porta 4203
 
 # Build
 npx nx build selecao
@@ -124,6 +125,14 @@ npm run generate:api
 npx nx affected --target=build
 npx nx affected --target=vite:test
 ```
+
+### Testar um app contra o backend real (local)
+
+Para exercitar um app contra as APIs do `uniplus-api` (login Keycloak + dados
+reais), o backend precisa validar o realm `unifesspa` — suba o `uniplus-api` com
+o override `frontend-test`, senão **toda mutação responde 401 + loop de re-login**
+(o GET de lista é `[AllowAnonymous]` e mascara). Passo a passo, credenciais e
+sintomas: [`docs/guia-testar-frontend-com-backend-local.md`](docs/guia-testar-frontend-com-backend-local.md).
 
 ## Localização do repositório
 

--- a/apps/configuracao-e2e/src/specs/instituicao.visual.spec.ts
+++ b/apps/configuracao-e2e/src/specs/instituicao.visual.spec.ts
@@ -1,0 +1,298 @@
+import { expect, test, type Page, type TestInfo } from '@playwright/test';
+import { mockConfiguracaoRuntimeConfig } from '../support/runtime-config';
+
+type VisualTheme = 'light' | 'dark' | 'contrast';
+type VisualViewport = 'mobile' | 'desktop';
+
+const REITORIA_ID = '01960000-0000-7000-0000-000000000001';
+const INSTITUICAO_ID = '01960000-0000-7000-0000-0000000000a1';
+
+const REITORIAS = [
+  {
+    id: REITORIA_ID,
+    nome: 'Reitoria',
+    alias: null,
+    slug: 'reitoria',
+    sigla: 'REITORIA',
+    codigo: 'REITORIA',
+    unidadeSuperiorId: null,
+    tipo: 'Reitoria',
+    unidadeAcademica: false,
+    vigenciaInicio: '2026-01-01',
+    vigenciaFim: null,
+    origem: 'CriadoNoUniPlus',
+    criadoEm: '2026-06-10T12:00:00Z',
+  },
+] as const;
+
+const INSTITUICAO = {
+  id: INSTITUICAO_ID,
+  codigoEmec: '3990',
+  nome: 'Universidade Federal do Sul e Sudeste do Pará',
+  sigla: 'Unifesspa',
+  organizacaoAcademica: 'Universidade',
+  categoriaAdministrativa: 'Pública Federal',
+  cnpj: null,
+  mantenedora: null,
+  codigoMantenedoraEmec: null,
+  situacao: null,
+  atoCredenciamento: null,
+  atoRecredenciamento: null,
+  conceitoInstitucional: null,
+  igc: null,
+  website: null,
+  enderecoSede: null,
+  municipioSede: null,
+  unidadeRaizId: REITORIA_ID,
+  criadoEm: '2026-06-10T12:00:00Z',
+} as const;
+
+const CORS_HEADERS = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'GET, POST, PUT, DELETE, OPTIONS',
+  'access-control-allow-headers': 'authorization, content-type, accept, idempotency-key',
+};
+
+test.describe('Instituição — cobertura visual DS', () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    const theme = metadataTheme(testInfo);
+    await mockConfiguracaoRuntimeConfig(page);
+    await page.addInitScript((dsTheme: VisualTheme) => {
+      window.localStorage.setItem(
+        'uniplus.a11y',
+        JSON.stringify({
+          theme: dsTheme === 'contrast' ? 'auto' : dsTheme,
+          contrast: dsTheme === 'contrast',
+          fontMode: 'default',
+        }),
+      );
+    }, theme);
+
+    await mockReitoriasApi(page);
+  });
+
+  test('modo leitura — ficha, banner singleton, breadcrumb e tema aderentes ao DS', async ({
+    page,
+  }, testInfo) => {
+    const theme = metadataTheme(testInfo);
+    const viewport = metadataViewport(testInfo);
+
+    await mockInstituicaoApi(page, { existe: true });
+    await page.goto('/instituicao');
+
+    await expect(page.locator('html')).toHaveAttribute('data-theme', theme);
+    await expect(page.getByRole('heading', { name: 'Instituição', level: 1 })).toBeVisible();
+
+    // Banner singleton sempre visível.
+    await expect(page.getByText('Registro único')).toBeVisible();
+    await expect(
+      page.getByText('Cada instância da plataforma atende uma única instituição'),
+    ).toBeVisible();
+
+    // Breadcrumb reflete a página ativa (dinâmico por rota).
+    const breadcrumb = page.getByRole('navigation', { name: 'Breadcrumb' });
+    await expect(breadcrumb.getByText('Instituição', { exact: true })).toBeVisible();
+
+    // Ficha de leitura: 7 seções.
+    const ficha = page.locator('.cfg-instituicao__ficha');
+    await expect(ficha).toBeVisible();
+    await expect(ficha.locator('.form-section__title')).toHaveCount(7);
+    await expect(ficha.getByText('REITORIA — Reitoria')).toBeVisible();
+    // Botão de criação não aparece quando há Instituição viva.
+    await expect(page.getByRole('button', { name: 'Cadastrar instituição' })).toHaveCount(0);
+
+    await assertNoHorizontalOverflow(page);
+    await assertSidebarInstituicaoAtiva(page, viewport);
+
+    await attachScreenshot(page, testInfo, 'instituicao-leitura');
+  });
+
+  test('modo edição — drawer preserva footer, rolagem única e ação de remoção', async ({
+    page,
+  }, testInfo) => {
+    await mockInstituicaoApi(page, { existe: true });
+    await page.goto('/instituicao');
+
+    await page.getByRole('button', { name: 'Editar' }).click();
+
+    const drawer = page.locator('dialog.uni-drawer').filter({ hasText: 'Editar instituição' });
+    await expect(drawer).toBeVisible();
+    await expect(page.locator('body')).toHaveClass(/uni-drawer-open/);
+    await expect(drawer.getByText('Identificação')).toBeVisible();
+    await expect(drawer.getByText('Classificação e-MEC')).toBeVisible();
+    await expect(drawer.getByText('Estrutura organizacional')).toBeVisible();
+    await expect(drawer.locator('.form-section__title')).toHaveCount(7);
+
+    const footer = drawer.locator('.cfg-form-footer');
+    await expect(footer.getByRole('button', { name: 'Remover' })).toBeVisible();
+    await expect(footer.getByRole('button', { name: 'Cancelar' })).toBeVisible();
+    await expect(footer.getByRole('button', { name: 'Salvar instituição' })).toBeVisible();
+
+    const metrics = await drawer.locator('.uni-drawer__panel').evaluate((panel) => {
+      const body = panel.querySelector('.uni-drawer__body') as HTMLElement;
+      const form = panel.querySelector('.cfg-form') as HTMLElement;
+      const footer = panel.querySelector('.cfg-form-footer') as HTMLElement;
+      const footerRect = footer.getBoundingClientRect();
+      return {
+        bodyOverflowY: getComputedStyle(body).overflowY,
+        formOverflowY: getComputedStyle(form).overflowY,
+        bodyOverflow: getComputedStyle(document.body).overflow,
+        footerInsideViewport: footerRect.bottom <= window.innerHeight + 1,
+      };
+    });
+
+    expect(metrics.bodyOverflowY).toBe('hidden');
+    expect(metrics.formOverflowY).toBe('auto');
+    expect(metrics.bodyOverflow).toBe('hidden');
+    expect(metrics.footerInsideViewport).toBe(true);
+
+    await attachScreenshot(page, testInfo, 'instituicao-drawer');
+
+    // Fecha sem salvar — não dispara mutação.
+    await footer.getByRole('button', { name: 'Cancelar' }).click();
+    await expect(drawer).toBeHidden();
+    await expect(page.locator('body')).not.toHaveClass(/uni-drawer-open/);
+  });
+
+  test('modo criação — empty-state e cadastro pelo drawer', async ({ page }, testInfo) => {
+    await mockInstituicaoApi(page, { existe: false });
+    await page.goto('/instituicao');
+
+    await expect(page.getByRole('heading', { name: 'Nenhuma instituição cadastrada' })).toBeVisible();
+    await expect(page.getByText('Registro único')).toBeVisible();
+    await expect(page.locator('.cfg-instituicao__ficha')).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Cadastrar instituição' }).first().click();
+
+    const drawer = page.locator('dialog.uni-drawer').filter({ hasText: 'Cadastrar instituição' });
+    await expect(drawer).toBeVisible();
+    // Em criação não há ação de remoção.
+    await expect(drawer.getByRole('button', { name: 'Remover' })).toHaveCount(0);
+
+    await drawer.getByLabel('Nome oficial').fill(INSTITUICAO.nome);
+    await drawer.getByLabel('Sigla').fill(INSTITUICAO.sigla);
+    await drawer.getByLabel('Código e-MEC').fill(INSTITUICAO.codigoEmec);
+    await drawer.getByLabel('Organização acadêmica').fill(INSTITUICAO.organizacaoAcademica);
+    await drawer.getByLabel('Categoria administrativa').fill(INSTITUICAO.categoriaAdministrativa);
+
+    const salvar = drawer.locator('.cfg-form-footer').getByRole('button', {
+      name: 'Salvar instituição',
+    });
+    await expect(salvar).toBeEnabled();
+    await salvar.click();
+
+    // Pós-criação o GET passa a devolver 200 → a ficha aparece.
+    await expect(drawer).toBeHidden();
+    await expect(page.locator('.cfg-instituicao__ficha')).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: INSTITUICAO.nome, level: 2 }),
+    ).toBeVisible();
+
+    await attachScreenshot(page, testInfo, 'instituicao-criacao');
+  });
+});
+
+async function mockReitoriasApi(page: Page): Promise<void> {
+  await page.route(/\/api\/unidades(\?.*)?$/, async (route, request) => {
+    if (request.method() === 'OPTIONS') {
+      await route.fulfill({ status: 204, headers: CORS_HEADERS });
+      return;
+    }
+    if (request.method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      headers: { ...CORS_HEADERS, 'content-type': 'application/json' },
+      body: JSON.stringify(REITORIAS),
+    });
+  });
+}
+
+async function mockInstituicaoApi(page: Page, options: { existe: boolean }): Promise<void> {
+  let existe = options.existe;
+
+  // GET /api/instituicao (singleton): 200 quando existe, 404 quando não.
+  await page.route(/\/api\/instituicao$/, async (route, request) => {
+    if (request.method() === 'OPTIONS') {
+      await route.fulfill({ status: 204, headers: CORS_HEADERS });
+      return;
+    }
+    if (request.method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+    if (existe) {
+      await route.fulfill({
+        status: 200,
+        headers: { ...CORS_HEADERS, 'content-type': 'application/json' },
+        body: JSON.stringify(INSTITUICAO),
+      });
+    } else {
+      await route.fulfill({ status: 404, headers: CORS_HEADERS });
+    }
+  });
+
+  // POST /api/admin/instituicao: cria e liga o flag para a ficha aparecer.
+  await page.route(/\/api\/admin\/instituicao$/, async (route, request) => {
+    if (request.method() === 'OPTIONS') {
+      await route.fulfill({ status: 204, headers: CORS_HEADERS });
+      return;
+    }
+    if (request.method() !== 'POST') {
+      await route.continue();
+      return;
+    }
+    existe = true;
+    await route.fulfill({
+      status: 201,
+      headers: { ...CORS_HEADERS, 'content-type': 'application/json' },
+      body: JSON.stringify(INSTITUICAO_ID),
+    });
+  });
+}
+
+async function assertNoHorizontalOverflow(page: Page): Promise<void> {
+  const viewport = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+  }));
+  expect(viewport.scrollWidth).toBeLessThanOrEqual(viewport.clientWidth);
+}
+
+async function assertSidebarInstituicaoAtiva(page: Page, viewport: VisualViewport): Promise<void> {
+  const sidebar = page.locator('#cfg-admin-sidebar');
+  if (viewport === 'mobile') {
+    await page.getByRole('button', { name: 'Abrir menu lateral' }).click();
+    await expect(sidebar).toBeVisible();
+  }
+  await expect(sidebar.getByRole('link', { name: 'Instituição' })).toHaveAttribute(
+    'aria-current',
+    'page',
+  );
+  if (viewport === 'mobile') {
+    await sidebar.getByRole('button', { name: 'Fechar menu lateral' }).click();
+    await expect(sidebar).toBeHidden();
+  }
+}
+
+async function attachScreenshot(
+  page: Page,
+  testInfo: TestInfo,
+  name: 'instituicao-leitura' | 'instituicao-drawer' | 'instituicao-criacao',
+): Promise<void> {
+  await testInfo.attach(`${testInfo.project.name}-${name}`, {
+    body: await page.screenshot({ fullPage: true }),
+    contentType: 'image/png',
+  });
+}
+
+function metadataTheme(testInfo: TestInfo): VisualTheme {
+  const theme = testInfo.project.metadata['theme'];
+  return theme === 'dark' || theme === 'contrast' ? theme : 'light';
+}
+
+function metadataViewport(testInfo: TestInfo): VisualViewport {
+  return testInfo.project.metadata['viewport'] === 'mobile' ? 'mobile' : 'desktop';
+}

--- a/apps/configuracao/src/app/app.routes.ts
+++ b/apps/configuracao/src/app/app.routes.ts
@@ -15,8 +15,15 @@ export const appRoutes: Routes = [
       { path: '', redirectTo: 'unidades', pathMatch: 'full' },
       {
         path: 'unidades',
+        data: { breadcrumb: 'Unidade' },
         loadChildren: () =>
           import('./features/unidades/unidades.routes').then((m) => m.UNIDADES_ROUTES),
+      },
+      {
+        path: 'instituicao',
+        data: { breadcrumb: 'Instituição' },
+        loadChildren: () =>
+          import('./features/instituicao/instituicao.routes').then((m) => m.INSTITUICAO_ROUTES),
       },
     ],
   },

--- a/apps/configuracao/src/app/features/instituicao/instituicao.page.spec.ts
+++ b/apps/configuracao/src/app/features/instituicao/instituicao.page.spec.ts
@@ -284,4 +284,57 @@ describe('InstituicaoPage', () => {
     expect(component.drawerAberto()).toBe(false);
     expect(fixture.nativeElement.querySelector('ui-empty-state')).not.toBeNull();
   });
+
+  it('InstituicaoForm_RemocaoEmVoo_BloqueiaSalvar', async () => {
+    await carregar(instituicaoSeed);
+    component.abrirEdicao();
+    component.pedirRemocao();
+    component.removerConfirmado();
+    await propagate();
+
+    // DELETE em voo (não flushado): removendo() = true.
+    const del = controller.expectOne(`${BASE}/api/admin/instituicao/${ID}`);
+    expect(del.request.method).toBe('DELETE');
+
+    // Tentar salvar nessa janela é no-op (guard de corrida): retorna antes de
+    // marcar submitting e não dispara PUT. Se um PUT fosse criado, o
+    // controller.verify() do afterEach acusaria a request não consumida.
+    component.salvar();
+    await propagate();
+    expect(component.submitting()).toBe(false);
+
+    del.flush(null, { status: 204, statusText: 'No Content' });
+    await propagate();
+    expect(component.instituicao()).toBeNull();
+  });
+
+  it('InstituicaoForm_ErroCampoOpcional_MapeiaInline', async () => {
+    await carregar(null);
+    component.abrirCadastro();
+    preencherObrigatorios();
+    component.salvar();
+    await propagate();
+
+    const req = controller.expectOne(`${BASE}/api/admin/instituicao`);
+    req.flush(
+      JSON.stringify({
+        type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.validacao',
+        title: 'Erro de validação',
+        status: 422,
+        code: 'uniplus.validacao',
+        traceId: 'test-trace',
+        errors: [{ field: 'Cnpj', code: 'FormatoInvalido', message: 'CNPJ inválido.' }],
+      }),
+      {
+        status: 422,
+        statusText: 'Unprocessable Entity',
+        headers: { 'content-type': 'application/problem+json' },
+      },
+    );
+    await propagate();
+
+    // Erro de campo opcional é mapeado ao controle e renderizado inline.
+    expect(component.erroDoCampo('cnpj')).toBe('CNPJ inválido.');
+    expect(component.drawerAberto()).toBe(true);
+  });
 });

--- a/apps/configuracao/src/app/features/instituicao/instituicao.page.spec.ts
+++ b/apps/configuracao/src/app/features/instituicao/instituicao.page.spec.ts
@@ -1,0 +1,287 @@
+import { HttpRequest, provideHttpClient, withInterceptors } from '@angular/common/http';
+import {
+  HttpTestingController,
+  TestRequest,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { ApplicationRef } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { apiResultInterceptor, buildVendorMimeAccept } from '@uniplus/shared-core/http';
+import { InstituicaoDto, ORGANIZACAO_BASE_PATH, UnidadeDto } from '@uniplus/shared-data/organizacao';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { InstituicaoPage } from './instituicao.page';
+
+const BASE = 'http://localhost:5000';
+const ID = '01960000-0000-7000-0000-0000000000a1';
+const REITORIA_ID = '01960000-0000-7000-0000-000000000001';
+
+const reitoriasSeed: readonly UnidadeDto[] = [
+  {
+    id: REITORIA_ID,
+    nome: 'Reitoria',
+    alias: null,
+    slug: 'reitoria',
+    sigla: 'REITORIA',
+    codigo: 'REITORIA',
+    unidadeSuperiorId: null,
+    tipo: 'Reitoria',
+    unidadeAcademica: false,
+    vigenciaInicio: '2026-01-01',
+    vigenciaFim: null,
+    origem: 'CriadoNoUniPlus',
+    criadoEm: '2026-06-10T12:00:00Z',
+  },
+];
+
+const instituicaoSeed: InstituicaoDto = {
+  id: ID,
+  codigoEmec: '3990',
+  nome: 'Universidade Federal do Sul e Sudeste do Pará',
+  sigla: 'Unifesspa',
+  organizacaoAcademica: 'Universidade',
+  categoriaAdministrativa: 'Pública Federal',
+  cnpj: null,
+  mantenedora: null,
+  codigoMantenedoraEmec: null,
+  situacao: null,
+  atoCredenciamento: null,
+  atoRecredenciamento: null,
+  conceitoInstitucional: null,
+  igc: null,
+  website: null,
+  enderecoSede: null,
+  municipioSede: null,
+  unidadeRaizId: REITORIA_ID,
+  criadoEm: '2026-06-10T12:00:00Z',
+};
+
+function problem(status: number, code: string, title: string): string {
+  return JSON.stringify({
+    type: `https://uniplus.unifesspa.edu.br/errors/${code}`,
+    title,
+    status,
+    code,
+    traceId: 'test-trace',
+  });
+}
+
+describe('InstituicaoPage', () => {
+  let fixture: ComponentFixture<InstituicaoPage>;
+  let component: InstituicaoPage;
+  let controller: HttpTestingController;
+  let appRef: ApplicationRef;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [InstituicaoPage],
+      providers: [
+        provideHttpClient(withInterceptors([apiResultInterceptor])),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        { provide: ORGANIZACAO_BASE_PATH, useValue: BASE },
+      ],
+    });
+
+    fixture = TestBed.createComponent(InstituicaoPage);
+    component = fixture.componentInstance;
+    controller = TestBed.inject(HttpTestingController);
+    appRef = TestBed.inject(ApplicationRef);
+  });
+
+  afterEach(() => controller.verify());
+
+  const propagate = async (): Promise<void> => {
+    await Promise.resolve();
+    appRef.tick();
+  };
+
+  function expectObter(): TestRequest {
+    const req = controller.expectOne(`${BASE}/api/instituicao`);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.headers.get('Accept')).toBe(buildVendorMimeAccept('instituicao', 1));
+    return req;
+  }
+
+  function expectReitorias(): TestRequest {
+    return controller.expectOne(
+      (r: HttpRequest<unknown>) =>
+        r.url === `${BASE}/api/unidades` && r.method === 'GET' && r.params.get('tipo') === '1',
+    );
+  }
+
+  // Carga inicial. `obter()` dispara no construtor; reitorias no detectChanges.
+  async function carregar(
+    instituicao: InstituicaoDto | null,
+    reitorias: readonly UnidadeDto[] = reitoriasSeed,
+  ): Promise<void> {
+    fixture.detectChanges();
+    const obter = expectObter();
+    if (instituicao) {
+      obter.flush(instituicao);
+    } else {
+      obter.flush(null, { status: 404, statusText: 'Not Found' });
+    }
+    expectReitorias().flush(reitorias);
+    await propagate();
+  }
+
+  function preencherObrigatorios(): void {
+    component.form.patchValue({
+      nome: 'Universidade Federal do Sul e Sudeste do Pará',
+      sigla: 'Unifesspa',
+      codigoEmec: '3990',
+      organizacaoAcademica: 'Universidade',
+      categoriaAdministrativa: 'Pública Federal',
+    });
+  }
+
+  it('InstituicaoPage_ModoLeitura_Exibe7Secoes', async () => {
+    await carregar(instituicaoSeed);
+
+    const ficha = fixture.nativeElement.querySelector('.cfg-instituicao__ficha');
+    expect(ficha).not.toBeNull();
+    expect(ficha.querySelectorAll('h3.form-section__title')).toHaveLength(7);
+
+    const texto = fixture.nativeElement.textContent as string;
+    expect(texto).toContain('Registro único');
+    expect(texto).toContain('Universidade Federal do Sul e Sudeste do Pará');
+    expect(texto).not.toContain('Nenhuma instituição cadastrada');
+  });
+
+  it('InstituicaoPage_ModoCriacao_ExibeEmptyState', async () => {
+    await carregar(null);
+
+    expect(fixture.nativeElement.querySelector('.cfg-instituicao__ficha')).toBeNull();
+    expect(fixture.nativeElement.querySelector('ui-empty-state')).not.toBeNull();
+    const texto = fixture.nativeElement.textContent as string;
+    expect(texto).toContain('Registro único');
+    expect(texto).toContain('Nenhuma instituição cadastrada');
+  });
+
+  it('InstituicaoPage_CampoOpcionalVazio_ExibeDash', async () => {
+    await carregar(instituicaoSeed);
+
+    const ficha = fixture.nativeElement.querySelector('.cfg-instituicao__ficha') as HTMLElement;
+    // CNPJ é null no seed → exibe travessão.
+    expect(ficha.textContent).toContain('—');
+    // Unidade raiz resolve para o rótulo da reitoria carregada.
+    expect(ficha.textContent).toContain('REITORIA — Reitoria');
+  });
+
+  it('InstituicaoForm_SelectReitoria_PopulaOptions', async () => {
+    await carregar(null);
+    expect(component.reitorias()).toHaveLength(1);
+    expect(component.reitorias()[0]?.sigla).toBe('REITORIA');
+  });
+
+  it('InstituicaoForm_CamposObrigatorios_MarcaErros', async () => {
+    await carregar(null);
+    component.abrirCadastro();
+    component.salvar();
+    await propagate();
+
+    // Nenhuma request de POST disparada (form inválido).
+    controller.expectNone(`${BASE}/api/admin/instituicao`);
+    expect(component.erroDoCampo('nome')).toBe('Campo obrigatório.');
+    expect(component.erroDoCampo('codigoEmec')).toBe('Campo obrigatório.');
+    expect(component.drawerAberto()).toBe(true);
+  });
+
+  it('InstituicaoForm_ErroSingleton_ExibeBanner', async () => {
+    await carregar(null);
+    component.abrirCadastro();
+    preencherObrigatorios();
+    component.salvar();
+    await propagate();
+
+    const req = controller.expectOne(`${BASE}/api/admin/instituicao`);
+    expect(req.request.method).toBe('POST');
+    req.flush(
+      problem(409, 'uniplus.organizacao.instituicao.ja_existe', 'Já existe'),
+      { status: 409, statusText: 'Conflict', headers: { 'content-type': 'application/problem+json' } },
+    );
+    await propagate();
+
+    expect(component.submitError()).toContain('Já existe uma instituição cadastrada');
+    expect(component.drawerAberto()).toBe(true);
+  });
+
+  it('InstituicaoForm_ErroUnidadeRaiz_MapeiaCampo', async () => {
+    await carregar(instituicaoSeed);
+    component.abrirEdicao();
+    const chaveInicial = component.idempotencyKeyAtual();
+    component.salvar();
+    await propagate();
+
+    const req = controller.expectOne(`${BASE}/api/admin/instituicao/${ID}`);
+    expect(req.request.method).toBe('PUT');
+    req.flush(
+      problem(
+        422,
+        'uniplus.organizacao.instituicao.unidade_raiz_nao_eh_reitoria',
+        'A unidade informada como raiz da instituição deve ser do tipo reitoria',
+      ),
+      {
+        status: 422,
+        statusText: 'Unprocessable Entity',
+        headers: { 'content-type': 'application/problem+json' },
+      },
+    );
+    await propagate();
+
+    expect(component.erroDoCampo('unidadeRaizId')).toContain('reitoria');
+    // Idempotency-Key é renovada após a falha (retry seguro com body corrigido).
+    expect(component.idempotencyKeyAtual()).not.toBe(chaveInicial);
+  });
+
+  it('InstituicaoForm_Criar_RequisicaoCorreta', async () => {
+    await carregar(null);
+    component.abrirCadastro();
+    preencherObrigatorios();
+    const chave = component.idempotencyKeyAtual();
+    component.salvar();
+    await propagate();
+
+    const req = controller.expectOne(`${BASE}/api/admin/instituicao`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.headers.get('Idempotency-Key')).toBe(chave);
+    expect(req.request.body).toMatchObject({
+      codigoEmec: '3990',
+      nome: 'Universidade Federal do Sul e Sudeste do Pará',
+      sigla: 'Unifesspa',
+      organizacaoAcademica: 'Universidade',
+      categoriaAdministrativa: 'Pública Federal',
+      cnpj: null,
+      unidadeRaizId: null,
+    });
+    req.flush(ID, { status: 201, statusText: 'Created' });
+    await propagate();
+
+    // Pós-sucesso: drawer fecha e recarrega o singleton (`obter()`); o resource
+    // de reitorias não re-dispara (params inalterados, sem reload).
+    expect(component.drawerAberto()).toBe(false);
+    expectObter().flush(instituicaoSeed);
+    await propagate();
+    expect(component.instituicao()?.sigla).toBe('Unifesspa');
+  });
+
+  it('InstituicaoPage_Remocao_RetornaModoCriacao', async () => {
+    await carregar(instituicaoSeed);
+    component.abrirEdicao();
+    component.pedirRemocao();
+    expect(component.dialogRemover()).toBe(true);
+
+    component.removerConfirmado();
+    await propagate();
+
+    const req = controller.expectOne(`${BASE}/api/admin/instituicao/${ID}`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush(null, { status: 204, statusText: 'No Content' });
+    await propagate();
+
+    expect(component.instituicao()).toBeNull();
+    expect(component.drawerAberto()).toBe(false);
+    expect(fixture.nativeElement.querySelector('ui-empty-state')).not.toBeNull();
+  });
+});

--- a/apps/configuracao/src/app/features/instituicao/instituicao.page.ts
+++ b/apps/configuracao/src/app/features/instituicao/instituicao.page.ts
@@ -1,0 +1,928 @@
+import { HttpParams } from '@angular/common/http';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import {
+  ApiResult,
+  ProblemDetails,
+  ProblemI18nService,
+  ProblemValidationError,
+  idempotencyKey,
+  useApiResource,
+  withIdempotencyKey,
+  withVendorMime,
+} from '@uniplus/shared-core/http';
+import { NotificationService } from '@uniplus/shared-core/notifications';
+import {
+  AtualizarInstituicaoCommand,
+  CriarInstituicaoCommand,
+  InstituicaoApi,
+  InstituicaoDto,
+  ORGANIZACAO_BASE_PATH,
+  UnidadeDto,
+} from '@uniplus/shared-data/organizacao';
+import {
+  AlertComponent,
+  ConfirmDialogComponent,
+  DrawerComponent,
+  EmptyStateComponent,
+  SpinnerComponent,
+} from '@uniplus/shared-ui/components';
+
+/** Valor de `TipoUnidade` da Reitoria no roster fechado (`TIPOS_UNIDADE`). */
+const TIPO_REITORIA = '1';
+
+/** Tamanho da janela ao buscar as Unidades do tipo Reitoria para o select. */
+const PAGE_SIZE = 100;
+
+/**
+ * Mensagem do banner de bloqueio quando o backend recusa uma segunda criação
+ * (409 singleton — CA-06 / §5.1 da spec).
+ */
+const SINGLETON_CONFLITO_MSG =
+  'Já existe uma instituição cadastrada nesta instância da plataforma. ' +
+  'Para criar uma nova, primeiro remova a existente.';
+
+interface InstituicaoForm {
+  nome: FormControl<string>;
+  sigla: FormControl<string>;
+  codigoEmec: FormControl<string>;
+  cnpj: FormControl<string>;
+  organizacaoAcademica: FormControl<string>;
+  categoriaAdministrativa: FormControl<string>;
+  mantenedora: FormControl<string>;
+  codigoMantenedoraEmec: FormControl<string>;
+  situacao: FormControl<string>;
+  atoCredenciamento: FormControl<string>;
+  atoRecredenciamento: FormControl<string>;
+  conceitoInstitucional: FormControl<string>;
+  igc: FormControl<string>;
+  website: FormControl<string>;
+  enderecoSede: FormControl<string>;
+  municipioSede: FormControl<string>;
+  unidadeRaizId: FormControl<string>;
+}
+
+@Component({
+  selector: 'cfg-instituicao-page',
+  standalone: true,
+  imports: [
+    ReactiveFormsModule,
+    AlertComponent,
+    ConfirmDialogComponent,
+    DrawerComponent,
+    EmptyStateComponent,
+    SpinnerComponent,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="page-header">
+      <div class="page-header__content">
+        <h1 class="page-header__title">Instituição</h1>
+        <p class="page-header__desc">
+          Cabeçalho institucional da plataforma — identificação e-MEC, situação regulatória e
+          contato da sede · UNI-REQ-0007.
+        </p>
+      </div>
+    </div>
+
+    <ui-alert
+      variant="info"
+      heading="Registro único"
+      [dynamic]="false"
+    >
+      Cada instância da plataforma atende uma única instituição. Não é possível criar nem listar
+      várias — apenas editar a Instituição existente. A remoção é lógica e só ocorre em
+      recadastramento institucional.
+    </ui-alert>
+
+    @if (loadError()) {
+      <ui-alert variant="danger" heading="Não foi possível carregar a instituição">
+        {{ loadError() }}
+        <div class="cfg-instituicao__retry">
+          <button
+            type="button"
+            class="btn btn--secondary btn--sm"
+            [disabled]="isLoading()"
+            (click)="carregar()"
+          >
+            Tentar novamente
+          </button>
+        </div>
+      </ui-alert>
+    } @else if (isLoading()) {
+      <section class="panel">
+        <div class="cfg-panel-empty">
+          <span class="cfg-instituicao__loading"><ui-spinner size="sm" /> Carregando instituição</span>
+        </div>
+      </section>
+    } @else if (instituicao(); as inst) {
+      <section class="panel" aria-labelledby="cfg-instituicao-ficha-title">
+        <div class="panel-head">
+          <div class="panel-head__title">
+            <h2 id="cfg-instituicao-ficha-title">{{ inst.nome }}</h2>
+            <span class="tag">{{ inst.sigla }}</span>
+          </div>
+          <button type="button" class="btn btn--primary" (click)="abrirEdicao()">
+            <i class="pi pi-pencil btn__icon" aria-hidden="true"></i>
+            Editar
+          </button>
+        </div>
+
+        <div class="cfg-instituicao__ficha">
+          <section aria-labelledby="cfg-ficha-identificacao">
+            <h3 id="cfg-ficha-identificacao" class="form-section__title">Identificação</h3>
+            <dl class="cfg-detail-list">
+              <dt>Nome oficial</dt>
+              <dd>{{ inst.nome }}</dd>
+              <dt>Sigla</dt>
+              <dd>{{ inst.sigla }}</dd>
+              <dt>Código e-MEC</dt>
+              <dd>{{ inst.codigoEmec }}</dd>
+              <dt>CNPJ</dt>
+              <dd>{{ inst.cnpj || naoInformado }}</dd>
+            </dl>
+          </section>
+
+          <section aria-labelledby="cfg-ficha-classificacao">
+            <h3 id="cfg-ficha-classificacao" class="form-section__title">Classificação e-MEC</h3>
+            <dl class="cfg-detail-list">
+              <dt>Organização acadêmica</dt>
+              <dd>{{ inst.organizacaoAcademica }}</dd>
+              <dt>Categoria administrativa</dt>
+              <dd>{{ inst.categoriaAdministrativa }}</dd>
+            </dl>
+          </section>
+
+          <section aria-labelledby="cfg-ficha-mantenedora">
+            <h3 id="cfg-ficha-mantenedora" class="form-section__title">Mantenedora</h3>
+            <dl class="cfg-detail-list">
+              <dt>Mantenedora</dt>
+              <dd>{{ inst.mantenedora || naoInformado }}</dd>
+              <dt>Código mantenedora e-MEC</dt>
+              <dd>{{ inst.codigoMantenedoraEmec || naoInformado }}</dd>
+            </dl>
+          </section>
+
+          <section aria-labelledby="cfg-ficha-situacao">
+            <h3 id="cfg-ficha-situacao" class="form-section__title">Situação regulatória</h3>
+            <dl class="cfg-detail-list">
+              <dt>Situação</dt>
+              <dd>{{ inst.situacao || naoInformado }}</dd>
+              <dt>Ato de credenciamento</dt>
+              <dd>{{ inst.atoCredenciamento || naoInformado }}</dd>
+              <dt>Ato de recredenciamento</dt>
+              <dd>{{ inst.atoRecredenciamento || naoInformado }}</dd>
+            </dl>
+          </section>
+
+          <section aria-labelledby="cfg-ficha-indicadores">
+            <h3 id="cfg-ficha-indicadores" class="form-section__title">Indicadores de qualidade</h3>
+            <dl class="cfg-detail-list">
+              <dt>Conceito institucional (CI)</dt>
+              <dd>{{ inst.conceitoInstitucional || naoInformado }}</dd>
+              <dt>Índice geral de cursos (IGC)</dt>
+              <dd>{{ inst.igc || naoInformado }}</dd>
+            </dl>
+          </section>
+
+          <section aria-labelledby="cfg-ficha-contato">
+            <h3 id="cfg-ficha-contato" class="form-section__title">Contato e localização da sede</h3>
+            <dl class="cfg-detail-list">
+              <dt>Site institucional</dt>
+              <dd>{{ inst.website || naoInformado }}</dd>
+              <dt>Endereço da sede</dt>
+              <dd>{{ inst.enderecoSede || naoInformado }}</dd>
+              <dt>Município da sede</dt>
+              <dd>{{ inst.municipioSede || naoInformado }}</dd>
+            </dl>
+          </section>
+
+          <section aria-labelledby="cfg-ficha-estrutura">
+            <h3 id="cfg-ficha-estrutura" class="form-section__title">Estrutura organizacional</h3>
+            <dl class="cfg-detail-list">
+              <dt>Unidade raiz (reitoria)</dt>
+              <dd>{{ unidadeRaizLabel() || naoInformado }}</dd>
+            </dl>
+          </section>
+        </div>
+      </section>
+    } @else {
+      <section class="panel" aria-labelledby="cfg-instituicao-vazia-title">
+        <div class="panel-head">
+          <div class="panel-head__title">
+            <h2 id="cfg-instituicao-vazia-title">Nenhuma instituição cadastrada</h2>
+          </div>
+          <button type="button" class="btn btn--primary" (click)="abrirCadastro()">
+            <i class="pi pi-plus btn__icon" aria-hidden="true"></i>
+            Cadastrar instituição
+          </button>
+        </div>
+        <ui-empty-state
+          heading="Cadastre a Instituição da plataforma"
+          description="Esta instância ainda não tem uma instituição cadastrada. Cadastre o cabeçalho institucional para vincular editais, comprovantes e a estrutura organizacional."
+        >
+          <button type="button" class="btn btn--primary" (click)="abrirCadastro()">
+            Cadastrar instituição
+          </button>
+        </ui-empty-state>
+      </section>
+    }
+
+    <ui-drawer
+      class="cfg-form-drawer"
+      [(visible)]="drawerAberto"
+      [heading]="drawerTitulo()"
+      ariaLabel="Formulário da instituição"
+      position="right"
+    >
+      @if (submitError()) {
+        <ui-alert variant="danger" heading="Não foi possível salvar">
+          {{ submitError() }}
+        </ui-alert>
+      }
+
+      <form
+        [formGroup]="form"
+        id="cfg-instituicao-form"
+        (ngSubmit)="salvar()"
+        novalidate
+        class="cfg-form"
+      >
+        <section aria-labelledby="cfg-form-identificacao">
+          <h3 id="cfg-form-identificacao" class="form-section__title">Identificação</h3>
+          <div class="form-grid">
+            <label class="field field--full" [class.is-error]="erroDoCampo('nome')">
+              <span class="field__label is-required">Nome oficial</span>
+              <input
+                class="input"
+                type="text"
+                formControlName="nome"
+                [attr.aria-invalid]="erroDoCampo('nome') ? 'true' : null"
+              />
+              <span class="field__hint">Nome conforme ato de criação e cadastro e-MEC.</span>
+              @if (erroDoCampo('nome')) {
+                <span class="field__error">{{ erroDoCampo('nome') }}</span>
+              }
+            </label>
+            <label class="field" [class.is-error]="erroDoCampo('sigla')">
+              <span class="field__label is-required">Sigla</span>
+              <input
+                class="input"
+                type="text"
+                formControlName="sigla"
+                [attr.aria-invalid]="erroDoCampo('sigla') ? 'true' : null"
+              />
+              @if (erroDoCampo('sigla')) {
+                <span class="field__error">{{ erroDoCampo('sigla') }}</span>
+              }
+            </label>
+            <label class="field" [class.is-error]="erroDoCampo('codigoEmec')">
+              <span class="field__label is-required">Código e-MEC</span>
+              <input
+                class="input"
+                type="text"
+                inputmode="numeric"
+                formControlName="codigoEmec"
+                [attr.aria-invalid]="erroDoCampo('codigoEmec') ? 'true' : null"
+              />
+              <span class="field__hint">
+                Chave natural e-MEC da instituição — usada em integrações com INEP e MEC.
+              </span>
+              @if (erroDoCampo('codigoEmec')) {
+                <span class="field__error">{{ erroDoCampo('codigoEmec') }}</span>
+              }
+            </label>
+            <label class="field field--full">
+              <span class="field__label">CNPJ</span>
+              <input
+                class="input"
+                type="text"
+                placeholder="NN.NNN.NNN/NNNN-NN"
+                formControlName="cnpj"
+              />
+              <span class="field__hint">CNPJ da pessoa jurídica. Opcional.</span>
+            </label>
+          </div>
+        </section>
+
+        <section aria-labelledby="cfg-form-classificacao">
+          <h3 id="cfg-form-classificacao" class="form-section__title">Classificação e-MEC</h3>
+          <div class="form-grid">
+            <label class="field field--full" [class.is-error]="erroDoCampo('organizacaoAcademica')">
+              <span class="field__label is-required">Organização acadêmica</span>
+              <input
+                class="input"
+                type="text"
+                list="cfg-organizacao-academica"
+                formControlName="organizacaoAcademica"
+                [attr.aria-invalid]="erroDoCampo('organizacaoAcademica') ? 'true' : null"
+              />
+              <datalist id="cfg-organizacao-academica">
+                <option value="Universidade"></option>
+                <option value="Centro universitário"></option>
+                <option value="Faculdade"></option>
+                <option value="Instituto federal de educação, ciência e tecnologia"></option>
+              </datalist>
+              @if (erroDoCampo('organizacaoAcademica')) {
+                <span class="field__error">{{ erroDoCampo('organizacaoAcademica') }}</span>
+              }
+            </label>
+            <label
+              class="field field--full"
+              [class.is-error]="erroDoCampo('categoriaAdministrativa')"
+            >
+              <span class="field__label is-required">Categoria administrativa</span>
+              <input
+                class="input"
+                type="text"
+                list="cfg-categoria-administrativa"
+                formControlName="categoriaAdministrativa"
+                [attr.aria-invalid]="erroDoCampo('categoriaAdministrativa') ? 'true' : null"
+              />
+              <datalist id="cfg-categoria-administrativa">
+                <option value="Pública Federal"></option>
+                <option value="Pública Estadual"></option>
+                <option value="Pública Municipal"></option>
+                <option value="Privada com fins lucrativos"></option>
+                <option value="Privada sem fins lucrativos"></option>
+              </datalist>
+              @if (erroDoCampo('categoriaAdministrativa')) {
+                <span class="field__error">{{ erroDoCampo('categoriaAdministrativa') }}</span>
+              }
+            </label>
+          </div>
+        </section>
+
+        <section aria-labelledby="cfg-form-mantenedora">
+          <h3 id="cfg-form-mantenedora" class="form-section__title">Mantenedora</h3>
+          <div class="form-grid">
+            <label class="field field--full">
+              <span class="field__label">Mantenedora</span>
+              <input class="input" type="text" formControlName="mantenedora" />
+            </label>
+            <label class="field field--full">
+              <span class="field__label">Código mantenedora e-MEC</span>
+              <input
+                class="input"
+                type="text"
+                inputmode="numeric"
+                formControlName="codigoMantenedoraEmec"
+              />
+            </label>
+          </div>
+        </section>
+
+        <section aria-labelledby="cfg-form-situacao">
+          <h3 id="cfg-form-situacao" class="form-section__title">Situação regulatória</h3>
+          <div class="form-grid">
+            <label class="field field--full">
+              <span class="field__label">Situação</span>
+              <input class="input" type="text" formControlName="situacao" />
+              <span class="field__hint">Situação regulatória atual junto ao MEC.</span>
+            </label>
+            <label class="field field--full">
+              <span class="field__label">Ato de credenciamento</span>
+              <input
+                class="input"
+                type="text"
+                placeholder="Ex.: Lei nº 12.824, de 5 de junho de 2013"
+                formControlName="atoCredenciamento"
+              />
+            </label>
+            <label class="field field--full">
+              <span class="field__label">Ato de recredenciamento</span>
+              <input
+                class="input"
+                type="text"
+                placeholder="Ex.: Portaria MEC nº …"
+                formControlName="atoRecredenciamento"
+              />
+            </label>
+          </div>
+        </section>
+
+        <section aria-labelledby="cfg-form-indicadores">
+          <h3 id="cfg-form-indicadores" class="form-section__title">Indicadores de qualidade</h3>
+          <div class="form-grid form-grid--pair">
+            <label class="field">
+              <span class="field__label">Conceito institucional (CI)</span>
+              <input
+                class="input"
+                type="text"
+                inputmode="numeric"
+                formControlName="conceitoInstitucional"
+              />
+              <span class="field__hint">Valor e-MEC (1–5).</span>
+            </label>
+            <label class="field">
+              <span class="field__label">Índice geral de cursos (IGC)</span>
+              <input class="input" type="text" inputmode="numeric" formControlName="igc" />
+            </label>
+          </div>
+        </section>
+
+        <section aria-labelledby="cfg-form-contato">
+          <h3 id="cfg-form-contato" class="form-section__title">Contato e localização da sede</h3>
+          <div class="form-grid">
+            <label class="field field--full">
+              <span class="field__label">Site institucional</span>
+              <input class="input" type="url" formControlName="website" />
+            </label>
+            <label class="field field--full">
+              <span class="field__label">Endereço da sede</span>
+              <input class="input" type="text" formControlName="enderecoSede" />
+            </label>
+            <label class="field field--full">
+              <span class="field__label">Município da sede</span>
+              <input class="input" type="text" formControlName="municipioSede" />
+            </label>
+          </div>
+        </section>
+
+        <section aria-labelledby="cfg-form-estrutura">
+          <h3 id="cfg-form-estrutura" class="form-section__title">Estrutura organizacional</h3>
+          <div class="form-grid">
+            <label class="field field--full" [class.is-error]="erroDoCampo('unidadeRaizId')">
+              <span class="field__label">Unidade raiz (reitoria)</span>
+              <select
+                class="select"
+                formControlName="unidadeRaizId"
+                [attr.aria-invalid]="erroDoCampo('unidadeRaizId') ? 'true' : null"
+              >
+                <option value="">(Não vinculada)</option>
+                @for (reitoria of reitorias(); track reitoria.id) {
+                  <option [value]="reitoria.id">{{ reitoria.sigla }} — {{ reitoria.nome }}</option>
+                }
+              </select>
+              <span class="field__hint">
+                Aponta para a Unidade viva do tipo Reitoria. Pode ficar sem vínculo durante o
+                cadastro inicial da estrutura.
+              </span>
+              @if (reitoriasComErro()) {
+                <span class="field__error">
+                  Não foi possível carregar as unidades para seleção.
+                  <button type="button" class="cfg-link-button" (click)="recarregarReitorias()">
+                    Tentar novamente
+                  </button>
+                </span>
+              }
+              @if (erroDoCampo('unidadeRaizId')) {
+                <span class="field__error">{{ erroDoCampo('unidadeRaizId') }}</span>
+              }
+            </label>
+          </div>
+        </section>
+      </form>
+
+      <div class="cfg-form-footer">
+        @if (instituicao()) {
+          <button
+            type="button"
+            class="btn btn--danger-ghost btn--rect"
+            [disabled]="submitting() || removendo()"
+            (click)="pedirRemocao()"
+          >
+            Remover
+          </button>
+        }
+        <button type="button" class="btn btn--tertiary btn--rect" (click)="drawerAberto.set(false)">
+          Cancelar
+        </button>
+        <button
+          type="submit"
+          form="cfg-instituicao-form"
+          class="btn btn--primary"
+          [disabled]="submitting() || form.invalid"
+        >
+          @if (submitting()) {
+            <ui-spinner size="sm" />
+          }
+          {{ submitting() ? 'Salvando...' : 'Salvar instituição' }}
+        </button>
+      </div>
+    </ui-drawer>
+
+    <ui-confirm-dialog
+      [(visible)]="dialogRemover"
+      heading="Remover instituição"
+      message="Você está removendo a Instituição desta plataforma. Esta operação preserva o histórico de auditoria e libera o cadastro de uma nova Instituição. Confirma a remoção?"
+      confirmLabel="Remover"
+      confirmVariant="danger"
+      (confirmed)="removerConfirmado()"
+    />
+  `,
+})
+export class InstituicaoPage {
+  private readonly api = inject(InstituicaoApi);
+  private readonly problemI18n = inject(ProblemI18nService);
+  private readonly notifications = inject(NotificationService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly basePath = inject(ORGANIZACAO_BASE_PATH);
+
+  /** Texto exibido em campos opcionais sem valor (acessível a leitor de tela). */
+  protected readonly naoInformado = '—';
+
+  protected readonly instituicao = signal<InstituicaoDto | null>(null);
+  protected readonly isLoading = signal(false);
+  protected readonly loadError = signal<string | null>(null);
+
+  protected readonly drawerAberto = signal(false);
+  protected readonly submitting = signal(false);
+  protected readonly submitError = signal<string | null>(null);
+  protected readonly idempotencyKeyAtual = signal(idempotencyKey.create());
+
+  protected readonly dialogRemover = signal(false);
+  protected readonly removendo = signal(false);
+
+  protected readonly drawerTitulo = computed(() =>
+    this.instituicao() ? 'Editar instituição' : 'Cadastrar instituição',
+  );
+
+  /**
+   * Unidades vivas do tipo Reitoria para popular o select de unidade raiz e
+   * resolver o nome exibido na ficha de leitura. Carregado de forma reativa via
+   * `useApiResource` (GET-only, ADR-0018) — sem acesso direto a `HttpClient` na
+   * página (fitness `no-direct-http-in-pages`). Filtro `?tipo=1` (Reitoria).
+   */
+  private readonly reitoriasResource = useApiResource<readonly UnidadeDto[]>(() => ({
+    url: `${this.basePath}/api/unidades`,
+    params: new HttpParams().set('tipo', TIPO_REITORIA).set('limit', String(PAGE_SIZE)),
+    context: withVendorMime('unidade', 1),
+  }));
+
+  protected readonly reitorias = computed(() => this.reitoriasResource.data() ?? []);
+
+  private readonly reitoriasPorId = computed(
+    () => new Map(this.reitorias().map((reitoria) => [reitoria.id, reitoria] as const)),
+  );
+
+  /**
+   * Falha ao carregar as reitorias — diferencia "sem reitorias" de "não
+   * carregou". Sinaliza com retry no select; não bloqueia o salvamento (o
+   * vínculo é opcional).
+   */
+  protected readonly reitoriasComErro = computed(() => {
+    const envelope = this.reitoriasResource.value();
+    return (
+      (envelope !== undefined && !envelope.ok) || this.reitoriasResource.error() !== undefined
+    );
+  });
+
+  /** Rótulo da unidade raiz na ficha de leitura (`null` quando não vinculada). */
+  protected readonly unidadeRaizLabel = computed<string | null>(() => {
+    const id = this.instituicao()?.unidadeRaizId ?? null;
+    if (id === null) {
+      return null;
+    }
+    const reitoria = this.reitoriasPorId().get(id);
+    return reitoria ? `${reitoria.sigla} — ${reitoria.nome}` : 'Não carregada';
+  });
+
+  protected readonly form: FormGroup<InstituicaoForm> = new FormGroup<InstituicaoForm>({
+    nome: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required, Validators.maxLength(255)],
+    }),
+    sigla: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required, Validators.maxLength(20)],
+    }),
+    codigoEmec: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
+    cnpj: new FormControl('', { nonNullable: true }),
+    organizacaoAcademica: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required],
+    }),
+    categoriaAdministrativa: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required],
+    }),
+    mantenedora: new FormControl('', { nonNullable: true }),
+    codigoMantenedoraEmec: new FormControl('', { nonNullable: true }),
+    situacao: new FormControl('', { nonNullable: true }),
+    atoCredenciamento: new FormControl('', { nonNullable: true }),
+    atoRecredenciamento: new FormControl('', { nonNullable: true }),
+    conceitoInstitucional: new FormControl('', { nonNullable: true }),
+    igc: new FormControl('', { nonNullable: true }),
+    website: new FormControl('', { nonNullable: true }),
+    enderecoSede: new FormControl('', { nonNullable: true }),
+    municipioSede: new FormControl('', { nonNullable: true }),
+    unidadeRaizId: new FormControl('', { nonNullable: true }),
+  });
+
+  constructor() {
+    this.carregar();
+  }
+
+  /** (Re)carrega o singleton. 404 = nenhuma viva → modo criação; 5xx = banner. */
+  protected carregar(): void {
+    if (this.isLoading()) {
+      return;
+    }
+    this.isLoading.set(true);
+    this.loadError.set(null);
+    this.api
+      .obter()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((result) => {
+        this.isLoading.set(false);
+        if (result.ok) {
+          this.instituicao.set(result.data);
+          this.loadError.set(null);
+          return;
+        }
+        if (result.status === 404) {
+          // Nenhuma Instituição viva — modo criação (empty-state), sem banner.
+          this.instituicao.set(null);
+          this.loadError.set(null);
+          return;
+        }
+        this.loadError.set(this.problemI18n.resolve(result.problem).title);
+        if (result.problem.status >= 500) {
+          this.notifications.errorFromProblem(result.problem);
+        }
+      });
+  }
+
+  protected abrirCadastro(): void {
+    this.instituicao.set(null);
+    this.form.reset(EMPTY_FORM);
+    this.submitError.set(null);
+    this.idempotencyKeyAtual.set(idempotencyKey.create());
+    this.drawerAberto.set(true);
+  }
+
+  protected abrirEdicao(): void {
+    const inst = this.instituicao();
+    if (inst === null) {
+      return;
+    }
+    this.form.reset({
+      nome: inst.nome,
+      sigla: inst.sigla,
+      codigoEmec: inst.codigoEmec,
+      cnpj: inst.cnpj ?? '',
+      organizacaoAcademica: inst.organizacaoAcademica,
+      categoriaAdministrativa: inst.categoriaAdministrativa,
+      mantenedora: inst.mantenedora ?? '',
+      codigoMantenedoraEmec: inst.codigoMantenedoraEmec ?? '',
+      situacao: inst.situacao ?? '',
+      atoCredenciamento: inst.atoCredenciamento ?? '',
+      atoRecredenciamento: inst.atoRecredenciamento ?? '',
+      conceitoInstitucional: inst.conceitoInstitucional ?? '',
+      igc: inst.igc ?? '',
+      website: inst.website ?? '',
+      enderecoSede: inst.enderecoSede ?? '',
+      municipioSede: inst.municipioSede ?? '',
+      unidadeRaizId: inst.unidadeRaizId ?? '',
+    });
+    this.submitError.set(null);
+    this.idempotencyKeyAtual.set(idempotencyKey.create());
+    this.drawerAberto.set(true);
+  }
+
+  protected salvar(): void {
+    if (this.submitting()) {
+      return;
+    }
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    this.submitting.set(true);
+    this.submitError.set(null);
+
+    const inst = this.instituicao();
+    if (inst === null) {
+      this.api
+        .criar(this.criarCommand(), withIdempotencyKey(this.idempotencyKeyAtual()))
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe((result) => this.handleSalvarResult(result));
+      return;
+    }
+
+    this.api
+      .atualizar(
+        inst.id,
+        this.atualizarCommand(inst.id),
+        withIdempotencyKey(this.idempotencyKeyAtual()),
+      )
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((result) => this.handleSalvarResult(result));
+  }
+
+  protected pedirRemocao(): void {
+    if (this.instituicao() === null) {
+      return;
+    }
+    this.dialogRemover.set(true);
+  }
+
+  protected removerConfirmado(): void {
+    const inst = this.instituicao();
+    if (inst === null || this.removendo()) {
+      return;
+    }
+
+    this.removendo.set(true);
+    this.api
+      .remover(inst.id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((result) => {
+        this.removendo.set(false);
+        if (result.ok) {
+          this.notifications.success('Instituição removida', inst.sigla);
+          this.dialogRemover.set(false);
+          this.drawerAberto.set(false);
+          this.instituicao.set(null);
+          return;
+        }
+        // Falha de remoção vai para notificação (o drawer pode já ter fechado).
+        this.notifications.errorFromProblem(result.problem, {
+          title: this.problemI18n.resolve(result.problem).title,
+        });
+      });
+  }
+
+  protected recarregarReitorias(): void {
+    this.reitoriasResource.reload();
+  }
+
+  protected erroDoCampo(nome: keyof InstituicaoForm): string | null {
+    const control = this.form.controls[nome];
+    const shouldShowError = control.touched || control.dirty;
+    if (!shouldShowError || control.errors === null) {
+      return null;
+    }
+    if (control.errors['backend']) {
+      const backend = control.errors['backend'] as { code: string; message: string };
+      return backend.message;
+    }
+    if (control.errors['required']) return 'Campo obrigatório.';
+    if (control.errors['maxlength']) return 'Valor acima do tamanho permitido.';
+    return 'Valor inválido.';
+  }
+
+  private handleSalvarResult(result: ApiResult<string | void>): void {
+    this.submitting.set(false);
+    if (result.ok) {
+      this.notifications.success(
+        this.instituicao() ? 'Instituição atualizada' : 'Instituição criada',
+      );
+      this.drawerAberto.set(false);
+      this.idempotencyKeyAtual.set(idempotencyKey.create());
+      this.carregar();
+      return;
+    }
+    this.aplicarFalha(result.problem);
+  }
+
+  private aplicarFalha(problem: ProblemDetails): void {
+    // 1) Validação FluentValidation com errors[] por campo (fallback do backend).
+    if (problem.status === 422 && problem.errors && problem.errors.length > 0) {
+      this.renovarIdempotencyKey();
+      this.aplicarErrosDeValidacao(problem.errors);
+      return;
+    }
+    // 2) Unidade raiz inválida — domain error 422 sem errors[], mapeado por code
+    //    ao controle correspondente (CA-08).
+    if (problem.code.includes('unidade_raiz')) {
+      this.renovarIdempotencyKey();
+      const control = this.form.controls.unidadeRaizId;
+      control.setErrors({
+        backend: { code: problem.code, message: this.problemI18n.resolve(problem).title },
+      });
+      control.markAsTouched();
+      this.submitError.set(null);
+      return;
+    }
+    // 3) Conflito singleton (409) — banner de bloqueio, não inline (CA-06).
+    if (problem.status === 409 || problem.code === 'uniplus.organizacao.instituicao.ja_existe') {
+      this.renovarIdempotencyKey();
+      this.submitError.set(SINGLETON_CONFLITO_MSG);
+      return;
+    }
+    // 4) Reuso de Idempotency-Key com body diferente — renova a chave.
+    if (problem.code === 'uniplus.idempotency.body_mismatch') {
+      this.renovarIdempotencyKey();
+    }
+    this.submitError.set(this.problemI18n.resolve(problem).title);
+    if (problem.status >= 500) {
+      this.notifications.errorFromProblem(problem);
+    }
+  }
+
+  private renovarIdempotencyKey(): void {
+    this.idempotencyKeyAtual.set(idempotencyKey.create());
+  }
+
+  private aplicarErrosDeValidacao(errors: ReadonlyArray<ProblemValidationError>): void {
+    let aplicouAlgum = false;
+    for (const erro of errors) {
+      const controlName = controlNameFromBackendField(erro.field);
+      if (controlName === null) continue;
+      const control = this.form.controls[controlName];
+      control.setErrors({ backend: { code: erro.code, message: erro.message } });
+      control.markAsTouched();
+      aplicouAlgum = true;
+    }
+
+    if (aplicouAlgum) {
+      this.submitError.set(null);
+      return;
+    }
+
+    this.submitError.set('Não foi possível mapear os erros de validação. Revise os campos.');
+  }
+
+  private criarCommand(): CriarInstituicaoCommand {
+    const raw = this.form.getRawValue();
+    return {
+      codigoEmec: raw.codigoEmec.trim(),
+      nome: raw.nome.trim(),
+      sigla: raw.sigla.trim(),
+      organizacaoAcademica: raw.organizacaoAcademica.trim(),
+      categoriaAdministrativa: raw.categoriaAdministrativa.trim(),
+      cnpj: nullIfBlank(raw.cnpj),
+      mantenedora: nullIfBlank(raw.mantenedora),
+      codigoMantenedoraEmec: nullIfBlank(raw.codigoMantenedoraEmec),
+      situacao: nullIfBlank(raw.situacao),
+      atoCredenciamento: nullIfBlank(raw.atoCredenciamento),
+      atoRecredenciamento: nullIfBlank(raw.atoRecredenciamento),
+      conceitoInstitucional: nullIfBlank(raw.conceitoInstitucional),
+      igc: nullIfBlank(raw.igc),
+      website: nullIfBlank(raw.website),
+      enderecoSede: nullIfBlank(raw.enderecoSede),
+      municipioSede: nullIfBlank(raw.municipioSede),
+      unidadeRaizId: nullIfBlank(raw.unidadeRaizId),
+    };
+  }
+
+  private atualizarCommand(id: string): AtualizarInstituicaoCommand {
+    return { id, ...this.criarCommand() };
+  }
+}
+
+const EMPTY_FORM = {
+  nome: '',
+  sigla: '',
+  codigoEmec: '',
+  cnpj: '',
+  organizacaoAcademica: '',
+  categoriaAdministrativa: '',
+  mantenedora: '',
+  codigoMantenedoraEmec: '',
+  situacao: '',
+  atoCredenciamento: '',
+  atoRecredenciamento: '',
+  conceitoInstitucional: '',
+  igc: '',
+  website: '',
+  enderecoSede: '',
+  municipioSede: '',
+  unidadeRaizId: '',
+} as const;
+
+const INSTITUICAO_CONTROL_NAMES: ReadonlySet<string> = new Set<keyof InstituicaoForm>([
+  'nome',
+  'sigla',
+  'codigoEmec',
+  'cnpj',
+  'organizacaoAcademica',
+  'categoriaAdministrativa',
+  'mantenedora',
+  'codigoMantenedoraEmec',
+  'situacao',
+  'atoCredenciamento',
+  'atoRecredenciamento',
+  'conceitoInstitucional',
+  'igc',
+  'website',
+  'enderecoSede',
+  'municipioSede',
+  'unidadeRaizId',
+]);
+
+function controlNameFromBackendField(field: string): keyof InstituicaoForm | null {
+  const normalized =
+    field
+      .split('.')
+      .at(-1)
+      ?.replace(/\[\d+\]$/u, '') ?? field;
+  const camelCase = normalized.charAt(0).toLocaleLowerCase('pt-BR') + normalized.slice(1);
+  return INSTITUICAO_CONTROL_NAMES.has(camelCase) ? (camelCase as keyof InstituicaoForm) : null;
+}
+
+function nullIfBlank(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/apps/configuracao/src/app/features/instituicao/instituicao.page.ts
+++ b/apps/configuracao/src/app/features/instituicao/instituicao.page.ts
@@ -300,15 +300,19 @@ interface InstituicaoForm {
                 <span class="field__error">{{ erroDoCampo('codigoEmec') }}</span>
               }
             </label>
-            <label class="field field--full">
+            <label class="field field--full" [class.is-error]="erroDoCampo('cnpj')">
               <span class="field__label">CNPJ</span>
               <input
                 class="input"
                 type="text"
                 placeholder="NN.NNN.NNN/NNNN-NN"
                 formControlName="cnpj"
+                [attr.aria-invalid]="erroDoCampo('cnpj') ? 'true' : null"
               />
               <span class="field__hint">CNPJ da pessoa jurídica. Opcional.</span>
+              @if (erroDoCampo('cnpj')) {
+                <span class="field__error">{{ erroDoCampo('cnpj') }}</span>
+              }
             </label>
           </div>
         </section>
@@ -364,18 +368,30 @@ interface InstituicaoForm {
         <section aria-labelledby="cfg-form-mantenedora">
           <h3 id="cfg-form-mantenedora" class="form-section__title">Mantenedora</h3>
           <div class="form-grid">
-            <label class="field field--full">
+            <label class="field field--full" [class.is-error]="erroDoCampo('mantenedora')">
               <span class="field__label">Mantenedora</span>
-              <input class="input" type="text" formControlName="mantenedora" />
+              <input
+                class="input"
+                type="text"
+                formControlName="mantenedora"
+                [attr.aria-invalid]="erroDoCampo('mantenedora') ? 'true' : null"
+              />
+              @if (erroDoCampo('mantenedora')) {
+                <span class="field__error">{{ erroDoCampo('mantenedora') }}</span>
+              }
             </label>
-            <label class="field field--full">
+            <label class="field field--full" [class.is-error]="erroDoCampo('codigoMantenedoraEmec')">
               <span class="field__label">Código mantenedora e-MEC</span>
               <input
                 class="input"
                 type="text"
                 inputmode="numeric"
                 formControlName="codigoMantenedoraEmec"
+                [attr.aria-invalid]="erroDoCampo('codigoMantenedoraEmec') ? 'true' : null"
               />
+              @if (erroDoCampo('codigoMantenedoraEmec')) {
+                <span class="field__error">{{ erroDoCampo('codigoMantenedoraEmec') }}</span>
+              }
             </label>
           </div>
         </section>
@@ -383,28 +399,44 @@ interface InstituicaoForm {
         <section aria-labelledby="cfg-form-situacao">
           <h3 id="cfg-form-situacao" class="form-section__title">Situação regulatória</h3>
           <div class="form-grid">
-            <label class="field field--full">
+            <label class="field field--full" [class.is-error]="erroDoCampo('situacao')">
               <span class="field__label">Situação</span>
-              <input class="input" type="text" formControlName="situacao" />
+              <input
+                class="input"
+                type="text"
+                formControlName="situacao"
+                [attr.aria-invalid]="erroDoCampo('situacao') ? 'true' : null"
+              />
               <span class="field__hint">Situação regulatória atual junto ao MEC.</span>
+              @if (erroDoCampo('situacao')) {
+                <span class="field__error">{{ erroDoCampo('situacao') }}</span>
+              }
             </label>
-            <label class="field field--full">
+            <label class="field field--full" [class.is-error]="erroDoCampo('atoCredenciamento')">
               <span class="field__label">Ato de credenciamento</span>
               <input
                 class="input"
                 type="text"
                 placeholder="Ex.: Lei nº 12.824, de 5 de junho de 2013"
                 formControlName="atoCredenciamento"
+                [attr.aria-invalid]="erroDoCampo('atoCredenciamento') ? 'true' : null"
               />
+              @if (erroDoCampo('atoCredenciamento')) {
+                <span class="field__error">{{ erroDoCampo('atoCredenciamento') }}</span>
+              }
             </label>
-            <label class="field field--full">
+            <label class="field field--full" [class.is-error]="erroDoCampo('atoRecredenciamento')">
               <span class="field__label">Ato de recredenciamento</span>
               <input
                 class="input"
                 type="text"
                 placeholder="Ex.: Portaria MEC nº …"
                 formControlName="atoRecredenciamento"
+                [attr.aria-invalid]="erroDoCampo('atoRecredenciamento') ? 'true' : null"
               />
+              @if (erroDoCampo('atoRecredenciamento')) {
+                <span class="field__error">{{ erroDoCampo('atoRecredenciamento') }}</span>
+              }
             </label>
           </div>
         </section>
@@ -412,19 +444,32 @@ interface InstituicaoForm {
         <section aria-labelledby="cfg-form-indicadores">
           <h3 id="cfg-form-indicadores" class="form-section__title">Indicadores de qualidade</h3>
           <div class="form-grid form-grid--pair">
-            <label class="field">
+            <label class="field" [class.is-error]="erroDoCampo('conceitoInstitucional')">
               <span class="field__label">Conceito institucional (CI)</span>
               <input
                 class="input"
                 type="text"
                 inputmode="numeric"
                 formControlName="conceitoInstitucional"
+                [attr.aria-invalid]="erroDoCampo('conceitoInstitucional') ? 'true' : null"
               />
               <span class="field__hint">Valor e-MEC (1–5).</span>
+              @if (erroDoCampo('conceitoInstitucional')) {
+                <span class="field__error">{{ erroDoCampo('conceitoInstitucional') }}</span>
+              }
             </label>
-            <label class="field">
+            <label class="field" [class.is-error]="erroDoCampo('igc')">
               <span class="field__label">Índice geral de cursos (IGC)</span>
-              <input class="input" type="text" inputmode="numeric" formControlName="igc" />
+              <input
+                class="input"
+                type="text"
+                inputmode="numeric"
+                formControlName="igc"
+                [attr.aria-invalid]="erroDoCampo('igc') ? 'true' : null"
+              />
+              @if (erroDoCampo('igc')) {
+                <span class="field__error">{{ erroDoCampo('igc') }}</span>
+              }
             </label>
           </div>
         </section>
@@ -432,17 +477,41 @@ interface InstituicaoForm {
         <section aria-labelledby="cfg-form-contato">
           <h3 id="cfg-form-contato" class="form-section__title">Contato e localização da sede</h3>
           <div class="form-grid">
-            <label class="field field--full">
+            <label class="field field--full" [class.is-error]="erroDoCampo('website')">
               <span class="field__label">Site institucional</span>
-              <input class="input" type="url" formControlName="website" />
+              <input
+                class="input"
+                type="url"
+                formControlName="website"
+                [attr.aria-invalid]="erroDoCampo('website') ? 'true' : null"
+              />
+              @if (erroDoCampo('website')) {
+                <span class="field__error">{{ erroDoCampo('website') }}</span>
+              }
             </label>
-            <label class="field field--full">
+            <label class="field field--full" [class.is-error]="erroDoCampo('enderecoSede')">
               <span class="field__label">Endereço da sede</span>
-              <input class="input" type="text" formControlName="enderecoSede" />
+              <input
+                class="input"
+                type="text"
+                formControlName="enderecoSede"
+                [attr.aria-invalid]="erroDoCampo('enderecoSede') ? 'true' : null"
+              />
+              @if (erroDoCampo('enderecoSede')) {
+                <span class="field__error">{{ erroDoCampo('enderecoSede') }}</span>
+              }
             </label>
-            <label class="field field--full">
+            <label class="field field--full" [class.is-error]="erroDoCampo('municipioSede')">
               <span class="field__label">Município da sede</span>
-              <input class="input" type="text" formControlName="municipioSede" />
+              <input
+                class="input"
+                type="text"
+                formControlName="municipioSede"
+                [attr.aria-invalid]="erroDoCampo('municipioSede') ? 'true' : null"
+              />
+              @if (erroDoCampo('municipioSede')) {
+                <span class="field__error">{{ erroDoCampo('municipioSede') }}</span>
+              }
             </label>
           </div>
         </section>
@@ -500,7 +569,7 @@ interface InstituicaoForm {
           type="submit"
           form="cfg-instituicao-form"
           class="btn btn--primary"
-          [disabled]="submitting() || form.invalid"
+          [disabled]="submitting() || removendo() || form.invalid"
         >
           @if (submitting()) {
             <ui-spinner size="sm" />
@@ -690,7 +759,10 @@ export class InstituicaoPage {
   }
 
   protected salvar(): void {
-    if (this.submitting()) {
+    // Bloqueia salvar enquanto uma remoção (soft-delete) está em voo: o drawer
+    // continua aberto durante o DELETE, e sem este guard um PUT concorrente
+    // correria com a remoção, produzindo UI de sucesso/erro inconsistente.
+    if (this.submitting() || this.removendo()) {
       return;
     }
     if (this.form.invalid) {

--- a/apps/configuracao/src/app/features/instituicao/instituicao.routes.ts
+++ b/apps/configuracao/src/app/features/instituicao/instituicao.routes.ts
@@ -1,0 +1,8 @@
+import { Routes } from '@angular/router';
+
+export const INSTITUICAO_ROUTES: Routes = [
+  {
+    path: '',
+    loadComponent: () => import('./instituicao.page').then((m) => m.InstituicaoPage),
+  },
+];

--- a/apps/configuracao/src/app/layout/layout.ts
+++ b/apps/configuracao/src/app/layout/layout.ts
@@ -1,5 +1,14 @@
 import { ChangeDetectionStrategy, Component, DestroyRef, computed, inject, signal } from '@angular/core';
-import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
+import { toSignal } from '@angular/core/rxjs-interop';
+import {
+  ActivatedRouteSnapshot,
+  NavigationEnd,
+  Router,
+  RouterLink,
+  RouterLinkActive,
+  RouterOutlet,
+} from '@angular/router';
+import { filter, map, startWith } from 'rxjs';
 import { AuthService, UserContextService, type UserRole } from '@uniplus/shared-auth/bootstrap';
 import { UserHeaderInfoComponent } from '@uniplus/shared-auth/components';
 import {
@@ -149,7 +158,7 @@ const ROLE_LABELS: Record<string, string> = {
                 <a class="breadcrumb__link" routerLink="/unidades">Configuração</a>
               </li>
               <li class="breadcrumb__item">
-                <span class="breadcrumb__current" aria-current="page">Unidade</span>
+                <span class="breadcrumb__current" aria-current="page">{{ breadcrumbAtual() }}</span>
               </li>
             </ol>
           </nav>
@@ -172,7 +181,23 @@ const ROLE_LABELS: Record<string, string> = {
 export class LayoutComponent {
   private readonly destroyRef = inject(DestroyRef);
   private readonly authService = inject(AuthService);
+  private readonly router = inject(Router);
   protected readonly userContext = inject(UserContextService);
+
+  /**
+   * Última folha do breadcrumb ("Início → Configuração → {atual}"), derivada do
+   * `data.breadcrumb` da rota ativada mais profunda. Reage a cada navegação;
+   * default "Unidade" (rota inicial). Mantém o breadcrumb coerente com a página
+   * em foco (CA-10 da story de Instituição).
+   */
+  protected readonly breadcrumbAtual = toSignal(
+    this.router.events.pipe(
+      filter((event) => event instanceof NavigationEnd),
+      startWith(null),
+      map(() => this.breadcrumbDaRotaAtiva()),
+    ),
+    { initialValue: this.breadcrumbDaRotaAtiva() },
+  );
   private readonly desktopMedia = typeof window !== 'undefined' && typeof window.matchMedia === 'function'
     ? window.matchMedia('(min-width: 1024px)')
     : null;
@@ -216,7 +241,7 @@ export class LayoutComponent {
         { label: 'Cidade', icon: 'pi-map-marker' },
         { label: 'Campus', icon: 'pi-building' },
         { label: 'Local de oferta', icon: 'pi-map' },
-        { label: 'Instituição', icon: 'pi-warehouse' },
+        { label: 'Instituição', icon: 'pi-warehouse', routerLink: '/instituicao', exact: true },
         { label: 'Unidade', icon: 'pi-sitemap', routerLink: '/unidades', exact: true },
         { label: 'Curso', icon: 'pi-book' },
         { label: 'Oferta de curso', icon: 'pi-file-edit' },
@@ -259,6 +284,19 @@ export class LayoutComponent {
 
   protected closeSidebar(): void {
     this.sidebarMobileOpen.set(false);
+  }
+
+  private breadcrumbDaRotaAtiva(): string {
+    let route: ActivatedRouteSnapshot | null = this.router.routerState.snapshot.root;
+    let label = 'Unidade';
+    while (route !== null) {
+      const breadcrumb = route.data['breadcrumb'];
+      if (typeof breadcrumb === 'string') {
+        label = breadcrumb;
+      }
+      route = route.firstChild;
+    }
+    return label;
   }
 }
 

--- a/apps/configuracao/src/styles.css
+++ b/apps/configuracao/src/styles.css
@@ -401,7 +401,8 @@ cfg-root {
   }
 }
 
-cfg-unidades-page {
+cfg-unidades-page,
+cfg-instituicao-page {
   display: flex;
   flex-direction: column;
   gap: var(--space-7);
@@ -598,6 +599,23 @@ cfg-unidades-page {
   font-size: var(--text-sm);
 }
 
+/*
+ * Corpo do card da ficha da Instituição: o panel-head já tem o seu padding, mas
+ * o body não tinha — os títulos de seção encostavam na divisória e na borda.
+ * Dá padding consistente ao body e espaça as seções via gap.
+ */
+.cfg-instituicao__ficha {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  padding: var(--space-5);
+}
+
+/* O padding do body já indenta; a lista de detalhes não repete o seu. */
+.cfg-instituicao__ficha .cfg-detail-list {
+  padding: 0;
+}
+
 .cfg-drawer-actions {
   justify-content: flex-end;
   padding: 0 var(--space-5) var(--space-5);
@@ -623,6 +641,22 @@ cfg-unidades-page {
   min-height: 0;
   overflow-y: auto;
   padding: var(--space-5);
+}
+
+/*
+ * Espaça os elementos internos da seção (título, alerta, grade de campos) via
+ * gap do flex em vez de depender só da margem do título — assim um ui-alert
+ * inserido entre o título e os campos recebe respiro nos dois lados.
+ */
+.cfg-form > section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+/* O gap acima já separa o título; zera a margem para não dobrar o espaço. */
+.cfg-form > section > .form-section__title {
+  margin-bottom: 0;
 }
 
 .form-grid {

--- a/docs/guia-testar-frontend-com-backend-local.md
+++ b/docs/guia-testar-frontend-com-backend-local.md
@@ -1,0 +1,56 @@
+# Guia: testar um frontend contra o backend local
+
+Como rodar um app do `uniplus-web` (ex.: `configuracao`, `selecao`) contra as
+APIs reais do `uniplus-api` conteinerizadas — autenticando no Keycloak de
+desenvolvimento e persistindo dados de verdade.
+
+## 1. Suba o backend com o override `frontend-test`
+
+No repositório `uniplus-api`, suba a stack com os **três** arquivos compose:
+
+```bash
+docker compose -f docker-compose.yml \
+               -f docker-compose.override.yml \
+               -f docker-compose.frontend-test.yml up -d
+```
+
+> **Obrigatório.** O `frontend-test.yml` realinha o `Auth__Authority` de todas as
+> APIs ao realm **`unifesspa`** — o realm em que os frontends autenticam. O
+> override base usa `unifesspa-dev-local`, e sem o realinhamento **toda mutação**
+> (POST/PUT/DELETE) responde **401** e o app entra em loop de re-login (o GET de
+> lista é `[AllowAnonymous]` e mascara o problema). Detalhes em
+> `uniplus-api/CONTRIBUTING.md` § "Testar um frontend contra as APIs conteinerizadas".
+
+## 2. Sirva o app
+
+```bash
+npx nx serve configuracao   # http://localhost:4203 (fala direto com a organizacao-api :5263)
+npx nx serve selecao        # http://localhost:4200 (via gateway Traefik :5000)
+```
+
+A URL e o realm de cada app vêm do `runtime-config.json` (ADR-0021). O app
+`configuracao` usa `apiUrl=http://localhost:5263` e o client OIDC
+`configuracao-web` no realm `unifesspa`.
+
+## 3. Faça login
+
+Usuário de teste com a role `plataforma-admin` (exigida pelo painel admin):
+
+| Campo | Valor |
+|---|---|
+| Usuário | `admin` |
+| Senha | `E2eTest!123` |
+
+## Sintomas comuns
+
+| Sintoma | Causa | Correção |
+|---|---|---|
+| Listas carregam, mas salvar dá erro e volta pro login | Realm desalinhado (API em `unifesspa-dev-local`) | Suba com o `frontend-test.yml` (passo 1) |
+| `ERR_CONNECTION_REFUSED` em :4203 | Dev server caiu | `npx nx serve configuracao` |
+| Redireciona ao Keycloak no meio de uma ação longa | `accessTokenLifespan` curto (300s) | Ampliar para 1800s (opcional — ver CONTRIBUTING do `uniplus-api`) |
+
+## E2E automatizado
+
+As specs visuais (`apps/<app>-e2e/src/specs/*.visual.spec.ts`) **mockam** a API via
+`page.route` e não dependem do backend real — rodam com `npx nx e2e <app>-e2e`.
+Este guia cobre o teste **manual/exploratório** contra o backend de verdade.

--- a/libs/shared-data/src/lib/api/organizacao/index.ts
+++ b/libs/shared-data/src/lib/api/organizacao/index.ts
@@ -1,5 +1,11 @@
 export { ORGANIZACAO_BASE_PATH } from './tokens';
 export {
+  InstituicaoApi,
+  type AtualizarInstituicaoCommand,
+  type CriarInstituicaoCommand,
+  type InstituicaoDto,
+} from './instituicao.api';
+export {
   ORIGENS_UNIDADE,
   TIPOS_UNIDADE,
   UnidadesApi,

--- a/libs/shared-data/src/lib/api/organizacao/instituicao.api.spec.ts
+++ b/libs/shared-data/src/lib/api/organizacao/instituicao.api.spec.ts
@@ -1,0 +1,159 @@
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  ApiResult,
+  apiResultInterceptor,
+  buildVendorMimeAccept,
+  isApiFailure,
+  isApiOk,
+  withIdempotencyKey,
+} from '@uniplus/shared-core/http';
+import {
+  AtualizarInstituicaoCommand,
+  CriarInstituicaoCommand,
+  InstituicaoApi,
+  InstituicaoDto,
+} from './instituicao.api';
+import { ORGANIZACAO_BASE_PATH } from './tokens';
+
+const BASE = 'http://localhost:5000';
+const ID = '01960000-0000-7000-0000-0000000000a1';
+
+const instituicaoSeed: InstituicaoDto = {
+  id: ID,
+  codigoEmec: '3990',
+  nome: 'Universidade Federal do Sul e Sudeste do Pará',
+  sigla: 'Unifesspa',
+  organizacaoAcademica: 'Universidade',
+  categoriaAdministrativa: 'Pública Federal',
+  cnpj: null,
+  mantenedora: null,
+  codigoMantenedoraEmec: null,
+  situacao: null,
+  atoCredenciamento: null,
+  atoRecredenciamento: null,
+  conceitoInstitucional: null,
+  igc: null,
+  website: null,
+  enderecoSede: null,
+  municipioSede: null,
+  unidadeRaizId: null,
+  criadoEm: '2026-06-10T12:00:00Z',
+};
+
+const criarCommand: CriarInstituicaoCommand = {
+  codigoEmec: instituicaoSeed.codigoEmec,
+  nome: instituicaoSeed.nome,
+  sigla: instituicaoSeed.sigla,
+  organizacaoAcademica: instituicaoSeed.organizacaoAcademica,
+  categoriaAdministrativa: instituicaoSeed.categoriaAdministrativa,
+  cnpj: null,
+  mantenedora: null,
+  codigoMantenedoraEmec: null,
+  situacao: null,
+  atoCredenciamento: null,
+  atoRecredenciamento: null,
+  conceitoInstitucional: null,
+  igc: null,
+  website: null,
+  enderecoSede: null,
+  municipioSede: null,
+  unidadeRaizId: null,
+};
+
+const atualizarCommand: AtualizarInstituicaoCommand = {
+  id: ID,
+  ...criarCommand,
+};
+
+describe('InstituicaoApi', () => {
+  let api: InstituicaoApi;
+  let controller: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([apiResultInterceptor])),
+        provideHttpClientTesting(),
+        { provide: ORGANIZACAO_BASE_PATH, useValue: BASE },
+      ],
+    });
+    api = TestBed.inject(InstituicaoApi);
+    controller = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => controller.verify());
+
+  it('obter() faz GET /api/instituicao (singleton, sem id) com Accept versionado', async () => {
+    const promise = firstValueFrom(api.obter());
+
+    const req = controller.expectOne(`${BASE}/api/instituicao`);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.headers.get('Accept')).toBe(buildVendorMimeAccept('instituicao', 1));
+    req.flush(instituicaoSeed);
+
+    const result = (await promise) as ApiResult<InstituicaoDto>;
+    expect(isApiOk(result)).toBe(true);
+    if (result.ok) {
+      expect(result.data.sigla).toBe('Unifesspa');
+    }
+  });
+
+  it('obter() devolve ApiFailure com status 404 quando não há Instituição viva', async () => {
+    const promise = firstValueFrom(api.obter());
+
+    const req = controller.expectOne(`${BASE}/api/instituicao`);
+    req.flush(null, { status: 404, statusText: 'Not Found' });
+
+    const result = (await promise) as ApiResult<InstituicaoDto>;
+    expect(isApiFailure(result)).toBe(true);
+    expect(result.status).toBe(404);
+  });
+
+  it('criar() faz POST /api/admin/instituicao com Idempotency-Key e Accept JSON', async () => {
+    const key = 'instituicao-create-key';
+    const promise = firstValueFrom(api.criar(criarCommand, withIdempotencyKey(key)));
+
+    const req = controller.expectOne(`${BASE}/api/admin/instituicao`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.headers.get('Idempotency-Key')).toBe(key);
+    expect(req.request.headers.get('Accept')).toBe('application/json');
+    expect(req.request.body).toEqual(criarCommand);
+    req.flush(ID, { status: 201, statusText: 'Created' });
+
+    const result = (await promise) as ApiResult<string>;
+    expect(isApiOk(result)).toBe(true);
+    if (result.ok) {
+      expect(result.data).toBe(ID);
+    }
+  });
+
+  it('atualizar() faz PUT /api/admin/instituicao/{id} com Idempotency-Key', async () => {
+    const key = 'instituicao-update-key';
+    const promise = firstValueFrom(api.atualizar(ID, atualizarCommand, withIdempotencyKey(key)));
+
+    const req = controller.expectOne(`${BASE}/api/admin/instituicao/${ID}`);
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.headers.get('Idempotency-Key')).toBe(key);
+    expect(req.request.body).toEqual(atualizarCommand);
+    req.flush(null, { status: 204, statusText: 'No Content' });
+
+    const result = (await promise) as ApiResult<void>;
+    expect(isApiOk(result)).toBe(true);
+  });
+
+  it('remover() faz DELETE sem Idempotency-Key porque o backend não exige o header', async () => {
+    const promise = firstValueFrom(api.remover(ID));
+
+    const req = controller.expectOne(`${BASE}/api/admin/instituicao/${ID}`);
+    expect(req.request.method).toBe('DELETE');
+    expect(req.request.headers.has('Idempotency-Key')).toBe(false);
+    req.flush(null, { status: 204, statusText: 'No Content' });
+
+    const result = (await promise) as ApiResult<void>;
+    expect(isApiOk(result)).toBe(true);
+  });
+});

--- a/libs/shared-data/src/lib/api/organizacao/instituicao.api.ts
+++ b/libs/shared-data/src/lib/api/organizacao/instituicao.api.ts
@@ -1,0 +1,85 @@
+import { HttpClient, HttpContext, HttpHeaders } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiResult, withVendorMime } from '@uniplus/shared-core/http';
+import type { components } from './schema';
+import { ORGANIZACAO_BASE_PATH } from './tokens';
+
+export type InstituicaoDto = components['schemas']['InstituicaoDto'];
+export type CriarInstituicaoCommand = components['schemas']['CriarInstituicaoCommand'];
+export type AtualizarInstituicaoCommand = components['schemas']['AtualizarInstituicaoCommand'];
+
+/**
+ * Cliente Angular standalone do recurso Instituição (módulo Organização
+ * Institucional). A Instituição é **singleton** (ADR-0055): não há listagem nem
+ * seletor — há a Instituição, criada uma vez e editada ao longo do tempo. Por
+ * isso `obter()` não recebe `id` (lê `GET /api/instituicao`) e devolve 404
+ * quando nenhuma foi cadastrada ainda.
+ *
+ * API thin (ADR-0013): tipos vêm do `schema.ts` gerado, a resposta é envelopada
+ * em `ApiResult<T>` pelo `apiResultInterceptor` upstream (ADR-0011), o Bearer é
+ * injetado pelo `tokenInterceptor` (ADR-0009) e o versionamento por vendor MIME
+ * (`application/vnd.uniplus.instituicao.v1+json`, ADR-0028 do `uniplus-api`) é
+ * declarado por `withVendorMime('instituicao', 1)`. Espelha `UnidadesApi`.
+ */
+@Injectable({ providedIn: 'root' })
+export class InstituicaoApi {
+  private readonly http = inject(HttpClient);
+  private readonly basePath = inject(ORGANIZACAO_BASE_PATH);
+
+  /**
+   * GET `/api/instituicao` — obtém o cabeçalho institucional (singleton). O
+   * `apiResultInterceptor` envelopa o 404 (nenhuma Instituição viva) como
+   * `ApiFailure` com `status: 404` — não lança; o caller decide o modo de tela
+   * (leitura vs criação) lendo `result.status`.
+   */
+  obter(): Observable<ApiResult<InstituicaoDto>> {
+    return this.http.get<ApiResult<InstituicaoDto>>(`${this.basePath}/api/instituicao`, {
+      context: withVendorMime('instituicao', 1),
+    });
+  }
+
+  /**
+   * POST `/api/admin/instituicao` — cria a Instituição. Restrito a
+   * `plataforma-admin`. Idempotency-Key obrigatório (ADR-0027) — declarado via
+   * `withIdempotencyKey(key)` no `context`. Retorna 409
+   * (`uniplus.organizacao.instituicao.ja_existe`) se já existe uma viva
+   * (singleton — CA-06). Resposta 201 com body `string` (o ID); `Accept` fixado
+   * em `application/json` porque o contrato também declara `text/plain` para 201.
+   */
+  criar(command: CriarInstituicaoCommand, context: HttpContext): Observable<ApiResult<string>> {
+    return this.http.post<ApiResult<string>>(`${this.basePath}/api/admin/instituicao`, command, {
+      context,
+      headers: new HttpHeaders({ Accept: 'application/json' }),
+    });
+  }
+
+  /**
+   * PUT `/api/admin/instituicao/{id}` — atualiza a Instituição existente.
+   * Restrito a `plataforma-admin`. Idempotency-Key obrigatório (ADR-0027).
+   * Resposta 204 No Content em sucesso.
+   */
+  atualizar(
+    id: string,
+    command: AtualizarInstituicaoCommand,
+    context: HttpContext,
+  ): Observable<ApiResult<void>> {
+    return this.http.put<ApiResult<void>>(
+      `${this.basePath}/api/admin/instituicao/${encodeURIComponent(id)}`,
+      command,
+      { context },
+    );
+  }
+
+  /**
+   * DELETE `/api/admin/instituicao/{id}` — remoção lógica (soft-delete) da
+   * Instituição. Restrito a `plataforma-admin`. Sem Idempotency-Key (o backend
+   * não exige o header). Resposta 204 No Content; libera o cadastro de uma nova
+   * Instituição.
+   */
+  remover(id: string): Observable<ApiResult<void>> {
+    return this.http.delete<ApiResult<void>>(
+      `${this.basePath}/api/admin/instituicao/${encodeURIComponent(id)}`,
+    );
+  }
+}


### PR DESCRIPTION
## Contexto

Implementa a tela de **Cadastro de Instituição** no app `configuracao` — o cabeçalho institucional da plataforma (identificação e-MEC, situação regulatória, indicadores e contato da sede). É a **exceção singleton** ao padrão CRUD (ADR-0055, §12 da macro): cada instância atende uma única instituição, então não há lista, paginação nem filtro — há a Instituição, criada uma vez e editada ao longo do tempo.

Espelha o backend já entregue em uniplus-api #585 (UNI-REQ-0007). O contrato OpenAPI e o `schema.ts` já estavam publicados — `InstituicaoDto`/`CriarInstituicaoCommand`/`AtualizarInstituicaoCommand` não foram regenerados.

## O que muda

| Camada | Arquivo | Conteúdo |
|---|---|---|
| Dados | `libs/shared-data/.../organizacao/instituicao.api.ts` (+ spec, barrel) | Cliente thin `InstituicaoApi` (`obter`/`criar`/`atualizar`/`remover`), espelhando `UnidadesApi`. `obter()` sem id; 404 = sem viva. |
| Feature | `apps/configuracao/.../features/instituicao/` | Container singleton (`instituicao.page.ts`), rota lazy, spec de componente. |
| Layout | `apps/configuracao/.../layout/layout.ts` + `app.routes.ts` | Habilita o item Instituição no menu (aria-current) e torna o breadcrumb dinâmico por `data.breadcrumb`. |
| E2E | `apps/configuracao-e2e/.../specs/instituicao.visual.spec.ts` | Cobertura visual DS (mock via `page.route`), modos leitura/edição/criação. |

## Comportamento

- **Modo leitura (200):** ficha de 7 seções (`<dl>`), botão Editar, banner singleton. Campos opcionais vazios exibem `—`.
- **Modo criação (404):** empty-state + botão Cadastrar. Nunca renderiza ambos os modos.
- **Drawer único** (criar/editar) com 7 seções de formulário tipado; remoção (soft-delete) por `btn--danger-ghost` confirmada em `<ui-dialog>`.
- **Idempotency-Key** por abertura do drawer, renovada após falha e sucesso (ADR-0014).
- **Mapeamento de erros:** 409 singleton → banner de bloqueio (CA-06); 422 de unidade raiz inválida → erro inline no campo por `code` (CA-08); validação FluentValidation por `errors[]`.
- **Select de unidade raiz** populado por Unidades vivas do tipo Reitoria via `useApiResource` (GET-only, ADR-0018) — sem `HttpClient` direto na página (fitness `no-direct-http-in-pages` verde).

## Critérios de aceite

CA-01 a CA-09 cobertos por testes de componente; CA-10 (a11y: aria-current, `<dl>/<dt>/<dd>`, breadcrumb) pela mudança de layout + E2E; CA-11 (LGPD) inaplicável (dado institucional, sem PII de candidatos).

## Validação local

| Suíte | Resultado |
|---|---|
| `shared-data` unit (inc. `InstituicaoApi` + fitness api-services/public-entrypoints) | 110/110 ✅ |
| `configuracao` unit (inc. página + fitness no-direct-http) | 32/32 ✅ |
| `configuracao-e2e` visual (instituição **18** + unidades **14** + auth-setup) | 33/33 ✅ (light/dark/contrast × mobile/desktop, **sem regressão em unidades**) |
| Lint (`shared-data`, `configuracao`, `configuracao-e2e`) | ✅ |
| Build produção `configuracao` | ✅ |

## Notas

- **Breadcrumb dinâmico** é uma mudança no layout compartilhado, justificada por CA-10 (a folha precisava refletir "Instituição"). Mantém-se "Unidade" em `/unidades` — confirmado sem regressão na suíte de unidades.
- A unidade raiz é anulável; o cadastro não é bloqueado por ela (§4.1 da spec).

Closes #386
Refs #585