### PR TITLE
build(docker): adiciona Dockerfile.configuracao do app web

### DIFF
--- a/docker/Dockerfile.configuracao
+++ b/docker/Dockerfile.configuracao
@@ -1,0 +1,20 @@
+# Stage 1: Build
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY package*.json nx.json tsconfig.base.json ./
+RUN npm ci
+COPY . .
+RUN npx nx build configuracao --configuration=production
+
+# Stage 2: Serve — base unprivileged (UID 101, listen :8080) — #4 hardening.
+FROM nginxinc/nginx-unprivileged:1.27-alpine
+COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build --chown=nginx:nginx /app/dist/apps/configuracao/browser /usr/share/nginx/html
+# Sobrescreve o runtime-config.json copiado do dist (que tem URLs DEV
+# de localhost) por placeholders inválidos. Garante que produção sem
+# ConfigMap montado FALHA RÁPIDO no fetch de auth/API em vez de
+# silenciosamente tentar localhost. ConfigMap K8s em produção monta
+# sobre este path com URLs reais (ADR-0021 + ADR-0020).
+COPY --chown=nginx:nginx docker/runtime-config.json /usr/share/nginx/html/assets/runtime-config.json
+EXPOSE 8080
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## O que muda

Adiciona `docker/Dockerfile.configuracao`, o único faltante entre os Dockerfiles dos apps web (selecao/ingresso/portal já existiam). Espelha o template — build Nx em produção + nginx unprivileged (:8080), com runtime-config sobrescrito por placeholders (ADR-0020/0021), montado por volume em dev.

## Por quê

O dev stack local do `uniplus-api` (#756) passa a conteinerizar os 4 frontends via `docker compose` com build cross-repo. Sem este Dockerfile, o build do app `configuracao` falha.

## Validação

`docker build -f docker/Dockerfile.configuracao .` → imagem OK; container serve `/health.json` (200) e, com o runtime-config dev montado, o app carrega e inicia o OIDC no realm `unifesspa`.

Refs unifesspa-edu-br/uniplus-api#756