### PR TITLE
fix(configuracao): desabilita inlineCritical no build de produção

### DIFF
--- a/apps/configuracao/project.json
+++ b/apps/configuracao/project.json
@@ -42,7 +42,15 @@
               "maximumError": "8kb"
             }
           ],
-          "outputHashing": "all"
+          "outputHashing": "all",
+          "optimization": {
+            "scripts": true,
+            "fonts": true,
+            "styles": {
+              "minify": true,
+              "inlineCritical": false
+            }
+          }
         },
         "development": {
           "optimization": false,


### PR DESCRIPTION
## O que muda

Adiciona o bloco `optimization` (com `styles.inlineCritical: false`) à config `production` do build do app **`configuracao`**, alinhando-o aos apps `selecao`/`ingresso`/`portal`, que já o tinham.

## Por quê

O `configuracao` era o **único** app sem `optimization` na config de produção, herdando o default do Angular (`optimization: true` → `styles.inlineCritical: true`). Com o critical CSS inline ligado, o `index.html` de produção fica com um `<style>` crítico e um `<link ... media="print" onload="this.media='all'">`. A CSP restritiva do nginx (`style-src-elem 'self'`, `script-src 'self'` sem `'unsafe-inline'`) bloqueia:

- o `<style>` crítico → `style-src-elem 'self'`;
- o handler inline `onload` → `script-src 'self'`, deixando o stylesheet preso em `media="print"`.

Resultado: o app renderizava **sem CSS** quando servido pela imagem de produção (nginx) — visível no dev stack conteinerizado (`configuracao-web` :4203) e, pelo mesmo mecanismo, em produção.

## Como validei

Rebuild da imagem `configuracao-web` com a correção:

- `index.html` de produção passa a ter `<link rel="stylesheet" href="styles-*.css">` normal (sem `<style>` crítico, sem `media="print"`/`onload`).
- App conteinerizado carrega **com CSS** no browser, sem os avisos de CSP de inline style/handler.

Descoberto ao conteinerizar os frontends no dev stack (unifesspa-edu-br/uniplus-api#756) — não é regressão dele; a inconsistência estava no build do `configuracao`.

Closes #428
