### PR TITLE
fix(admin): corrige largura do drawer lateral de detalhes da unidade

### DIFF
--- a/apps/configuracao/src/app/features/unidades/unidades.page.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.ts
@@ -369,7 +369,7 @@ const BACKEND_FIELD_TO_CONTROL = {
     </ng-template>
 
     <ui-drawer
-      class="cfg-detail-drawer"
+      class="cfg-form-drawer"
       [(visible)]="drawerOpen"
       heading="Detalhes da unidade"
       ariaLabel="Detalhes da unidade selecionada"


### PR DESCRIPTION
## Resumo

Corrige a largura do drawer lateral para a exibição de detalhes unidade, página de exibição de unidades.

## O que foi feito
Reutilização de classes css já existentes para evitar retrabalhos e redundâncias.

## Mudanças

<!-- Lista detalhada das mudanças por categoria -->

### Modificados
apps/configuracao/src/styles.css

## Testes

- [x] Testes de usabilidade no modo desktop e mobile.

## Checklist

- [x] Testes de usabilidade no modo desktop
- [x] Testes de usabilidade no modo mobile
