### PR TITLE
docs: ordenação de combos e cursor opaco (#408 #409 #410)

### DIFF
--- a/docs/ordenacao-de-combos-e-cursor.md
+++ b/docs/ordenacao-de-combos-e-cursor.md
@@ -1,0 +1,56 @@
+# Ordenação de combos e tratamento do cursor
+
+Referência para o time de frontend sobre **quais listagens já vêm ordenadas por
+nome do servidor** (e não precisam de sort no cliente) e sobre o **contrato do
+cursor de paginação** como string opaca.
+
+Contexto: `uniplus-api#700` (PR `uniplus-api#714`) introduziu uma fundação
+reutilizável de ordenação **keyset** sob o mesmo cursor opaco (ADR-0094). Estados
+e cidades já adotaram ordenação alfabética por nome; o conteúdo interno do cursor
+mudou (âncora passou de `Id` para a tupla `(sort key, Id)`), mas o cursor
+**continua opaco** (AES-GCM, ADR-0026).
+
+## Ordenação por listagem
+
+| Listagem / combo | Endpoint | Ordem do servidor | Sort client-side? |
+|---|---|---|---|
+| Estados | `GET /api/estados` | alfabética por nome (ADR-0094) | **Não** — confiar no servidor |
+| Cidades | `GET /api/cidades?uf=` | alfabética por nome (ADR-0094) | **Não** |
+| Campus | `GET /api/campi` | por `Id` (ainda não-keyset) | Apenas se precisar exibir por nome |
+| Local de Oferta | `GET /api/locais-oferta` | por `Id` (ainda não-keyset) | Apenas se precisar exibir por nome |
+| Unidade | `GET /api/unidades` | por `Id` (ainda não-keyset) | A árvore ordena por nome no cliente (`montarArvore`) |
+
+**Regra:** quando o backend passar a ordenar uma dessas listagens por nome (via a
+fundação keyset, ADR-0094), **remova o sort client-side correspondente** — como
+já vale para estados e cidades. Ordenar no cliente só reordena a **janela
+paginada atual**, não dá ordem global sob paginação e pode embaralhar a sequência
+do cursor.
+
+## Cursor de paginação — string opaca
+
+- O cursor é **AES-GCM opaco** (ADR-0026). O conteúdo interno mudou em
+  `uniplus-api#700`, mas o cliente **nunca** o decifra.
+- Leia o cursor **somente** do header `Link` (`rel="prev"` / `rel="next"`) via
+  `extractPrevCursor` / `extractNextCursor`, e repasse com `cursorToString`
+  (`@uniplus/shared-core/http`).
+- O tipo `Cursor` é **branded** em compile time — atribuir uma `string` crua
+  exige `createCursor(...)`, o que evita parse/comparação acidental com URLs.
+- **Não** extraia `Id` do cursor nem assuma seu formato. Navegação bidirecional:
+  envie `direction` (`'next'`/`'prev'`) casado ao cursor (ADR-0089).
+
+## Verificação (issues #408 / #409) — estado em 2026-06-23
+
+- **#408 (remover sort client-side de UF/cidade):** não há sort client-side a
+  remover. O único seletor de cidade do front (`cfg-endereco-form`,
+  `GET /api/cidades`) consome a ordem do servidor diretamente; não existe combo de
+  UF/estados no frontend até aqui. A paginação por cursor preserva a ordem do
+  servidor (navegação por substituição, ADR-0089/0026).
+- **#409 (cursor como string opaca):** confirmado. Nenhum código decodifica,
+  parseia ou inspeciona o cursor (sem `atob`/`JSON.parse`/`split`); o tipo
+  branded `Cursor` reforça isso em compile time.
+
+## Referências
+
+- `uniplus-api#700` (PR `uniplus-api#714`)
+- ADR-0094 (keyset ordenado) · ADR-0089 (navegação bidirecional) · ADR-0026
+  (cursor opaco cifrado)


### PR DESCRIPTION
## Resumo

Tasks rápidas derivadas de `uniplus-api#700` (ordenação keyset, ADR-0094): estados e cidades passaram a vir ordenados por nome do servidor, sob cursor opaco.

Investiguei o front e **as três se resolvem com documentação + verificação** — não há código a alterar:

- **#408 (remover sort client-side de UF/cidade):** não existe sort client-side a remover. O único seletor de cidade (`cfg-endereco-form`, `GET /api/cidades`) já consome a ordem do servidor; não há combo de UF/estados no front.
- **#409 (cursor como string opaca):** confirmado — o tipo `Cursor` é *branded* (trava parse em compile time) e nenhum código decodifica/inspeciona o cursor (sem `atob`/`JSON.parse`/`split`).
- **#410 (documentar ordenação):** adiciona `docs/ordenacao-de-combos-e-cursor.md` com a tabela de ordenação por listagem (server-side vs por Id), a regra de remoção de sort client-side e o contrato do cursor opaco.

## Mudanças

- `docs/ordenacao-de-combos-e-cursor.md` (novo) — único arquivo; doc-only, sem mudança de código/comportamento.

Closes #408
Closes #409
Closes #410

