### PR TITLE
docs: tutorial de onboarding para rodar e testar a aplicação do zero

### DIFF
--- a/docs/tutorial-rodar-e-testar-a-aplicacao.md
+++ b/docs/tutorial-rodar-e-testar-a-aplicacao.md
@@ -1,0 +1,264 @@
+# Tutorial: rodar e testar a aplicação do zero
+
+Guia passo a passo para quem **acabou de baixar os projetos** e quer rodar a
+aplicação, **logar nela** e executar os testes (unitários e E2E).
+
+A plataforma tem dois repositórios que sobem juntos:
+
+| Repositório | Papel | O que você roda |
+|---|---|---|
+| `uniplus-api` | Backend .NET + infra (PostgreSQL, Keycloak, etc. via Docker) | `docker compose ... up -d` |
+| `uniplus-web` | Frontend Angular (Nx) | `npx nx serve <app>` |
+
+> **Atalho:** se você já tem os repositórios e a infra de pé, use a referência
+> rápida em [`guia-testar-frontend-com-backend-local.md`](guia-testar-frontend-com-backend-local.md).
+> Este tutorial cobre o fluxo completo desde o clone.
+
+---
+
+## Pré-requisitos
+
+| Ferramenta | Versão | Verificação |
+|---|---|---|
+| Docker | 24+ | `docker --version` |
+| Docker Compose | 2.20+ | `docker compose version` |
+| .NET SDK | 10.0 | `dotnet --version` |
+| Node.js | **22** (ver `.nvmrc`) | `node --version` |
+| Python 3 | 3.8+ (para os snippets do Keycloak Admin API) | `python3 --version` |
+| Git | 2.40+ | `git --version` |
+| GitHub CLI (opcional) | 2.50+ | `gh --version` |
+
+> O frontend exige **Node 22** — se você usa `nvm`, rode `nvm use 22` dentro de
+> `uniplus-web` (há um `.nvmrc`). Node 24 (default de algumas máquinas) quebra o build.
+
+---
+
+## Passo 1 — Clonar os repositórios
+
+Mantenha os dois lado a lado (a convenção do projeto é uma pasta `repositories/`):
+
+```bash
+mkdir -p uniplus/repositories && cd uniplus/repositories
+git clone https://github.com/unifesspa-edu-br/uniplus-api.git
+git clone https://github.com/unifesspa-edu-br/uniplus-web.git
+```
+
+---
+
+## Passo 2 — Subir o backend (APIs + infra + Keycloak)
+
+Num clone fresco, `docker/.env` e `docker/docker-compose.override.yml` **não
+existem** (são gitignored) — copie-os dos `.example` primeiro. Depois suba a
+stack com os **três** arquivos compose; o terceiro (`frontend-test.yml`) é
+**obrigatório** para testar o frontend — ele realinha a autenticação de todas as
+APIs ao realm `unifesspa` (ver "Solução de problemas").
+
+```bash
+cd uniplus-api
+cp docker/.env.example docker/.env
+cp docker/docker-compose.override.example.yml docker/docker-compose.override.yml
+
+cd docker
+docker compose -f docker-compose.yml \
+               -f docker-compose.override.yml \
+               -f docker-compose.frontend-test.yml up -d
+```
+
+> Setup canônico do backend (mais detalhes): `uniplus-api/docs/setup-ambiente-local.md`.
+
+Isso sobe PostgreSQL, Redis, Kafka, MinIO, **Keycloak** (que importa o realm
+`unifesspa` automaticamente) e as APIs de módulo (`organizacao-api` em `:5263`,
+`selecao-api`, etc.).
+
+Aguarde tudo ficar **healthy**:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.frontend-test.yml ps
+```
+
+> Se as APIs ficarem `unhealthy`, normalmente é o **Keycloak ainda subindo** (o
+> health-check `oidc-discovery` depende dele). Aguarde alguns segundos e reveja.
+
+---
+
+## Passo 3 — Servir o frontend
+
+Em outro terminal:
+
+```bash
+cd uniplus-web
+nvm use 22            # se usar nvm
+npm ci                # instala dependências (primeira vez)
+npx nx serve configuracao   # painel administrativo  -> http://localhost:4203
+```
+
+Cada app lê o backend e o Keycloak do seu `runtime-config.json`. O
+`configuracao` fala **direto** com a `organizacao-api` (`:5263`) — é o caminho
+testado neste tutorial.
+
+> `npx nx serve selecao` (`:4200`) funciona via gateway Traefik `:5000`. Os apps
+> `ingresso` (`:4201`) e `portal` (`:4202`) sobem, mas o Traefik de dev hoje só
+> roteia as rotas de Seleção (`/api/editais`, `/api/selecao/*`) — testá-los
+> contra o backend local ainda exige rotas adicionais no `traefik/dynamic.yml`.
+
+---
+
+## Passo 4 — Logar na aplicação
+
+Abra **http://localhost:4203** — o app redireciona para o login do Keycloak
+(realm `unifesspa`).
+
+O realm já vem semeado com usuários de teste. O `admin` tem a role
+`plataforma-admin` (exigida pelo painel). **Porém a senha semeada é temporária**
+(`Changeme!123`) — no primeiro login o Keycloak pede para trocá-la.
+
+Para usar uma senha **fixa e conhecida** (`E2eTest!123`, a mesma dos testes E2E),
+redefina-a uma vez via Keycloak Admin API:
+
+```bash
+KC=http://localhost:8080
+TOKEN=$(curl -s "$KC/realms/master/protocol/openid-connect/token" \
+  -d grant_type=password -d client_id=admin-cli -d username=admin -d password=admin \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["access_token"])')
+# id do usuário admin no realm unifesspa (UID é read-only no shell; use outro nome)
+ADMIN_ID=$(curl -s "$KC/admin/realms/unifesspa/users?username=admin&exact=true" \
+  -H "Authorization: Bearer $TOKEN" | python3 -c 'import sys,json; print(json.load(sys.stdin)[0]["id"])')
+# define senha permanente
+curl -s -X PUT "$KC/admin/realms/unifesspa/users/$ADMIN_ID/reset-password" \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"type":"password","value":"E2eTest!123","temporary":false}'
+```
+
+Credenciais de login:
+
+| Campo | Valor |
+|---|---|
+| Usuário | `admin` |
+| Senha | `E2eTest!123` (após o reset acima) |
+| Realm | `unifesspa` (já configurado no app) |
+
+> O admin do **Keycloak** (console em `:8080`) é `admin` / `admin` no realm
+> `master` — não confundir com o usuário `admin` da aplicação no realm `unifesspa`.
+
+Logado, você cai no painel. Em **Configuração → Instituição** dá para cadastrar a
+Instituição (singleton) e, em **Configuração → Unidade**, a estrutura
+organizacional — exercitando o CRUD completo contra o backend real.
+
+---
+
+## Passo 5 — Executar os testes
+
+### Frontend — unitários (Vitest)
+
+```bash
+cd uniplus-web
+npx nx vite:test configuracao          # um app
+npx nx run-many --target=vite:test --all
+```
+
+### Frontend — E2E (Playwright)
+
+As specs visuais **mockam a API** via `page.route` — não exigem as APIs de pé,
+só o **Keycloak** (o *setup project* `auth-setup` reseta a senha do usuário de
+teste e faz login real). Como o Keycloak já subiu no Passo 2, basta:
+
+```bash
+cd uniplus-web
+npx playwright install chromium firefox   # baixa os browsers (primeira vez)
+KEYCLOAK_ADMIN=admin KEYCLOAK_ADMIN_PASSWORD=admin \
+  npx nx e2e configuracao-e2e
+```
+
+> `KEYCLOAK_ADMIN_PASSWORD` é obrigatória: sem ela o `auth-setup` aborta. Num
+> clone fresco os browsers do Playwright ainda não estão instalados — daí o
+> `npx playwright install`.
+
+(Roda a matriz de temas × viewports. Para um recorte rápido, acrescente
+`-- --project=visual-desktop-light <arquivo>.visual.spec.ts`.)
+
+### Backend (opcional)
+
+```bash
+cd uniplus-api
+dotnet test UniPlus.slnx                         # tudo
+dotnet test --filter "Category!=Integration"     # só unitários (sem Docker)
+```
+
+---
+
+## Passo 6 — (opcional) sessões manuais longas
+
+O `accessTokenLifespan` do realm é 300s. Para testar manualmente sem refresh
+frequente, amplie para 30 min (reverta depois se quiser):
+
+```bash
+TOKEN=$(curl -s http://localhost:8080/realms/master/protocol/openid-connect/token \
+  -d grant_type=password -d client_id=admin-cli -d username=admin -d password=admin \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["access_token"])')
+curl -s -X PUT http://localhost:8080/admin/realms/unifesspa \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"accessTokenLifespan":1800}'
+```
+
+---
+
+## Comandos úteis
+
+```bash
+# Servir aplicações (uniplus-web)
+npx nx serve selecao          # http://localhost:4200 (via gateway Traefik :5000)
+npx nx serve ingresso         # http://localhost:4201
+npx nx serve portal           # http://localhost:4202
+npx nx serve configuracao     # http://localhost:4203 (direto na organizacao-api :5263)
+
+# Build
+npx nx build configuracao
+npx nx run-many --target=build --all
+
+# Testes unitários (Vitest)
+npx nx vite:test configuracao
+npx nx run-many --target=vite:test --all
+
+# Lint
+npx nx lint configuracao
+npx nx run-many --target=lint --all
+
+# Testes E2E (Playwright) — exige Keycloak de pé
+KEYCLOAK_ADMIN=admin KEYCLOAK_ADMIN_PASSWORD=admin npx nx e2e configuracao-e2e
+
+# Gerar clients de API a partir do contrato OpenAPI
+npm run generate:api
+
+# Grafo de dependências do workspace
+npx nx graph
+
+# Affected (o que mudou em relação à base) — usado no CI
+npx nx affected --target=build
+npx nx affected --target=vite:test
+
+# Backend (uniplus-api) — a partir da raiz do repositório uniplus-api
+docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml -f docker/docker-compose.frontend-test.yml up -d   # subir stack p/ testar frontend
+dotnet test UniPlus.slnx                          # todos os testes
+dotnet test --filter "Category!=Integration"      # só unitários (sem Docker)
+```
+
+---
+
+## Solução de problemas
+
+| Sintoma | Causa | Correção |
+|---|---|---|
+| Listas carregam, mas **salvar dá erro e volta pro login** | Realm desalinhado: as APIs validam `unifesspa-dev-local`, o app autentica em `unifesspa`. O GET de lista é anônimo e mascara; só a mutação dá **401** | Suba o backend **com** `docker-compose.frontend-test.yml` (Passo 2) |
+| `ERR_CONNECTION_REFUSED` em `:4203` | Dev server não está rodando | `npx nx serve configuracao` |
+| APIs `unhealthy` | Keycloak ainda subindo / parado | Aguardar; conferir `docker compose ps` do `docker-keycloak-1` |
+| Keycloak pede troca de senha no login | Senha semeada é temporária (`Changeme!123`) | Resetar para `E2eTest!123` (Passo 4) |
+| Build do frontend quebra | Node ≠ 22 | `nvm use 22` |
+| E2E falha em `auth-setup` (`KEYCLOAK_ADMIN_PASSWORD não definido`) | Variável ausente | Prefixar o comando com `KEYCLOAK_ADMIN_PASSWORD=admin` |
+| Redireciona ao Keycloak no meio de uma ação | `accessTokenLifespan` curto | Ampliar para 1800s (Passo 6) |
+
+---
+
+## Referências
+
+- `uniplus-api/CONTRIBUTING.md` § "Testar um frontend contra as APIs conteinerizadas"
+- `uniplus-web/docs/guia-testar-frontend-com-backend-local.md` (referência rápida)


### PR DESCRIPTION
Adiciona `docs/tutorial-rodar-e-testar-a-aplicacao.md` — guia de onboarding completo, do clone até rodar os testes logando na aplicação.

## Conteúdo
- **Pré-requisitos** (Docker 24+/Compose 2.20+, .NET 10, Node 22, Python 3).
- **Clone** dos dois repos em `repositories/`.
- **Backend**: subir com o override `frontend-test` (realm `unifesspa`), incluindo o `cp` dos `.example` (gitignored num clone fresco).
- **Frontend**: `nvm use 22` → `npm ci` → `npx nx serve configuracao` (:4203).
- **Login**: `admin`; cobre a senha semeada **temporária** `Changeme!123` e o reset para `E2eTest!123`.
- **Testes**: unit (Vitest) + E2E (Playwright, com `npx playwright install` e `KEYCLOAK_ADMIN_PASSWORD`).
- **Comandos úteis** (escritos diretamente, sem citar CLAUDE.md) e **solução de problemas**.

## Notas
- Complementa o guia rápido `docs/guia-testar-frontend-com-backend-local.md` (cross-link).
- **Revisado com apoio do Codex CLI** (cruzando os dois repos): correções de clone fresco (`cp` dos `.example`), `npx playwright install`, `exact=true` no curl do Keycloak, ressalvas de gateway, versões Docker/Compose; e fix do `UID` read-only no shell.
- Consistente com `uniplus-api/CONTRIBUTING.md` §"Testar um frontend".

Closes #405