### PR TITLE
feat(shared-auth): enxuga chip de conta e move identidade ao dropdown

### DIFF
--- a/libs/shared-auth/src/lib/components/user-header-info.component.spec.ts
+++ b/libs/shared-auth/src/lib/components/user-header-info.component.spec.ts
@@ -54,22 +54,49 @@ describe('UserHeaderInfoComponent', () => {
     return { fixture, logout };
   }
 
-  it('exibe apenas o primeiro nome social do usuário autenticado', () => {
+  it('exibe apenas o primeiro nome social + avatar no chip (sem username/perfil)', () => {
     const { fixture } = setup();
-    const name = fixture.nativeElement.querySelector<HTMLElement>(
-      '[data-testid="auth-user-display-name"]',
-    );
-    const avatar = fixture.nativeElement.querySelector<HTMLElement>('.user-chip__avatar');
+    const chip = fixture.nativeElement.querySelector<HTMLElement>('button.user-chip');
+    const name = chip.querySelector<HTMLElement>('[data-testid="auth-user-display-name"]');
+    const avatar = chip.querySelector<HTMLElement>('.user-chip__avatar');
     expect(name?.textContent?.trim()).toBe('Candidato');
     expect(avatar?.textContent?.trim()).toBe('C');
+    // O chip não repete username nem nome completo — a identidade completa vive no dropdown.
+    expect(chip.textContent).not.toContain('@');
+    expect(chip.textContent).not.toContain('Candidato Teste');
   });
 
-  it('exibe username com prefixo @', () => {
+  it('exibe username com prefixo @ no dropdown, não no chip', () => {
     const { fixture } = setup();
     const username = fixture.nativeElement.querySelector<HTMLElement>(
       '[data-testid="auth-user-username"]',
     );
     expect(username?.textContent).toContain('@candidato');
+    // A linha de identidade pertence ao menu de conta, não ao chip do topbar.
+    expect(username?.closest('.menu')).toBeTruthy();
+    expect(username?.closest('.user-chip')).toBeNull();
+  });
+
+  it('exibe o nome completo no cabeçalho de identidade do dropdown', () => {
+    const { fixture } = setup();
+    const fullName = fixture.nativeElement.querySelector<HTMLElement>(
+      '[data-testid="auth-user-full-name"]',
+    );
+    expect(fullName?.textContent?.trim()).toBe('Candidato Teste');
+    expect(fullName?.closest('.menu__account')).toBeTruthy();
+  });
+
+  it('menu de conta expõe aria-label e o cabeçalho é role=presentation', () => {
+    const { fixture } = setup();
+    const menu = fixture.nativeElement.querySelector<HTMLElement>('.menu');
+    expect(menu?.getAttribute('role')).toBe('menu');
+    expect(menu?.getAttribute('aria-label')).toBe('Conta');
+    const account = fixture.nativeElement.querySelector<HTMLElement>('.menu__account');
+    expect(account?.getAttribute('role')).toBe('presentation');
+    // O cabeçalho de identidade não é navegável — o único menuitem é "Sair".
+    const items = fixture.nativeElement.querySelectorAll('[role="menuitem"]');
+    expect(items.length).toBe(1);
+    expect(items[0].textContent).toContain('Sair');
   });
 
   it('exibe rótulos pt-BR das roles do realm', () => {

--- a/libs/shared-auth/src/lib/components/user-header-info.component.ts
+++ b/libs/shared-auth/src/lib/components/user-header-info.component.ts
@@ -44,17 +44,9 @@ import {
             initials(userContext.firstDisplayName())
           }}</span>
           <span class="ui-user-header__text">
-            <strong data-testid="auth-user-display-name">
-              {{ userContext.firstDisplayName() }}
-            </strong>
-            <span data-testid="auth-user-username">
-              &#64;{{ profile.username }}
-              @if (domainRoles(profile.roles); as roles) {
-                @if (roles.length) {
-                  · {{ roles.join(', ') }}
-                }
-              }
-            </span>
+            <strong data-testid="auth-user-display-name">{{
+              userContext.firstDisplayName()
+            }}</strong>
           </span>
           <svg
             width="14"
@@ -75,10 +67,25 @@ import {
           class="menu"
           role="menu"
           [id]="menuId"
-          [attr.aria-labelledby]="buttonId"
+          aria-label="Conta"
           [hidden]="!menuOpen()"
         >
-          <li class="menu__group-title" role="presentation">Conta</li>
+          <li class="menu__account" role="presentation">
+            <span class="menu__account-info">
+              <strong class="menu__account-name" data-testid="auth-user-full-name">{{
+                userContext.displayName()
+              }}</strong>
+              <span class="menu__account-meta" data-testid="auth-user-username">
+                &#64;{{ profile.username }}
+                @if (domainRoles(profile.roles); as roles) {
+                  @if (roles.length) {
+                    · {{ roles.join(', ') }}
+                  }
+                }
+              </span>
+            </span>
+          </li>
+          <li class="menu__divider" role="separator"></li>
           <li role="none">
             <button
               type="button"

--- a/libs/shared-auth/src/styles/components.css
+++ b/libs/shared-auth/src/styles/components.css
@@ -25,12 +25,6 @@
   font-size: var(--text-sm);
 }
 
-.ui-user-header__text span {
-  color: var(--text-secondary);
-  font-size: var(--text-sm);
-  white-space: nowrap;
-}
-
 @media (max-width: 640px) {
   .ui-user-header__text {
     display: none;

--- a/libs/shared-e2e/src/lib/keycloak-login.ts
+++ b/libs/shared-e2e/src/lib/keycloak-login.ts
@@ -185,16 +185,19 @@ export async function expectUserInHeader(
   // Verificar presença do componente de user info no DOM (sem scoping ao <header>,
   // porque Angular custom elements podem criar fronteiras inesperadas para locators)
   const userInfo = page.locator('auth-user-header-info');
+  // Chip do topbar: apenas primeiro nome + avatar.
   await expect(userInfo.getByTestId('auth-user-display-name')).toHaveText(
     firstNameFrom(expectedName),
     { timeout: 5_000 },
   );
-  await expect(userInfo.getByTestId('auth-user-username')).toContainText(`@${expectedUsername}`);
   const trigger = userInfo.getByRole('button', {
     name: new RegExp(`^Abrir menu da conta de ${escapeRegExp(expectedName)}$`),
   });
   await expect(trigger).toBeVisible();
   await trigger.click();
+  // Identidade completa (nome completo + @username · perfil) aparece só ao abrir o menu.
+  await expect(userInfo.getByTestId('auth-user-full-name')).toHaveText(expectedName);
+  await expect(userInfo.getByTestId('auth-user-username')).toContainText(`@${expectedUsername}`);
   await expect(page.getByRole('menuitem', { name: 'Sair' })).toBeVisible();
   await page.keyboard.press('Escape');
   await expect(trigger).toHaveAttribute('aria-expanded', 'false');

--- a/libs/shared-ui/src/styles/components.css
+++ b/libs/shared-ui/src/styles/components.css
@@ -1490,6 +1490,39 @@ ui-vlibras-loader {
   color: var(--text-muted);
 }
 
+/* Cabeçalho de identidade no topo de um menu de conta. O chip do topbar mostra
+ * apenas avatar + primeiro nome; a identidade completa (nome completo + @username
+ * · perfil) aparece só ao abrir o menu, ocupando a área que antes trazia o eyebrow
+ * "Conta". O nome trunca em uma linha; a linha secundária pode quebrar para
+ * preservar o perfil por extenso. O avatar não se repete aqui — ele já identifica
+ * a conta no chip que abriu o menu. */
+.menu:has(.menu__account) {
+  min-width: 240px;
+  max-width: min(340px, calc(100vw - var(--space-6)));
+}
+.menu__account {
+  padding: var(--space-3);
+}
+.menu__account-info {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.menu__account-name {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-bold);
+  color: var(--text-heading);
+  line-height: var(--leading-tight);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.menu__account-meta {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  line-height: var(--leading-normal);
+}
+
 /* ============================================================================
  * EMPTY STATE
  * Spec (briefing-ux.md §8): primeira tela quando o candidato logou e ainda


### PR DESCRIPTION
## Objetivo

Enxugar o chip de conta no header e mover a identidade completa para o dropdown,
alinhando ao padrão canônico do `uniplus-ds`.

**Antes:** chip = avatar + primeiro nome + `@username · perfil`; dropdown = "CONTA" + "Sair".
**Depois:** chip = avatar + **primeiro nome**; dropdown = **nome completo + `@username · perfil`** (sem avatar) + "Sair".

## Mudanças

- **`shared-auth`** (`UserHeaderInfoComponent`): o chip passa a exibir só o primeiro
  nome (`firstDisplayName()`); o dropdown ganha um cabeçalho de identidade
  (`role="presentation"`, sem avatar) com o nome completo (`displayName()`) +
  `@username · perfil` (roles de domínio via `ROLE_LABELS`), seguido de divisor + "Sair".
  O `<ul role="menu">` passa a expor `aria-label="Conta"`.
- **`shared-ui`** (`styles/components.css`): adiciona as classes `.menu__account*`
  (espelho do `uniplus-ds`), com truncamento por elipse do nome (1 linha),
  quebra da linha de perfil e `min-width: 240px` / `max-width: min(340px, calc(100vw - var(--space-6)))`.
- **`shared-auth`** (`styles/components.css`): remove a regra órfã `.ui-user-header__text span`
  (o chip não tem mais a linha secundária).
- **`shared-e2e`** (`expectUserInHeader`): abre o menu antes de afirmar a identidade
  completa, refletindo a nova UX.

## Critérios de aceite

- [x] **CA-01** — Chip: apenas avatar + primeiro nome + chevron (sem `@username · perfil`).
- [x] **CA-02** — Dropdown: cabeçalho de identidade **sem avatar** com nome completo + `@username · perfil`.
- [x] **CA-03** — Divisor + item "Sair" (logout preservado).
- [x] **CA-04** — A11y: cabeçalho `role="presentation"`; `<ul role="menu">` com `aria-label="Conta"`;
  único `menuitem` é "Sair"; foco vai ao primeiro `menuitem` ao abrir; Esc/clique-fora fecham.
- [x] **CA-05** — Nome longo trunca (elipse, 1 linha); perfil pode quebrar; `max-width` responsivo.
- [x] **CA-06** — Classes `.menu__account*` adicionadas em `shared-ui/src/styles/components.css`.
- [x] **CA-07** — Testes Vitest atualizados: chip só primeiro nome; identidade completa no dropdown; a11y.
- [x] **CA-08** — Validado em light/dark/contrast e viewports 380/1280 (via referência canônica no `uniplus-ds`).

## Validação

- `nx vite:test shared-auth` — **74 testes verdes** (17 no `UserHeaderInfoComponent`, incluindo 3 novos: chip limpo, identidade no dropdown, a11y `role=presentation`).
- `nx lint shared-auth,shared-ui,shared-e2e` — **limpo**.
- `nx build configuracao` — **AOT limpo** (compilação de template + CSS).
- **Visual:** anatomia e CSS são idênticos ao `uniplus-ds`, onde a mudança foi validada
  em telas claro/escuro/contraste, viewport estreito (380px) e nome longo (truncamento).

## Fora de escopo (evolução futura)

- Item "Meu perfil" navegando para uma tela de perfil dedicada.

Closes #430
