### PR TITLE
Alinha api clients aos paths de módulo do contrato (ADR-0064)

### DIFF
--- a/apps/configuracao-e2e/src/runtime-config.spec.ts
+++ b/apps/configuracao-e2e/src/runtime-config.spec.ts
@@ -5,6 +5,6 @@ test('serve runtime config do app Configuração', async ({ page }) => {
 
   expect(response?.ok()).toBe(true);
   await expect(page.locator('body')).toContainText('configuracao-web');
-  await expect(page.locator('body')).toContainText('http://localhost:5263');
+  await expect(page.locator('body')).toContainText('http://localhost:5000');
   await expect(page.locator('body')).toContainText('unifesspa');
 });

--- a/apps/configuracao-e2e/src/specs/endereco.flow.spec.ts
+++ b/apps/configuracao-e2e/src/specs/endereco.flow.spec.ts
@@ -54,14 +54,14 @@ async function jsonRoute(route: Route, body: unknown, status = 200): Promise<voi
 }
 
 async function mockApi(page: Page, capturado: { post?: unknown }): Promise<void> {
-  await page.route(/\/api\/campi(\?.*)?$/, (route) => jsonRoute(route, []));
+  await page.route(/\/api\/configuracao\/campi(\?.*)?$/, (route) => jsonRoute(route, []));
   // Playwright casa rotas na ordem inversa de registro: a regra genérica de CEP
   // (404) vem primeiro; a específica do CEP resolvido é registrada depois para
   // ter prioridade sobre a genérica.
   await page.route(/\/api\/cep\/\d+$/, (route) => jsonRoute(route, null, 404));
   await page.route(/\/api\/cep\/68507590$/, (route) => jsonRoute(route, CEP_LOGRADOURO));
   await page.route(/\/api\/cidades(\?.*)?$/, (route) => jsonRoute(route, CIDADES));
-  await page.route(/\/api\/admin\/campi$/, async (route) => {
+  await page.route(/\/api\/configuracao\/admin\/campi$/, async (route) => {
     capturado.post = route.request().postDataJSON();
     await route.fulfill({ status: 201, contentType: 'application/json', headers: CORS_HEADERS, body: '"new-id"' });
   });

--- a/apps/configuracao-e2e/src/specs/instituicao.visual.spec.ts
+++ b/apps/configuracao-e2e/src/specs/instituicao.visual.spec.ts
@@ -195,7 +195,7 @@ test.describe('Instituição — cobertura visual DS', () => {
 });
 
 async function mockReitoriasApi(page: Page): Promise<void> {
-  await page.route(/\/api\/unidades(\?.*)?$/, async (route, request) => {
+  await page.route(/\/api\/organizacao\/unidades(\?.*)?$/, async (route, request) => {
     if (request.method() === 'OPTIONS') {
       await route.fulfill({ status: 204, headers: CORS_HEADERS });
       return;
@@ -215,8 +215,8 @@ async function mockReitoriasApi(page: Page): Promise<void> {
 async function mockInstituicaoApi(page: Page, options: { existe: boolean }): Promise<void> {
   let existe = options.existe;
 
-  // GET /api/instituicao (singleton): 200 quando existe, 404 quando não.
-  await page.route(/\/api\/instituicao$/, async (route, request) => {
+  // GET /api/organizacao/instituicao (singleton): 200 quando existe, 404 quando não.
+  await page.route(/\/api\/organizacao\/instituicao$/, async (route, request) => {
     if (request.method() === 'OPTIONS') {
       await route.fulfill({ status: 204, headers: CORS_HEADERS });
       return;
@@ -236,8 +236,8 @@ async function mockInstituicaoApi(page: Page, options: { existe: boolean }): Pro
     }
   });
 
-  // POST /api/admin/instituicao: cria e liga o flag para a ficha aparecer.
-  await page.route(/\/api\/admin\/instituicao$/, async (route, request) => {
+  // POST /api/organizacao/admin/instituicao: cria e liga o flag para a ficha aparecer.
+  await page.route(/\/api\/organizacao\/admin\/instituicao$/, async (route, request) => {
     if (request.method() === 'OPTIONS') {
       await route.fulfill({ status: 204, headers: CORS_HEADERS });
       return;

--- a/apps/configuracao-e2e/src/specs/reserva-demografica.flow.spec.ts
+++ b/apps/configuracao-e2e/src/specs/reserva-demografica.flow.spec.ts
@@ -41,13 +41,13 @@ async function mockApi(
   capturado: { post?: unknown; deleted?: boolean },
   lista: readonly unknown[],
 ): Promise<void> {
-  await page.route(/\/api\/admin\/referencias-reserva-demografica\/[^/]+$/, async (route) => {
+  await page.route(/\/api\/configuracao\/admin\/referencias-reserva-demografica\/[^/]+$/, async (route) => {
     if (route.request().method() === 'DELETE') {
       capturado.deleted = true;
     }
     await route.fulfill({ status: 204, headers: CORS_HEADERS });
   });
-  await page.route(/\/api\/admin\/referencias-reserva-demografica$/, async (route) => {
+  await page.route(/\/api\/configuracao\/admin\/referencias-reserva-demografica$/, async (route) => {
     if (route.request().method() === 'POST') {
       capturado.post = route.request().postDataJSON();
     }
@@ -58,7 +58,7 @@ async function mockApi(
       body: '"new-id"',
     });
   });
-  await page.route(/\/api\/referencias-reserva-demografica(\?.*)?$/, (route) =>
+  await page.route(/\/api\/configuracao\/referencias-reserva-demografica(\?.*)?$/, (route) =>
     jsonRoute(route, lista),
   );
 }

--- a/apps/configuracao-e2e/src/specs/unidades.visual.spec.ts
+++ b/apps/configuracao-e2e/src/specs/unidades.visual.spec.ts
@@ -197,7 +197,7 @@ async function mockUnidadesApi(page: Page): Promise<void> {
   };
   let firstCreateKey: string | undefined;
 
-  await page.route(/\/api\/admin\/unidades$/, async (route, request) => {
+  await page.route(/\/api\/organizacao\/admin\/unidades$/, async (route, request) => {
     if (request.method() === 'OPTIONS') {
       await route.fulfill({ status: 204, headers: corsHeaders });
       return;
@@ -256,7 +256,7 @@ async function mockUnidadesApi(page: Page): Promise<void> {
     });
   });
 
-  await page.route(/\/api\/unidades(\?.*)?$/, async (route, request) => {
+  await page.route(/\/api\/organizacao\/unidades(\?.*)?$/, async (route, request) => {
     if (request.method() === 'OPTIONS') {
       await route.fulfill({ status: 204, headers: corsHeaders });
       return;

--- a/apps/configuracao-e2e/src/support/runtime-config.ts
+++ b/apps/configuracao-e2e/src/support/runtime-config.ts
@@ -1,7 +1,7 @@
 import type { Page } from '@playwright/test';
 
 const CONFIGURACAO_E2E_RUNTIME_CONFIG = {
-  apiUrl: 'http://localhost:5263',
+  apiUrl: 'http://localhost:5000',
   oidc: {
     issuerUrl: `${keycloakUrl()}/realms/unifesspa`,
     clientId: 'configuracao-web',

--- a/apps/configuracao/public/assets/runtime-config.json
+++ b/apps/configuracao/public/assets/runtime-config.json
@@ -1,5 +1,5 @@
 {
-  "apiUrl": "http://localhost:5263",
+  "apiUrl": "http://localhost:5000",
   "oidc": {
     "issuerUrl": "http://localhost:8080/realms/unifesspa",
     "clientId": "configuracao-web"

--- a/apps/configuracao/src/app/features/campi/campi.page.spec.ts
+++ b/apps/configuracao/src/app/features/campi/campi.page.spec.ts
@@ -68,7 +68,7 @@ describe('CampiPage', () => {
   };
 
   async function flushLista(itens: readonly CampusDto[]): Promise<void> {
-    const req = controller.expectOne((r) => r.url === `${BASE}/api/campi`);
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/campi`);
     expect(req.request.params.get('limit')).toBe('50');
     req.flush(itens);
     await propagate();
@@ -96,7 +96,7 @@ describe('CampiPage', () => {
 
     component['salvar']();
 
-    const post = controller.expectOne(`${BASE}/api/admin/campi`);
+    const post = controller.expectOne(`${BASE}/api/configuracao/admin/campi`);
     expect(post.request.method).toBe('POST');
     expect(post.request.headers.get('Idempotency-Key')).toBe(key);
     expect(post.request.body).toMatchObject({
@@ -128,7 +128,7 @@ describe('CampiPage', () => {
 
     component['salvar']();
 
-    controller.expectNone(`${BASE}/api/admin/campi`);
+    controller.expectNone(`${BASE}/api/configuracao/admin/campi`);
     expect(component['enderecoErro']()).toContain('cidade');
   });
 
@@ -137,7 +137,7 @@ describe('CampiPage', () => {
     component['pedirRemocao'](campusSeed);
     component['removerConfirmado']();
 
-    const req = controller.expectOne(`${BASE}/api/admin/campi/${campusSeed.id}`);
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/campi/${campusSeed.id}`);
     expect(req.request.method).toBe('DELETE');
     req.flush(null, { status: 204, statusText: 'No Content' });
     await propagate();

--- a/apps/configuracao/src/app/features/campi/campi.page.ts
+++ b/apps/configuracao/src/app/features/campi/campi.page.ts
@@ -297,7 +297,7 @@ export class CampiPage {
   >(undefined);
 
   private readonly lista = useApiResource<readonly CampusDto[]>(() => ({
-    url: `${this.basePath}/api/campi`,
+    url: `${this.basePath}/api/configuracao/campi`,
     params: this.montarParams(),
     context: withVendorMime('campus', 1),
   }));

--- a/apps/configuracao/src/app/features/instituicao/instituicao.page.spec.ts
+++ b/apps/configuracao/src/app/features/instituicao/instituicao.page.spec.ts
@@ -99,7 +99,7 @@ describe('InstituicaoPage', () => {
   };
 
   function expectObter(): TestRequest {
-    const req = controller.expectOne(`${BASE}/api/instituicao`);
+    const req = controller.expectOne(`${BASE}/api/organizacao/instituicao`);
     expect(req.request.method).toBe('GET');
     expect(req.request.headers.get('Accept')).toBe(buildVendorMimeAccept('instituicao', 1));
     return req;
@@ -108,7 +108,7 @@ describe('InstituicaoPage', () => {
   function expectReitorias(): TestRequest {
     return controller.expectOne(
       (r: HttpRequest<unknown>) =>
-        r.url === `${BASE}/api/unidades` && r.method === 'GET' && r.params.get('tipo') === '1',
+        r.url === `${BASE}/api/organizacao/unidades` && r.method === 'GET' && r.params.get('tipo') === '1',
     );
   }
 
@@ -184,7 +184,7 @@ describe('InstituicaoPage', () => {
     await propagate();
 
     // Nenhuma request de POST disparada (form inválido).
-    controller.expectNone(`${BASE}/api/admin/instituicao`);
+    controller.expectNone(`${BASE}/api/organizacao/admin/instituicao`);
     expect(component.erroDoCampo('nome')).toBe('Campo obrigatório.');
     expect(component.erroDoCampo('codigoEmec')).toBe('Campo obrigatório.');
     expect(component.drawerAberto()).toBe(true);
@@ -197,7 +197,7 @@ describe('InstituicaoPage', () => {
     component.salvar();
     await propagate();
 
-    const req = controller.expectOne(`${BASE}/api/admin/instituicao`);
+    const req = controller.expectOne(`${BASE}/api/organizacao/admin/instituicao`);
     expect(req.request.method).toBe('POST');
     req.flush(
       problem(409, 'uniplus.organizacao.instituicao.ja_existe', 'Já existe'),
@@ -216,7 +216,7 @@ describe('InstituicaoPage', () => {
     component.salvar();
     await propagate();
 
-    const req = controller.expectOne(`${BASE}/api/admin/instituicao/${ID}`);
+    const req = controller.expectOne(`${BASE}/api/organizacao/admin/instituicao/${ID}`);
     expect(req.request.method).toBe('PUT');
     req.flush(
       problem(
@@ -245,7 +245,7 @@ describe('InstituicaoPage', () => {
     component.salvar();
     await propagate();
 
-    const req = controller.expectOne(`${BASE}/api/admin/instituicao`);
+    const req = controller.expectOne(`${BASE}/api/organizacao/admin/instituicao`);
     expect(req.request.method).toBe('POST');
     expect(req.request.headers.get('Idempotency-Key')).toBe(chave);
     expect(req.request.body).toMatchObject({
@@ -277,7 +277,7 @@ describe('InstituicaoPage', () => {
     component.removerConfirmado();
     await propagate();
 
-    const req = controller.expectOne(`${BASE}/api/admin/instituicao/${ID}`);
+    const req = controller.expectOne(`${BASE}/api/organizacao/admin/instituicao/${ID}`);
     expect(req.request.method).toBe('DELETE');
     req.flush(null, { status: 204, statusText: 'No Content' });
     await propagate();
@@ -295,7 +295,7 @@ describe('InstituicaoPage', () => {
     await propagate();
 
     // DELETE em voo (não flushado): removendo() = true.
-    const del = controller.expectOne(`${BASE}/api/admin/instituicao/${ID}`);
+    const del = controller.expectOne(`${BASE}/api/organizacao/admin/instituicao/${ID}`);
     expect(del.request.method).toBe('DELETE');
 
     // Tentar salvar nessa janela é no-op (guard de corrida): retorna antes de
@@ -317,7 +317,7 @@ describe('InstituicaoPage', () => {
     component.salvar();
     await propagate();
 
-    const req = controller.expectOne(`${BASE}/api/admin/instituicao`);
+    const req = controller.expectOne(`${BASE}/api/organizacao/admin/instituicao`);
     req.flush(
       JSON.stringify({
         type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.validacao',

--- a/apps/configuracao/src/app/features/instituicao/instituicao.page.ts
+++ b/apps/configuracao/src/app/features/instituicao/instituicao.page.ts
@@ -615,7 +615,7 @@ export class InstituicaoPage {
    * página (fitness `no-direct-http-in-pages`). Filtro `?tipo=1` (Reitoria).
    */
   private readonly reitoriasResource = useApiResource<readonly UnidadeDto[]>(() => ({
-    url: `${this.basePath}/api/unidades`,
+    url: `${this.basePath}/api/organizacao/unidades`,
     params: new HttpParams().set('tipo', TIPO_REITORIA).set('limit', String(PAGE_SIZE)),
     context: withVendorMime('unidade', 1),
   }));

--- a/apps/configuracao/src/app/features/locais-oferta/locais-oferta.page.spec.ts
+++ b/apps/configuracao/src/app/features/locais-oferta/locais-oferta.page.spec.ts
@@ -68,14 +68,14 @@ describe('LocaisOfertaPage', () => {
   };
 
   async function flushLista(itens: readonly LocalOfertaDto[]): Promise<void> {
-    const req = controller.expectOne((r) => r.url === `${BASE}/api/locais-oferta`);
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/locais-oferta`);
     req.flush(itens);
     await propagate();
   }
 
   async function flushCampiLookup(): Promise<void> {
     await propagate();
-    controller.expectOne((r) => r.url === `${BASE}/api/campi`).flush([]);
+    controller.expectOne((r) => r.url === `${BASE}/api/configuracao/campi`).flush([]);
     await propagate();
   }
 
@@ -101,7 +101,7 @@ describe('LocaisOfertaPage', () => {
 
     component['salvar']();
 
-    const post = controller.expectOne(`${BASE}/api/admin/locais-oferta`);
+    const post = controller.expectOne(`${BASE}/api/configuracao/admin/locais-oferta`);
     expect(post.request.method).toBe('POST');
     expect(post.request.body).toMatchObject({
       tipo: 'poloEad',
@@ -119,7 +119,7 @@ describe('LocaisOfertaPage', () => {
     const localVinculado: LocalOfertaDto = { ...localSeed, campusResponsavelId: 'cmp1' };
     await flushLista([localVinculado]);
     await propagate();
-    controller.expectOne((r) => r.url === `${BASE}/api/campi`).flush([
+    controller.expectOne((r) => r.url === `${BASE}/api/configuracao/campi`).flush([
       {
         id: 'cmp1',
         sigla: 'MAB',
@@ -140,7 +140,7 @@ describe('LocaisOfertaPage', () => {
     await flushCampiLookup();
     // sem tipo nem cidade
     component['salvar']();
-    controller.expectNone(`${BASE}/api/admin/locais-oferta`);
+    controller.expectNone(`${BASE}/api/configuracao/admin/locais-oferta`);
     expect(component['enderecoErro']()).toContain('cidade');
   });
 });

--- a/apps/configuracao/src/app/features/locais-oferta/locais-oferta.page.ts
+++ b/apps/configuracao/src/app/features/locais-oferta/locais-oferta.page.ts
@@ -316,7 +316,7 @@ export class LocaisOfertaPage {
   >(undefined);
 
   private readonly lista = useApiResource<readonly LocalOfertaDto[]>(() => ({
-    url: `${this.basePath}/api/locais-oferta`,
+    url: `${this.basePath}/api/configuracao/locais-oferta`,
     params: this.montarParams(),
     context: withVendorMime('local-oferta', 1),
   }));
@@ -330,7 +330,7 @@ export class LocaisOfertaPage {
       return undefined;
     }
     return {
-      url: `${this.basePath}/api/campi`,
+      url: `${this.basePath}/api/configuracao/campi`,
       params: new HttpParams().set('limit', String(CAMPI_LOOKUP_LIMIT)),
       context: withVendorMime('campus', 1),
     };

--- a/apps/configuracao/src/app/features/reserva-demografica/reserva-demografica-list.page.spec.ts
+++ b/apps/configuracao/src/app/features/reserva-demografica/reserva-demografica-list.page.spec.ts
@@ -12,7 +12,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { ReservaDemograficaListPage } from './reserva-demografica-list.page';
 
 const BASE = 'http://localhost:5000';
-const URL = `${BASE}/api/referencias-reserva-demografica`;
+const URL = `${BASE}/api/configuracao/referencias-reserva-demografica`;
 
 const seed: ReferenciaReservaDemograficaDto = {
   id: '01960000-0000-7000-0000-0000000000e1',
@@ -89,7 +89,7 @@ describe('ReservaDemograficaListPage', () => {
     });
     component['salvar']();
 
-    const post = controller.expectOne(`${BASE}/api/admin/referencias-reserva-demografica`);
+    const post = controller.expectOne(`${BASE}/api/configuracao/admin/referencias-reserva-demografica`);
     expect(post.request.method).toBe('POST');
     expect(post.request.body).toEqual({
       censoReferencia: '2022',
@@ -112,7 +112,7 @@ describe('ReservaDemograficaListPage', () => {
 
     expect(component['form'].controls.censoReferencia.hasError('duplicado')).toBe(true);
     component['salvar']();
-    controller.expectNone(`${BASE}/api/admin/referencias-reserva-demografica`);
+    controller.expectNone(`${BASE}/api/configuracao/admin/referencias-reserva-demografica`);
   });
 
   it('CA-04: percentual fora de [0,100] é inválido; limites são aceitos', async () => {
@@ -138,7 +138,7 @@ describe('ReservaDemograficaListPage', () => {
     await flushLista([seed]);
     component['pedirRemocao'](seed);
     component['removerConfirmado']();
-    const req = controller.expectOne(`${BASE}/api/admin/referencias-reserva-demografica/${seed.id}`);
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/referencias-reserva-demografica/${seed.id}`);
     expect(req.request.method).toBe('DELETE');
     req.flush(null, { status: 204, statusText: 'No Content' });
     await propagate();

--- a/apps/configuracao/src/app/features/reserva-demografica/reserva-demografica-list.page.ts
+++ b/apps/configuracao/src/app/features/reserva-demografica/reserva-demografica-list.page.ts
@@ -381,7 +381,7 @@ export class ReservaDemograficaListPage {
   >(undefined);
 
   private readonly lista = useApiResource<readonly ReferenciaReservaDemograficaDto[]>(() => ({
-    url: `${this.basePath}/api/referencias-reserva-demografica`,
+    url: `${this.basePath}/api/configuracao/referencias-reserva-demografica`,
     params: this.montarParams(),
     context: withVendorMime('referencia-reserva-demografica', 1),
   }));

--- a/apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
@@ -89,7 +89,7 @@ describe('UnidadesPage', () => {
   function expectListGet(matcher?: (request: HttpRequest<unknown>) => boolean): TestRequest {
     const req = controller.expectOne(
       (request) =>
-        request.url === `${BASE}/api/unidades` &&
+        request.url === `${BASE}/api/organizacao/unidades` &&
         request.method === 'GET' &&
         (matcher ? matcher(request) : true),
     );
@@ -143,7 +143,7 @@ describe('UnidadesPage', () => {
     appRef.tick();
     // Antes do debounce, nenhuma request com q (não dispara por tecla).
     controller.expectNone(
-      (request) => request.url === `${BASE}/api/unidades` && request.params.has('q'),
+      (request) => request.url === `${BASE}/api/organizacao/unidades` && request.params.has('q'),
     );
 
     await sleep(DEBOUNCE_FOLGA_MS);
@@ -177,7 +177,7 @@ describe('UnidadesPage', () => {
 
   it('navega Próximo/Anterior por substituição, com direction casado e sem limit (ADR-0089)', async () => {
     await flushInicial([unidadesSeed[0]], {
-      Link: `<${BASE}/api/unidades?cursor=pagina-2&direction=next>; rel="next"`,
+      Link: `<${BASE}/api/organizacao/unidades?cursor=pagina-2&direction=next>; rel="next"`,
     });
 
     expect(component['unidades']()).toHaveLength(1);
@@ -195,7 +195,7 @@ describe('UnidadesPage', () => {
         !r.params.has('limit'),
     );
     reqNext.flush([unidadesSeed[1]], {
-      headers: { Link: `<${BASE}/api/unidades?cursor=pagina-1&direction=prev>; rel="prev"` },
+      headers: { Link: `<${BASE}/api/organizacao/unidades?cursor=pagina-1&direction=prev>; rel="prev"` },
     });
     await propagate();
 
@@ -224,7 +224,7 @@ describe('UnidadesPage', () => {
 
   it('mudar o filtro reseta a paginação para a primeira página e substitui a lista', async () => {
     await flushInicial([unidadesSeed[0]], {
-      Link: `<${BASE}/api/unidades?cursor=pagina-2&direction=next>; rel="next"`,
+      Link: `<${BASE}/api/organizacao/unidades?cursor=pagina-2&direction=next>; rel="next"`,
     });
     component['proximaPagina']();
     await propagate();
@@ -272,7 +272,7 @@ describe('UnidadesPage', () => {
 
     component['salvar']();
 
-    const post = controller.expectOne(`${BASE}/api/admin/unidades`);
+    const post = controller.expectOne(`${BASE}/api/organizacao/admin/unidades`);
     expect(post.request.method).toBe('POST');
     expect(post.request.headers.get('Idempotency-Key')).toBe(key);
     expect(post.request.body).toMatchObject({
@@ -314,7 +314,7 @@ describe('UnidadesPage', () => {
 
     component['salvar']();
 
-    const req1 = controller.expectOne(`${BASE}/api/admin/unidades`);
+    const req1 = controller.expectOne(`${BASE}/api/organizacao/admin/unidades`);
     expect(req1.request.method).toBe('POST');
     expect(req1.request.headers.get('Idempotency-Key')).toBe(primeiraChave);
     expect(req1.request.body).toMatchObject({
@@ -361,7 +361,7 @@ describe('UnidadesPage', () => {
     component['form'].controls.vigenciaFim.setValue('2026-06-10');
     component['salvar']();
 
-    const retry = controller.expectOne(`${BASE}/api/admin/unidades`);
+    const retry = controller.expectOne(`${BASE}/api/organizacao/admin/unidades`);
     expect(retry.request.headers.get('Idempotency-Key')).toBe(segundaChave);
     expect(retry.request.body).toMatchObject({
       vigenciaInicio: '2026-06-10',
@@ -400,7 +400,7 @@ describe('UnidadesPage', () => {
     const primeiraChave = component['idempotencyKeyAtual']();
     component['salvar']();
 
-    controller.expectOne(`${BASE}/api/admin/unidades`).flush(
+    controller.expectOne(`${BASE}/api/organizacao/admin/unidades`).flush(
       {
         type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.idempotency.body_mismatch',
         title: 'Mesma Idempotency-Key reusada com body diferente',
@@ -444,7 +444,7 @@ describe('UnidadesPage', () => {
     const primeiraChave = component['idempotencyKeyAtual']();
     component['salvar']();
 
-    controller.expectOne(`${BASE}/api/admin/unidades`).flush(
+    controller.expectOne(`${BASE}/api/organizacao/admin/unidades`).flush(
       {
         type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.unidade.sigla_duplicada',
         title: 'Sigla já utilizada por outra unidade viva',
@@ -480,7 +480,7 @@ describe('UnidadesPage', () => {
 
     component['salvar']();
 
-    const put = controller.expectOne(`${BASE}/api/admin/unidades/${INSTITUTO_ID}`);
+    const put = controller.expectOne(`${BASE}/api/organizacao/admin/unidades/${INSTITUTO_ID}`);
     expect(put.request.method).toBe('PUT');
     expect(put.request.headers.get('Idempotency-Key')).toBe(key);
     expect(put.request.body).not.toHaveProperty('vigenciaInicio');
@@ -508,7 +508,7 @@ describe('UnidadesPage', () => {
 
     component['salvar']();
 
-    const put = controller.expectOne(`${BASE}/api/admin/unidades/${INSTITUTO_ID}`);
+    const put = controller.expectOne(`${BASE}/api/organizacao/admin/unidades/${INSTITUTO_ID}`);
     expect(put.request.method).toBe('PUT');
     expect(put.request.body).toMatchObject({
       id: INSTITUTO_ID,
@@ -563,7 +563,7 @@ describe('UnidadesPage', () => {
 
     component['removerConfirmado']();
 
-    const del = controller.expectOne(`${BASE}/api/admin/unidades/${INSTITUTO_ID}`);
+    const del = controller.expectOne(`${BASE}/api/organizacao/admin/unidades/${INSTITUTO_ID}`);
     expect(del.request.method).toBe('DELETE');
     expect(del.request.headers.has('Idempotency-Key')).toBe(false);
     del.flush(null, { status: 204, statusText: 'No Content' });
@@ -595,7 +595,7 @@ describe('UnidadesPage', () => {
 
   it('permite tentar novamente quando a navegação falha, preservando a página atual', async () => {
     await flushInicial([unidadesSeed[0]], {
-      Link: `<${BASE}/api/unidades?cursor=pagina-2&direction=next>; rel="next"`,
+      Link: `<${BASE}/api/organizacao/unidades?cursor=pagina-2&direction=next>; rel="next"`,
     });
     expect(component['unidades']()).toHaveLength(1);
 
@@ -636,7 +636,7 @@ describe('UnidadesPage', () => {
     component['pedirRemocao'](unidadesSeed[1]);
     component['removerConfirmado']();
     controller
-      .expectOne(`${BASE}/api/admin/unidades/${INSTITUTO_ID}`)
+      .expectOne(`${BASE}/api/organizacao/admin/unidades/${INSTITUTO_ID}`)
       .flush(null, { status: 204, statusText: 'No Content' });
 
     await propagate();
@@ -687,7 +687,7 @@ describe('UnidadesPage', () => {
     component['pedirRemocao'](unidadesSeed[1]);
     component['removerConfirmado']();
     controller
-      .expectOne(`${BASE}/api/admin/unidades/${INSTITUTO_ID}`)
+      .expectOne(`${BASE}/api/organizacao/admin/unidades/${INSTITUTO_ID}`)
       .flush(null, { status: 204, statusText: 'No Content' });
 
     await propagate();

--- a/apps/configuracao/src/app/features/unidades/unidades.page.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.ts
@@ -716,12 +716,12 @@ export class UnidadesPage {
   });
 
   /**
-   * GET reativo de `/api/unidades`. Re-dispara quando filtro (`q`/`tipo`) ou
+   * GET reativo de `/api/organizacao/unidades`. Re-dispara quando filtro (`q`/`tipo`) ou
    * `cursor` mudam; `httpResource` cancela a request anterior nativamente — sem
    * `unsubscribe`/guarda manual. Vendor MIME `unidade v1` no HttpContext.
    */
   private readonly lista = useApiResource<readonly UnidadeDto[]>(() => ({
-    url: `${this.basePath}/api/unidades`,
+    url: `${this.basePath}/api/organizacao/unidades`,
     params: this.montarParams(),
     context: withVendorMime('unidade', 1),
   }));
@@ -847,7 +847,7 @@ export class UnidadesPage {
       params = params.set('q', q);
     }
     return {
-      url: `${this.basePath}/api/unidades`,
+      url: `${this.basePath}/api/organizacao/unidades`,
       params,
       context: withVendorMime('unidade', 1),
     };

--- a/apps/selecao-e2e/src/specs/editais-error-flows.authenticated.spec.ts
+++ b/apps/selecao-e2e/src/specs/editais-error-flows.authenticated.spec.ts
@@ -41,7 +41,7 @@ const EDITAL_OK = {
   bonusRegionalHabilitado: false,
   criadoEm: '2026-05-10T00:00:00Z',
   _links: {
-    self: { href: '/api/editais/01960000-0000-7000-0000-000000000111' },
+    self: { href: '/api/selecao/editais/01960000-0000-7000-0000-000000000111' },
   },
 } as const;
 
@@ -50,9 +50,9 @@ test.describe('Editais — fluxos 5xx (CA-08 da Story #171)', () => {
     test('mostra toast com trace-id, banner inline com mesma mensagem; retry recarrega para 200', async ({
       page,
     }) => {
-      // 1ª chamada GET /api/editais → 503 (problem+json); 2ª → 200 com 1 edital.
+      // 1ª chamada GET /api/selecao/editais → 503 (problem+json); 2ª → 200 com 1 edital.
       let getListCalls = 0;
-      await page.route(/\/api\/editais(\?[^/]*)?$/, async (route, request) => {
+      await page.route(/\/api\/selecao\/editais(\?[^/]*)?$/, async (route, request) => {
         if (request.method() !== 'GET') {
           await route.continue();
           return;
@@ -121,7 +121,7 @@ test.describe('Editais — fluxos 5xx (CA-08 da Story #171)', () => {
       // chromium-only (config), então grantPermissions é seguro aqui.
       await context.grantPermissions(['clipboard-read', 'clipboard-write']);
 
-      await page.route(/\/api\/editais(\?[^/]*)?$/, async (route, request) => {
+      await page.route(/\/api\/selecao\/editais(\?[^/]*)?$/, async (route, request) => {
         if (request.method() !== 'GET') {
           await route.continue();
           return;
@@ -152,11 +152,11 @@ test.describe('Editais — fluxos 5xx (CA-08 da Story #171)', () => {
     });
   });
 
-  test.describe('CA-08.2 POST /api/editais 503 → toast persistente + banner inline simultâneos', () => {
+  test.describe('CA-08.2 POST /api/selecao/editais 503 → toast persistente + banner inline simultâneos', () => {
     test('submit valido com 503 dispara toast e mantém role=alert no form', async ({
       page,
     }) => {
-      await page.route(/\/api\/editais$/, async (route, request) => {
+      await page.route(/\/api\/selecao\/editais$/, async (route, request) => {
         if (request.method() !== 'POST') {
           await route.continue();
           return;
@@ -199,13 +199,13 @@ test.describe('Editais — fluxos 5xx (CA-08 da Story #171)', () => {
     });
   });
 
-  test.describe('CA-08.3 GET /api/editais/{id} 503 → effect dispara toast', () => {
+  test.describe('CA-08.3 GET /api/selecao/editais/{id} 503 → effect dispara toast', () => {
     test('detalhe com 503 mantém role=alert na page e dispara toast persistente via effect()', async ({
       page,
     }) => {
       const detailId = '01960000-0000-7000-0000-0000000005ff';
       await page.route(
-        new RegExp(`/api/editais/${detailId}$`),
+        new RegExp(`/api/selecao/editais/${detailId}$`),
         async (route, request) => {
           if (request.method() !== 'GET') {
             await route.continue();
@@ -239,7 +239,7 @@ test.describe('Editais — fluxos 5xx (CA-08 da Story #171)', () => {
     test('listagem em estado de erro (banner DataTable + toast aberto) sem violations WCAG A/AA', async ({
       page,
     }) => {
-      await page.route(/\/api\/editais(\?[^/]*)?$/, async (route, request) => {
+      await page.route(/\/api\/selecao\/editais(\?[^/]*)?$/, async (route, request) => {
         if (request.method() !== 'GET') {
           await route.continue();
           return;

--- a/apps/selecao-e2e/src/specs/edital-happy-path.authenticated.spec.ts
+++ b/apps/selecao-e2e/src/specs/edital-happy-path.authenticated.spec.ts
@@ -13,7 +13,7 @@ import { test, expect } from '../fixtures/auth.fixture';
  * - cancelar do form de criação volta para a lista.
  *
  * **Não-escopo:** validar criação real de edital ponta-a-ponta. O fluxo de
- * POST `/api/editais` depende de premissas de backend (TipoProcesso enum
+ * POST `/api/selecao/editais` depende de premissas de backend (TipoProcesso enum
  * válido, RBAC do admin, validators FluentValidation) que evoluem
  * independente do frontend e tornariam o smoke flaky.
  */

--- a/apps/selecao-e2e/src/specs/shell.aaa.spec.ts
+++ b/apps/selecao-e2e/src/specs/shell.aaa.spec.ts
@@ -21,8 +21,8 @@ const EDITAIS = [
     bonusRegionalHabilitado: false,
     criadoEm: '2026-05-30T00:00:00Z',
     _links: {
-      self: { href: '/api/editais/01960000-0000-7000-0000-000000000377' },
-      collection: { href: '/api/editais' },
+      self: { href: '/api/selecao/editais/01960000-0000-7000-0000-000000000377' },
+      collection: { href: '/api/selecao/editais' },
     },
   },
 ] as const;
@@ -32,7 +32,7 @@ test.describe('Seleção — gate AAA aplicável @aaa', () => {
     const { theme, fontMode } = settingsFromProjectName(testInfo.project.name);
     await installA11yPreference(page, theme, fontMode);
 
-    await page.route(/\/api\/editais(\?.*)?$/, async (route, request) => {
+    await page.route(/\/api\/selecao\/editais(\?.*)?$/, async (route, request) => {
       if (request.method() !== 'GET') {
         await route.continue();
         return;

--- a/apps/selecao-e2e/src/specs/shell.ds-matrix.spec.ts
+++ b/apps/selecao-e2e/src/specs/shell.ds-matrix.spec.ts
@@ -15,8 +15,8 @@ const EDITAIS = [
     bonusRegionalHabilitado: false,
     criadoEm: '2026-05-30T00:00:00Z',
     _links: {
-      self: { href: '/api/editais/01960000-0000-7000-0000-000000000377' },
-      collection: { href: '/api/editais' },
+      self: { href: '/api/selecao/editais/01960000-0000-7000-0000-000000000377' },
+      collection: { href: '/api/selecao/editais' },
     },
   },
 ] as const;
@@ -35,7 +35,7 @@ test.describe('Shell Uni+ DS — matriz responsiva e tema', () => {
       );
     }, theme);
 
-    await page.route(/\/api\/editais(\?.*)?$/, async (route, request) => {
+    await page.route(/\/api\/selecao\/editais(\?.*)?$/, async (route, request) => {
       if (request.method() !== 'GET') {
         await route.continue();
         return;

--- a/apps/selecao/src/app/features/editais/editais-create.page.spec.ts
+++ b/apps/selecao/src/app/features/editais/editais-create.page.spec.ts
@@ -58,7 +58,7 @@ describe('EditaisCreatePage', () => {
   it('form invalid não dispara POST e marca controls como touched', () => {
     component['enviar']();
 
-    controller.expectNone(`${BASE}/api/editais`);
+    controller.expectNone(`${BASE}/api/selecao/editais`);
     expect(component.form.controls.titulo.touched).toBe(true);
     expect(component.form.controls.numeroEdital.touched).toBe(true);
   });
@@ -72,7 +72,7 @@ describe('EditaisCreatePage', () => {
 
     expect(component.submitting()).toBe(true);
 
-    const req = controller.expectOne(`${BASE}/api/editais`);
+    const req = controller.expectOne(`${BASE}/api/selecao/editais`);
     expect(req.request.method).toBe('POST');
     expect(req.request.headers.get('Idempotency-Key')).toBe(keyOriginal);
     expect(req.request.body).toEqual(COMANDO_VALIDO);
@@ -92,7 +92,7 @@ describe('EditaisCreatePage', () => {
 
     component['enviar']();
 
-    controller.expectOne(`${BASE}/api/editais`).flush(
+    controller.expectOne(`${BASE}/api/selecao/editais`).flush(
       {
         type: 'about:blank',
         title: 'Falha de validação',
@@ -127,7 +127,7 @@ describe('EditaisCreatePage', () => {
     preencherFormComValido();
     component['enviar']();
 
-    controller.expectOne(`${BASE}/api/editais`).flush(
+    controller.expectOne(`${BASE}/api/selecao/editais`).flush(
       {
         type: 'about:blank',
         title: 'Falha de validação',
@@ -150,7 +150,7 @@ describe('EditaisCreatePage', () => {
     preencherFormComValido();
     component['enviar']();
 
-    controller.expectOne(`${BASE}/api/editais`).flush(
+    controller.expectOne(`${BASE}/api/selecao/editais`).flush(
       {
         type: 'about:blank',
         title: 'Edital já existente',
@@ -174,7 +174,7 @@ describe('EditaisCreatePage', () => {
     const keyOriginal = component.idempotencyKeyAtual();
 
     component['enviar']();
-    controller.expectOne(`${BASE}/api/editais`).flush(
+    controller.expectOne(`${BASE}/api/selecao/editais`).flush(
       {
         type: 'about:blank',
         title: 'Falha de validação',
@@ -203,7 +203,7 @@ describe('EditaisCreatePage', () => {
 
     // Segundo submit: form-scoped key preservada — backend reconhece como replay legítimo.
     component['enviar']();
-    const reqRetry = controller.expectOne(`${BASE}/api/editais`);
+    const reqRetry = controller.expectOne(`${BASE}/api/selecao/editais`);
     expect(reqRetry.request.headers.get('Idempotency-Key')).toBe(keyOriginal);
     reqRetry.flush('id-novo-pos-correcao', { status: 201, statusText: 'Created' });
 
@@ -215,7 +215,7 @@ describe('EditaisCreatePage', () => {
     const keyOriginal = component.idempotencyKeyAtual();
 
     component['enviar']();
-    controller.expectOne(`${BASE}/api/editais`).flush(
+    controller.expectOne(`${BASE}/api/selecao/editais`).flush(
       {
         type: 'about:blank',
         title: 'Edital já existente',
@@ -234,7 +234,7 @@ describe('EditaisCreatePage', () => {
 
     // Retry: mesma key viaja de novo
     component['enviar']();
-    const reqRetry = controller.expectOne(`${BASE}/api/editais`);
+    const reqRetry = controller.expectOne(`${BASE}/api/selecao/editais`);
     expect(reqRetry.request.headers.get('Idempotency-Key')).toBe(keyOriginal);
     reqRetry.flush('id-novo', { status: 201, statusText: 'Created' });
   });
@@ -247,7 +247,7 @@ describe('EditaisCreatePage', () => {
     const botao = fixture.nativeElement.querySelector('button[type="submit"]') as HTMLButtonElement;
     expect(botao.disabled).toBe(true);
 
-    controller.expectOne(`${BASE}/api/editais`).flush('id', { status: 201, statusText: 'Created' });
+    controller.expectOne(`${BASE}/api/selecao/editais`).flush('id', { status: 201, statusText: 'Created' });
   });
 
   // Cobre o caminho real do usuário: preencher inputs via DOM (input event)
@@ -282,7 +282,7 @@ describe('EditaisCreatePage', () => {
 
     component['enviar']();
 
-    const req = controller.expectOne(`${BASE}/api/editais`);
+    const req = controller.expectOne(`${BASE}/api/selecao/editais`);
     expect(req.request.body).toEqual({
       numeroEdital: 42,
       anoEdital: 2026,

--- a/apps/selecao/src/app/features/editais/editais-create.page.ts
+++ b/apps/selecao/src/app/features/editais/editais-create.page.ts
@@ -34,7 +34,7 @@ interface CriarEditalForm {
 }
 
 /**
- * Container (ADR-0017) da feature Editais — criação via POST `/api/editais`.
+ * Container (ADR-0017) da feature Editais — criação via POST `/api/selecao/editais`.
  *
  * **Form-scoped Idempotency-Key (ADR-0014):** a key é gerada uma vez na
  * inicialização do form (signal) e reusada em retries enquanto o submit

--- a/apps/selecao/src/app/features/editais/editais-detail.page.spec.ts
+++ b/apps/selecao/src/app/features/editais/editais-detail.page.spec.ts
@@ -60,10 +60,10 @@ describe('EditaisDetailPage', () => {
     appRef.tick();
   };
 
-  it('carga inicial dispara GET /api/editais/{id} e popula data() do resource', async () => {
+  it('carga inicial dispara GET /api/selecao/editais/{id} e popula data() do resource', async () => {
     fixture.detectChanges();
 
-    const req = controller.expectOne(`${BASE}/api/editais/${ID}`);
+    const req = controller.expectOne(`${BASE}/api/selecao/editais/${ID}`);
     expect(req.request.method).toBe('GET');
     expect(req.request.headers.get('Accept')).toBe('application/vnd.uniplus.edital.v1+json');
     req.flush(editalSeed());
@@ -81,7 +81,7 @@ describe('EditaisDetailPage', () => {
   it('404 problem+json popula errorMessage via problem-i18n e mantém edital=null', async () => {
     fixture.detectChanges();
 
-    controller.expectOne(`${BASE}/api/editais/${ID}`).flush(
+    controller.expectOne(`${BASE}/api/selecao/editais/${ID}`).flush(
       {
         type: 'about:blank',
         title: 'Edital não encontrado',
@@ -103,7 +103,7 @@ describe('EditaisDetailPage', () => {
 
   it('podePublicar=true quando status === "Rascunho" (única transição permitida)', async () => {
     fixture.detectChanges();
-    controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Rascunho' }));
+    controller.expectOne(`${BASE}/api/selecao/editais/${ID}`).flush(editalSeed({ status: 'Rascunho' }));
     await propagate();
 
     expect(component['podePublicar']()).toBe(true);
@@ -111,7 +111,7 @@ describe('EditaisDetailPage', () => {
 
   it('podePublicar=false quando status diferente de "Rascunho"', async () => {
     fixture.detectChanges();
-    controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Publicado' }));
+    controller.expectOne(`${BASE}/api/selecao/editais/${ID}`).flush(editalSeed({ status: 'Publicado' }));
     await propagate();
 
     expect(component['podePublicar']()).toBe(false);
@@ -121,12 +121,12 @@ describe('EditaisDetailPage', () => {
     fixture.detectChanges();
     // Cenário hipotético defensivo: backend (incorretamente) emite _links.publicar.
     // Frontend deve ignorar — gating é exclusivamente por status do recurso.
-    controller.expectOne(`${BASE}/api/editais/${ID}`).flush({
+    controller.expectOne(`${BASE}/api/selecao/editais/${ID}`).flush({
       ...editalSeed({ status: 'Publicado' }),
       _links: {
-        self: `/api/editais/${ID}`,
-        collection: '/api/editais',
-        publicar: `/api/editais/${ID}/publicar`,
+        self: `/api/selecao/editais/${ID}`,
+        collection: '/api/selecao/editais',
+        publicar: `/api/selecao/editais/${ID}/publicar`,
       },
     } as never);
     await propagate();
@@ -136,37 +136,37 @@ describe('EditaisDetailPage', () => {
 
   it('_links navigation (self/collection) presente em recurso single per ADR-0029', async () => {
     fixture.detectChanges();
-    controller.expectOne(`${BASE}/api/editais/${ID}`).flush({
+    controller.expectOne(`${BASE}/api/selecao/editais/${ID}`).flush({
       ...editalSeed({ status: 'Rascunho' }),
       _links: {
-        self: `/api/editais/${ID}`,
-        collection: '/api/editais',
+        self: `/api/selecao/editais/${ID}`,
+        collection: '/api/selecao/editais',
       },
     });
     await propagate();
 
-    expect(component.edital()?._links?.['self']).toBe(`/api/editais/${ID}`);
-    expect(component.edital()?._links?.['collection']).toBe('/api/editais');
+    expect(component.edital()?._links?.['self']).toBe(`/api/selecao/editais/${ID}`);
+    expect(component.edital()?._links?.['collection']).toBe('/api/selecao/editais');
     // Action links nunca aparecem em _links (descobertos via OpenAPI).
     expect(component.edital()?._links?.['publicar']).toBeUndefined();
   });
 
   it('confirmarPublicacao envia POST com Idempotency-Key, recebe 204 e refetcha o edital', async () => {
     fixture.detectChanges();
-    controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Rascunho' }));
+    controller.expectOne(`${BASE}/api/selecao/editais/${ID}`).flush(editalSeed({ status: 'Rascunho' }));
     await propagate();
 
     component['confirmarPublicacao']();
     expect(component.submitting()).toBe(true);
 
-    const reqPublicar = controller.expectOne(`${BASE}/api/editais/${ID}/publicar`);
+    const reqPublicar = controller.expectOne(`${BASE}/api/selecao/editais/${ID}/publicar`);
     expect(reqPublicar.request.method).toBe('POST');
     expect(reqPublicar.request.headers.get('Idempotency-Key')).toMatch(/^[0-9a-f-]{36}$/);
     reqPublicar.flush(null, { status: 204, statusText: 'No Content' });
     await propagate();
 
     // Refetch via editalResource.reload() — dispara novo GET preservando URL atual.
-    const reqRefetch = controller.expectOne(`${BASE}/api/editais/${ID}`);
+    const reqRefetch = controller.expectOne(`${BASE}/api/selecao/editais/${ID}`);
     reqRefetch.flush(editalSeed({ status: 'Publicado' }));
     await propagate();
 
@@ -177,11 +177,11 @@ describe('EditaisDetailPage', () => {
 
   it('confirmarPublicacao com 422 ja_publicado popula errorMessage e NÃO refetcha', async () => {
     fixture.detectChanges();
-    controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Rascunho' }));
+    controller.expectOne(`${BASE}/api/selecao/editais/${ID}`).flush(editalSeed({ status: 'Rascunho' }));
     await propagate();
 
     component['confirmarPublicacao']();
-    controller.expectOne(`${BASE}/api/editais/${ID}/publicar`).flush(
+    controller.expectOne(`${BASE}/api/selecao/editais/${ID}/publicar`).flush(
       {
         type: 'about:blank',
         title: 'Edital já publicado',
@@ -204,7 +204,7 @@ describe('EditaisDetailPage', () => {
 
   it('botão Publicar aparece quando podePublicar=true e dispara dialog', async () => {
     fixture.detectChanges();
-    controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Rascunho' }));
+    controller.expectOne(`${BASE}/api/selecao/editais/${ID}`).flush(editalSeed({ status: 'Rascunho' }));
     await propagate();
     fixture.detectChanges();
 
@@ -218,7 +218,7 @@ describe('EditaisDetailPage', () => {
 
   it('botão Publicar NÃO aparece quando podePublicar=false', async () => {
     fixture.detectChanges();
-    controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Publicado' }));
+    controller.expectOne(`${BASE}/api/selecao/editais/${ID}`).flush(editalSeed({ status: 'Publicado' }));
     await propagate();
     fixture.detectChanges();
 
@@ -228,7 +228,7 @@ describe('EditaisDetailPage', () => {
 
   it('mudança no input editalId cancela GET stale e dispara nova request (httpResource race-cancellation nativa)', async () => {
     fixture.detectChanges();
-    const reqId1 = controller.expectOne(`${BASE}/api/editais/${ID}`);
+    const reqId1 = controller.expectOne(`${BASE}/api/selecao/editais/${ID}`);
     expect(reqId1.cancelled).toBe(false);
 
     // Usuário navega antes do id1 retornar — Angular reusa a instância do componente.
@@ -244,7 +244,7 @@ describe('EditaisDetailPage', () => {
     // dependências reativas mudam.
     expect(reqId1.cancelled).toBe(true);
 
-    const reqId2 = controller.expectOne(`${BASE}/api/editais/${ID_NOVO}`);
+    const reqId2 = controller.expectOne(`${BASE}/api/selecao/editais/${ID_NOVO}`);
     reqId2.flush(editalSeed({ id: ID_NOVO, titulo: 'PSE 2027' }));
     await propagate();
 
@@ -254,7 +254,7 @@ describe('EditaisDetailPage', () => {
 
   it('confirmarPublicacao ignora chamada dupla enquanto submitting=true (guard de double-submit)', async () => {
     fixture.detectChanges();
-    controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Rascunho' }));
+    controller.expectOne(`${BASE}/api/selecao/editais/${ID}`).flush(editalSeed({ status: 'Rascunho' }));
     await propagate();
 
     component['confirmarPublicacao']();
@@ -264,11 +264,11 @@ describe('EditaisDetailPage', () => {
     // Deve haver exatamente 1 POST em voo, não 2 — caso contrário o
     // expectOne lançaria "Match URL ... found 2 requests" e o teste falharia.
     controller
-      .expectOne(`${BASE}/api/editais/${ID}/publicar`)
+      .expectOne(`${BASE}/api/selecao/editais/${ID}/publicar`)
       .flush(null, { status: 204, statusText: 'No Content' });
     await propagate();
 
-    controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Publicado' }));
+    controller.expectOne(`${BASE}/api/selecao/editais/${ID}`).flush(editalSeed({ status: 'Publicado' }));
     await propagate();
 
     expect(component.submitting()).toBe(false);
@@ -277,16 +277,16 @@ describe('EditaisDetailPage', () => {
 
   it('mudança no input editalId zera mensagemSucesso e errorMessage do publish anterior', async () => {
     fixture.detectChanges();
-    controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Rascunho' }));
+    controller.expectOne(`${BASE}/api/selecao/editais/${ID}`).flush(editalSeed({ status: 'Rascunho' }));
     await propagate();
 
     // Simula publish bem-sucedido — popula mensagemSucesso.
     component['confirmarPublicacao']();
     controller
-      .expectOne(`${BASE}/api/editais/${ID}/publicar`)
+      .expectOne(`${BASE}/api/selecao/editais/${ID}/publicar`)
       .flush(null, { status: 204, statusText: 'No Content' });
     await propagate();
-    controller.expectOne(`${BASE}/api/editais/${ID}`).flush(editalSeed({ status: 'Publicado' }));
+    controller.expectOne(`${BASE}/api/selecao/editais/${ID}`).flush(editalSeed({ status: 'Publicado' }));
     await propagate();
     expect(component.mensagemSucesso()).toBe('Edital publicado com sucesso.');
 
@@ -301,7 +301,7 @@ describe('EditaisDetailPage', () => {
     expect(component.loading()).toBe(true);
 
     controller
-      .expectOne(`${BASE}/api/editais/${ID_NOVO}`)
+      .expectOne(`${BASE}/api/selecao/editais/${ID_NOVO}`)
       .flush(editalSeed({ id: ID_NOVO, titulo: 'PSE 2027' }));
     await propagate();
     expect(component.edital()?.titulo).toBe('PSE 2027');

--- a/apps/selecao/src/app/features/editais/editais-detail.page.ts
+++ b/apps/selecao/src/app/features/editais/editais-detail.page.ts
@@ -156,13 +156,13 @@ export class EditaisDetailPage {
   private readonly basePath = inject(SELECAO_BASE_PATH);
 
   /**
-   * Resource reativo do GET `/api/editais/{editalId}`. Re-dispara automaticamente
+   * Resource reativo do GET `/api/selecao/editais/{editalId}`. Re-dispara automaticamente
    * quando `editalId()` muda; a request anterior é cancelada nativamente pelo
    * `httpResource` (race-cancellation). Vendor MIME `edital v1` declarado no `HttpContext`
    * (ADR-0028 backend, ADR-0016 cliente).
    */
   private readonly editalResource = useApiResource<EditalDto>(() => ({
-    url: `${this.basePath}/api/editais/${encodeURIComponent(this.editalId())}`,
+    url: `${this.basePath}/api/selecao/editais/${encodeURIComponent(this.editalId())}`,
     context: withVendorMime('edital', 1),
   }));
 

--- a/apps/selecao/src/app/features/editais/editais-list.page.spec.ts
+++ b/apps/selecao/src/app/features/editais/editais-list.page.spec.ts
@@ -52,13 +52,13 @@ describe('EditaisListPage', () => {
 
   afterEach(() => controller.verify());
 
-  it('carga inicial dispara GET /api/editais sem cursor e popula a lista', () => {
+  it('carga inicial dispara GET /api/selecao/editais sem cursor e popula a lista', () => {
     fixture.detectChanges();
 
     expect(component.loading()).toBe(true);
 
     const req = controller.expectOne(
-      (request) => request.url === `${BASE}/api/editais` && !request.params.has('cursor'),
+      (request) => request.url === `${BASE}/api/selecao/editais` && !request.params.has('cursor'),
     );
     expect(req.request.headers.get('Accept')).toBe(ACCEPT);
     req.flush([editalSeed('41'), editalSeed('42')]);
@@ -71,12 +71,12 @@ describe('EditaisListPage', () => {
   it('extrai prev/next cursors do header Link da resposta de sucesso', () => {
     fixture.detectChanges();
 
-    const req = controller.expectOne(`${BASE}/api/editais`);
+    const req = controller.expectOne(`${BASE}/api/selecao/editais`);
     req.flush([editalSeed('40')], {
       headers: {
         Link:
-          '<https://api/editais?cursor=opaque-prev&direction=prev>; rel="prev", ' +
-          '<https://api/editais?cursor=opaque-next-page&direction=next>; rel="next"',
+          '<https://api/selecao/editais?cursor=opaque-prev&direction=prev>; rel="prev", ' +
+          '<https://api/selecao/editais?cursor=opaque-next-page&direction=next>; rel="next"',
       },
     });
 
@@ -87,9 +87,9 @@ describe('EditaisListPage', () => {
   it('navegação "Próximo" substitui a página, envia direction=next e atualiza cursores', () => {
     fixture.detectChanges();
 
-    controller.expectOne(`${BASE}/api/editais`).flush([editalSeed('40')], {
+    controller.expectOne(`${BASE}/api/selecao/editais`).flush([editalSeed('40')], {
       headers: {
-        Link: '<https://api/editais?cursor=cursor-pagina-2&direction=next>; rel="next"',
+        Link: '<https://api/selecao/editais?cursor=cursor-pagina-2&direction=next>; rel="next"',
       },
     });
 
@@ -103,15 +103,15 @@ describe('EditaisListPage', () => {
 
     const req = controller.expectOne(
       (request) =>
-        request.url === `${BASE}/api/editais` &&
+        request.url === `${BASE}/api/selecao/editais` &&
         request.params.get('cursor') === 'cursor-pagina-2' &&
         request.params.get('direction') === 'next',
     );
     req.flush([editalSeed('41'), editalSeed('42')], {
       headers: {
         Link:
-          '<https://api/editais?cursor=cursor-pagina-1&direction=prev>; rel="prev", ' +
-          '<https://api/editais?cursor=cursor-pagina-3&direction=next>; rel="next"',
+          '<https://api/selecao/editais?cursor=cursor-pagina-1&direction=prev>; rel="prev", ' +
+          '<https://api/selecao/editais?cursor=cursor-pagina-3&direction=next>; rel="next"',
       },
     });
 
@@ -127,9 +127,9 @@ describe('EditaisListPage', () => {
     fixture.detectChanges();
 
     // 1ª página com next disponível
-    controller.expectOne(`${BASE}/api/editais`).flush([editalSeed('43')], {
+    controller.expectOne(`${BASE}/api/selecao/editais`).flush([editalSeed('43')], {
       headers: {
-        Link: '<https://api/editais?cursor=c2&direction=next>; rel="next"',
+        Link: '<https://api/selecao/editais?cursor=c2&direction=next>; rel="next"',
       },
     });
     const cursorProximo = component.nextCursor();
@@ -141,7 +141,7 @@ describe('EditaisListPage', () => {
       .expectOne((request) => request.params.get('cursor') === 'c2')
       .flush([editalSeed('44')], {
         headers: {
-          Link: '<https://api/editais?cursor=c1&direction=prev>; rel="prev"',
+          Link: '<https://api/selecao/editais?cursor=c1&direction=prev>; rel="prev"',
         },
       });
 
@@ -166,7 +166,7 @@ describe('EditaisListPage', () => {
     fixture.detectChanges();
 
     const req = controller.expectOne(
-      (request) => request.url === `${BASE}/api/editais` && !request.params.has('cursor'),
+      (request) => request.url === `${BASE}/api/selecao/editais` && !request.params.has('cursor'),
     );
     expect(req.request.params.has('direction')).toBe(false);
     req.flush([editalSeed('40')]);
@@ -175,9 +175,9 @@ describe('EditaisListPage', () => {
   it('última página (sem rel="prev"/"next") zera os cursores', () => {
     fixture.detectChanges();
 
-    controller.expectOne(`${BASE}/api/editais`).flush([editalSeed('40')], {
+    controller.expectOne(`${BASE}/api/selecao/editais`).flush([editalSeed('40')], {
       headers: {
-        Link: '<https://api/editais>; rel="self"',
+        Link: '<https://api/selecao/editais>; rel="self"',
       },
     });
 
@@ -188,7 +188,7 @@ describe('EditaisListPage', () => {
   it('falha 4xx na carga inicial popula errorMessage; cursor permanece null', () => {
     fixture.detectChanges();
 
-    controller.expectOne(`${BASE}/api/editais`).flush(
+    controller.expectOne(`${BASE}/api/selecao/editais`).flush(
       {
         type: 'about:blank',
         title: 'Token de acesso inválido',
@@ -213,9 +213,9 @@ describe('EditaisListPage', () => {
     fixture.detectChanges();
 
     // 1ª página OK: ganha cursor para a próxima
-    controller.expectOne(`${BASE}/api/editais`).flush([editalSeed('40')], {
+    controller.expectOne(`${BASE}/api/selecao/editais`).flush([editalSeed('40')], {
       headers: {
-        Link: '<https://api/editais?cursor=cursor-retry&direction=next>; rel="next"',
+        Link: '<https://api/selecao/editais?cursor=cursor-retry&direction=next>; rel="next"',
       },
     });
 
@@ -265,7 +265,7 @@ describe('EditaisListPage', () => {
 
   it('renderiza ui-data-table com dados e header correto após carga inicial', () => {
     fixture.detectChanges();
-    controller.expectOne(`${BASE}/api/editais`).flush([editalSeed('40')]);
+    controller.expectOne(`${BASE}/api/selecao/editais`).flush([editalSeed('40')]);
     fixture.detectChanges();
 
     const heading = fixture.debugElement.query(By.css('h1.page-header__title'))
@@ -281,7 +281,7 @@ describe('EditaisListPage', () => {
   it('5xx dispara toast persistente via NotificationService (CA-04)', () => {
     fixture.detectChanges();
 
-    controller.expectOne(`${BASE}/api/editais`).flush(
+    controller.expectOne(`${BASE}/api/selecao/editais`).flush(
       {
         type: 'about:blank',
         title: 'Falha temporária do servidor',
@@ -307,7 +307,7 @@ describe('EditaisListPage', () => {
   it('4xx NÃO dispara toast — apenas banner inline (CA-04)', () => {
     fixture.detectChanges();
 
-    controller.expectOne(`${BASE}/api/editais`).flush(
+    controller.expectOne(`${BASE}/api/selecao/editais`).flush(
       {
         type: 'about:blank',
         title: 'Token inválido',
@@ -329,7 +329,7 @@ describe('EditaisListPage', () => {
   it('errorTraceId é propagado ao DataTable em falha 5xx', () => {
     fixture.detectChanges();
 
-    controller.expectOne(`${BASE}/api/editais`).flush(
+    controller.expectOne(`${BASE}/api/selecao/editais`).flush(
       {
         type: 'about:blank',
         title: 'Falha do servidor',

--- a/docs/guia-testar-frontend-com-backend-local.md
+++ b/docs/guia-testar-frontend-com-backend-local.md
@@ -1,52 +1,76 @@
 # Guia: testar um frontend contra o backend local
 
-Como rodar um app do `uniplus-web` (ex.: `configuracao`, `selecao`) contra as
-APIs reais do `uniplus-api` conteinerizadas — autenticando no Keycloak de
-desenvolvimento e persistindo dados de verdade.
+Como rodar um app do `uniplus-web` (`selecao`, `configuracao`, `ingresso`,
+`portal`) contra as APIs reais do `uniplus-api` conteinerizadas — autenticando no
+Keycloak de desenvolvimento e persistindo dados de verdade.
 
 ## 1. Suba o backend com o override `frontend-test`
 
-No repositório `uniplus-api`, suba a stack com os **três** arquivos compose:
+No repositório `uniplus-api`, copie o template do override (gitignored) e suba a
+stack com os **três** arquivos compose:
 
 ```bash
+cd repositories/uniplus-api/docker
+cp docker-compose.override.example.yml docker-compose.override.yml   # 1ª vez
+
 docker compose -f docker-compose.yml \
                -f docker-compose.override.yml \
-               -f docker-compose.frontend-test.yml up -d
+               -f docker-compose.frontend-test.yml up -d --build --wait
 ```
 
-> **Obrigatório.** O `frontend-test.yml` realinha o `Auth__Authority` de todas as
-> APIs ao realm **`unifesspa`** — o realm em que os frontends autenticam. O
-> override base usa `unifesspa-dev-local`, e sem o realinhamento **toda mutação**
-> (POST/PUT/DELETE) responde **401** e o app entra em loop de re-login (o GET de
-> lista é `[AllowAnonymous]` e mascara o problema). Detalhes em
-> `uniplus-api/CONTRIBUTING.md` § "Testar um frontend contra as APIs conteinerizadas".
+Isso sobe a infra (Postgres/Redis/Kafka/MinIO/Apicurio/Keycloak) + as **3 APIs**
+(`uniplus-api` na :5200 — o monólito com os 4 módulos internos; `geo-api` na :5400;
+`portal-api` na :5302) + um **gateway Traefik na :5000**.
+
+> **Por que o `frontend-test.yml`?** Ele faz duas coisas obrigatórias:
+> 1. **Realinha o `Auth__Authority`** das APIs ao realm **`unifesspa`** — o realm em
+>    que os frontends autenticam (clients `*-web`). O override base usa
+>    `unifesspa-dev-local`, e sem o realinhamento **toda mutação** (POST/PUT/DELETE)
+>    responde **401** e o app entra em loop de re-login (o GET de lista é
+>    `[AllowAnonymous]` e mascara o problema).
+> 2. **Sobe o gateway na :5000**, que separa o tráfego: `/api/{cidades,estados,cep,
+>    logradouros}` → `geo-api`; todo o resto de `/api/` → monólito. É o `apiUrl`
+>    único que os apps consomem (espelha o ingress de HML/PROD no uniplus-infra).
 
 ## 2. Sirva o app
 
 ```bash
-npx nx serve configuracao   # http://localhost:4203 (fala direto com a organizacao-api :5263)
-npx nx serve selecao        # http://localhost:4200 (via gateway Traefik :5000)
+cd repositories/uniplus-web
+npx nx serve selecao        # http://localhost:4200  (client selecao-web)
+npx nx serve ingresso       # http://localhost:4201  (client ingresso-web)
+npx nx serve portal         # http://localhost:4202  (client portal-web)
+npx nx serve configuracao   # http://localhost:4203  (client configuracao-web)
 ```
 
-A URL e o realm de cada app vêm do `runtime-config.json` (ADR-0021). O app
-`configuracao` usa `apiUrl=http://localhost:5263` e o client OIDC
-`configuracao-web` no realm `unifesspa`.
+O `apiUrl` e o realm de cada app vêm do `runtime-config.json`
+(`apps/<app>/public/assets/`). Todos apontam para o gateway
+`apiUrl=http://localhost:5000` e o issuer `http://localhost:8080/realms/unifesspa`.
+
+Os api clients chamam os paths com prefixo de módulo do contrato (ADR-0064) —
+`/api/selecao/editais`, `/api/configuracao/campi`, `/api/organizacao/unidades` — e
+os de geo sem prefixo (`/api/cidades`, `/api/cep`). O gateway roteia ambos; **não
+há reescrita de path** (o shim legado `/api/editais` foi removido).
 
 ## 3. Faça login
 
-Usuário de teste com a role `plataforma-admin` (exigida pelo painel admin):
+Usuários do realm `unifesspa` (senha inicial **temporária** — o Keycloak pede para
+trocar no primeiro login; basta repetir a mesma senha):
 
-| Campo | Valor |
-|---|---|
-| Usuário | `admin` |
-| Senha | `E2eTest!123` |
+| Usuário | Senha inicial | Papel |
+|---|---|---|
+| `admin` | `Changeme!123` | `plataforma-admin` (painel admin completo) |
+| `gestor` | `Changeme!123` | gestor |
+| `avaliador` | `Changeme!123` | avaliador |
+| `candidato` | `Changeme!123` | candidato (portal) |
 
 ## Sintomas comuns
 
 | Sintoma | Causa | Correção |
 |---|---|---|
 | Listas carregam, mas salvar dá erro e volta pro login | Realm desalinhado (API em `unifesspa-dev-local`) | Suba com o `frontend-test.yml` (passo 1) |
-| `ERR_CONNECTION_REFUSED` em :4203 | Dev server caiu | `npx nx serve configuracao` |
+| `404` em `/api/cidades` ou `/api/cep` | `geo-api` fora do ar ou gateway sem rota geo | Confirme `geo-api` healthy e o `frontend-test.yml` (gateway) no `up` |
+| `404` em `/api/{modulo}/...` | Gateway fora do ar (subiu sem o `frontend-test.yml`) | Inclua o `frontend-test.yml` no `up` |
+| `ERR_CONNECTION_REFUSED` em :420x | Dev server caiu | `npx nx serve <app>` |
 | Redireciona ao Keycloak no meio de uma ação longa | `accessTokenLifespan` curto (300s) | Ampliar para 1800s (opcional — ver CONTRIBUTING do `uniplus-api`) |
 
 ## E2E automatizado

--- a/libs/shared-core/src/lib/http/api-result.interceptor.spec.ts
+++ b/libs/shared-core/src/lib/http/api-result.interceptor.spec.ts
@@ -60,10 +60,10 @@ describe('apiResultInterceptor', () => {
       const body: Edital = { id: 'edt-1', numero: 42 };
       let received: ApiResult<Edital> | undefined;
 
-      http.get<ApiResult<Edital>>('/api/editais/edt-1').subscribe((res) => (received = res));
+      http.get<ApiResult<Edital>>('/api/selecao/editais/edt-1').subscribe((res) => (received = res));
 
       controller
-        .expectOne('/api/editais/edt-1')
+        .expectOne('/api/selecao/editais/edt-1')
         .flush(body, { status: 200, statusText: 'OK', headers: { 'X-Page-Size': '20' } });
 
       expect(received).toBeDefined();
@@ -77,10 +77,10 @@ describe('apiResultInterceptor', () => {
     it('201 (created) também é envelopado como ApiResult.ok', () => {
       let received: ApiResult<Edital> | undefined;
 
-      http.post<ApiResult<Edital>>('/api/editais', {}).subscribe((res) => (received = res));
+      http.post<ApiResult<Edital>>('/api/selecao/editais', {}).subscribe((res) => (received = res));
 
       controller
-        .expectOne('/api/editais')
+        .expectOne('/api/selecao/editais')
         .flush({ id: 'edt-9', numero: 9 }, { status: 201, statusText: 'Created' });
 
       expect(isApiOk(received as ApiResult<Edital>)).toBe(true);
@@ -91,11 +91,11 @@ describe('apiResultInterceptor', () => {
       let received: ApiResult<null> | undefined;
 
       http
-        .post<ApiResult<null>>('/api/editais/edt-1/publicar', {})
+        .post<ApiResult<null>>('/api/selecao/editais/edt-1/publicar', {})
         .subscribe((res) => (received = res));
 
       controller
-        .expectOne('/api/editais/edt-1/publicar')
+        .expectOne('/api/selecao/editais/edt-1/publicar')
         .flush(null, { status: 204, statusText: 'No Content' });
 
       expect(isApiOk(received as ApiResult<null>)).toBe(true);
@@ -107,10 +107,10 @@ describe('apiResultInterceptor', () => {
     it('404 emite ApiResult.fail com ProblemDetails parseado', () => {
       let received: ApiResult<Edital> | undefined;
 
-      http.get<ApiResult<Edital>>('/api/editais/missing').subscribe((res) => (received = res));
+      http.get<ApiResult<Edital>>('/api/selecao/editais/missing').subscribe((res) => (received = res));
 
       controller
-        .expectOne('/api/editais/missing')
+        .expectOne('/api/selecao/editais/missing')
         .flush(baseProblem, { status: 404, statusText: 'Not Found', headers: PROBLEM_HEADERS });
 
       expect(isApiFailure(received as ApiResult<Edital>)).toBe(true);
@@ -134,10 +134,10 @@ describe('apiResultInterceptor', () => {
       };
       let received: ApiResult<unknown> | undefined;
 
-      http.post<ApiResult<unknown>>('/api/editais', {}).subscribe((res) => (received = res));
+      http.post<ApiResult<unknown>>('/api/selecao/editais', {}).subscribe((res) => (received = res));
 
       controller
-        .expectOne('/api/editais')
+        .expectOne('/api/selecao/editais')
         .flush(problem, { status: 422, statusText: 'Unprocessable', headers: PROBLEM_HEADERS });
 
       const fail = received as ApiFailure;
@@ -152,9 +152,9 @@ describe('apiResultInterceptor', () => {
     it('401 (ADR-0034) é envelopado igualmente como ApiResult.fail', () => {
       let received: ApiResult<unknown> | undefined;
 
-      http.get<ApiResult<unknown>>('/api/editais').subscribe((res) => (received = res));
+      http.get<ApiResult<unknown>>('/api/selecao/editais').subscribe((res) => (received = res));
 
-      controller.expectOne('/api/editais').flush(
+      controller.expectOne('/api/selecao/editais').flush(
         {
           ...baseProblem,
           type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.auth.unauthorized',
@@ -178,10 +178,10 @@ describe('apiResultInterceptor', () => {
       let received: ApiResult<unknown> | undefined;
 
       http
-        .get<ApiResult<unknown>>('/api/editais', { context: withVendorMime('edital', 99) })
+        .get<ApiResult<unknown>>('/api/selecao/editais', { context: withVendorMime('edital', 99) })
         .subscribe((res) => (received = res));
 
-      controller.expectOne('/api/editais').flush(
+      controller.expectOne('/api/selecao/editais').flush(
         {
           ...baseProblem,
           type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.contract.versao_nao_suportada',
@@ -201,9 +201,9 @@ describe('apiResultInterceptor', () => {
     it('500 emite ApiResult.fail preservando code do backend', () => {
       let received: ApiResult<unknown> | undefined;
 
-      http.get<ApiResult<unknown>>('/api/editais').subscribe((res) => (received = res));
+      http.get<ApiResult<unknown>>('/api/selecao/editais').subscribe((res) => (received = res));
 
-      controller.expectOne('/api/editais').flush(
+      controller.expectOne('/api/selecao/editais').flush(
         {
           ...baseProblem,
           type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.servidor.indisponivel',
@@ -222,10 +222,10 @@ describe('apiResultInterceptor', () => {
     it('quando o body chega como string JSON, ainda parseia corretamente', () => {
       let received: ApiResult<unknown> | undefined;
 
-      http.get<ApiResult<unknown>>('/api/editais/x').subscribe((res) => (received = res));
+      http.get<ApiResult<unknown>>('/api/selecao/editais/x').subscribe((res) => (received = res));
 
       controller
-        .expectOne('/api/editais/x')
+        .expectOne('/api/selecao/editais/x')
         .flush(JSON.stringify(baseProblem), {
           status: 404,
           statusText: 'Not Found',
@@ -241,9 +241,9 @@ describe('apiResultInterceptor', () => {
     it('status 0 sintetiza ProblemDetails com code uniplus.client.network_error', () => {
       let received: ApiResult<unknown> | undefined;
 
-      http.get<ApiResult<unknown>>('/api/editais').subscribe((res) => (received = res));
+      http.get<ApiResult<unknown>>('/api/selecao/editais').subscribe((res) => (received = res));
 
-      controller.expectOne('/api/editais').error(new ProgressEvent('error'), {
+      controller.expectOne('/api/selecao/editais').error(new ProgressEvent('error'), {
         status: 0,
         statusText: 'Unknown',
       });
@@ -257,9 +257,9 @@ describe('apiResultInterceptor', () => {
     it('500 sem application/problem+json sintetiza unexpected_response', () => {
       let received: ApiResult<unknown> | undefined;
 
-      http.get<ApiResult<unknown>>('/api/editais').subscribe((res) => (received = res));
+      http.get<ApiResult<unknown>>('/api/selecao/editais').subscribe((res) => (received = res));
 
-      controller.expectOne('/api/editais').flush('<html>Erro</html>', {
+      controller.expectOne('/api/selecao/editais').flush('<html>Erro</html>', {
         status: 500,
         statusText: 'Internal Server Error',
         headers: { 'Content-Type': 'text/html' },
@@ -273,9 +273,9 @@ describe('apiResultInterceptor', () => {
     it('422 com errors:[] (array vazio) é normalizado como ausência de errors', () => {
       let received: ApiResult<unknown> | undefined;
 
-      http.post<ApiResult<unknown>>('/api/editais', {}).subscribe((res) => (received = res));
+      http.post<ApiResult<unknown>>('/api/selecao/editais', {}).subscribe((res) => (received = res));
 
-      controller.expectOne('/api/editais').flush(
+      controller.expectOne('/api/selecao/editais').flush(
         {
           ...baseProblem,
           status: 422,
@@ -293,10 +293,10 @@ describe('apiResultInterceptor', () => {
     it('400 com body application/problem+json mas shape incompleto vira unexpected_response', () => {
       let received: ApiResult<unknown> | undefined;
 
-      http.get<ApiResult<unknown>>('/api/editais').subscribe((res) => (received = res));
+      http.get<ApiResult<unknown>>('/api/selecao/editais').subscribe((res) => (received = res));
 
       controller
-        .expectOne('/api/editais')
+        .expectOne('/api/selecao/editais')
         .flush({ message: 'apenas message' }, {
           status: 400,
           statusText: 'Bad Request',
@@ -311,20 +311,20 @@ describe('apiResultInterceptor', () => {
   describe('vendor MIME injection (ADR-0028)', () => {
     it('quando withVendorMime é usado, request anexa Accept correto', () => {
       http
-        .get<ApiResult<Edital>>('/api/editais/edt-1', {
+        .get<ApiResult<Edital>>('/api/selecao/editais/edt-1', {
           context: withVendorMime('edital', 1),
         })
         .subscribe();
 
-      const req = controller.expectOne('/api/editais/edt-1');
+      const req = controller.expectOne('/api/selecao/editais/edt-1');
       expect(req.request.headers.get('Accept')).toBe('application/vnd.uniplus.edital.v1+json');
       req.flush({ id: 'edt-1', numero: 1 });
     });
 
     it('sem withVendorMime, request não recebe Accept vendor (default Angular preserva)', () => {
-      http.get<ApiResult<Edital>>('/api/editais', { context: new HttpContext() }).subscribe();
+      http.get<ApiResult<Edital>>('/api/selecao/editais', { context: new HttpContext() }).subscribe();
 
-      const req = controller.expectOne('/api/editais');
+      const req = controller.expectOne('/api/selecao/editais');
       const accept = req.request.headers.get('Accept');
       expect(accept ?? '').not.toContain('vnd.uniplus');
       req.flush([]);
@@ -336,12 +336,12 @@ describe('apiResultInterceptor', () => {
       const explicitKey = idempotencyKey.create();
 
       http
-        .post<ApiResult<Edital>>('/api/editais', { titulo: 'X' }, {
+        .post<ApiResult<Edital>>('/api/selecao/editais', { titulo: 'X' }, {
           context: withIdempotencyKey(explicitKey),
         })
         .subscribe();
 
-      const req = controller.expectOne('/api/editais');
+      const req = controller.expectOne('/api/selecao/editais');
       expect(req.request.headers.get('Idempotency-Key')).toBe(explicitKey);
       req.flush({ id: 'edt-9', numero: 9 }, { status: 201, statusText: 'Created' });
     });
@@ -353,19 +353,19 @@ describe('apiResultInterceptor', () => {
       );
 
       http
-        .post<ApiResult<Edital>>('/api/editais', { titulo: 'X' }, { context: composed })
+        .post<ApiResult<Edital>>('/api/selecao/editais', { titulo: 'X' }, { context: composed })
         .subscribe();
 
-      const req = controller.expectOne('/api/editais');
+      const req = controller.expectOne('/api/selecao/editais');
       expect(req.request.headers.get('Accept')).toBe('application/vnd.uniplus.edital.v1+json');
       expect(req.request.headers.get('Idempotency-Key')).not.toBeNull();
       req.flush({ id: 'edt-1', numero: 1 }, { status: 201, statusText: 'Created' });
     });
 
     it('sem withIdempotencyKey, request não recebe header Idempotency-Key', () => {
-      http.get<ApiResult<Edital>>('/api/editais').subscribe();
+      http.get<ApiResult<Edital>>('/api/selecao/editais').subscribe();
 
-      const req = controller.expectOne('/api/editais');
+      const req = controller.expectOne('/api/selecao/editais');
       expect(req.request.headers.get('Idempotency-Key')).toBeNull();
       req.flush([]);
     });

--- a/libs/shared-core/src/lib/http/link-header.spec.ts
+++ b/libs/shared-core/src/lib/http/link-header.spec.ts
@@ -23,11 +23,11 @@ describe('parseLink — RFC 5988/8288 (ADR-0015)', () => {
   describe('header com 1 link-value', () => {
     it('parseia rel="next" único e expõe URI completa', () => {
       const links = parseLink(
-        '<https://api.uniplus.unifesspa.edu.br/api/editais?cursor=ABC123>; rel="next"',
+        '<https://api.uniplus.unifesspa.edu.br/api/selecao/editais?cursor=ABC123>; rel="next"',
       );
       expect(links.size).toBe(1);
       const next = links.get('next');
-      expect(next?.uri).toBe('https://api.uniplus.unifesspa.edu.br/api/editais?cursor=ABC123');
+      expect(next?.uri).toBe('https://api.uniplus.unifesspa.edu.br/api/selecao/editais?cursor=ABC123');
       expect(next?.params['rel']).toBe('next');
     });
 

--- a/libs/shared-core/src/lib/http/pagination.spec.ts
+++ b/libs/shared-core/src/lib/http/pagination.spec.ts
@@ -42,7 +42,7 @@ describe('Cursor branded type (ADR-0015)', () => {
 describe('extractNextCursor — header Link → próximo cursor opaco', () => {
   describe('caminhos felizes', () => {
     it('rel="next" com cursor= no query string retorna Cursor', () => {
-      const linkHeader = '<https://api.uniplus.unifesspa.edu.br/api/editais?cursor=ABC123>; rel="next"';
+      const linkHeader = '<https://api.uniplus.unifesspa.edu.br/api/selecao/editais?cursor=ABC123>; rel="next"';
       expect(extractRequiredNextCursor(linkHeader)).toBe('ABC123');
     });
 
@@ -62,7 +62,7 @@ describe('extractNextCursor — header Link → próximo cursor opaco', () => {
     });
 
     it('preserva URI relativa quando servidor não emite host (RFC 5988 §5.4)', () => {
-      const linkHeader = '</api/editais?cursor=REL>; rel="next"';
+      const linkHeader = '</api/selecao/editais?cursor=REL>; rel="next"';
       expect(extractRequiredNextCursor(linkHeader)).toBe('REL');
     });
 
@@ -137,7 +137,7 @@ describe('extractPrevCursor — header Link → cursor da página anterior (ADR-
 
     it('extrai cursor de prev preservando os filtros na URI (q/tipo)', () => {
       const linkHeader =
-        '<https://api/unidades?q=ceps&tipo=3&cursor=PREV2&direction=prev>; rel="prev"';
+        '<https://api/organizacao/unidades?q=ceps&tipo=3&cursor=PREV2&direction=prev>; rel="prev"';
       expect(extractRequiredPrevCursor(linkHeader)).toBe('PREV2');
     });
 

--- a/libs/shared-core/src/lib/http/use-api-resource.spec.ts
+++ b/libs/shared-core/src/lib/http/use-api-resource.spec.ts
@@ -74,7 +74,7 @@ describe('useApiResource', () => {
   afterEach(() => env.controller.verify());
 
   it('carga inicial com URL string dispara GET e popula data() em 200', async () => {
-    const resource = env.create<Edital>(() => '/api/editais/edt-1');
+    const resource = env.create<Edital>(() => '/api/selecao/editais/edt-1');
     env.tickEffects();
 
     expect(resource.isLoading()).toBe(true);
@@ -82,7 +82,7 @@ describe('useApiResource', () => {
 
     const seed: Edital = { id: 'edt-1', numero: 42 };
     env.controller
-      .expectOne('/api/editais/edt-1')
+      .expectOne('/api/selecao/editais/edt-1')
       .flush(seed, { status: 200, statusText: 'OK' });
     await env.stable();
 
@@ -96,10 +96,10 @@ describe('useApiResource', () => {
 
   it('mudança reativa do URL cancela request anterior e dispara nova (race-cancellation nativa)', async () => {
     const id = signal('edt-1');
-    const resource = env.create<Edital>(() => `/api/editais/${id()}`);
+    const resource = env.create<Edital>(() => `/api/selecao/editais/${id()}`);
     env.tickEffects();
 
-    const reqAntiga = env.controller.expectOne('/api/editais/edt-1');
+    const reqAntiga = env.controller.expectOne('/api/selecao/editais/edt-1');
     expect(reqAntiga.cancelled).toBe(false);
 
     id.set('edt-2');
@@ -109,7 +109,7 @@ describe('useApiResource', () => {
     // reativas mudam — substitui o race guard manual ("if (this.id() !== id) return").
     expect(reqAntiga.cancelled).toBe(true);
 
-    const reqNova = env.controller.expectOne('/api/editais/edt-2');
+    const reqNova = env.controller.expectOne('/api/selecao/editais/edt-2');
     reqNova.flush({ id: 'edt-2', numero: 99 }, { status: 200, statusText: 'OK' });
     await env.stable();
 
@@ -117,11 +117,11 @@ describe('useApiResource', () => {
   });
 
   it('404 problem+json popula problem() e mantém data()=null', async () => {
-    const resource = env.create<Edital>(() => '/api/editais/missing');
+    const resource = env.create<Edital>(() => '/api/selecao/editais/missing');
     env.tickEffects();
 
     env.controller
-      .expectOne('/api/editais/missing')
+      .expectOne('/api/selecao/editais/missing')
       .flush(baseProblem, { status: 404, statusText: 'Not Found', headers: PROBLEM_HEADERS });
     await env.stable();
 
@@ -138,11 +138,11 @@ describe('useApiResource', () => {
   });
 
   it('network error (status 0) é envelopado como ApiFailure com code uniplus.client.network_error', async () => {
-    const resource = env.create<Edital>(() => '/api/editais/edt-1');
+    const resource = env.create<Edital>(() => '/api/selecao/editais/edt-1');
     env.tickEffects();
 
     env.controller
-      .expectOne('/api/editais/edt-1')
+      .expectOne('/api/selecao/editais/edt-1')
       .error(new ProgressEvent('error'), { status: 0, statusText: 'Unknown Error' });
     await env.stable();
 
@@ -152,11 +152,11 @@ describe('useApiResource', () => {
   });
 
   it('reload() refaz a request preservando dependências reativas atuais', async () => {
-    const resource = env.create<Edital>(() => '/api/editais/edt-1');
+    const resource = env.create<Edital>(() => '/api/selecao/editais/edt-1');
     env.tickEffects();
 
     env.controller
-      .expectOne('/api/editais/edt-1')
+      .expectOne('/api/selecao/editais/edt-1')
       .flush({ id: 'edt-1', numero: 1 }, { status: 200, statusText: 'OK' });
     await env.stable();
 
@@ -166,7 +166,7 @@ describe('useApiResource', () => {
     env.tickEffects();
 
     env.controller
-      .expectOne('/api/editais/edt-1')
+      .expectOne('/api/selecao/editais/edt-1')
       .flush({ id: 'edt-1', numero: 2 }, { status: 200, statusText: 'OK' });
     await env.stable();
 
@@ -176,7 +176,7 @@ describe('useApiResource', () => {
   it('request() retorna undefined => nenhum GET disparado, status=idle', async () => {
     const ativo = signal(false);
     const resource = env.create<Edital>(() =>
-      ativo() ? '/api/editais/edt-1' : undefined,
+      ativo() ? '/api/selecao/editais/edt-1' : undefined,
     );
     env.tickEffects();
 
@@ -189,7 +189,7 @@ describe('useApiResource', () => {
     env.tickEffects();
 
     env.controller
-      .expectOne('/api/editais/edt-1')
+      .expectOne('/api/selecao/editais/edt-1')
       .flush({ id: 'edt-1', numero: 7 }, { status: 200, statusText: 'OK' });
     await env.stable();
 
@@ -198,12 +198,12 @@ describe('useApiResource', () => {
 
   it('aceita HttpResourceRequest com context (compõe withVendorMime no Accept)', async () => {
     const resource = env.create<Edital>(() => ({
-      url: '/api/editais/edt-1',
+      url: '/api/selecao/editais/edt-1',
       context: withVendorMime('edital', 1),
     }));
     env.tickEffects();
 
-    const req = env.controller.expectOne('/api/editais/edt-1');
+    const req = env.controller.expectOne('/api/selecao/editais/edt-1');
     expect(req.request.headers.get('Accept')).toBe('application/vnd.uniplus.edital.v1+json');
 
     req.flush({ id: 'edt-1', numero: 42 }, { status: 200, statusText: 'OK' });
@@ -217,12 +217,12 @@ describe('useApiResource', () => {
     // qualquer HttpContext do caller é propagado intacto pelo httpResource.
     const FLAG_TOKEN = new HttpContextToken<boolean>(() => false);
     const resource = env.create<Edital>(() => ({
-      url: '/api/editais/edt-1',
+      url: '/api/selecao/editais/edt-1',
       context: new HttpContext().set(FLAG_TOKEN, true),
     }));
     env.tickEffects();
 
-    const req = env.controller.expectOne('/api/editais/edt-1');
+    const req = env.controller.expectOne('/api/selecao/editais/edt-1');
     expect(req.request.context.get(FLAG_TOKEN)).toBe(true);
     req.flush({ id: 'edt-1', numero: 1 }, { status: 200, statusText: 'OK' });
     await env.stable();
@@ -231,30 +231,30 @@ describe('useApiResource', () => {
   });
 
   it('headers() expõe response headers (ex.: Link rel="next" para cursor pagination)', async () => {
-    const resource = env.create<readonly Edital[]>(() => '/api/editais');
+    const resource = env.create<readonly Edital[]>(() => '/api/selecao/editais');
     env.tickEffects();
 
-    env.controller.expectOne('/api/editais').flush(
+    env.controller.expectOne('/api/selecao/editais').flush(
       [{ id: 'edt-1', numero: 1 }],
       {
         status: 200,
         statusText: 'OK',
-        headers: { Link: '</api/editais?cursor=ABC>; rel="next"' },
+        headers: { Link: '</api/selecao/editais?cursor=ABC>; rel="next"' },
       },
     );
     await env.stable();
 
-    expect(resource.headers()?.get('Link')).toBe('</api/editais?cursor=ABC>; rel="next"');
+    expect(resource.headers()?.get('Link')).toBe('</api/selecao/editais?cursor=ABC>; rel="next"');
   });
 
   it('hasValue() reflete presença de envelope (loading=false e value definido)', async () => {
-    const resource = env.create<Edital>(() => '/api/editais/edt-1');
+    const resource = env.create<Edital>(() => '/api/selecao/editais/edt-1');
     env.tickEffects();
 
     expect(resource.hasValue()).toBe(false);
 
     env.controller
-      .expectOne('/api/editais/edt-1')
+      .expectOne('/api/selecao/editais/edt-1')
       .flush({ id: 'edt-1', numero: 5 }, { status: 200, statusText: 'OK' });
     await env.stable();
 
@@ -262,10 +262,10 @@ describe('useApiResource', () => {
   });
 
   it('422 com errors[] de validação preserva o array no problem()', async () => {
-    const resource = env.create<Edital>(() => '/api/editais');
+    const resource = env.create<Edital>(() => '/api/selecao/editais');
     env.tickEffects();
 
-    env.controller.expectOne('/api/editais').flush(
+    env.controller.expectOne('/api/selecao/editais').flush(
       {
         ...baseProblem,
         type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.validacao',
@@ -320,7 +320,7 @@ describe('useApiResource — guarda contra Resource.value() throw em status erro
     const appRef = TestBed.inject(ApplicationRef);
     const injector = TestBed.inject(Injector);
     const resource = TestBed.runInInjectionContext(() =>
-      useApiResource<Edital>(() => '/api/editais/edt-1', { injector }),
+      useApiResource<Edital>(() => '/api/selecao/editais/edt-1', { injector }),
     );
     appRef.tick();
     await appRef.whenStable();

--- a/libs/shared-core/src/lib/http/use-api-resource.ts
+++ b/libs/shared-core/src/lib/http/use-api-resource.ts
@@ -102,13 +102,13 @@ export interface UseApiResourceRef<T> {
  *
  * - **String reativa** — quando só a URL muda:
  *   ```ts
- *   const r = useApiResource<EditalDto>(() => `/api/editais/${this.id()}`);
+ *   const r = useApiResource<EditalDto>(() => `/api/selecao/editais/${this.id()}`);
  *   ```
  * - **`HttpResourceRequest` reativo** — quando precisa de `params`/`headers`/
  *   `context` (vendor MIME, etc.):
  *   ```ts
  *   const r = useApiResource<EditalDto>(() => ({
- *     url: `/api/editais/${this.id()}`,
+ *     url: `/api/selecao/editais/${this.id()}`,
  *     context: withVendorMime('edital', 1),
  *   }));
  *   ```

--- a/libs/shared-data/src/lib/api/configuracao/campi.api.spec.ts
+++ b/libs/shared-data/src/lib/api/configuracao/campi.api.spec.ts
@@ -54,9 +54,9 @@ describe('CampiApi', () => {
 
   afterEach(() => controller.verify());
 
-  it('listar() faz GET /api/campi com limit e Accept versionado', async () => {
+  it('listar() faz GET /api/configuracao/campi com limit e Accept versionado', async () => {
     const promise = firstValueFrom(api.listar({ limit: 50 }));
-    const req = controller.expectOne((r) => r.url === `${BASE}/api/campi`);
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/campi`);
     expect(req.request.params.get('limit')).toBe('50');
     expect(req.request.headers.get('Accept')).toBe(buildVendorMimeAccept('campus', 1));
     req.flush([campusSeed]);
@@ -66,7 +66,7 @@ describe('CampiApi', () => {
 
   it('listar() com cursor envia cursor + direction e omite limit', async () => {
     const promise = firstValueFrom(api.listar({ cursor: 'abc', direction: 'prev' }));
-    const req = controller.expectOne((r) => r.url === `${BASE}/api/campi`);
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/campi`);
     expect(req.request.params.get('cursor')).toBe('abc');
     expect(req.request.params.get('direction')).toBe('prev');
     expect(req.request.params.has('limit')).toBe(false);
@@ -74,9 +74,9 @@ describe('CampiApi', () => {
     await promise;
   });
 
-  it('criar() faz POST /api/admin/campi com Idempotency-Key e Accept JSON', async () => {
+  it('criar() faz POST /api/configuracao/admin/campi com Idempotency-Key e Accept JSON', async () => {
     const promise = firstValueFrom(api.criar(criarCommand, withIdempotencyKey('k')));
-    const req = controller.expectOne(`${BASE}/api/admin/campi`);
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/campi`);
     expect(req.request.method).toBe('POST');
     expect(req.request.headers.get('Idempotency-Key')).toBe('k');
     expect(req.request.headers.get('Accept')).toBe('application/json');
@@ -85,9 +85,9 @@ describe('CampiApi', () => {
     expect(isApiOk(result)).toBe(true);
   });
 
-  it('remover() faz DELETE /api/admin/campi/{id}', async () => {
+  it('remover() faz DELETE /api/configuracao/admin/campi/{id}', async () => {
     const promise = firstValueFrom(api.remover(ID));
-    const req = controller.expectOne(`${BASE}/api/admin/campi/${ID}`);
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/campi/${ID}`);
     expect(req.request.method).toBe('DELETE');
     req.flush(null, { status: 204, statusText: 'No Content' });
     const result = (await promise) as ApiResult<void>;

--- a/libs/shared-data/src/lib/api/configuracao/campi.api.ts
+++ b/libs/shared-data/src/lib/api/configuracao/campi.api.ts
@@ -30,7 +30,7 @@ export class CampiApi {
   private readonly http = inject(HttpClient);
   private readonly basePath = inject(CONFIGURACAO_BASE_PATH);
 
-  /** GET `/api/campi` — lista paginada por cursor (ADR-0026). */
+  /** GET `/api/configuracao/campi` — lista paginada por cursor (ADR-0026). */
   listar(query: CampiQuery = {}): Observable<ApiResult<readonly CampusDto[]>> {
     let params = new HttpParams();
     if (query.cursor !== undefined) {
@@ -38,45 +38,45 @@ export class CampiApi {
     } else {
       params = params.set('limit', String(query.limit ?? 100));
     }
-    return this.http.get<ApiResult<readonly CampusDto[]>>(`${this.basePath}/api/campi`, {
+    return this.http.get<ApiResult<readonly CampusDto[]>>(`${this.basePath}/api/configuracao/campi`, {
       params,
       context: withVendorMime('campus', 1),
     });
   }
 
-  /** GET `/api/campi/{id}` — detalhe de um Campus. */
+  /** GET `/api/configuracao/campi/{id}` — detalhe de um Campus. */
   obter(id: string): Observable<ApiResult<CampusDto>> {
     return this.http.get<ApiResult<CampusDto>>(
-      `${this.basePath}/api/campi/${encodeURIComponent(id)}`,
+      `${this.basePath}/api/configuracao/campi/${encodeURIComponent(id)}`,
       { context: withVendorMime('campus', 1) },
     );
   }
 
-  /** POST `/api/admin/campi` — cria um Campus. Idempotency-Key obrigatório (ADR-0027). */
+  /** POST `/api/configuracao/admin/campi` — cria um Campus. Idempotency-Key obrigatório (ADR-0027). */
   criar(command: CriarCampusCommand, context: HttpContext): Observable<ApiResult<string>> {
-    return this.http.post<ApiResult<string>>(`${this.basePath}/api/admin/campi`, command, {
+    return this.http.post<ApiResult<string>>(`${this.basePath}/api/configuracao/admin/campi`, command, {
       context,
       headers: new HttpHeaders({ Accept: 'application/json' }),
     });
   }
 
-  /** PUT `/api/admin/campi/{id}` — atualiza um Campus. */
+  /** PUT `/api/configuracao/admin/campi/{id}` — atualiza um Campus. */
   atualizar(
     id: string,
     command: AtualizarCampusCommand,
     context: HttpContext,
   ): Observable<ApiResult<void>> {
     return this.http.put<ApiResult<void>>(
-      `${this.basePath}/api/admin/campi/${encodeURIComponent(id)}`,
+      `${this.basePath}/api/configuracao/admin/campi/${encodeURIComponent(id)}`,
       command,
       { context },
     );
   }
 
-  /** DELETE `/api/admin/campi/{id}` — remoção lógica (soft-delete). */
+  /** DELETE `/api/configuracao/admin/campi/{id}` — remoção lógica (soft-delete). */
   remover(id: string): Observable<ApiResult<void>> {
     return this.http.delete<ApiResult<void>>(
-      `${this.basePath}/api/admin/campi/${encodeURIComponent(id)}`,
+      `${this.basePath}/api/configuracao/admin/campi/${encodeURIComponent(id)}`,
     );
   }
 }

--- a/libs/shared-data/src/lib/api/configuracao/locais-oferta.api.spec.ts
+++ b/libs/shared-data/src/lib/api/configuracao/locais-oferta.api.spec.ts
@@ -70,18 +70,18 @@ describe('LocaisOfertaApi', () => {
     ]);
   });
 
-  it('listar() faz GET /api/locais-oferta com Accept versionado', async () => {
+  it('listar() faz GET /api/configuracao/locais-oferta com Accept versionado', async () => {
     const promise = firstValueFrom(api.listar({ limit: 25 }));
-    const req = controller.expectOne((r) => r.url === `${BASE}/api/locais-oferta`);
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/locais-oferta`);
     expect(req.request.headers.get('Accept')).toBe(buildVendorMimeAccept('local-oferta', 1));
     req.flush([localSeed]);
     const result = (await promise) as ApiResult<readonly LocalOfertaDto[]>;
     expect(isApiOk(result)).toBe(true);
   });
 
-  it('criar() faz POST /api/admin/locais-oferta com Idempotency-Key', async () => {
+  it('criar() faz POST /api/configuracao/admin/locais-oferta com Idempotency-Key', async () => {
     const promise = firstValueFrom(api.criar(criarCommand, withIdempotencyKey('k')));
-    const req = controller.expectOne(`${BASE}/api/admin/locais-oferta`);
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/locais-oferta`);
     expect(req.request.method).toBe('POST');
     expect(req.request.headers.get('Idempotency-Key')).toBe('k');
     req.flush(ID, { status: 201, statusText: 'Created' });
@@ -89,11 +89,11 @@ describe('LocaisOfertaApi', () => {
     expect(isApiOk(result)).toBe(true);
   });
 
-  it('atualizar() faz PUT /api/admin/locais-oferta/{id}', async () => {
+  it('atualizar() faz PUT /api/configuracao/admin/locais-oferta/{id}', async () => {
     const promise = firstValueFrom(
       api.atualizar(ID, { ...criarCommand, id: ID }, withIdempotencyKey('k2')),
     );
-    const req = controller.expectOne(`${BASE}/api/admin/locais-oferta/${ID}`);
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/locais-oferta/${ID}`);
     expect(req.request.method).toBe('PUT');
     req.flush(null, { status: 204, statusText: 'No Content' });
     const result = (await promise) as ApiResult<void>;

--- a/libs/shared-data/src/lib/api/configuracao/locais-oferta.api.ts
+++ b/libs/shared-data/src/lib/api/configuracao/locais-oferta.api.ts
@@ -50,7 +50,7 @@ export class LocaisOfertaApi {
   private readonly http = inject(HttpClient);
   private readonly basePath = inject(CONFIGURACAO_BASE_PATH);
 
-  /** GET `/api/locais-oferta` — lista paginada por cursor (ADR-0026). */
+  /** GET `/api/configuracao/locais-oferta` — lista paginada por cursor (ADR-0026). */
   listar(query: LocaisOfertaQuery = {}): Observable<ApiResult<readonly LocalOfertaDto[]>> {
     let params = new HttpParams();
     if (query.cursor !== undefined) {
@@ -59,44 +59,44 @@ export class LocaisOfertaApi {
       params = params.set('limit', String(query.limit ?? 100));
     }
     return this.http.get<ApiResult<readonly LocalOfertaDto[]>>(
-      `${this.basePath}/api/locais-oferta`,
+      `${this.basePath}/api/configuracao/locais-oferta`,
       { params, context: withVendorMime('local-oferta', 1) },
     );
   }
 
-  /** GET `/api/locais-oferta/{id}` — detalhe de um Local de Oferta. */
+  /** GET `/api/configuracao/locais-oferta/{id}` — detalhe de um Local de Oferta. */
   obter(id: string): Observable<ApiResult<LocalOfertaDto>> {
     return this.http.get<ApiResult<LocalOfertaDto>>(
-      `${this.basePath}/api/locais-oferta/${encodeURIComponent(id)}`,
+      `${this.basePath}/api/configuracao/locais-oferta/${encodeURIComponent(id)}`,
       { context: withVendorMime('local-oferta', 1) },
     );
   }
 
-  /** POST `/api/admin/locais-oferta` — cria. Idempotency-Key obrigatório (ADR-0027). */
+  /** POST `/api/configuracao/admin/locais-oferta` — cria. Idempotency-Key obrigatório (ADR-0027). */
   criar(command: CriarLocalOfertaCommand, context: HttpContext): Observable<ApiResult<string>> {
-    return this.http.post<ApiResult<string>>(`${this.basePath}/api/admin/locais-oferta`, command, {
+    return this.http.post<ApiResult<string>>(`${this.basePath}/api/configuracao/admin/locais-oferta`, command, {
       context,
       headers: new HttpHeaders({ Accept: 'application/json' }),
     });
   }
 
-  /** PUT `/api/admin/locais-oferta/{id}` — atualiza. */
+  /** PUT `/api/configuracao/admin/locais-oferta/{id}` — atualiza. */
   atualizar(
     id: string,
     command: AtualizarLocalOfertaCommand,
     context: HttpContext,
   ): Observable<ApiResult<void>> {
     return this.http.put<ApiResult<void>>(
-      `${this.basePath}/api/admin/locais-oferta/${encodeURIComponent(id)}`,
+      `${this.basePath}/api/configuracao/admin/locais-oferta/${encodeURIComponent(id)}`,
       command,
       { context },
     );
   }
 
-  /** DELETE `/api/admin/locais-oferta/{id}` — remoção lógica (soft-delete). */
+  /** DELETE `/api/configuracao/admin/locais-oferta/{id}` — remoção lógica (soft-delete). */
   remover(id: string): Observable<ApiResult<void>> {
     return this.http.delete<ApiResult<void>>(
-      `${this.basePath}/api/admin/locais-oferta/${encodeURIComponent(id)}`,
+      `${this.basePath}/api/configuracao/admin/locais-oferta/${encodeURIComponent(id)}`,
     );
   }
 }

--- a/libs/shared-data/src/lib/api/configuracao/reserva-demografica.api.spec.ts
+++ b/libs/shared-data/src/lib/api/configuracao/reserva-demografica.api.spec.ts
@@ -58,7 +58,7 @@ describe('ReservaDemograficaApi', () => {
 
   it('listar() faz GET com limit e Accept versionado', async () => {
     const promise = firstValueFrom(api.listar({ limit: 50 }));
-    const req = controller.expectOne((r) => r.url === `${BASE}/api/referencias-reserva-demografica`);
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/referencias-reserva-demografica`);
     expect(req.request.params.get('limit')).toBe('50');
     expect(req.request.headers.get('Accept')).toBe(
       buildVendorMimeAccept('referencia-reserva-demografica', 1),
@@ -70,7 +70,7 @@ describe('ReservaDemograficaApi', () => {
 
   it('listar() com cursor envia cursor + direction e omite limit', async () => {
     const promise = firstValueFrom(api.listar({ cursor: 'abc', direction: 'prev' }));
-    const req = controller.expectOne((r) => r.url === `${BASE}/api/referencias-reserva-demografica`);
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/referencias-reserva-demografica`);
     expect(req.request.params.get('cursor')).toBe('abc');
     expect(req.request.params.get('direction')).toBe('prev');
     expect(req.request.params.has('limit')).toBe(false);
@@ -80,7 +80,7 @@ describe('ReservaDemograficaApi', () => {
 
   it('criar() faz POST admin com Idempotency-Key e Accept JSON', async () => {
     const promise = firstValueFrom(api.criar(criarCommand, withIdempotencyKey('k')));
-    const req = controller.expectOne(`${BASE}/api/admin/referencias-reserva-demografica`);
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/referencias-reserva-demografica`);
     expect(req.request.method).toBe('POST');
     expect(req.request.headers.get('Idempotency-Key')).toBe('k');
     expect(req.request.headers.get('Accept')).toBe('application/json');
@@ -93,7 +93,7 @@ describe('ReservaDemograficaApi', () => {
     const promise = firstValueFrom(
       api.atualizar(ID, { ...criarCommand, id: ID }, withIdempotencyKey('k2')),
     );
-    const req = controller.expectOne(`${BASE}/api/admin/referencias-reserva-demografica/${ID}`);
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/referencias-reserva-demografica/${ID}`);
     expect(req.request.method).toBe('PUT');
     req.flush(null, { status: 204, statusText: 'No Content' });
     expect(isApiOk((await promise) as ApiResult<void>)).toBe(true);
@@ -101,7 +101,7 @@ describe('ReservaDemograficaApi', () => {
 
   it('remover() faz DELETE admin/{id} (soft-delete)', async () => {
     const promise = firstValueFrom(api.remover(ID));
-    const req = controller.expectOne(`${BASE}/api/admin/referencias-reserva-demografica/${ID}`);
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/referencias-reserva-demografica/${ID}`);
     expect(req.request.method).toBe('DELETE');
     req.flush(null, { status: 204, statusText: 'No Content' });
     expect(isApiOk((await promise) as ApiResult<void>)).toBe(true);

--- a/libs/shared-data/src/lib/api/configuracao/reserva-demografica.api.ts
+++ b/libs/shared-data/src/lib/api/configuracao/reserva-demografica.api.ts
@@ -34,7 +34,7 @@ export class ReservaDemograficaApi {
   private readonly http = inject(HttpClient);
   private readonly basePath = inject(CONFIGURACAO_BASE_PATH);
 
-  /** GET `/api/referencias-reserva-demografica` — lista (ativas) por cursor. */
+  /** GET `/api/configuracao/referencias-reserva-demografica` — lista (ativas) por cursor. */
   listar(
     query: ReservaDemograficaQuery = {},
   ): Observable<ApiResult<readonly ReferenciaReservaDemograficaDto[]>> {
@@ -45,48 +45,48 @@ export class ReservaDemograficaApi {
       params = params.set('limit', String(query.limit ?? 100));
     }
     return this.http.get<ApiResult<readonly ReferenciaReservaDemograficaDto[]>>(
-      `${this.basePath}/api/referencias-reserva-demografica`,
+      `${this.basePath}/api/configuracao/referencias-reserva-demografica`,
       { params, context: withVendorMime('referencia-reserva-demografica', 1) },
     );
   }
 
-  /** GET `/api/referencias-reserva-demografica/{id}` — detalhe. */
+  /** GET `/api/configuracao/referencias-reserva-demografica/{id}` — detalhe. */
   obter(id: string): Observable<ApiResult<ReferenciaReservaDemograficaDto>> {
     return this.http.get<ApiResult<ReferenciaReservaDemograficaDto>>(
-      `${this.basePath}/api/referencias-reserva-demografica/${encodeURIComponent(id)}`,
+      `${this.basePath}/api/configuracao/referencias-reserva-demografica/${encodeURIComponent(id)}`,
       { context: withVendorMime('referencia-reserva-demografica', 1) },
     );
   }
 
-  /** POST `/api/admin/referencias-reserva-demografica` — cria. Idempotency-Key (ADR-0027). */
+  /** POST `/api/configuracao/admin/referencias-reserva-demografica` — cria. Idempotency-Key (ADR-0027). */
   criar(
     command: CriarReferenciaReservaDemograficaCommand,
     context: HttpContext,
   ): Observable<ApiResult<string>> {
     return this.http.post<ApiResult<string>>(
-      `${this.basePath}/api/admin/referencias-reserva-demografica`,
+      `${this.basePath}/api/configuracao/admin/referencias-reserva-demografica`,
       command,
       { context, headers: new HttpHeaders({ Accept: 'application/json' }) },
     );
   }
 
-  /** PUT `/api/admin/referencias-reserva-demografica/{id}` — atualiza. */
+  /** PUT `/api/configuracao/admin/referencias-reserva-demografica/{id}` — atualiza. */
   atualizar(
     id: string,
     command: AtualizarReferenciaReservaDemograficaCommand,
     context: HttpContext,
   ): Observable<ApiResult<void>> {
     return this.http.put<ApiResult<void>>(
-      `${this.basePath}/api/admin/referencias-reserva-demografica/${encodeURIComponent(id)}`,
+      `${this.basePath}/api/configuracao/admin/referencias-reserva-demografica/${encodeURIComponent(id)}`,
       command,
       { context },
     );
   }
 
-  /** DELETE `/api/admin/referencias-reserva-demografica/{id}` — soft-delete. */
+  /** DELETE `/api/configuracao/admin/referencias-reserva-demografica/{id}` — soft-delete. */
   remover(id: string): Observable<ApiResult<void>> {
     return this.http.delete<ApiResult<void>>(
-      `${this.basePath}/api/admin/referencias-reserva-demografica/${encodeURIComponent(id)}`,
+      `${this.basePath}/api/configuracao/admin/referencias-reserva-demografica/${encodeURIComponent(id)}`,
     );
   }
 }

--- a/libs/shared-data/src/lib/api/organizacao/instituicao.api.spec.ts
+++ b/libs/shared-data/src/lib/api/organizacao/instituicao.api.spec.ts
@@ -87,10 +87,10 @@ describe('InstituicaoApi', () => {
 
   afterEach(() => controller.verify());
 
-  it('obter() faz GET /api/instituicao (singleton, sem id) com Accept versionado', async () => {
+  it('obter() faz GET /api/organizacao/instituicao (singleton, sem id) com Accept versionado', async () => {
     const promise = firstValueFrom(api.obter());
 
-    const req = controller.expectOne(`${BASE}/api/instituicao`);
+    const req = controller.expectOne(`${BASE}/api/organizacao/instituicao`);
     expect(req.request.method).toBe('GET');
     expect(req.request.headers.get('Accept')).toBe(buildVendorMimeAccept('instituicao', 1));
     req.flush(instituicaoSeed);
@@ -105,7 +105,7 @@ describe('InstituicaoApi', () => {
   it('obter() devolve ApiFailure com status 404 quando não há Instituição viva', async () => {
     const promise = firstValueFrom(api.obter());
 
-    const req = controller.expectOne(`${BASE}/api/instituicao`);
+    const req = controller.expectOne(`${BASE}/api/organizacao/instituicao`);
     req.flush(null, { status: 404, statusText: 'Not Found' });
 
     const result = (await promise) as ApiResult<InstituicaoDto>;
@@ -113,11 +113,11 @@ describe('InstituicaoApi', () => {
     expect(result.status).toBe(404);
   });
 
-  it('criar() faz POST /api/admin/instituicao com Idempotency-Key e Accept JSON', async () => {
+  it('criar() faz POST /api/organizacao/admin/instituicao com Idempotency-Key e Accept JSON', async () => {
     const key = 'instituicao-create-key';
     const promise = firstValueFrom(api.criar(criarCommand, withIdempotencyKey(key)));
 
-    const req = controller.expectOne(`${BASE}/api/admin/instituicao`);
+    const req = controller.expectOne(`${BASE}/api/organizacao/admin/instituicao`);
     expect(req.request.method).toBe('POST');
     expect(req.request.headers.get('Idempotency-Key')).toBe(key);
     expect(req.request.headers.get('Accept')).toBe('application/json');
@@ -131,11 +131,11 @@ describe('InstituicaoApi', () => {
     }
   });
 
-  it('atualizar() faz PUT /api/admin/instituicao/{id} com Idempotency-Key', async () => {
+  it('atualizar() faz PUT /api/organizacao/admin/instituicao/{id} com Idempotency-Key', async () => {
     const key = 'instituicao-update-key';
     const promise = firstValueFrom(api.atualizar(ID, atualizarCommand, withIdempotencyKey(key)));
 
-    const req = controller.expectOne(`${BASE}/api/admin/instituicao/${ID}`);
+    const req = controller.expectOne(`${BASE}/api/organizacao/admin/instituicao/${ID}`);
     expect(req.request.method).toBe('PUT');
     expect(req.request.headers.get('Idempotency-Key')).toBe(key);
     expect(req.request.body).toEqual(atualizarCommand);
@@ -148,7 +148,7 @@ describe('InstituicaoApi', () => {
   it('remover() faz DELETE sem Idempotency-Key porque o backend não exige o header', async () => {
     const promise = firstValueFrom(api.remover(ID));
 
-    const req = controller.expectOne(`${BASE}/api/admin/instituicao/${ID}`);
+    const req = controller.expectOne(`${BASE}/api/organizacao/admin/instituicao/${ID}`);
     expect(req.request.method).toBe('DELETE');
     expect(req.request.headers.has('Idempotency-Key')).toBe(false);
     req.flush(null, { status: 204, statusText: 'No Content' });

--- a/libs/shared-data/src/lib/api/organizacao/instituicao.api.ts
+++ b/libs/shared-data/src/lib/api/organizacao/instituicao.api.ts
@@ -22,7 +22,7 @@ export type CidadeReferenciaInput = components['schemas']['CidadeReferenciaInput
  * Cliente Angular standalone do recurso Instituição (módulo Organização
  * Institucional). A Instituição é **singleton** (ADR-0055): não há listagem nem
  * seletor — há a Instituição, criada uma vez e editada ao longo do tempo. Por
- * isso `obter()` não recebe `id` (lê `GET /api/instituicao`) e devolve 404
+ * isso `obter()` não recebe `id` (lê `GET /api/organizacao/instituicao`) e devolve 404
  * quando nenhuma foi cadastrada ainda.
  *
  * API thin (ADR-0013): tipos vêm do `schema.ts` gerado, a resposta é envelopada
@@ -37,19 +37,19 @@ export class InstituicaoApi {
   private readonly basePath = inject(ORGANIZACAO_BASE_PATH);
 
   /**
-   * GET `/api/instituicao` — obtém o cabeçalho institucional (singleton). O
+   * GET `/api/organizacao/instituicao` — obtém o cabeçalho institucional (singleton). O
    * `apiResultInterceptor` envelopa o 404 (nenhuma Instituição viva) como
    * `ApiFailure` com `status: 404` — não lança; o caller decide o modo de tela
    * (leitura vs criação) lendo `result.status`.
    */
   obter(): Observable<ApiResult<InstituicaoDto>> {
-    return this.http.get<ApiResult<InstituicaoDto>>(`${this.basePath}/api/instituicao`, {
+    return this.http.get<ApiResult<InstituicaoDto>>(`${this.basePath}/api/organizacao/instituicao`, {
       context: withVendorMime('instituicao', 1),
     });
   }
 
   /**
-   * POST `/api/admin/instituicao` — cria a Instituição. Restrito a
+   * POST `/api/organizacao/admin/instituicao` — cria a Instituição. Restrito a
    * `plataforma-admin`. Idempotency-Key obrigatório (ADR-0027) — declarado via
    * `withIdempotencyKey(key)` no `context`. Retorna 409
    * (`uniplus.organizacao.instituicao.ja_existe`) se já existe uma viva
@@ -57,14 +57,14 @@ export class InstituicaoApi {
    * em `application/json` porque o contrato também declara `text/plain` para 201.
    */
   criar(command: CriarInstituicaoCommand, context: HttpContext): Observable<ApiResult<string>> {
-    return this.http.post<ApiResult<string>>(`${this.basePath}/api/admin/instituicao`, command, {
+    return this.http.post<ApiResult<string>>(`${this.basePath}/api/organizacao/admin/instituicao`, command, {
       context,
       headers: new HttpHeaders({ Accept: 'application/json' }),
     });
   }
 
   /**
-   * PUT `/api/admin/instituicao/{id}` — atualiza a Instituição existente.
+   * PUT `/api/organizacao/admin/instituicao/{id}` — atualiza a Instituição existente.
    * Restrito a `plataforma-admin`. Idempotency-Key obrigatório (ADR-0027).
    * Resposta 204 No Content em sucesso.
    */
@@ -74,21 +74,21 @@ export class InstituicaoApi {
     context: HttpContext,
   ): Observable<ApiResult<void>> {
     return this.http.put<ApiResult<void>>(
-      `${this.basePath}/api/admin/instituicao/${encodeURIComponent(id)}`,
+      `${this.basePath}/api/organizacao/admin/instituicao/${encodeURIComponent(id)}`,
       command,
       { context },
     );
   }
 
   /**
-   * DELETE `/api/admin/instituicao/{id}` — remoção lógica (soft-delete) da
+   * DELETE `/api/organizacao/admin/instituicao/{id}` — remoção lógica (soft-delete) da
    * Instituição. Restrito a `plataforma-admin`. Sem Idempotency-Key (o backend
    * não exige o header). Resposta 204 No Content; libera o cadastro de uma nova
    * Instituição.
    */
   remover(id: string): Observable<ApiResult<void>> {
     return this.http.delete<ApiResult<void>>(
-      `${this.basePath}/api/admin/instituicao/${encodeURIComponent(id)}`,
+      `${this.basePath}/api/organizacao/admin/instituicao/${encodeURIComponent(id)}`,
     );
   }
 }

--- a/libs/shared-data/src/lib/api/organizacao/unidades.api.spec.ts
+++ b/libs/shared-data/src/lib/api/organizacao/unidades.api.spec.ts
@@ -84,11 +84,11 @@ describe('UnidadesApi', () => {
 
   afterEach(() => controller.verify());
 
-  it('obter() faz GET /api/unidades/{id} com encoding seguro', async () => {
+  it('obter() faz GET /api/organizacao/unidades/{id} com encoding seguro', async () => {
     const id = 'id com espaço/01';
     const promise = firstValueFrom(api.obter(id));
 
-    const req = controller.expectOne(`${BASE}/api/unidades/${encodeURIComponent(id)}`);
+    const req = controller.expectOne(`${BASE}/api/organizacao/unidades/${encodeURIComponent(id)}`);
     expect(req.request.method).toBe('GET');
     expect(req.request.headers.get('Accept')).toBe(buildVendorMimeAccept('unidade', 1));
     req.flush(unidadeSeed);
@@ -96,11 +96,11 @@ describe('UnidadesApi', () => {
     await promise;
   });
 
-  it('criar() faz POST /api/admin/unidades com Idempotency-Key e Accept JSON', async () => {
+  it('criar() faz POST /api/organizacao/admin/unidades com Idempotency-Key e Accept JSON', async () => {
     const key = 'unidade-create-key';
     const promise = firstValueFrom(api.criar(criarCommand, withIdempotencyKey(key)));
 
-    const req = controller.expectOne(`${BASE}/api/admin/unidades`);
+    const req = controller.expectOne(`${BASE}/api/organizacao/admin/unidades`);
     expect(req.request.method).toBe('POST');
     expect(req.request.headers.get('Idempotency-Key')).toBe(key);
     expect(req.request.headers.get('Accept')).toBe('application/json');
@@ -125,11 +125,11 @@ describe('UnidadesApi', () => {
     );
   });
 
-  it('atualizar() faz PUT /api/admin/unidades/{id} com Idempotency-Key', async () => {
+  it('atualizar() faz PUT /api/organizacao/admin/unidades/{id} com Idempotency-Key', async () => {
     const key = 'unidade-update-key';
     const promise = firstValueFrom(api.atualizar(ID, atualizarCommand, withIdempotencyKey(key)));
 
-    const req = controller.expectOne(`${BASE}/api/admin/unidades/${ID}`);
+    const req = controller.expectOne(`${BASE}/api/organizacao/admin/unidades/${ID}`);
     expect(req.request.method).toBe('PUT');
     expect(req.request.headers.get('Idempotency-Key')).toBe(key);
     expect(req.request.body).toEqual(atualizarCommand);
@@ -142,7 +142,7 @@ describe('UnidadesApi', () => {
   it('remover() faz DELETE sem Idempotency-Key porque o backend não exige o header', async () => {
     const promise = firstValueFrom(api.remover(ID));
 
-    const req = controller.expectOne(`${BASE}/api/admin/unidades/${ID}`);
+    const req = controller.expectOne(`${BASE}/api/organizacao/admin/unidades/${ID}`);
     expect(req.request.method).toBe('DELETE');
     expect(req.request.headers.has('Idempotency-Key')).toBe(false);
     req.flush(null, { status: 204, statusText: 'No Content' });

--- a/libs/shared-data/src/lib/api/organizacao/unidades.api.ts
+++ b/libs/shared-data/src/lib/api/organizacao/unidades.api.ts
@@ -48,13 +48,13 @@ export class UnidadesApi {
 
   obter(id: string): Observable<ApiResult<UnidadeDto>> {
     return this.http.get<ApiResult<UnidadeDto>>(
-      `${this.basePath}/api/unidades/${encodeURIComponent(id)}`,
+      `${this.basePath}/api/organizacao/unidades/${encodeURIComponent(id)}`,
       { context: withVendorMime('unidade', 1) },
     );
   }
 
   criar(command: CriarUnidadeCommand, context: HttpContext): Observable<ApiResult<string>> {
-    return this.http.post<ApiResult<string>>(`${this.basePath}/api/admin/unidades`, command, {
+    return this.http.post<ApiResult<string>>(`${this.basePath}/api/organizacao/admin/unidades`, command, {
       context,
       headers: new HttpHeaders({ Accept: 'application/json' }),
     });
@@ -66,7 +66,7 @@ export class UnidadesApi {
     context: HttpContext,
   ): Observable<ApiResult<void>> {
     return this.http.put<ApiResult<void>>(
-      `${this.basePath}/api/admin/unidades/${encodeURIComponent(id)}`,
+      `${this.basePath}/api/organizacao/admin/unidades/${encodeURIComponent(id)}`,
       command,
       { context },
     );
@@ -74,7 +74,7 @@ export class UnidadesApi {
 
   remover(id: string): Observable<ApiResult<void>> {
     return this.http.delete<ApiResult<void>>(
-      `${this.basePath}/api/admin/unidades/${encodeURIComponent(id)}`,
+      `${this.basePath}/api/organizacao/admin/unidades/${encodeURIComponent(id)}`,
     );
   }
 }

--- a/libs/shared-data/src/lib/api/selecao/editais.api.spec.ts
+++ b/libs/shared-data/src/lib/api/selecao/editais.api.spec.ts
@@ -45,11 +45,11 @@ describe('EditaisApi', () => {
 
   afterEach(() => controller.verify());
 
-  it('listar() sem cursor faz GET /api/editais sem query params, com vendor MIME v1', async () => {
+  it('listar() sem cursor faz GET /api/selecao/editais sem query params, com vendor MIME v1', async () => {
     const promise = firstValueFrom(api.listar());
 
     const req = controller.expectOne(
-      (request) => request.url === `${BASE}/api/editais` && request.params.keys().length === 0,
+      (request) => request.url === `${BASE}/api/selecao/editais` && request.params.keys().length === 0,
     );
     expect(req.request.method).toBe('GET');
     expect(req.request.headers.get('Accept')).toBe(buildVendorMimeAccept('edital', 1));
@@ -71,7 +71,7 @@ describe('EditaisApi', () => {
     const promise = firstValueFrom(api.listar(cursor));
 
     const req = controller.expectOne(
-      (request) => request.url === `${BASE}/api/editais` && request.params.has('cursor'),
+      (request) => request.url === `${BASE}/api/selecao/editais` && request.params.has('cursor'),
     );
     expect(req.request.params.get('cursor')).toBe('opaque-cursor-AES-GCM-blob');
     expect(req.request.params.has('limit')).toBe(false);
@@ -87,7 +87,7 @@ describe('EditaisApi', () => {
     const promise = firstValueFrom(api.listar(cursor, 'next'));
 
     const req = controller.expectOne(
-      (request) => request.url === `${BASE}/api/editais` && request.params.has('cursor'),
+      (request) => request.url === `${BASE}/api/selecao/editais` && request.params.has('cursor'),
     );
     expect(req.request.params.get('cursor')).toBe('next-page-cursor');
     expect(req.request.params.get('direction')).toBe('next');
@@ -103,7 +103,7 @@ describe('EditaisApi', () => {
     const promise = firstValueFrom(api.listar(cursor, 'prev'));
 
     const req = controller.expectOne(
-      (request) => request.url === `${BASE}/api/editais` && request.params.has('cursor'),
+      (request) => request.url === `${BASE}/api/selecao/editais` && request.params.has('cursor'),
     );
     expect(req.request.params.get('cursor')).toBe('prev-page-cursor');
     expect(req.request.params.get('direction')).toBe('prev');
@@ -116,7 +116,7 @@ describe('EditaisApi', () => {
     const promise = firstValueFrom(api.listar(undefined, 'next'));
 
     const req = controller.expectOne(
-      (request) => request.url === `${BASE}/api/editais` && request.params.keys().length === 0,
+      (request) => request.url === `${BASE}/api/selecao/editais` && request.params.keys().length === 0,
     );
     expect(req.request.params.has('cursor')).toBe(false);
     expect(req.request.params.has('direction')).toBe(false);
@@ -125,12 +125,12 @@ describe('EditaisApi', () => {
     await promise;
   });
 
-  it('obter() faz GET /api/editais/{id} com encoding seguro do path param', async () => {
+  it('obter() faz GET /api/selecao/editais/{id} com encoding seguro do path param', async () => {
     const id = 'edt with space/01';
 
     const promise = firstValueFrom(api.obter(id));
 
-    const req = controller.expectOne(`${BASE}/api/editais/${encodeURIComponent(id)}`);
+    const req = controller.expectOne(`${BASE}/api/selecao/editais/${encodeURIComponent(id)}`);
     expect(req.request.method).toBe('GET');
     expect(req.request.headers.get('Accept')).toBe(buildVendorMimeAccept('edital', 1));
     req.flush(editalSeed);
@@ -145,7 +145,7 @@ describe('EditaisApi', () => {
   it('obter() entrega ApiFailure quando o backend devolve 404 problem+json', async () => {
     const promise = firstValueFrom(api.obter('inexistente'));
 
-    controller.expectOne(`${BASE}/api/editais/inexistente`).flush(
+    controller.expectOne(`${BASE}/api/selecao/editais/inexistente`).flush(
       {
         type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.selecao.edital.nao_encontrado',
         title: 'Edital não encontrado',
@@ -177,11 +177,11 @@ describe('EditaisApi', () => {
       maximoOpcoesCurso: 2,
     };
 
-    it('faz POST /api/editais com Idempotency-Key + Accept: application/json e devolve 201 com o ID', async () => {
+    it('faz POST /api/selecao/editais com Idempotency-Key + Accept: application/json e devolve 201 com o ID', async () => {
       const key = '01890a5d-ac96-774b-bcce-b302099a8057';
       const promise = firstValueFrom(api.criar(comando, withIdempotencyKey(key)));
 
-      const req = controller.expectOne(`${BASE}/api/editais`);
+      const req = controller.expectOne(`${BASE}/api/selecao/editais`);
       expect(req.request.method).toBe('POST');
       expect(req.request.headers.get('Idempotency-Key')).toBe(key);
       // Accept fixado evita que backend devolva text/plain (que quebraria
@@ -191,7 +191,7 @@ describe('EditaisApi', () => {
       req.flush('01960000-0000-7000-0000-000000000099', {
         status: 201,
         statusText: 'Created',
-        headers: { Location: '/api/editais/01960000-0000-7000-0000-000000000099' },
+        headers: { Location: '/api/selecao/editais/01960000-0000-7000-0000-000000000099' },
       });
 
       const result = (await promise) as ApiResult<string>;
@@ -199,7 +199,7 @@ describe('EditaisApi', () => {
       if (result.ok) {
         expect(result.data).toBe('01960000-0000-7000-0000-000000000099');
         expect(result.headers.get('Location')).toBe(
-          '/api/editais/01960000-0000-7000-0000-000000000099',
+          '/api/selecao/editais/01960000-0000-7000-0000-000000000099',
         );
       }
     });
@@ -208,7 +208,7 @@ describe('EditaisApi', () => {
       const key = '01890a5d-ac96-774b-bcce-b302099a8058';
       const promise = firstValueFrom(api.criar(comando, withIdempotencyKey(key)));
 
-      controller.expectOne(`${BASE}/api/editais`).flush(
+      controller.expectOne(`${BASE}/api/selecao/editais`).flush(
         {
           type: 'about:blank',
           title: 'Falha de validação',
@@ -241,7 +241,7 @@ describe('EditaisApi', () => {
       const key = '01890a5d-ac96-774b-bcce-b302099a8059';
       const promise = firstValueFrom(api.criar(comando, withIdempotencyKey(key)));
 
-      controller.expectOne(`${BASE}/api/editais`).flush(
+      controller.expectOne(`${BASE}/api/selecao/editais`).flush(
         {
           type: 'about:blank',
           title: 'Edital já existente',
@@ -269,7 +269,7 @@ describe('EditaisApi', () => {
 
       const promise = firstValueFrom(api.criar(comando, withIdempotencyKey(key)));
 
-      const req = controller.expectOne(`${BASE}/api/editais`);
+      const req = controller.expectOne(`${BASE}/api/selecao/editais`);
       expect(req.request.headers.get('Idempotency-Key')).toBe(key);
       req.flush('01960000-0000-7000-0000-000000000099', {
         status: 201,
@@ -288,11 +288,11 @@ describe('EditaisApi', () => {
   describe('publicar()', () => {
     const ID = '01960000-0000-7000-0000-000000000099';
 
-    it('faz POST /api/editais/{id}/publicar com Idempotency-Key + vendor MIME v1 e devolve 204 ApiResult.ok', async () => {
+    it('faz POST /api/selecao/editais/{id}/publicar com Idempotency-Key + vendor MIME v1 e devolve 204 ApiResult.ok', async () => {
       const key = '01890a5d-ac96-774b-bcce-b302099a805b';
       const promise = firstValueFrom(api.publicar(ID, withIdempotencyKey(key)));
 
-      const req = controller.expectOne(`${BASE}/api/editais/${ID}/publicar`);
+      const req = controller.expectOne(`${BASE}/api/selecao/editais/${ID}/publicar`);
       expect(req.request.method).toBe('POST');
       expect(req.request.headers.get('Idempotency-Key')).toBe(key);
       // Vendor MIME mantido por simetria com obter()/listar() (ADR-0028).
@@ -311,7 +311,7 @@ describe('EditaisApi', () => {
       const key = '01890a5d-ac96-774b-bcce-b302099a805c';
       const promise = firstValueFrom(api.publicar(ID, withIdempotencyKey(key)));
 
-      controller.expectOne(`${BASE}/api/editais/${ID}/publicar`).flush(
+      controller.expectOne(`${BASE}/api/selecao/editais/${ID}/publicar`).flush(
         {
           type: 'about:blank',
           title: 'Edital já publicado',
@@ -339,7 +339,7 @@ describe('EditaisApi', () => {
       firstValueFrom(api.publicar(idComEspaco, withIdempotencyKey(key)));
 
       const req = controller.expectOne(
-        `${BASE}/api/editais/${encodeURIComponent(idComEspaco)}/publicar`,
+        `${BASE}/api/selecao/editais/${encodeURIComponent(idComEspaco)}/publicar`,
       );
       req.flush(null, { status: 204, statusText: 'No Content' });
     });

--- a/libs/shared-data/src/lib/api/selecao/editais.api.ts
+++ b/libs/shared-data/src/lib/api/selecao/editais.api.ts
@@ -27,7 +27,7 @@ export type EditalDto = components['schemas']['EditalDto'];
 export type CriarEditalCommand = components['schemas']['CriarEditalCommand'];
 
 /**
- * Cliente Angular standalone do recurso `/api/editais` (módulo Seleção).
+ * Cliente Angular standalone do recurso `/api/selecao/editais` (módulo Seleção).
  * API thin (ADR-0013): tipos vêm do `schema.ts` gerado, response é
  * envelopada em `ApiResult<T>` pelo `apiResultInterceptor` upstream
  * (ADR-0011), Bearer é injetado pelo `tokenInterceptor` (ADR-0009),
@@ -43,7 +43,7 @@ export class EditaisApi {
   private readonly basePath = inject(SELECAO_BASE_PATH);
 
   /**
-   * GET `/api/editais` — lista paginada por cursor opaco bidirecional
+   * GET `/api/selecao/editais` — lista paginada por cursor opaco bidirecional
    * (ADR-0026 + ADR-0031 + ADR-0089 do `uniplus-api`; consumer client-side
    * via ADR-0015).
    *
@@ -72,22 +72,22 @@ export class EditaisApi {
         params = params.set('direction', direction);
       }
     }
-    return this.http.get<ApiResult<readonly EditalDto[]>>(`${this.basePath}/api/editais`, {
+    return this.http.get<ApiResult<readonly EditalDto[]>>(`${this.basePath}/api/selecao/editais`, {
       context: withVendorMime('edital', 1),
       params,
     });
   }
 
-  /** GET `/api/editais/{id}` — detalhe de um edital. */
+  /** GET `/api/selecao/editais/{id}` — detalhe de um edital. */
   obter(id: string): Observable<ApiResult<EditalDto>> {
     return this.http.get<ApiResult<EditalDto>>(
-      `${this.basePath}/api/editais/${encodeURIComponent(id)}`,
+      `${this.basePath}/api/selecao/editais/${encodeURIComponent(id)}`,
       { context: withVendorMime('edital', 1) },
     );
   }
 
   /**
-   * POST `/api/editais` — cria um novo edital.
+   * POST `/api/selecao/editais` — cria um novo edital.
    *
    * **Header obrigatório:** `Idempotency-Key` (ADR-0027 do `uniplus-api`,
    * ADR-0014 do consumer). O caller declara via `withIdempotencyKey(key)` ou
@@ -107,14 +107,14 @@ export class EditaisApi {
    * chega como `string` JSON-decodificada.
    */
   criar(command: CriarEditalCommand, context: HttpContext): Observable<ApiResult<string>> {
-    return this.http.post<ApiResult<string>>(`${this.basePath}/api/editais`, command, {
+    return this.http.post<ApiResult<string>>(`${this.basePath}/api/selecao/editais`, command, {
       context,
       headers: new HttpHeaders({ Accept: 'application/json' }),
     });
   }
 
   /**
-   * POST `/api/editais/{id}/publicar` — publica um edital em rascunho.
+   * POST `/api/selecao/editais/{id}/publicar` — publica um edital em rascunho.
    *
    * **Header obrigatório:** `Idempotency-Key` (ADR-0027 do `uniplus-api`).
    * O caller declara via `withIdempotencyKey(key)` no `HttpContext`; este
@@ -130,7 +130,7 @@ export class EditaisApi {
     const idempotencyKeyValue = context.get(IDEMPOTENCY_KEY_TOKEN);
     const ctxComposto = withVendorMime('edital', 1).set(IDEMPOTENCY_KEY_TOKEN, idempotencyKeyValue);
     return this.http.post<ApiResult<void>>(
-      `${this.basePath}/api/editais/${encodeURIComponent(id)}/publicar`,
+      `${this.basePath}/api/selecao/editais/${encodeURIComponent(id)}/publicar`,
       null,
       { context: ctxComposto },
     );

--- a/libs/shared-data/src/lib/api/selecao/tokens.ts
+++ b/libs/shared-data/src/lib/api/selecao/tokens.ts
@@ -4,7 +4,7 @@ import { InjectionToken } from '@angular/core';
  * Origin absoluta da `uniplus-api` que serve o módulo Seleção
  * (ex.: `http://localhost:5000` em dev local; `https://api.uniplus.unifesspa.edu.br`
  * em produção). Os paths declarados pelo contrato V1 (ADR-0030 do `uniplus-api`)
- * são absolutos a partir do origin (`/api/editais`, etc.) — não inclua sufixo
+ * são absolutos a partir do origin (`/api/selecao/editais`, etc.) — não inclua sufixo
  * `/api/v1` no valor provido.
  *
  * Provido uma vez por aplicação em `app.config.ts` a partir de


### PR DESCRIPTION
## Contexto

Os api clients do `uniplus-web` chamavam paths **pré-ADR-0064** sem prefixo de módulo (`/api/campi`, `/api/editais`, `/api/instituicao`), e só funcionavam atrás de um gateway que reescrevia os paths (band-aid). O backend consolidado (monólito modular — uniplus-api#733, PR uniplus-api#734) serve cada módulo sob `/api/{modulo}/`.

## O que muda (correção na raiz)

- **Api clients** (`libs/shared-data/.../*.api.ts`) e **URLs diretas das pages** (`useApiResource`) prefixados: `/api/editais` → `/api/selecao/editais`, `/api/campi` → `/api/configuracao/campi`, `/api/instituicao`/`/api/unidades` → `/api/organizacao/...`.
- **Specs** unitários e **mocks de e2e** (Playwright `page.route`) atualizados — tanto a forma string quanto a forma **regex com barras escapadas** (`/\/api\/editais/` → `/\/api\/selecao\/editais/`).
- **`runtime-config` do configuracao:** `apiUrl` `:5263` → `:5000` (gateway).
- Geo (`/api/cidades`, `/api/estados`, `/api/cep`) e compartilhados (`/api/auth/me`, `/api/profile/me`) inalterados.

## Validação

- `vite:test` (shared-data, shared-core, selecao, configuracao), **lint** (incl. e2e) e **build** verdes.
- E2E manual contra o backend real (combo `frontend-test`): `selecao` (criar/publicar edital) e `configuracao` (criar unidade e referência demográfica) pela UI.

## Revisão Codex — findings tratados

- **[P2] Mocks de rota e2e (selecao/configuracao):** corrigidos — os matchers em forma regex escapada tinham escapado do alinhamento inicial; agora batem os paths prefixados.
- **[P2] Baselines OpenAPI stale (`libs/shared-data/openapi/` + `schema.ts`):** **deferido ao #421** de propósito. Sincronizar o contrato completo traz junto a mudança de enums numéricos→string (`TipoUnidade`/`OrigemUnidade`), que exige migrar a lógica de form do `unidades.page.ts` + re-teste. O `paths` do `schema.ts` é metadata type-only (não usada em runtime); os clients escritos à mão são a fonte das URLs e estão corretos. `codegen-api-check` permanece verde (schema↔baseline consistentes).

## Referências

- Contraparte de backend: uniplus-api#734 (PR) / uniplus-api#733.
- Follow-up de sync do contrato + enums: #421.

Closes #422