### PR TITLE
feat(configuracao): cadastros de Fase Canônica e Tipo de Banca

### DIFF
--- a/apps/configuracao-e2e/src/specs/fases-canonicas.flow.spec.ts
+++ b/apps/configuracao-e2e/src/specs/fases-canonicas.flow.spec.ts
@@ -1,0 +1,201 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+import { mockConfiguracaoRuntimeConfig } from '../support/runtime-config';
+
+/**
+ * E2E funcional do cadastro de Fase canônica (issue #393). Convenção do repo:
+ * runtime-config e API mockados por `page.route`; autenticação real (Keycloak)
+ * via projeto `fluxo-chromium` (auth-setup + storageState).
+ */
+
+const CORS_HEADERS = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'GET, POST, PUT, DELETE, OPTIONS',
+  'access-control-allow-headers': 'authorization, content-type, accept, idempotency-key',
+};
+
+const FASE_ID = '01960000-0000-7000-0000-0000000000f1';
+
+const faseSeed = {
+  id: FASE_ID,
+  codigo: 'AVALIACAO',
+  nome: 'Avaliação',
+  descricao: null,
+  donoTipico: 'CEPS',
+  agrupaEtapas: true,
+  permiteComplementacao: false,
+  baseLegal: null,
+  criadoEm: '2026-06-10T12:00:00Z',
+};
+
+async function jsonRoute(route: Route, body: unknown, status = 200): Promise<void> {
+  if (route.request().method() === 'OPTIONS') {
+    await route.fulfill({ status: 204, headers: CORS_HEADERS });
+    return;
+  }
+  await route.fulfill({
+    status,
+    contentType: 'application/json',
+    headers: CORS_HEADERS,
+    body: JSON.stringify(body),
+  });
+}
+
+interface Capturado {
+  readonly posts: unknown[];
+  readonly puts: unknown[];
+  readonly deletedIds: string[];
+}
+
+function novoCapturado(): Capturado {
+  return { posts: [], puts: [], deletedIds: [] };
+}
+
+async function mockApi(
+  page: Page,
+  capturado: Capturado,
+  lista: readonly unknown[],
+  opcoes: { readonly criarStatus?: number; readonly criarBody?: unknown } = {},
+): Promise<void> {
+  await page.route(/\/api\/configuracao\/admin\/fases-canonicas\/[^/?]+$/, async (route) => {
+    if (route.request().method() === 'DELETE') {
+      const partes = route.request().url().split('/');
+      capturado.deletedIds.push(partes[partes.length - 1] ?? '');
+      await route.fulfill({ status: 204, headers: CORS_HEADERS });
+      return;
+    }
+    if (route.request().method() === 'PUT') {
+      capturado.puts.push(route.request().postDataJSON());
+      await route.fulfill({ status: 204, headers: CORS_HEADERS });
+      return;
+    }
+    await route.fulfill({ status: 204, headers: CORS_HEADERS });
+  });
+  await page.route(/\/api\/configuracao\/admin\/fases-canonicas(\?.*)?$/, async (route) => {
+    if (route.request().method() === 'POST') {
+      capturado.posts.push(route.request().postDataJSON());
+      const status = opcoes.criarStatus ?? 201;
+      await route.fulfill({
+        status,
+        contentType: status >= 400 ? 'application/problem+json' : 'application/json',
+        headers: CORS_HEADERS,
+        body: JSON.stringify(opcoes.criarBody ?? 'nova-fase-id'),
+      });
+      return;
+    }
+    await route.fulfill({ status: 204, headers: CORS_HEADERS });
+  });
+  await page.route(/\/api\/configuracao\/fases-canonicas(\?.*)?$/, (route) => jsonRoute(route, lista));
+}
+
+async function abrirPagina(page: Page): Promise<void> {
+  await page.goto('/fases-canonicas');
+  await expect(page.getByRole('heading', { name: 'Fase Canônica', level: 1 })).toBeVisible();
+}
+
+test.describe('Fase canônica — CRUD (#393)', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockConfiguracaoRuntimeConfig(page);
+  });
+
+  test('CA-01 / CA-10: lista fases vivas e mantém o banner de código imutável', async ({ page }) => {
+    await mockApi(page, novoCapturado(), [faseSeed]);
+    await abrirPagina(page);
+
+    await expect(page.getByText('AVALIACAO')).toBeVisible();
+    await expect(page.getByText('Código imutável após criação')).toBeVisible();
+  });
+
+  test('CA-03: cria fase canônica com código, nome e dono típico válidos', async ({ page }) => {
+    const capturado = novoCapturado();
+    await mockApi(page, capturado, []);
+    await abrirPagina(page);
+
+    await page.getByRole('button', { name: 'Nova fase canônica' }).first().click();
+    await page.locator('[formControlName="codigo"]').selectOption('CLASSIFICACAO');
+    await page.locator('[formControlName="nome"]').fill('Classificação');
+    await page.locator('[formControlName="donoTipico"]').selectOption('CEPS');
+    await page.getByRole('button', { name: 'Criar fase canônica' }).click();
+
+    await expect.poll(() => capturado.posts.length).toBe(1);
+    expect(capturado.posts[0]).toMatchObject({ codigo: 'CLASSIFICACAO', nome: 'Classificação' });
+  });
+
+  test('CA-05: grupos condicionais aparecem e somem conforme o código selecionado', async ({
+    page,
+  }) => {
+    await mockApi(page, novoCapturado(), []);
+    await abrirPagina(page);
+
+    await page.getByRole('button', { name: 'Nova fase canônica' }).first().click();
+
+    await page.locator('[formControlName="codigo"]').selectOption('AVALIACAO');
+    await expect(page.locator('#cfg-fase-grupo-agrupa')).toBeVisible();
+    await expect(page.locator('#cfg-fase-grupo-compl')).toBeHidden();
+
+    await page.locator('[formControlName="codigo"]').selectOption('HOMOLOGACAO');
+    await expect(page.locator('#cfg-fase-grupo-compl')).toBeVisible();
+    await expect(page.locator('#cfg-fase-grupo-agrupa')).toBeHidden();
+
+    await page.locator('[formControlName="codigo"]').selectOption('MATRICULA');
+    await expect(page.locator('#cfg-fase-grupo-agrupa')).toBeHidden();
+    await expect(page.locator('#cfg-fase-grupo-compl')).toBeHidden();
+  });
+
+  test('CA-06 / CA-11: código é readonly na edição e o payload de atualização não inclui codigo', async ({
+    page,
+  }) => {
+    const capturado = novoCapturado();
+    await mockApi(page, capturado, [faseSeed]);
+    await abrirPagina(page);
+
+    await page.getByRole('button', { name: 'Editar' }).first().click();
+    const codigoInput = page.locator('[formControlName="codigo"]');
+    await expect(codigoInput).toHaveAttribute('readonly', '');
+    await expect(codigoInput).toHaveValue('AVALIACAO');
+
+    await page.locator('[formControlName="nome"]').fill('Avaliação (revisada)');
+    await page.getByRole('button', { name: 'Salvar fase canônica' }).click();
+
+    await expect.poll(() => capturado.puts.length).toBe(1);
+    expect(capturado.puts[0]).not.toHaveProperty('codigo');
+    expect(capturado.puts[0]).toMatchObject({ nome: 'Avaliação (revisada)' });
+  });
+
+  test('CA-07: código duplicado (409) é rejeitado com erro inline sem fechar o drawer', async ({
+    page,
+  }) => {
+    await mockApi(page, novoCapturado(), [], {
+      criarStatus: 409,
+      criarBody: {
+        type: 'https://uniplus.dev/erros/uniplus.configuracao.fase_canonica.codigo_ja_existe',
+        title: 'Já existe uma fase canônica ativa com este código',
+        status: 409,
+        code: 'uniplus.configuracao.fase_canonica.codigo_ja_existe',
+      },
+    });
+    await abrirPagina(page);
+
+    await page.getByRole('button', { name: 'Nova fase canônica' }).first().click();
+    await page.locator('[formControlName="codigo"]').selectOption('AVALIACAO');
+    await page.locator('[formControlName="nome"]').fill('Avaliação (dup)');
+    await page.locator('[formControlName="donoTipico"]').selectOption('CEPS');
+    await page.getByRole('button', { name: 'Criar fase canônica' }).click();
+
+    const codigoField = page.locator('[formControlName="codigo"]').locator('..');
+    await expect(codigoField.getByText('Já existe uma fase canônica ativa com este código')).toBeVisible();
+    await expect(page.locator('#cfg-fase-canonica-form')).toBeVisible();
+  });
+
+  test('CA-08: inativa uma fase canônica após confirmação', async ({ page }) => {
+    const capturado = novoCapturado();
+    await mockApi(page, capturado, [faseSeed]);
+    await abrirPagina(page);
+
+    await page.getByRole('button', { name: 'Inativar' }).first().click();
+    const dialog = page.locator('dialog.uni-dialog');
+    await dialog.getByRole('button', { name: 'Inativar' }).click();
+
+    await expect.poll(() => capturado.deletedIds.length).toBe(1);
+    expect(capturado.deletedIds[0]).toBe(FASE_ID);
+  });
+});

--- a/apps/configuracao-e2e/src/specs/fases-canonicas.flow.spec.ts
+++ b/apps/configuracao-e2e/src/specs/fases-canonicas.flow.spec.ts
@@ -101,7 +101,10 @@ test.describe('Fase canônica — CRUD (#393)', () => {
     await mockApi(page, novoCapturado(), [faseSeed]);
     await abrirPagina(page);
 
-    await expect(page.getByText('AVALIACAO')).toBeVisible();
+    // Escopado à tabela: o código também aparece como <option> no select
+    // (fechado) do drawer de criação, sempre presente no DOM (modo() inicia
+    // em 'criar'), o que tornaria `page.getByText('AVALIACAO')` ambíguo.
+    await expect(page.locator('table').getByText('AVALIACAO')).toBeVisible();
     await expect(page.getByText('Código imutável após criação')).toBeVisible();
   });
 

--- a/apps/configuracao-e2e/src/specs/tipos-banca.flow.spec.ts
+++ b/apps/configuracao-e2e/src/specs/tipos-banca.flow.spec.ts
@@ -102,7 +102,10 @@ test.describe('Tipo de banca — CRUD (#393)', () => {
     await mockApi(page, novoCapturado(), [bancaSeed]);
     await abrirPagina(page);
 
-    await expect(page.getByText('BANCA_ENTREVISTA')).toBeVisible();
+    // Escopado à tabela: o código também aparece como <option> no select
+    // (fechado) do drawer de criação, sempre presente no DOM (modo() inicia
+    // em 'criar'), o que tornaria `page.getByText('BANCA_ENTREVISTA')` ambíguo.
+    await expect(page.locator('table').getByText('BANCA_ENTREVISTA')).toBeVisible();
     await expect(page.getByText('Código imutável após criação')).toBeVisible();
   });
 

--- a/apps/configuracao-e2e/src/specs/tipos-banca.flow.spec.ts
+++ b/apps/configuracao-e2e/src/specs/tipos-banca.flow.spec.ts
@@ -1,0 +1,177 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+import { mockConfiguracaoRuntimeConfig } from '../support/runtime-config';
+
+/**
+ * E2E funcional do cadastro de Tipo de banca (issue #393). Convenção do repo:
+ * runtime-config e API mockados por `page.route`; autenticação real (Keycloak)
+ * via projeto `fluxo-chromium` (auth-setup + storageState).
+ */
+
+const CORS_HEADERS = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'GET, POST, PUT, DELETE, OPTIONS',
+  'access-control-allow-headers': 'authorization, content-type, accept, idempotency-key',
+};
+
+const BANCA_ID = '01960000-0000-7000-0000-0000000000b2';
+
+const bancaSeed = {
+  id: BANCA_ID,
+  codigo: 'BANCA_ENTREVISTA',
+  nome: 'Banca de Entrevista',
+  faseTipica: 'Avaliação',
+  descricao: null,
+  criadoEm: '2026-06-10T12:00:00Z',
+};
+
+async function jsonRoute(route: Route, body: unknown, status = 200): Promise<void> {
+  if (route.request().method() === 'OPTIONS') {
+    await route.fulfill({ status: 204, headers: CORS_HEADERS });
+    return;
+  }
+  await route.fulfill({
+    status,
+    contentType: 'application/json',
+    headers: CORS_HEADERS,
+    body: JSON.stringify(body),
+  });
+}
+
+interface Capturado {
+  readonly posts: unknown[];
+  readonly puts: unknown[];
+  readonly deletedIds: string[];
+}
+
+function novoCapturado(): Capturado {
+  return { posts: [], puts: [], deletedIds: [] };
+}
+
+async function mockApi(
+  page: Page,
+  capturado: Capturado,
+  lista: readonly unknown[],
+  fasesCanonicas: readonly unknown[] = [],
+): Promise<void> {
+  await page.route(/\/api\/configuracao\/admin\/tipos-banca\/[^/?]+$/, async (route) => {
+    if (route.request().method() === 'DELETE') {
+      const partes = route.request().url().split('/');
+      capturado.deletedIds.push(partes[partes.length - 1] ?? '');
+      await route.fulfill({ status: 204, headers: CORS_HEADERS });
+      return;
+    }
+    if (route.request().method() === 'PUT') {
+      capturado.puts.push(route.request().postDataJSON());
+      await route.fulfill({ status: 204, headers: CORS_HEADERS });
+      return;
+    }
+    await route.fulfill({ status: 204, headers: CORS_HEADERS });
+  });
+  await page.route(/\/api\/configuracao\/admin\/tipos-banca(\?.*)?$/, async (route) => {
+    if (route.request().method() === 'POST') {
+      capturado.posts.push(route.request().postDataJSON());
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        headers: CORS_HEADERS,
+        body: JSON.stringify('novo-tipo-banca-id'),
+      });
+      return;
+    }
+    await route.fulfill({ status: 204, headers: CORS_HEADERS });
+  });
+  await page.route(/\/api\/configuracao\/tipos-banca(\?.*)?$/, (route) => jsonRoute(route, lista));
+  await page.route(/\/api\/configuracao\/fases-canonicas(\?.*)?$/, (route) =>
+    jsonRoute(route, fasesCanonicas),
+  );
+}
+
+async function abrirPagina(page: Page): Promise<void> {
+  await page.goto('/tipos-banca');
+  await expect(page.getByRole('heading', { name: 'Tipo de Banca', level: 1 })).toBeVisible();
+}
+
+test.describe('Tipo de banca — CRUD (#393)', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockConfiguracaoRuntimeConfig(page);
+  });
+
+  test('CA-01 / CA-10: lista tipos de banca vivos e mantém o banner de código imutável', async ({
+    page,
+  }) => {
+    await mockApi(page, novoCapturado(), [bancaSeed]);
+    await abrirPagina(page);
+
+    await expect(page.getByText('BANCA_ENTREVISTA')).toBeVisible();
+    await expect(page.getByText('Código imutável após criação')).toBeVisible();
+  });
+
+  test('CA-04: cria tipo de banca com código canônico válido e nome', async ({ page }) => {
+    const capturado = novoCapturado();
+    await mockApi(page, capturado, []);
+    await abrirPagina(page);
+
+    await page.getByRole('button', { name: 'Novo tipo de banca' }).first().click();
+    await page.locator('[formControlName="codigo"]').selectOption('BANCA_ANALISE_DOCUMENTAL');
+    await page.locator('[formControlName="nome"]').fill('Banca de Análise Documental');
+    await page.getByRole('button', { name: 'Criar tipo de banca' }).click();
+
+    await expect.poll(() => capturado.posts.length).toBe(1);
+    expect(capturado.posts[0]).toMatchObject({
+      codigo: 'BANCA_ANALISE_DOCUMENTAL',
+      nome: 'Banca de Análise Documental',
+    });
+  });
+
+  test('Fase típica aceita texto livre sem corresponder a nenhuma fase canônica', async ({
+    page,
+  }) => {
+    const capturado = novoCapturado();
+    await mockApi(page, capturado, [], [{ id: 'f1', codigo: 'AVALIACAO', nome: 'Avaliação' }]);
+    await abrirPagina(page);
+
+    await page.getByRole('button', { name: 'Novo tipo de banca' }).first().click();
+    await page.locator('[formControlName="codigo"]').selectOption('BANCA_CORRECAO_REDACOES');
+    await page.locator('[formControlName="nome"]').fill('Banca de Correção');
+    await page.locator('[formControlName="faseTipica"]').fill('Uma fase qualquer sem correspondência');
+    await page.getByRole('button', { name: 'Criar tipo de banca' }).click();
+
+    await expect.poll(() => capturado.posts.length).toBe(1);
+    expect(capturado.posts[0]).toMatchObject({
+      faseTipica: 'Uma fase qualquer sem correspondência',
+    });
+  });
+
+  test('CA-06 / CA-11: código é readonly na edição e o payload de atualização não inclui codigo', async ({
+    page,
+  }) => {
+    const capturado = novoCapturado();
+    await mockApi(page, capturado, [bancaSeed]);
+    await abrirPagina(page);
+
+    await page.getByRole('button', { name: 'Editar' }).first().click();
+    const codigoInput = page.locator('[formControlName="codigo"]');
+    await expect(codigoInput).toHaveAttribute('readonly', '');
+    await expect(codigoInput).toHaveValue('BANCA_ENTREVISTA');
+
+    await page.locator('[formControlName="nome"]').fill('Banca de Entrevista (revisada)');
+    await page.getByRole('button', { name: 'Salvar tipo de banca' }).click();
+
+    await expect.poll(() => capturado.puts.length).toBe(1);
+    expect(capturado.puts[0]).not.toHaveProperty('codigo');
+    expect(capturado.puts[0]).toMatchObject({ nome: 'Banca de Entrevista (revisada)' });
+  });
+
+  test('CA-09: inativa um tipo de banca após confirmação', async ({ page }) => {
+    const capturado = novoCapturado();
+    await mockApi(page, capturado, [bancaSeed]);
+    await abrirPagina(page);
+
+    await page.getByRole('button', { name: 'Inativar' }).first().click();
+    const dialog = page.locator('dialog.uni-dialog');
+    await dialog.getByRole('button', { name: 'Inativar' }).click();
+
+    await expect.poll(() => capturado.deletedIds.length).toBe(1);
+    expect(capturado.deletedIds[0]).toBe(BANCA_ID);
+  });
+});

--- a/apps/configuracao/src/app/app.routes.ts
+++ b/apps/configuracao/src/app/app.routes.ts
@@ -67,6 +67,20 @@ export const appRoutes: Routes = [
             (m) => m.OFERTAS_CURSO_ROUTES,
           ),
       },
+      {
+        path: 'fases-canonicas',
+        data: { breadcrumb: 'Fase Canônica' },
+        loadChildren: () =>
+          import('./features/fases-canonicas/fases-canonicas.routes').then(
+            (m) => m.FASES_CANONICAS_ROUTES,
+          ),
+      },
+      {
+        path: 'tipos-banca',
+        data: { breadcrumb: 'Tipo de Banca' },
+        loadChildren: () =>
+          import('./features/tipos-banca/tipos-banca.routes').then((m) => m.TIPOS_BANCA_ROUTES),
+      },
     ],
   },
   { path: '**', redirectTo: '' },

--- a/apps/configuracao/src/app/features/fases-canonicas/fases-canonicas.page.spec.ts
+++ b/apps/configuracao/src/app/features/fases-canonicas/fases-canonicas.page.spec.ts
@@ -1,0 +1,218 @@
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ApplicationRef } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { apiResultInterceptor } from '@uniplus/shared-core/http';
+import { CONFIGURACAO_BASE_PATH, FaseCanonicaDto } from '@uniplus/shared-data/configuracao';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { FasesCanonicasPage } from './fases-canonicas.page';
+
+const BASE = 'http://localhost:5000';
+
+const faseAvaliacaoSeed: FaseCanonicaDto = {
+  id: '01960000-0000-7000-0000-0000000000f1',
+  codigo: 'AVALIACAO',
+  nome: 'Avaliação',
+  descricao: null,
+  donoTipico: 'CEPS',
+  agrupaEtapas: true,
+  permiteComplementacao: false,
+  baseLegal: null,
+  criadoEm: '2026-06-10T12:00:00Z',
+};
+
+describe('FasesCanonicasPage', () => {
+  let fixture: ComponentFixture<FasesCanonicasPage>;
+  let component: FasesCanonicasPage;
+  let controller: HttpTestingController;
+  let appRef: ApplicationRef;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [FasesCanonicasPage],
+      providers: [
+        provideHttpClient(withInterceptors([apiResultInterceptor])),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        { provide: CONFIGURACAO_BASE_PATH, useValue: BASE },
+      ],
+    });
+    fixture = TestBed.createComponent(FasesCanonicasPage);
+    component = fixture.componentInstance;
+    controller = TestBed.inject(HttpTestingController);
+    appRef = TestBed.inject(ApplicationRef);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => controller.verify());
+
+  const propagate = async (): Promise<void> => {
+    await Promise.resolve();
+    appRef.tick();
+  };
+
+  async function flushLista(itens: readonly FaseCanonicaDto[]): Promise<void> {
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/fases-canonicas`);
+    expect(req.request.params.get('limit')).toBe('50');
+    req.flush(itens);
+    await propagate();
+  }
+
+  it('CA-01: renderiza a lista de fases canônicas', async () => {
+    await flushLista([faseAvaliacaoSeed]);
+    expect(component['fases']()).toHaveLength(1);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('Avaliação');
+    expect(fixture.nativeElement.textContent).toContain('AVALIACAO');
+  });
+
+  it('CA-10: banner de código imutável é visível mesmo com lista vazia', async () => {
+    await flushLista([]);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('Código imutável após criação');
+  });
+
+  it('CA-02: filtro de dono típico filtra registros carregados', async () => {
+    const faseCrca: FaseCanonicaDto = { ...faseAvaliacaoSeed, id: 'f2', codigo: 'MATRICULA', donoTipico: 'CRCA' };
+    await flushLista([faseAvaliacaoSeed, faseCrca]);
+
+    component['donoTipicoFiltro'].set('CRCA');
+    expect(component['fasesFiltradas']()).toEqual([faseCrca]);
+  });
+
+  it('CA-05: grupo "Agrupamento de etapas" só aparece para AVALIACAO', async () => {
+    await flushLista([]);
+    component['abrirCadastro']();
+    expect(component['showGrupoAgrupa']()).toBe(false);
+
+    component['form'].controls.codigo.setValue('AVALIACAO');
+    expect(component['showGrupoAgrupa']()).toBe(true);
+    expect(component['showGrupoCompl']()).toBe(false);
+
+    component['form'].controls.codigo.setValue('HOMOLOGACAO');
+    expect(component['showGrupoAgrupa']()).toBe(false);
+    expect(component['showGrupoCompl']()).toBe(true);
+
+    component['form'].controls.codigo.setValue('MATRICULA');
+    expect(component['showGrupoAgrupa']()).toBe(false);
+    expect(component['showGrupoCompl']()).toBe(false);
+  });
+
+  it('CA-05: interação real via DOM no select [ngValue] de "Agrupa etapas" atualiza o boolean do form', async () => {
+    await flushLista([]);
+    component['abrirCadastro']();
+    component['form'].controls.codigo.setValue('AVALIACAO');
+    fixture.detectChanges();
+
+    const agrupaSelect = fixture.nativeElement.querySelector(
+      '[formControlName="agrupaEtapas"]',
+    ) as HTMLSelectElement;
+    expect(agrupaSelect).toBeTruthy();
+    expect(component['form'].controls.agrupaEtapas.value).toBe(false);
+
+    agrupaSelect.value = agrupaSelect.options[0].value; // "Sim" → [ngValue]="true"
+    agrupaSelect.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    expect(component['form'].controls.agrupaEtapas.value).toBe(true);
+  });
+
+  it('CA-05: submeter fora de AVALIACAO/HOMOLOGACAO/RECURSOS força os sinalizadores para false', async () => {
+    await flushLista([]);
+    component['abrirCadastro']();
+    component['form'].setValue({
+      codigo: 'MATRICULA',
+      donoTipico: 'CEPS',
+      nome: 'Matrícula',
+      descricao: '',
+      baseLegal: '',
+      agrupaEtapas: true, // valor "vazado" de uma seleção anterior — não deve ser enviado
+      permiteComplementacao: true,
+    });
+
+    component['salvar']();
+
+    const post = controller.expectOne(`${BASE}/api/configuracao/admin/fases-canonicas`);
+    expect(post.request.body).toMatchObject({
+      codigo: 'MATRICULA',
+      agrupaEtapas: false,
+      permiteComplementacao: false,
+    });
+    post.flush('new-id', { status: 201, statusText: 'Created' });
+    await propagate();
+    await flushLista([]);
+  });
+
+  it('CA-06: código é readonly na edição e o payload de atualização não inclui o campo codigo', async () => {
+    await flushLista([faseAvaliacaoSeed]);
+    component['abrirEdicao'](faseAvaliacaoSeed);
+    expect(component['form'].controls.codigo.value).toBe('AVALIACAO');
+    fixture.detectChanges();
+    const codigoInput = fixture.nativeElement.querySelector(
+      '[formcontrolname="codigo"]',
+    ) as HTMLInputElement;
+    expect(codigoInput.readOnly).toBe(true);
+
+    component['form'].controls.nome.setValue('Avaliação (revisada)');
+    component['salvar']();
+
+    const put = controller.expectOne(
+      `${BASE}/api/configuracao/admin/fases-canonicas/${faseAvaliacaoSeed.id}`,
+    );
+    expect(put.request.method).toBe('PUT');
+    expect(put.request.body).not.toHaveProperty('codigo');
+    expect(put.request.body).toMatchObject({ id: faseAvaliacaoSeed.id, nome: 'Avaliação (revisada)' });
+    put.flush(null, { status: 204, statusText: 'No Content' });
+    await propagate();
+    await flushLista([faseAvaliacaoSeed]);
+  });
+
+  it('CA-07: código duplicado (409) é rejeitado com erro no campo sem fechar o drawer', async () => {
+    await flushLista([]);
+    component['abrirCadastro']();
+    component['form'].setValue({
+      codigo: 'AVALIACAO',
+      donoTipico: 'CEPS',
+      nome: 'Avaliação (dup)',
+      descricao: '',
+      baseLegal: '',
+      agrupaEtapas: false,
+      permiteComplementacao: false,
+    });
+
+    component['salvar']();
+
+    const post = controller.expectOne(`${BASE}/api/configuracao/admin/fases-canonicas`);
+    post.flush(
+      {
+        type: 'https://uniplus.dev/erros/uniplus.configuracao.fase_canonica.codigo_ja_existe',
+        title: 'Já existe uma fase canônica ativa com este código',
+        status: 409,
+        code: 'uniplus.configuracao.fase_canonica.codigo_ja_existe',
+      },
+      { status: 409, statusText: 'Conflict', headers: { 'Content-Type': 'application/problem+json' } },
+    );
+    await propagate();
+
+    expect(component['formOpen']()).toBe(true);
+    expect(component['erroDoCampo']('codigo')).toContain(
+      'Já existe uma fase canônica ativa com este código',
+    );
+    expect(component['formError']()).toBeNull();
+  });
+
+  it('CA-08: inativa uma fase canônica após confirmação', async () => {
+    await flushLista([faseAvaliacaoSeed]);
+    component['pedirRemocao'](faseAvaliacaoSeed);
+    component['removerConfirmado']();
+
+    const req = controller.expectOne(
+      `${BASE}/api/configuracao/admin/fases-canonicas/${faseAvaliacaoSeed.id}`,
+    );
+    expect(req.request.method).toBe('DELETE');
+    req.flush(null, { status: 204, statusText: 'No Content' });
+    await propagate();
+    await flushLista([]);
+  });
+});

--- a/apps/configuracao/src/app/features/fases-canonicas/fases-canonicas.page.ts
+++ b/apps/configuracao/src/app/features/fases-canonicas/fases-canonicas.page.ts
@@ -1,0 +1,817 @@
+import { HttpParams } from '@angular/common/http';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  effect,
+  inject,
+  linkedSignal,
+  signal,
+  untracked,
+} from '@angular/core';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import {
+  ApiResult,
+  Cursor,
+  PaginationDirection,
+  ProblemDetails,
+  ProblemI18nService,
+  ProblemValidationError,
+  cursorToString,
+  extractNextCursor,
+  extractPrevCursor,
+  idempotencyKey,
+  useApiResource,
+  withIdempotencyKey,
+  withVendorMime,
+} from '@uniplus/shared-core/http';
+import { NotificationService } from '@uniplus/shared-core/notifications';
+import {
+  CODIGOS_FASE_CANONICA,
+  CONFIGURACAO_BASE_PATH,
+  DONOS_TIPICOS_FASE,
+  FaseCanonicaDto,
+  FasesCanonicasApi,
+  type AtualizarFaseCanonicaCommand,
+  type CriarFaseCanonicaCommand,
+} from '@uniplus/shared-data/configuracao';
+import {
+  AlertComponent,
+  ConfirmDialogComponent,
+  DrawerComponent,
+  EmptyStateComponent,
+  PagerComponent,
+  SpinnerComponent,
+} from '@uniplus/shared-ui/components';
+
+/** Tamanho da janela de cada página (cursor pagination, ADR-0026). */
+const PAGE_SIZE = 50;
+
+/** Vendor code do DomainError `FaseCanonica.CodigoJaExiste` (uniplus-api, 409 Conflict). */
+const FASE_CANONICA_CODIGO_JA_EXISTE_CODE = 'uniplus.configuracao.fase_canonica.codigo_ja_existe';
+
+type ModoFormulario = 'criar' | 'editar';
+
+interface FaseForm {
+  codigo: FormControl<string>;
+  donoTipico: FormControl<string>;
+  nome: FormControl<string>;
+  descricao: FormControl<string>;
+  baseLegal: FormControl<string>;
+  agrupaEtapas: FormControl<boolean>;
+  permiteComplementacao: FormControl<boolean>;
+}
+
+const FASE_CONTROL_NAMES: ReadonlySet<string> = new Set<keyof FaseForm>([
+  'codigo',
+  'donoTipico',
+  'nome',
+  'descricao',
+  'baseLegal',
+  'agrupaEtapas',
+  'permiteComplementacao',
+]);
+
+@Component({
+  selector: 'cfg-fases-canonicas-page',
+  standalone: true,
+  imports: [
+    ReactiveFormsModule,
+    AlertComponent,
+    ConfirmDialogComponent,
+    DrawerComponent,
+    EmptyStateComponent,
+    PagerComponent,
+    SpinnerComponent,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="page-header">
+      <div class="page-header__content">
+        <h1 class="page-header__title">Fase Canônica</h1>
+        <p class="page-header__desc">
+          Vocabulário de cronograma — momentos do ciclo de vida do processo seletivo ·
+          UNI-REQ-0064.
+        </p>
+      </div>
+    </div>
+
+    <ui-alert variant="warning" heading="Código imutável após criação" [dynamic]="false">
+      O código de uma fase canônica ou de um tipo de banca não pode ser alterado após a criação —
+      pertence ao vocabulário canônico fixo e é congelado por snapshot nos cronogramas dos
+      editais. Para corrigir, crie uma nova entrada e inative a anterior.
+    </ui-alert>
+
+    @if (errorMessage()) {
+      <ui-alert variant="danger" heading="Não foi possível carregar as fases canônicas">
+        {{ errorMessage() }}
+        <div class="cfg-fases-canonicas__retry">
+          <button
+            type="button"
+            class="btn btn--secondary btn--sm"
+            [disabled]="loading()"
+            (click)="tentarNovamente()"
+          >
+            Tentar novamente
+          </button>
+        </div>
+      </ui-alert>
+    }
+
+    <section class="panel" aria-labelledby="cfg-fases-canonicas-list-title">
+      <div class="panel-head">
+        <div class="panel-head__title">
+          <h2 id="cfg-fases-canonicas-list-title">Fases canônicas</h2>
+          @if (loading()) {
+            <span class="cfg-fases-canonicas__loading"><ui-spinner size="sm" /> Carregando</span>
+          }
+        </div>
+        <button type="button" class="btn btn--primary" (click)="abrirCadastro()">
+          <i class="pi pi-plus btn__icon" aria-hidden="true"></i>
+          Nova fase canônica
+        </button>
+      </div>
+
+      <div class="filter-bar" role="search" aria-label="Filtrar fases canônicas">
+        <div class="filter-bar__group">
+          <label class="field field--search">
+            <span class="field__label sr-only">Buscar por código ou nome</span>
+            <input
+              class="input"
+              type="search"
+              placeholder="Buscar por código ou nome…"
+              [value]="termoBusca()"
+              (input)="termoBusca.set($any($event.target).value)"
+            />
+          </label>
+          <label class="field">
+            <span class="field__label sr-only">Filtrar por dono típico</span>
+            <select class="select" [value]="donoTipicoFiltro()" (change)="donoTipicoFiltro.set($any($event.target).value)">
+              <option value="">Todos os donos típicos</option>
+              @for (dono of donosTipicos; track dono) {
+                <option [value]="dono">{{ dono }}</option>
+              }
+            </select>
+          </label>
+        </div>
+      </div>
+
+      @if (fasesFiltradas().length > 0) {
+        <div class="table-responsive">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Código</th>
+                <th scope="col">Nome</th>
+                <th scope="col">Dono típico</th>
+                <th scope="col">Agrupa etapas</th>
+                <th scope="col">Permite compl.</th>
+                <th scope="col"><span class="sr-only">Ações</span></th>
+              </tr>
+            </thead>
+            <tbody>
+              @for (fase of fasesFiltradas(); track fase.id) {
+                <tr>
+                  <td data-label="Código"><code>{{ fase.codigo }}</code></td>
+                  <td data-label="Nome">{{ fase.nome }}</td>
+                  <td data-label="Dono típico">
+                    <span class="tag">{{ fase.donoTipico || '—' }}</span>
+                  </td>
+                  <td data-label="Agrupa etapas">
+                    @if (fase.agrupaEtapas) {
+                      <span class="tag tag--success">Sim</span>
+                    } @else {
+                      <span aria-label="Não aplicável">—</span>
+                    }
+                  </td>
+                  <td data-label="Permite compl.">
+                    @if (fase.permiteComplementacao) {
+                      <span class="tag tag--success">Sim</span>
+                    } @else if (fase.codigo === 'HABILITACAO') {
+                      <span class="tag" title="Vedação SiSU">Não</span>
+                    } @else {
+                      <span aria-label="Não aplicável">—</span>
+                    }
+                  </td>
+                  <td class="table-responsive__actions" data-label="Ações">
+                    <button
+                      type="button"
+                      class="btn btn--tertiary btn--sm btn--rect"
+                      [disabled]="loading()"
+                      (click)="abrirEdicao(fase)"
+                    >
+                      Editar
+                    </button>
+                    <button
+                      type="button"
+                      class="btn btn--tertiary btn--sm btn--rect"
+                      [disabled]="loading()"
+                      (click)="pedirRemocao(fase)"
+                    >
+                      Inativar
+                    </button>
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+      } @else if (!loading() && !errorMessage()) {
+        @if (temFiltro()) {
+          <ui-empty-state
+            heading="Nenhuma fase encontrada"
+            description="Ajuste a busca ou o filtro de dono típico para ver resultados."
+          >
+            <button type="button" class="btn btn--secondary" (click)="limparFiltros()">
+              Limpar filtros
+            </button>
+          </ui-empty-state>
+        } @else {
+          <ui-empty-state
+            heading="Nenhuma fase canônica cadastrada"
+            description="Cadastre a primeira fase para montar o cronograma de processos seletivos."
+          >
+            <button type="button" class="btn btn--primary" (click)="abrirCadastro()">
+              Nova fase canônica
+            </button>
+          </ui-empty-state>
+        }
+      }
+
+      @if (prevCursor() !== null || nextCursor() !== null) {
+        <ui-pager
+          statusText="Navegação por páginas"
+          navigationLabel="Paginação de fases canônicas"
+          [hasPrevious]="prevCursor() !== null"
+          [hasNext]="nextCursor() !== null"
+          [isDisabled]="loading()"
+          (previous)="paginaAnterior()"
+          (next)="proximaPagina()"
+        />
+      }
+    </section>
+
+    <ui-drawer
+      class="cfg-form-drawer"
+      [(visible)]="formOpen"
+      [heading]="formHeading()"
+      ariaLabel="Formulário de fase canônica"
+      position="right"
+    >
+      @if (formError()) {
+        <ui-alert variant="danger" heading="Não foi possível salvar">{{ formError() }}</ui-alert>
+      }
+
+      <form
+        [formGroup]="form"
+        id="cfg-fase-canonica-form"
+        (ngSubmit)="salvar()"
+        novalidate
+        class="cfg-form"
+      >
+        <section aria-labelledby="cfg-fase-identificacao">
+          <h3 id="cfg-fase-identificacao" class="form-section__title">Identificação</h3>
+          <div class="form-grid form-grid--1col">
+            @if (modo() === 'criar') {
+              <label class="field" [class.is-error]="erroDoCampo('codigo')">
+                <span class="field__label is-required">Código</span>
+                <select
+                  class="select"
+                  formControlName="codigo"
+                  [attr.aria-invalid]="erroDoCampo('codigo') ? 'true' : null"
+                >
+                  <option value="" disabled>Selecione o código</option>
+                  @for (codigo of codigosFase; track codigo) {
+                    <option [value]="codigo">{{ codigo }}</option>
+                  }
+                </select>
+                <span class="field__hint">Imutável após a criação.</span>
+                @if (erroDoCampo('codigo')) {
+                  <span class="field__error">{{ erroDoCampo('codigo') }}</span>
+                }
+              </label>
+            } @else {
+              <label class="field" [class.is-error]="erroDoCampo('codigo')">
+                <span class="field__label is-required">Código</span>
+                <input class="input" type="text" formControlName="codigo" readonly />
+                <span class="field__hint">Imutável após criação.</span>
+                @if (erroDoCampo('codigo')) {
+                  <span class="field__error">{{ erroDoCampo('codigo') }}</span>
+                }
+              </label>
+            }
+            <label class="field" [class.is-error]="erroDoCampo('donoTipico')">
+              <span class="field__label is-required">Dono típico</span>
+              <select
+                class="select"
+                formControlName="donoTipico"
+                [attr.aria-invalid]="erroDoCampo('donoTipico') ? 'true' : null"
+              >
+                <option value="" disabled>Selecione o dono típico</option>
+                @for (dono of donosTipicos; track dono) {
+                  <option [value]="dono">{{ dono }}</option>
+                }
+              </select>
+              <span class="field__hint">
+                Rótulo orientativo, não vinculante. MEC = data delegada SiSU; CONSEPE = recurso de
+                2ª instância.
+              </span>
+              @if (erroDoCampo('donoTipico')) {
+                <span class="field__error">{{ erroDoCampo('donoTipico') }}</span>
+              }
+            </label>
+            <label class="field" [class.is-error]="erroDoCampo('nome')">
+              <span class="field__label is-required">Nome</span>
+              <input
+                class="input"
+                type="text"
+                formControlName="nome"
+                [attr.aria-invalid]="erroDoCampo('nome') ? 'true' : null"
+              />
+              @if (erroDoCampo('nome')) {
+                <span class="field__error">{{ erroDoCampo('nome') }}</span>
+              }
+            </label>
+            <label class="field">
+              <span class="field__label">Descrição</span>
+              <textarea class="textarea" formControlName="descricao"></textarea>
+            </label>
+            <label class="field">
+              <span class="field__label">Base legal</span>
+              <input class="input" type="text" formControlName="baseLegal" placeholder="Ex.: Lei 9.784/1999, art. 56" />
+              <span class="field__hint">Dispositivo legal aplicável. Opcional.</span>
+            </label>
+          </div>
+        </section>
+
+        @if (showGrupoAgrupa()) {
+          <fieldset
+            id="cfg-fase-grupo-agrupa"
+            class="form-section"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            <legend class="form-section__title">Agrupamento de etapas</legend>
+            <label class="field">
+              <span class="field__label">Agrupa etapas</span>
+              <select class="select" formControlName="agrupaEtapas">
+                <option [ngValue]="true">Sim</option>
+                <option [ngValue]="false">Não</option>
+              </select>
+              <span class="field__hint">Aplicável apenas à fase AVALIACAO.</span>
+            </label>
+          </fieldset>
+        }
+
+        @if (showGrupoCompl()) {
+          <fieldset
+            id="cfg-fase-grupo-compl"
+            class="form-section"
+            aria-live="polite"
+            aria-atomic="true"
+          >
+            <legend class="form-section__title">Complementação de documentos</legend>
+            <label class="field">
+              <span class="field__label">Permite complementação</span>
+              <select class="select" formControlName="permiteComplementacao">
+                <option [ngValue]="true">Sim</option>
+                <option [ngValue]="false">Não</option>
+              </select>
+              <span class="field__hint">Aplicável apenas às fases HOMOLOGACAO e RECURSOS.</span>
+            </label>
+          </fieldset>
+        }
+      </form>
+
+      <div class="cfg-form-footer">
+        <button type="button" class="btn btn--tertiary btn--rect" (click)="formOpen.set(false)">
+          Cancelar
+        </button>
+        <button
+          type="submit"
+          form="cfg-fase-canonica-form"
+          class="btn btn--primary"
+          [disabled]="saving()"
+        >
+          @if (saving()) {
+            <ui-spinner size="sm" />
+          }
+          {{ saving() ? 'Salvando...' : modo() === 'criar' ? 'Criar fase canônica' : 'Salvar fase canônica' }}
+        </button>
+      </div>
+    </ui-drawer>
+
+    <ui-confirm-dialog
+      [(visible)]="confirmOpen"
+      heading="Inativar fase canônica"
+      [message]="confirmMessage()"
+      confirmLabel="Inativar"
+      confirmVariant="danger"
+      (confirmed)="removerConfirmado()"
+    />
+  `,
+})
+export class FasesCanonicasPage {
+  private readonly api = inject(FasesCanonicasApi);
+  private readonly problemI18n = inject(ProblemI18nService);
+  private readonly notifications = inject(NotificationService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly basePath = inject(CONFIGURACAO_BASE_PATH);
+
+  protected readonly codigosFase = CODIGOS_FASE_CANONICA;
+  protected readonly donosTipicos = DONOS_TIPICOS_FASE;
+
+  protected readonly saving = signal(false);
+  protected readonly formOpen = signal(false);
+  protected readonly confirmOpen = signal(false);
+  protected readonly formError = signal<string | null>(null);
+  protected readonly modo = signal<ModoFormulario>('criar');
+  protected readonly faseEmEdicaoId = signal<string | null>(null);
+  protected readonly faseParaRemover = signal<FaseCanonicaDto | null>(null);
+  protected readonly idempotencyKeyAtual = signal(idempotencyKey.create());
+  protected readonly termoBusca = signal('');
+  protected readonly donoTipicoFiltro = signal('');
+
+  private readonly pagina = signal<
+    { readonly cursor: Cursor; readonly direction: PaginationDirection } | undefined
+  >(undefined);
+
+  private readonly lista = useApiResource<readonly FaseCanonicaDto[]>(() => ({
+    url: `${this.basePath}/api/configuracao/fases-canonicas`,
+    params: this.montarParams(),
+    context: withVendorMime('fase-canonica', 1),
+  }));
+
+  protected readonly loading = this.lista.isLoading;
+
+  private readonly cursores = linkedSignal<
+    ApiResult<readonly FaseCanonicaDto[]> | undefined,
+    { readonly prev: Cursor | null; readonly next: Cursor | null }
+  >({
+    source: () => this.lista.value(),
+    computation: (envelope, previous) => {
+      const atual = previous?.value ?? { prev: null, next: null };
+      if (envelope === undefined) {
+        return atual;
+      }
+      const primeiraPagina = untracked(() => this.pagina() === undefined);
+      if (!envelope.ok) {
+        return primeiraPagina ? { prev: null, next: null } : atual;
+      }
+      const link = untracked(() => this.lista.headers()?.get('Link') ?? null);
+      return { prev: extractPrevCursor(link), next: extractNextCursor(link) };
+    },
+  });
+
+  protected readonly prevCursor = computed(() => this.cursores().prev);
+  protected readonly nextCursor = computed(() => this.cursores().next);
+
+  protected readonly fases = linkedSignal<
+    ApiResult<readonly FaseCanonicaDto[]> | undefined,
+    readonly FaseCanonicaDto[]
+  >({
+    source: () => this.lista.value(),
+    computation: (envelope, previous) => {
+      const atual = previous?.value ?? [];
+      if (envelope === undefined) {
+        return atual;
+      }
+      const primeiraPagina = untracked(() => this.pagina() === undefined);
+      if (!envelope.ok) {
+        return primeiraPagina ? [] : atual;
+      }
+      return [...envelope.data];
+    },
+  });
+
+  // Busca e filtro de dono típico client-side sobre a página carregada: o
+  // backend (api#592) só pagina por cursor, sem filtro de texto/dono no
+  // contrato (GET /api/configuracao/fases-canonicas aceita só cursor/limit/direction).
+  protected readonly fasesFiltradas = computed(() => {
+    const termo = this.termoBusca().trim().toLocaleLowerCase('pt-BR');
+    const dono = this.donoTipicoFiltro();
+    return this.fases().filter((fase) => {
+      const casaTermo =
+        termo.length === 0 ||
+        fase.codigo.toLocaleLowerCase('pt-BR').includes(termo) ||
+        fase.nome.toLocaleLowerCase('pt-BR').includes(termo);
+      const casaDono = dono.length === 0 || fase.donoTipico === dono;
+      return casaTermo && casaDono;
+    });
+  });
+
+  protected readonly temFiltro = computed(
+    () => this.termoBusca().trim().length > 0 || this.donoTipicoFiltro().length > 0,
+  );
+
+  protected readonly errorMessage = computed<string | null>(() => {
+    const problem = this.lista.problem();
+    if (problem) {
+      return this.problemI18n.resolve(problem).title;
+    }
+    return this.lista.error() ? 'Erro inesperado ao carregar fases canônicas.' : null;
+  });
+
+  protected readonly formHeading = computed(() =>
+    this.modo() === 'criar' ? 'Nova fase canônica' : 'Editar fase canônica',
+  );
+
+  protected readonly confirmMessage = computed(() => {
+    const fase = this.faseParaRemover();
+    return fase
+      ? `Deseja inativar a fase ${fase.codigo}? A inativação impede novos editais de utilizar esta fase, mas não altera o que já foi congelado — a cópia por valor de cada cronograma permanece íntegra (snapshot-copy desacoplado) e não bloqueia esta remoção lógica.`
+      : 'Deseja inativar esta fase canônica?';
+  });
+
+  protected readonly form: FormGroup<FaseForm> = new FormGroup<FaseForm>({
+    codigo: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
+    donoTipico: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
+    nome: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required, Validators.maxLength(255)],
+    }),
+    descricao: new FormControl('', { nonNullable: true }),
+    baseLegal: new FormControl('', { nonNullable: true }),
+    agrupaEtapas: new FormControl(false, { nonNullable: true }),
+    permiteComplementacao: new FormControl(false, { nonNullable: true }),
+  });
+
+  // Código selecionado atual — reage tanto ao `select` de criação quanto ao
+  // `form.reset()` da edição, para controlar a visibilidade dos grupos
+  // condicionais (ADR de UI da story #393: fieldset segue o código, não o modo).
+  private readonly codigoAtual = toSignal(this.form.controls.codigo.valueChanges, {
+    initialValue: this.form.controls.codigo.value,
+  });
+
+  protected readonly showGrupoAgrupa = computed(() => this.codigoAtual() === 'AVALIACAO');
+  protected readonly showGrupoCompl = computed(
+    () => this.codigoAtual() === 'HOMOLOGACAO' || this.codigoAtual() === 'RECURSOS',
+  );
+
+  constructor() {
+    effect(() => {
+      const problem = this.lista.problem();
+      if (problem && problem.status >= 500) {
+        const titulo = this.problemI18n.resolve(problem).title;
+        untracked(() => this.notifications.errorFromProblem(problem, { title: titulo }));
+      }
+    });
+  }
+
+  protected proximaPagina(): void {
+    const proximo = this.nextCursor();
+    if (proximo !== null && !this.loading()) {
+      this.pagina.set({ cursor: proximo, direction: 'next' });
+    }
+  }
+
+  protected paginaAnterior(): void {
+    const anterior = this.prevCursor();
+    if (anterior !== null && !this.loading()) {
+      this.pagina.set({ cursor: anterior, direction: 'prev' });
+    }
+  }
+
+  protected tentarNovamente(): void {
+    if (!this.loading()) {
+      this.lista.reload();
+    }
+  }
+
+  protected limparFiltros(): void {
+    this.termoBusca.set('');
+    this.donoTipicoFiltro.set('');
+  }
+
+  protected abrirCadastro(): void {
+    this.modo.set('criar');
+    this.faseEmEdicaoId.set(null);
+    this.form.reset({
+      codigo: '',
+      donoTipico: '',
+      nome: '',
+      descricao: '',
+      baseLegal: '',
+      agrupaEtapas: false,
+      permiteComplementacao: false,
+    });
+    this.formError.set(null);
+    this.idempotencyKeyAtual.set(idempotencyKey.create());
+    this.formOpen.set(true);
+  }
+
+  protected abrirEdicao(fase: FaseCanonicaDto): void {
+    this.modo.set('editar');
+    this.faseEmEdicaoId.set(fase.id);
+    this.form.reset({
+      codigo: fase.codigo,
+      donoTipico: fase.donoTipico ?? '',
+      nome: fase.nome,
+      descricao: fase.descricao ?? '',
+      baseLegal: fase.baseLegal ?? '',
+      agrupaEtapas: fase.agrupaEtapas,
+      permiteComplementacao: fase.permiteComplementacao,
+    });
+    this.formError.set(null);
+    this.idempotencyKeyAtual.set(idempotencyKey.create());
+    this.formOpen.set(true);
+  }
+
+  protected pedirRemocao(fase: FaseCanonicaDto): void {
+    this.faseParaRemover.set(fase);
+    this.confirmOpen.set(true);
+  }
+
+  protected removerConfirmado(): void {
+    const fase = this.faseParaRemover();
+    if (fase === null || this.saving()) {
+      return;
+    }
+    this.saving.set(true);
+    this.api
+      .remover(fase.id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((result) => {
+        this.saving.set(false);
+        if (result.ok) {
+          this.notifications.success('Fase canônica inativada', fase.codigo);
+          this.confirmOpen.set(false);
+          this.faseParaRemover.set(null);
+          this.recarregar();
+          return;
+        }
+        this.notifications.errorFromProblem(result.problem, {
+          title: this.problemI18n.resolve(result.problem).title,
+        });
+      });
+  }
+
+  protected salvar(): void {
+    if (this.saving()) {
+      return;
+    }
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    this.saving.set(true);
+    this.formError.set(null);
+
+    if (this.modo() === 'criar') {
+      this.api
+        .criar(this.criarCommand(), withIdempotencyKey(this.idempotencyKeyAtual()))
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe((result) => this.handleSalvarResult(result));
+      return;
+    }
+
+    this.api
+      .atualizar(
+        this.faseEmEdicaoId() ?? '',
+        this.atualizarCommand(),
+        withIdempotencyKey(this.idempotencyKeyAtual()),
+      )
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((result) => this.handleSalvarResult(result));
+  }
+
+  protected erroDoCampo(nome: keyof FaseForm): string | null {
+    const control = this.form.controls[nome];
+    const shouldShowError = control.touched || control.dirty;
+    if (!shouldShowError || control.errors === null) {
+      return null;
+    }
+    if (control.errors['backend']) {
+      const backend = control.errors['backend'] as { code: string; message: string };
+      return backend.message;
+    }
+    if (control.errors['required']) return 'Campo obrigatório.';
+    if (control.errors['maxlength']) return 'Valor acima do tamanho permitido.';
+    return 'Valor inválido.';
+  }
+
+  private montarParams(): HttpParams {
+    const pagina = this.pagina();
+    if (pagina === undefined) {
+      return new HttpParams().set('limit', String(PAGE_SIZE));
+    }
+    return new HttpParams()
+      .set('cursor', cursorToString(pagina.cursor))
+      .set('direction', pagina.direction);
+  }
+
+  private recarregar(): void {
+    if (this.pagina() === undefined) {
+      this.lista.reload();
+    } else {
+      this.pagina.set(undefined);
+    }
+  }
+
+  private handleSalvarResult(result: ApiResult<string | void>): void {
+    this.saving.set(false);
+    if (result.ok) {
+      this.notifications.success(
+        this.modo() === 'criar' ? 'Fase canônica criada' : 'Fase canônica atualizada',
+      );
+      this.formOpen.set(false);
+      this.idempotencyKeyAtual.set(idempotencyKey.create());
+      this.recarregar();
+      return;
+    }
+    this.aplicarFalha(result.problem);
+  }
+
+  private aplicarFalha(problem: ProblemDetails): void {
+    if (problem.status === 422 && problem.errors && problem.errors.length > 0) {
+      this.renovarIdempotencyKey();
+      this.aplicarErrosDeValidacao(problem.errors);
+      return;
+    }
+    // FaseCanonica.CodigoJaExiste é um DomainError único (409, sem `errors[]`
+    // — esse array só existe no pipeline FluentValidation/422); mapeado ao
+    // campo manualmente para exibir o erro inline exigido pelo CA-07.
+    if (problem.code === FASE_CANONICA_CODIGO_JA_EXISTE_CODE) {
+      this.renovarIdempotencyKey();
+      this.form.controls.codigo.setErrors({
+        backend: { code: problem.code, message: this.problemI18n.resolve(problem).title },
+      });
+      this.form.controls.codigo.markAsTouched();
+      return;
+    }
+    if (problem.status === 409 || problem.code === 'uniplus.idempotency.body_mismatch') {
+      this.renovarIdempotencyKey();
+    }
+    this.formError.set(this.problemI18n.resolve(problem).title);
+    if (problem.status >= 500) {
+      this.notifications.errorFromProblem(problem);
+    }
+  }
+
+  private renovarIdempotencyKey(): void {
+    this.idempotencyKeyAtual.set(idempotencyKey.create());
+  }
+
+  private aplicarErrosDeValidacao(errors: ReadonlyArray<ProblemValidationError>): void {
+    let aplicouAlgum = false;
+    for (const erro of errors) {
+      const controlName = controlNameFromBackendField(erro.field);
+      if (controlName === null) continue;
+      const control = this.form.controls[controlName];
+      control.setErrors({ backend: { code: erro.code, message: erro.message } });
+      control.markAsTouched();
+      aplicouAlgum = true;
+    }
+
+    if (aplicouAlgum) {
+      this.formError.set(null);
+      return;
+    }
+    this.formError.set('Não foi possível mapear os erros de validação. Revise os campos.');
+  }
+
+  private criarCommand(): CriarFaseCanonicaCommand {
+    const raw = this.form.getRawValue();
+    return {
+      codigo: raw.codigo,
+      nome: raw.nome.trim(),
+      descricao: nullIfBlank(raw.descricao),
+      donoTipico: nullIfBlank(raw.donoTipico),
+      agrupaEtapas: raw.codigo === 'AVALIACAO' ? raw.agrupaEtapas : false,
+      permiteComplementacao:
+        raw.codigo === 'HOMOLOGACAO' || raw.codigo === 'RECURSOS' ? raw.permiteComplementacao : false,
+      baseLegal: nullIfBlank(raw.baseLegal),
+    };
+  }
+
+  private atualizarCommand(): AtualizarFaseCanonicaCommand {
+    const raw = this.form.getRawValue();
+    return {
+      id: this.faseEmEdicaoId() ?? '',
+      nome: raw.nome.trim(),
+      descricao: nullIfBlank(raw.descricao),
+      donoTipico: nullIfBlank(raw.donoTipico),
+      agrupaEtapas: raw.codigo === 'AVALIACAO' ? raw.agrupaEtapas : false,
+      permiteComplementacao:
+        raw.codigo === 'HOMOLOGACAO' || raw.codigo === 'RECURSOS' ? raw.permiteComplementacao : false,
+      baseLegal: nullIfBlank(raw.baseLegal),
+    };
+  }
+}
+
+function controlNameFromBackendField(field: string): keyof FaseForm | null {
+  const normalized =
+    field
+      .split('.')
+      .at(-1)
+      ?.replace(/\[\d+\]$/u, '') ?? field;
+  const camelCase = normalized.charAt(0).toLocaleLowerCase('pt-BR') + normalized.slice(1);
+  return FASE_CONTROL_NAMES.has(camelCase) ? (camelCase as keyof FaseForm) : null;
+}
+
+function nullIfBlank(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/apps/configuracao/src/app/features/fases-canonicas/fases-canonicas.routes.ts
+++ b/apps/configuracao/src/app/features/fases-canonicas/fases-canonicas.routes.ts
@@ -1,0 +1,8 @@
+import { Routes } from '@angular/router';
+
+export const FASES_CANONICAS_ROUTES: Routes = [
+  {
+    path: '',
+    loadComponent: () => import('./fases-canonicas.page').then((m) => m.FasesCanonicasPage),
+  },
+];

--- a/apps/configuracao/src/app/features/tipos-banca/tipos-banca.page.spec.ts
+++ b/apps/configuracao/src/app/features/tipos-banca/tipos-banca.page.spec.ts
@@ -1,0 +1,215 @@
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ApplicationRef } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { apiResultInterceptor } from '@uniplus/shared-core/http';
+import { CONFIGURACAO_BASE_PATH, TipoBancaDto } from '@uniplus/shared-data/configuracao';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { TiposBancaPage } from './tipos-banca.page';
+
+const BASE = 'http://localhost:5000';
+
+const bancaSeed: TipoBancaDto = {
+  id: '01960000-0000-7000-0000-0000000000b2',
+  codigo: 'BANCA_ENTREVISTA',
+  nome: 'Banca de Entrevista',
+  faseTipica: 'Avaliação',
+  descricao: null,
+  criadoEm: '2026-06-10T12:00:00Z',
+};
+
+describe('TiposBancaPage', () => {
+  let fixture: ComponentFixture<TiposBancaPage>;
+  let component: TiposBancaPage;
+  let controller: HttpTestingController;
+  let appRef: ApplicationRef;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TiposBancaPage],
+      providers: [
+        provideHttpClient(withInterceptors([apiResultInterceptor])),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        { provide: CONFIGURACAO_BASE_PATH, useValue: BASE },
+      ],
+    });
+    fixture = TestBed.createComponent(TiposBancaPage);
+    component = fixture.componentInstance;
+    controller = TestBed.inject(HttpTestingController);
+    appRef = TestBed.inject(ApplicationRef);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => controller.verify());
+
+  const propagate = async (): Promise<void> => {
+    await Promise.resolve();
+    appRef.tick();
+  };
+
+  async function flushLista(itens: readonly TipoBancaDto[]): Promise<void> {
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/tipos-banca`);
+    expect(req.request.params.get('limit')).toBe('50');
+    req.flush(itens);
+    await propagate();
+  }
+
+  it('CA-01: renderiza a lista de tipos de banca', async () => {
+    await flushLista([bancaSeed]);
+    expect(component['bancas']()).toHaveLength(1);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('Banca de Entrevista');
+    expect(fixture.nativeElement.textContent).toContain('BANCA_ENTREVISTA');
+  });
+
+  it('CA-10: banner de código imutável é visível mesmo com lista vazia', async () => {
+    await flushLista([]);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('Código imutável após criação');
+  });
+
+  it('CA-04: cria tipo de banca com código canônico válido e nome', async () => {
+    await flushLista([]);
+    component['abrirCadastro']();
+
+    // Abrir o cadastro dispara o carregamento lazy das sugestões de fase típica
+    // — o `httpResource` só emite a request após um tick (mesmo padrão de
+    // `opcoesSuperiorResource` em unidades.page.spec.ts).
+    await propagate();
+    const sugestoes = controller.expectOne(
+      (r) => r.url === `${BASE}/api/configuracao/fases-canonicas`,
+    );
+    sugestoes.flush([]);
+    await propagate();
+
+    component['form'].setValue({
+      codigo: 'BANCA_ANALISE_DOCUMENTAL',
+      nome: 'Banca de Análise Documental',
+      faseTipica: 'Homologação',
+      descricao: '',
+    });
+
+    component['salvar']();
+
+    const post = controller.expectOne(`${BASE}/api/configuracao/admin/tipos-banca`);
+    expect(post.request.method).toBe('POST');
+    expect(post.request.body).toMatchObject({
+      codigo: 'BANCA_ANALISE_DOCUMENTAL',
+      nome: 'Banca de Análise Documental',
+      faseTipica: 'Homologação',
+    });
+    post.flush('new-id', { status: 201, statusText: 'Created' });
+    await propagate();
+    await flushLista([bancaSeed]);
+    expect(component['formOpen']()).toBe(false);
+  });
+
+  it('CA-06: código é readonly na edição e o payload de atualização não inclui o campo codigo', async () => {
+    await flushLista([bancaSeed]);
+    component['abrirEdicao'](bancaSeed);
+    await propagate();
+
+    const sugestoes = controller.expectOne(
+      (r) => r.url === `${BASE}/api/configuracao/fases-canonicas`,
+    );
+    sugestoes.flush([]);
+    await propagate();
+
+    expect(component['form'].controls.codigo.value).toBe('BANCA_ENTREVISTA');
+    fixture.detectChanges();
+    const codigoInput = fixture.nativeElement.querySelector(
+      '[formcontrolname="codigo"]',
+    ) as HTMLInputElement;
+    expect(codigoInput.readOnly).toBe(true);
+
+    component['form'].controls.nome.setValue('Banca de Entrevista (revisada)');
+    component['salvar']();
+
+    const put = controller.expectOne(`${BASE}/api/configuracao/admin/tipos-banca/${bancaSeed.id}`);
+    expect(put.request.method).toBe('PUT');
+    expect(put.request.body).not.toHaveProperty('codigo');
+    expect(put.request.body).toMatchObject({
+      id: bancaSeed.id,
+      nome: 'Banca de Entrevista (revisada)',
+    });
+    put.flush(null, { status: 204, statusText: 'No Content' });
+    await propagate();
+    await flushLista([bancaSeed]);
+  });
+
+  it('aceita "Fase típica" como texto livre não vinculado ao cadastro de fases', async () => {
+    await flushLista([]);
+    component['abrirCadastro']();
+    await propagate();
+    const sugestoes = controller.expectOne(
+      (r) => r.url === `${BASE}/api/configuracao/fases-canonicas`,
+    );
+    sugestoes.flush([]);
+    await propagate();
+
+    component['form'].setValue({
+      codigo: 'BANCA_CORRECAO_REDACOES',
+      nome: 'Banca de Correção',
+      faseTipica: 'Uma fase qualquer sem correspondência',
+      descricao: '',
+    });
+    component['salvar']();
+
+    const post = controller.expectOne(`${BASE}/api/configuracao/admin/tipos-banca`);
+    expect(post.request.body).toMatchObject({ faseTipica: 'Uma fase qualquer sem correspondência' });
+    post.flush('new-id', { status: 201, statusText: 'Created' });
+    await propagate();
+    await flushLista([]);
+  });
+
+  it('código duplicado (409) é rejeitado com erro no campo sem fechar o drawer', async () => {
+    await flushLista([]);
+    component['abrirCadastro']();
+    await propagate();
+    const sugestoes = controller.expectOne(
+      (r) => r.url === `${BASE}/api/configuracao/fases-canonicas`,
+    );
+    sugestoes.flush([]);
+    await propagate();
+
+    component['form'].setValue({
+      codigo: 'BANCA_ENTREVISTA',
+      nome: 'Banca de Entrevista (dup)',
+      faseTipica: '',
+      descricao: '',
+    });
+    component['salvar']();
+
+    const post = controller.expectOne(`${BASE}/api/configuracao/admin/tipos-banca`);
+    post.flush(
+      {
+        type: 'https://uniplus.dev/erros/uniplus.configuracao.tipo_banca.codigo_ja_existe',
+        title: 'Já existe um tipo de banca ativo com este código',
+        status: 409,
+        code: 'uniplus.configuracao.tipo_banca.codigo_ja_existe',
+      },
+      { status: 409, statusText: 'Conflict', headers: { 'Content-Type': 'application/problem+json' } },
+    );
+    await propagate();
+
+    expect(component['formOpen']()).toBe(true);
+    expect(component['erroDoCampo']('codigo')).toContain(
+      'Já existe um tipo de banca ativo com este código',
+    );
+    expect(component['formError']()).toBeNull();
+  });
+
+  it('CA-09: inativa um tipo de banca após confirmação', async () => {
+    await flushLista([bancaSeed]);
+    component['pedirRemocao'](bancaSeed);
+    component['removerConfirmado']();
+
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/tipos-banca/${bancaSeed.id}`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush(null, { status: 204, statusText: 'No Content' });
+    await propagate();
+    await flushLista([]);
+  });
+});

--- a/apps/configuracao/src/app/features/tipos-banca/tipos-banca.page.ts
+++ b/apps/configuracao/src/app/features/tipos-banca/tipos-banca.page.ts
@@ -1,0 +1,724 @@
+import { HttpParams } from '@angular/common/http';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  effect,
+  inject,
+  linkedSignal,
+  signal,
+  untracked,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import {
+  ApiResult,
+  Cursor,
+  PaginationDirection,
+  ProblemDetails,
+  ProblemI18nService,
+  ProblemValidationError,
+  cursorToString,
+  extractNextCursor,
+  extractPrevCursor,
+  idempotencyKey,
+  useApiResource,
+  withIdempotencyKey,
+  withVendorMime,
+} from '@uniplus/shared-core/http';
+import { NotificationService } from '@uniplus/shared-core/notifications';
+import {
+  CODIGOS_TIPO_BANCA,
+  CONFIGURACAO_BASE_PATH,
+  FaseCanonicaDto,
+  TipoBancaDto,
+  TiposBancaApi,
+  type AtualizarTipoBancaCommand,
+  type CriarTipoBancaCommand,
+} from '@uniplus/shared-data/configuracao';
+import {
+  AlertComponent,
+  ConfirmDialogComponent,
+  DrawerComponent,
+  EmptyStateComponent,
+  PagerComponent,
+  SpinnerComponent,
+} from '@uniplus/shared-ui/components';
+
+/** Tamanho da janela de cada página (cursor pagination, ADR-0026). */
+const PAGE_SIZE = 50;
+
+/** Vendor code do DomainError `TipoBanca.CodigoJaExiste` (uniplus-api, 409 Conflict). */
+const TIPO_BANCA_CODIGO_JA_EXISTE_CODE = 'uniplus.configuracao.tipo_banca.codigo_ja_existe';
+
+type ModoFormulario = 'criar' | 'editar';
+
+interface BancaForm {
+  codigo: FormControl<string>;
+  nome: FormControl<string>;
+  faseTipica: FormControl<string>;
+  descricao: FormControl<string>;
+}
+
+const BANCA_CONTROL_NAMES: ReadonlySet<string> = new Set<keyof BancaForm>([
+  'codigo',
+  'nome',
+  'faseTipica',
+  'descricao',
+]);
+
+@Component({
+  selector: 'cfg-tipos-banca-page',
+  standalone: true,
+  imports: [
+    ReactiveFormsModule,
+    AlertComponent,
+    ConfirmDialogComponent,
+    DrawerComponent,
+    EmptyStateComponent,
+    PagerComponent,
+    SpinnerComponent,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="page-header">
+      <div class="page-header__content">
+        <h1 class="page-header__title">Tipo de Banca</h1>
+        <p class="page-header__desc">
+          Vocabulário de cronograma — categorias de banca que atuam ao longo do processo seletivo
+          · UNI-REQ-0064.
+        </p>
+      </div>
+    </div>
+
+    <ui-alert variant="warning" heading="Código imutável após criação" [dynamic]="false">
+      O código de uma fase canônica ou de um tipo de banca não pode ser alterado após a criação —
+      pertence ao vocabulário canônico fixo e é congelado por snapshot nos cronogramas dos
+      editais. Para corrigir, crie uma nova entrada e inative a anterior.
+    </ui-alert>
+
+    @if (errorMessage()) {
+      <ui-alert variant="danger" heading="Não foi possível carregar os tipos de banca">
+        {{ errorMessage() }}
+        <div class="cfg-tipos-banca__retry">
+          <button
+            type="button"
+            class="btn btn--secondary btn--sm"
+            [disabled]="loading()"
+            (click)="tentarNovamente()"
+          >
+            Tentar novamente
+          </button>
+        </div>
+      </ui-alert>
+    }
+
+    <section class="panel" aria-labelledby="cfg-tipos-banca-list-title">
+      <div class="panel-head">
+        <div class="panel-head__title">
+          <h2 id="cfg-tipos-banca-list-title">Tipos de banca</h2>
+          @if (loading()) {
+            <span class="cfg-tipos-banca__loading"><ui-spinner size="sm" /> Carregando</span>
+          }
+        </div>
+        <button type="button" class="btn btn--primary" (click)="abrirCadastro()">
+          <i class="pi pi-plus btn__icon" aria-hidden="true"></i>
+          Novo tipo de banca
+        </button>
+      </div>
+
+      <div class="filter-bar" role="search" aria-label="Filtrar tipos de banca">
+        <div class="filter-bar__group">
+          <label class="field field--search">
+            <span class="field__label sr-only">Buscar por código ou nome</span>
+            <input
+              class="input"
+              type="search"
+              placeholder="Buscar por código ou nome…"
+              [value]="termoBusca()"
+              (input)="termoBusca.set($any($event.target).value)"
+            />
+          </label>
+        </div>
+      </div>
+
+      @if (bancasFiltradas().length > 0) {
+        <div class="table-responsive">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Código</th>
+                <th scope="col">Nome</th>
+                <th scope="col">Fase típica</th>
+                <th scope="col"><span class="sr-only">Ações</span></th>
+              </tr>
+            </thead>
+            <tbody>
+              @for (banca of bancasFiltradas(); track banca.id) {
+                <tr>
+                  <td data-label="Código"><code>{{ banca.codigo }}</code></td>
+                  <td data-label="Nome">{{ banca.nome }}</td>
+                  <td data-label="Fase típica">{{ banca.faseTipica || '—' }}</td>
+                  <td class="table-responsive__actions" data-label="Ações">
+                    <button
+                      type="button"
+                      class="btn btn--tertiary btn--sm btn--rect"
+                      [disabled]="loading()"
+                      (click)="abrirEdicao(banca)"
+                    >
+                      Editar
+                    </button>
+                    <button
+                      type="button"
+                      class="btn btn--tertiary btn--sm btn--rect"
+                      [disabled]="loading()"
+                      (click)="pedirRemocao(banca)"
+                    >
+                      Inativar
+                    </button>
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+      } @else if (!loading() && !errorMessage()) {
+        @if (temFiltro()) {
+          <ui-empty-state
+            heading="Nenhum tipo de banca encontrado"
+            description="Ajuste a busca para ver resultados."
+          >
+            <button type="button" class="btn btn--secondary" (click)="limparFiltros()">
+              Limpar filtros
+            </button>
+          </ui-empty-state>
+        } @else {
+          <ui-empty-state
+            heading="Nenhum tipo de banca cadastrado"
+            description="Cadastre o primeiro tipo de banca para montar o cronograma de processos seletivos."
+          >
+            <button type="button" class="btn btn--primary" (click)="abrirCadastro()">
+              Novo tipo de banca
+            </button>
+          </ui-empty-state>
+        }
+      }
+
+      @if (prevCursor() !== null || nextCursor() !== null) {
+        <ui-pager
+          statusText="Navegação por páginas"
+          navigationLabel="Paginação de tipos de banca"
+          [hasPrevious]="prevCursor() !== null"
+          [hasNext]="nextCursor() !== null"
+          [isDisabled]="loading()"
+          (previous)="paginaAnterior()"
+          (next)="proximaPagina()"
+        />
+      }
+    </section>
+
+    <ui-drawer
+      class="cfg-form-drawer"
+      [(visible)]="formOpen"
+      [heading]="formHeading()"
+      ariaLabel="Formulário de tipo de banca"
+      position="right"
+    >
+      @if (formError()) {
+        <ui-alert variant="danger" heading="Não foi possível salvar">{{ formError() }}</ui-alert>
+      }
+
+      <form
+        [formGroup]="form"
+        id="cfg-tipo-banca-form"
+        (ngSubmit)="salvar()"
+        novalidate
+        class="cfg-form"
+      >
+        <section aria-labelledby="cfg-banca-identificacao">
+          <h3 id="cfg-banca-identificacao" class="form-section__title">Identificação</h3>
+          <div class="form-grid form-grid--1col">
+            @if (modo() === 'criar') {
+              <label class="field" [class.is-error]="erroDoCampo('codigo')">
+                <span class="field__label is-required">Código</span>
+                <select
+                  class="select"
+                  formControlName="codigo"
+                  [attr.aria-invalid]="erroDoCampo('codigo') ? 'true' : null"
+                >
+                  <option value="" disabled>Selecione o código</option>
+                  @for (codigo of codigosBanca; track codigo) {
+                    <option [value]="codigo">{{ codigo }}</option>
+                  }
+                </select>
+                <span class="field__hint">Imutável após a criação.</span>
+                @if (erroDoCampo('codigo')) {
+                  <span class="field__error">{{ erroDoCampo('codigo') }}</span>
+                }
+              </label>
+            } @else {
+              <label class="field" [class.is-error]="erroDoCampo('codigo')">
+                <span class="field__label is-required">Código</span>
+                <input class="input" type="text" formControlName="codigo" readonly />
+                <span class="field__hint">Imutável após criação.</span>
+                @if (erroDoCampo('codigo')) {
+                  <span class="field__error">{{ erroDoCampo('codigo') }}</span>
+                }
+              </label>
+            }
+            <label class="field" [class.is-error]="erroDoCampo('nome')">
+              <span class="field__label is-required">Nome</span>
+              <input
+                class="input"
+                type="text"
+                formControlName="nome"
+                [attr.aria-invalid]="erroDoCampo('nome') ? 'true' : null"
+              />
+              @if (erroDoCampo('nome')) {
+                <span class="field__error">{{ erroDoCampo('nome') }}</span>
+              }
+            </label>
+            <label class="field">
+              <span class="field__label">Fase típica</span>
+              <input
+                class="input"
+                type="text"
+                formControlName="faseTipica"
+                list="cfg-fase-tipica-sugestoes"
+              />
+              <datalist id="cfg-fase-tipica-sugestoes">
+                @for (nome of sugestoesFaseTipica(); track nome) {
+                  <option [value]="nome"></option>
+                }
+              </datalist>
+              <span class="field__hint">
+                Fase em que a banca usualmente atua — rótulo orientativo, não é vínculo com o
+                cadastro de fases. Aceita qualquer texto.
+              </span>
+            </label>
+            <label class="field">
+              <span class="field__label">Descrição</span>
+              <textarea class="textarea" formControlName="descricao"></textarea>
+            </label>
+          </div>
+        </section>
+      </form>
+
+      <div class="cfg-form-footer">
+        <button type="button" class="btn btn--tertiary btn--rect" (click)="formOpen.set(false)">
+          Cancelar
+        </button>
+        <button
+          type="submit"
+          form="cfg-tipo-banca-form"
+          class="btn btn--primary"
+          [disabled]="saving()"
+        >
+          @if (saving()) {
+            <ui-spinner size="sm" />
+          }
+          {{ saving() ? 'Salvando...' : modo() === 'criar' ? 'Criar tipo de banca' : 'Salvar tipo de banca' }}
+        </button>
+      </div>
+    </ui-drawer>
+
+    <ui-confirm-dialog
+      [(visible)]="confirmOpen"
+      heading="Inativar tipo de banca"
+      [message]="confirmMessage()"
+      confirmLabel="Inativar"
+      confirmVariant="danger"
+      (confirmed)="removerConfirmado()"
+    />
+  `,
+})
+export class TiposBancaPage {
+  private readonly api = inject(TiposBancaApi);
+  private readonly problemI18n = inject(ProblemI18nService);
+  private readonly notifications = inject(NotificationService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly basePath = inject(CONFIGURACAO_BASE_PATH);
+
+  protected readonly codigosBanca = CODIGOS_TIPO_BANCA;
+
+  protected readonly saving = signal(false);
+  protected readonly formOpen = signal(false);
+  protected readonly confirmOpen = signal(false);
+  protected readonly formError = signal<string | null>(null);
+  protected readonly modo = signal<ModoFormulario>('criar');
+  protected readonly bancaEmEdicaoId = signal<string | null>(null);
+  protected readonly bancaParaRemover = signal<TipoBancaDto | null>(null);
+  protected readonly idempotencyKeyAtual = signal(idempotencyKey.create());
+  protected readonly termoBusca = signal('');
+
+  private readonly pagina = signal<
+    { readonly cursor: Cursor; readonly direction: PaginationDirection } | undefined
+  >(undefined);
+
+  private readonly lista = useApiResource<readonly TipoBancaDto[]>(() => ({
+    url: `${this.basePath}/api/configuracao/tipos-banca`,
+    params: this.montarParams(),
+    context: withVendorMime('tipo-banca', 1),
+  }));
+
+  protected readonly loading = this.lista.isLoading;
+
+  private readonly cursores = linkedSignal<
+    ApiResult<readonly TipoBancaDto[]> | undefined,
+    { readonly prev: Cursor | null; readonly next: Cursor | null }
+  >({
+    source: () => this.lista.value(),
+    computation: (envelope, previous) => {
+      const atual = previous?.value ?? { prev: null, next: null };
+      if (envelope === undefined) {
+        return atual;
+      }
+      const primeiraPagina = untracked(() => this.pagina() === undefined);
+      if (!envelope.ok) {
+        return primeiraPagina ? { prev: null, next: null } : atual;
+      }
+      const link = untracked(() => this.lista.headers()?.get('Link') ?? null);
+      return { prev: extractPrevCursor(link), next: extractNextCursor(link) };
+    },
+  });
+
+  protected readonly prevCursor = computed(() => this.cursores().prev);
+  protected readonly nextCursor = computed(() => this.cursores().next);
+
+  protected readonly bancas = linkedSignal<
+    ApiResult<readonly TipoBancaDto[]> | undefined,
+    readonly TipoBancaDto[]
+  >({
+    source: () => this.lista.value(),
+    computation: (envelope, previous) => {
+      const atual = previous?.value ?? [];
+      if (envelope === undefined) {
+        return atual;
+      }
+      const primeiraPagina = untracked(() => this.pagina() === undefined);
+      if (!envelope.ok) {
+        return primeiraPagina ? [] : atual;
+      }
+      return [...envelope.data];
+    },
+  });
+
+  // Busca client-side sobre a página carregada: o backend (api#592) só pagina
+  // por cursor, sem filtro de texto no contrato.
+  protected readonly bancasFiltradas = computed(() => {
+    const termo = this.termoBusca().trim().toLocaleLowerCase('pt-BR');
+    if (termo.length === 0) {
+      return this.bancas();
+    }
+    return this.bancas().filter(
+      (banca) =>
+        banca.codigo.toLocaleLowerCase('pt-BR').includes(termo) ||
+        banca.nome.toLocaleLowerCase('pt-BR').includes(termo),
+    );
+  });
+
+  protected readonly temFiltro = computed(() => this.termoBusca().trim().length > 0);
+
+  protected readonly errorMessage = computed<string | null>(() => {
+    const problem = this.lista.problem();
+    if (problem) {
+      return this.problemI18n.resolve(problem).title;
+    }
+    return this.lista.error() ? 'Erro inesperado ao carregar tipos de banca.' : null;
+  });
+
+  protected readonly formHeading = computed(() =>
+    this.modo() === 'criar' ? 'Novo tipo de banca' : 'Editar tipo de banca',
+  );
+
+  protected readonly confirmMessage = computed(() => {
+    const banca = this.bancaParaRemover();
+    return banca
+      ? `Deseja inativar o tipo de banca ${banca.codigo}? A inativação impede novos editais de requerer esta banca, mas não altera bancas já congeladas — a cópia por valor permanece íntegra.`
+      : 'Deseja inativar este tipo de banca?';
+  });
+
+  // Sugestões de "Fase típica" — carregadas lazy na primeira abertura do
+  // formulário (sem custo enquanto o drawer nunca abre). Campo texto livre
+  // sem FK (UNI-REQ-0064): a lista só alimenta o `datalist`, não valida.
+  private readonly carregarSugestoesFaseTipica = signal(false);
+  private readonly sugestoesFaseTipicaResource = useApiResource<readonly FaseCanonicaDto[]>(() => {
+    if (!this.carregarSugestoesFaseTipica()) {
+      return undefined;
+    }
+    return {
+      url: `${this.basePath}/api/configuracao/fases-canonicas`,
+      params: new HttpParams().set('limit', '100'),
+      context: withVendorMime('fase-canonica', 1),
+    };
+  });
+  protected readonly sugestoesFaseTipica = computed(() =>
+    (this.sugestoesFaseTipicaResource.data() ?? []).map((fase) => fase.nome),
+  );
+
+  protected readonly form: FormGroup<BancaForm> = new FormGroup<BancaForm>({
+    codigo: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
+    nome: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required, Validators.maxLength(255)],
+    }),
+    faseTipica: new FormControl('', { nonNullable: true }),
+    descricao: new FormControl('', { nonNullable: true }),
+  });
+
+  constructor() {
+    effect(() => {
+      const problem = this.lista.problem();
+      if (problem && problem.status >= 500) {
+        const titulo = this.problemI18n.resolve(problem).title;
+        untracked(() => this.notifications.errorFromProblem(problem, { title: titulo }));
+      }
+    });
+  }
+
+  protected proximaPagina(): void {
+    const proximo = this.nextCursor();
+    if (proximo !== null && !this.loading()) {
+      this.pagina.set({ cursor: proximo, direction: 'next' });
+    }
+  }
+
+  protected paginaAnterior(): void {
+    const anterior = this.prevCursor();
+    if (anterior !== null && !this.loading()) {
+      this.pagina.set({ cursor: anterior, direction: 'prev' });
+    }
+  }
+
+  protected tentarNovamente(): void {
+    if (!this.loading()) {
+      this.lista.reload();
+    }
+  }
+
+  protected limparFiltros(): void {
+    this.termoBusca.set('');
+  }
+
+  protected abrirCadastro(): void {
+    this.modo.set('criar');
+    this.bancaEmEdicaoId.set(null);
+    this.form.reset({ codigo: '', nome: '', faseTipica: '', descricao: '' });
+    this.formError.set(null);
+    this.idempotencyKeyAtual.set(idempotencyKey.create());
+    this.prepararSugestoesFaseTipica();
+    this.formOpen.set(true);
+  }
+
+  protected abrirEdicao(banca: TipoBancaDto): void {
+    this.modo.set('editar');
+    this.bancaEmEdicaoId.set(banca.id);
+    this.form.reset({
+      codigo: banca.codigo,
+      nome: banca.nome,
+      faseTipica: banca.faseTipica ?? '',
+      descricao: banca.descricao ?? '',
+    });
+    this.formError.set(null);
+    this.idempotencyKeyAtual.set(idempotencyKey.create());
+    this.prepararSugestoesFaseTipica();
+    this.formOpen.set(true);
+  }
+
+  protected pedirRemocao(banca: TipoBancaDto): void {
+    this.bancaParaRemover.set(banca);
+    this.confirmOpen.set(true);
+  }
+
+  protected removerConfirmado(): void {
+    const banca = this.bancaParaRemover();
+    if (banca === null || this.saving()) {
+      return;
+    }
+    this.saving.set(true);
+    this.api
+      .remover(banca.id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((result) => {
+        this.saving.set(false);
+        if (result.ok) {
+          this.notifications.success('Tipo de banca inativado', banca.codigo);
+          this.confirmOpen.set(false);
+          this.bancaParaRemover.set(null);
+          this.recarregar();
+          return;
+        }
+        this.notifications.errorFromProblem(result.problem, {
+          title: this.problemI18n.resolve(result.problem).title,
+        });
+      });
+  }
+
+  protected salvar(): void {
+    if (this.saving()) {
+      return;
+    }
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    this.saving.set(true);
+    this.formError.set(null);
+
+    if (this.modo() === 'criar') {
+      this.api
+        .criar(this.criarCommand(), withIdempotencyKey(this.idempotencyKeyAtual()))
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe((result) => this.handleSalvarResult(result));
+      return;
+    }
+
+    this.api
+      .atualizar(
+        this.bancaEmEdicaoId() ?? '',
+        this.atualizarCommand(),
+        withIdempotencyKey(this.idempotencyKeyAtual()),
+      )
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((result) => this.handleSalvarResult(result));
+  }
+
+  protected erroDoCampo(nome: keyof BancaForm): string | null {
+    const control = this.form.controls[nome];
+    const shouldShowError = control.touched || control.dirty;
+    if (!shouldShowError || control.errors === null) {
+      return null;
+    }
+    if (control.errors['backend']) {
+      const backend = control.errors['backend'] as { code: string; message: string };
+      return backend.message;
+    }
+    if (control.errors['required']) return 'Campo obrigatório.';
+    if (control.errors['maxlength']) return 'Valor acima do tamanho permitido.';
+    return 'Valor inválido.';
+  }
+
+  private prepararSugestoesFaseTipica(): void {
+    if (!this.carregarSugestoesFaseTipica()) {
+      this.carregarSugestoesFaseTipica.set(true);
+    } else {
+      this.sugestoesFaseTipicaResource.reload();
+    }
+  }
+
+  private montarParams(): HttpParams {
+    const pagina = this.pagina();
+    if (pagina === undefined) {
+      return new HttpParams().set('limit', String(PAGE_SIZE));
+    }
+    return new HttpParams()
+      .set('cursor', cursorToString(pagina.cursor))
+      .set('direction', pagina.direction);
+  }
+
+  private recarregar(): void {
+    if (this.pagina() === undefined) {
+      this.lista.reload();
+    } else {
+      this.pagina.set(undefined);
+    }
+  }
+
+  private handleSalvarResult(result: ApiResult<string | void>): void {
+    this.saving.set(false);
+    if (result.ok) {
+      this.notifications.success(
+        this.modo() === 'criar' ? 'Tipo de banca criado' : 'Tipo de banca atualizado',
+      );
+      this.formOpen.set(false);
+      this.idempotencyKeyAtual.set(idempotencyKey.create());
+      this.recarregar();
+      return;
+    }
+    this.aplicarFalha(result.problem);
+  }
+
+  private aplicarFalha(problem: ProblemDetails): void {
+    if (problem.status === 422 && problem.errors && problem.errors.length > 0) {
+      this.renovarIdempotencyKey();
+      this.aplicarErrosDeValidacao(problem.errors);
+      return;
+    }
+    // TipoBanca.CodigoJaExiste é um DomainError único (409, sem `errors[]` —
+    // esse array só existe no pipeline FluentValidation/422); mapeado ao
+    // campo manualmente para exibir o erro inline.
+    if (problem.code === TIPO_BANCA_CODIGO_JA_EXISTE_CODE) {
+      this.renovarIdempotencyKey();
+      this.form.controls.codigo.setErrors({
+        backend: { code: problem.code, message: this.problemI18n.resolve(problem).title },
+      });
+      this.form.controls.codigo.markAsTouched();
+      return;
+    }
+    if (problem.status === 409 || problem.code === 'uniplus.idempotency.body_mismatch') {
+      this.renovarIdempotencyKey();
+    }
+    this.formError.set(this.problemI18n.resolve(problem).title);
+    if (problem.status >= 500) {
+      this.notifications.errorFromProblem(problem);
+    }
+  }
+
+  private renovarIdempotencyKey(): void {
+    this.idempotencyKeyAtual.set(idempotencyKey.create());
+  }
+
+  private aplicarErrosDeValidacao(errors: ReadonlyArray<ProblemValidationError>): void {
+    let aplicouAlgum = false;
+    for (const erro of errors) {
+      const controlName = controlNameFromBackendField(erro.field);
+      if (controlName === null) continue;
+      const control = this.form.controls[controlName];
+      control.setErrors({ backend: { code: erro.code, message: erro.message } });
+      control.markAsTouched();
+      aplicouAlgum = true;
+    }
+
+    if (aplicouAlgum) {
+      this.formError.set(null);
+      return;
+    }
+    this.formError.set('Não foi possível mapear os erros de validação. Revise os campos.');
+  }
+
+  private criarCommand(): CriarTipoBancaCommand {
+    const raw = this.form.getRawValue();
+    return {
+      codigo: raw.codigo,
+      nome: raw.nome.trim(),
+      faseTipica: nullIfBlank(raw.faseTipica),
+      descricao: nullIfBlank(raw.descricao),
+    };
+  }
+
+  private atualizarCommand(): AtualizarTipoBancaCommand {
+    const raw = this.form.getRawValue();
+    return {
+      id: this.bancaEmEdicaoId() ?? '',
+      nome: raw.nome.trim(),
+      faseTipica: nullIfBlank(raw.faseTipica),
+      descricao: nullIfBlank(raw.descricao),
+    };
+  }
+}
+
+function controlNameFromBackendField(field: string): keyof BancaForm | null {
+  const normalized =
+    field
+      .split('.')
+      .at(-1)
+      ?.replace(/\[\d+\]$/u, '') ?? field;
+  const camelCase = normalized.charAt(0).toLocaleLowerCase('pt-BR') + normalized.slice(1);
+  return BANCA_CONTROL_NAMES.has(camelCase) ? (camelCase as keyof BancaForm) : null;
+}
+
+function nullIfBlank(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/apps/configuracao/src/app/features/tipos-banca/tipos-banca.routes.ts
+++ b/apps/configuracao/src/app/features/tipos-banca/tipos-banca.routes.ts
@@ -1,0 +1,8 @@
+import { Routes } from '@angular/router';
+
+export const TIPOS_BANCA_ROUTES: Routes = [
+  {
+    path: '',
+    loadComponent: () => import('./tipos-banca.page').then((m) => m.TiposBancaPage),
+  },
+];

--- a/apps/configuracao/src/app/layout/layout.ts
+++ b/apps/configuracao/src/app/layout/layout.ts
@@ -246,8 +246,18 @@ export class LayoutComponent {
         { label: 'Condição de Atendimento', icon: 'pi-heart' },
         { label: 'Recurso de Acessibilidade', icon: 'pi-universal-access' },
         { label: 'Tipo de Deficiência', icon: 'pi-eye' },
-        { label: 'Fase Canônica', icon: 'pi-star' },
-        { label: 'Tipo de Banca', icon: 'pi-shield' },
+        {
+          label: 'Fase Canônica',
+          icon: 'pi-star',
+          routerLink: '/fases-canonicas',
+          exact: true,
+        },
+        {
+          label: 'Tipo de Banca',
+          icon: 'pi-shield',
+          routerLink: '/tipos-banca',
+          exact: true,
+        },
         {
           label: 'Reserva Demográfica',
           icon: 'pi-chart-bar',

--- a/apps/configuracao/src/styles.css
+++ b/apps/configuracao/src/styles.css
@@ -717,6 +717,12 @@ cfg-pesos-enem-page {
   }
 }
 
+/* Vocabulários fechados (Fase canônica, Tipo de banca): formulário compacto
+   com poucos campos — mantém 1 coluna mesmo em telas largas (issue #393). */
+.cfg-form-drawer .form-grid--1col {
+  grid-template-columns: 1fr;
+}
+
 @media (max-width: 767px) {
   .cfg-topbar-actions auth-user-header-info {
     display: none;

--- a/libs/shared-data/src/lib/api/configuracao/fases-canonicas.api.spec.ts
+++ b/libs/shared-data/src/lib/api/configuracao/fases-canonicas.api.spec.ts
@@ -1,0 +1,122 @@
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  ApiResult,
+  apiResultInterceptor,
+  buildVendorMimeAccept,
+  isApiOk,
+  withIdempotencyKey,
+} from '@uniplus/shared-core/http';
+import { CriarFaseCanonicaCommand, FaseCanonicaDto, FasesCanonicasApi } from './fases-canonicas.api';
+import { CONFIGURACAO_BASE_PATH } from './tokens';
+
+const BASE = 'http://localhost:5000';
+const ID = '01960000-0000-7000-0000-0000000000f1';
+
+const faseSeed: FaseCanonicaDto = {
+  id: ID,
+  codigo: 'AVALIACAO',
+  nome: 'Avaliação',
+  descricao: null,
+  donoTipico: 'CEPS',
+  agrupaEtapas: true,
+  permiteComplementacao: false,
+  baseLegal: null,
+  criadoEm: '2026-06-10T12:00:00Z',
+};
+
+const criarCommand: CriarFaseCanonicaCommand = {
+  codigo: 'AVALIACAO',
+  nome: 'Avaliação',
+  descricao: null,
+  donoTipico: 'CEPS',
+  agrupaEtapas: true,
+  permiteComplementacao: false,
+  baseLegal: null,
+};
+
+describe('FasesCanonicasApi', () => {
+  let api: FasesCanonicasApi;
+  let controller: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([apiResultInterceptor])),
+        provideHttpClientTesting(),
+        { provide: CONFIGURACAO_BASE_PATH, useValue: BASE },
+      ],
+    });
+    api = TestBed.inject(FasesCanonicasApi);
+    controller = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => controller.verify());
+
+  it('listar() faz GET /api/configuracao/fases-canonicas com limit e Accept versionado', async () => {
+    const promise = firstValueFrom(api.listar({ limit: 50 }));
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/fases-canonicas`);
+    expect(req.request.params.get('limit')).toBe('50');
+    expect(req.request.headers.get('Accept')).toBe(buildVendorMimeAccept('fase-canonica', 1));
+    req.flush([faseSeed]);
+    const result = (await promise) as ApiResult<readonly FaseCanonicaDto[]>;
+    expect(isApiOk(result)).toBe(true);
+  });
+
+  it('listar() com cursor envia cursor + direction e omite limit', async () => {
+    const promise = firstValueFrom(api.listar({ cursor: 'abc', direction: 'prev' }));
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/fases-canonicas`);
+    expect(req.request.params.get('cursor')).toBe('abc');
+    expect(req.request.params.get('direction')).toBe('prev');
+    expect(req.request.params.has('limit')).toBe(false);
+    req.flush([faseSeed]);
+    await promise;
+  });
+
+  it('criar() faz POST /api/configuracao/admin/fases-canonicas com Idempotency-Key e Accept JSON', async () => {
+    const promise = firstValueFrom(api.criar(criarCommand, withIdempotencyKey('k')));
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/fases-canonicas`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.headers.get('Idempotency-Key')).toBe('k');
+    expect(req.request.headers.get('Accept')).toBe('application/json');
+    req.flush(ID, { status: 201, statusText: 'Created' });
+    const result = (await promise) as ApiResult<string>;
+    expect(isApiOk(result)).toBe(true);
+  });
+
+  it('atualizar() faz PUT /api/configuracao/admin/fases-canonicas/{id} sem o campo codigo', async () => {
+    const promise = firstValueFrom(
+      api.atualizar(
+        ID,
+        {
+          id: ID,
+          nome: 'Avaliação (revisada)',
+          descricao: null,
+          donoTipico: 'CEPS',
+          agrupaEtapas: true,
+          permiteComplementacao: false,
+          baseLegal: null,
+        },
+        withIdempotencyKey('k'),
+      ),
+    );
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/fases-canonicas/${ID}`);
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).not.toHaveProperty('codigo');
+    req.flush(null, { status: 204, statusText: 'No Content' });
+    const result = (await promise) as ApiResult<void>;
+    expect(isApiOk(result)).toBe(true);
+  });
+
+  it('remover() faz DELETE /api/configuracao/admin/fases-canonicas/{id}', async () => {
+    const promise = firstValueFrom(api.remover(ID));
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/fases-canonicas/${ID}`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush(null, { status: 204, statusText: 'No Content' });
+    const result = (await promise) as ApiResult<void>;
+    expect(isApiOk(result)).toBe(true);
+  });
+});

--- a/libs/shared-data/src/lib/api/configuracao/fases-canonicas.api.ts
+++ b/libs/shared-data/src/lib/api/configuracao/fases-canonicas.api.ts
@@ -1,0 +1,110 @@
+import { HttpClient, HttpContext, HttpHeaders, HttpParams } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiResult, withVendorMime } from '@uniplus/shared-core/http';
+import type { components } from './schema';
+import { CONFIGURACAO_BASE_PATH } from './tokens';
+
+export type FaseCanonicaDto = components['schemas']['FaseCanonicaDto'];
+export type CriarFaseCanonicaCommand = components['schemas']['CriarFaseCanonicaCommand'];
+export type AtualizarFaseCanonicaCommand = components['schemas']['AtualizarFaseCanonicaCommand'];
+
+/** Filtro de listagem de Fases canônicas (cursor pagination, ADR-0026). */
+export interface FasesCanonicasQuery {
+  readonly cursor?: string;
+  readonly direction?: 'next' | 'prev';
+  readonly limit?: number;
+}
+
+/**
+ * Código canônico das 14 fases fixas do ciclo de vida do processo seletivo
+ * (UNI-REQ-0064). Roster fechado — usado só pelo `select` de criação; a
+ * edição trata `codigo` como imutável (readonly).
+ */
+export const CODIGOS_FASE_CANONICA = [
+  'INSCRICAO',
+  'HOMOLOGACAO',
+  'ENSALAMENTO',
+  'AVALIACAO',
+  'CLASSIFICACAO',
+  'RESULTADO_PRELIMINAR',
+  'RECURSOS',
+  'RESULTADO_FINAL',
+  'HABILITACAO',
+  'HETEROIDENTIFICACAO',
+  'MATRICULA',
+  'HOMOLOGACAO_RESULTADO_FINAL',
+  'LISTA_ESPERA',
+  'CHAMADA',
+] as const;
+
+export type CodigoFaseCanonica = (typeof CODIGOS_FASE_CANONICA)[number];
+
+/** Rótulo orientativo do dono típico — não vinculante (UNI-REQ-0064). */
+export const DONOS_TIPICOS_FASE = ['CEPS', 'CRCA', 'MEC', 'CONSEPE'] as const;
+
+/**
+ * Cliente Angular standalone do recurso Fase canônica (módulo Configuração).
+ * Vocabulário fechado de cronograma — código imutável após a criação
+ * (`Atualizar*Command` não aceita `codigo`).
+ *
+ * API thin (ADR-0013): tipos do `schema.ts` gerado; resposta envelopada em
+ * `ApiResult<T>` (ADR-0011); versionamento por vendor MIME `fase-canonica v1`
+ * (ADR-0016). Espelha `CampiApi`/`CursosApi`.
+ */
+@Injectable({ providedIn: 'root' })
+export class FasesCanonicasApi {
+  private readonly http = inject(HttpClient);
+  private readonly basePath = inject(CONFIGURACAO_BASE_PATH);
+
+  /** GET `/api/configuracao/fases-canonicas` — lista paginada por cursor (ADR-0026). */
+  listar(query: FasesCanonicasQuery = {}): Observable<ApiResult<readonly FaseCanonicaDto[]>> {
+    let params = new HttpParams();
+    if (query.cursor !== undefined) {
+      params = params.set('cursor', query.cursor).set('direction', query.direction ?? 'next');
+    } else {
+      params = params.set('limit', String(query.limit ?? 100));
+    }
+    return this.http.get<ApiResult<readonly FaseCanonicaDto[]>>(
+      `${this.basePath}/api/configuracao/fases-canonicas`,
+      { params, context: withVendorMime('fase-canonica', 1) },
+    );
+  }
+
+  /** GET `/api/configuracao/fases-canonicas/{id}` — detalhe de uma Fase canônica. */
+  obter(id: string): Observable<ApiResult<FaseCanonicaDto>> {
+    return this.http.get<ApiResult<FaseCanonicaDto>>(
+      `${this.basePath}/api/configuracao/fases-canonicas/${encodeURIComponent(id)}`,
+      { context: withVendorMime('fase-canonica', 1) },
+    );
+  }
+
+  /** POST `/api/configuracao/admin/fases-canonicas` — cria. Idempotency-Key obrigatório. */
+  criar(command: CriarFaseCanonicaCommand, context: HttpContext): Observable<ApiResult<string>> {
+    return this.http.post<ApiResult<string>>(
+      `${this.basePath}/api/configuracao/admin/fases-canonicas`,
+      command,
+      { context, headers: new HttpHeaders({ Accept: 'application/json' }) },
+    );
+  }
+
+  /** PUT `/api/configuracao/admin/fases-canonicas/{id}` — atualiza (sem `codigo`, imutável). */
+  atualizar(
+    id: string,
+    command: AtualizarFaseCanonicaCommand,
+    context: HttpContext,
+  ): Observable<ApiResult<void>> {
+    return this.http.put<ApiResult<void>>(
+      `${this.basePath}/api/configuracao/admin/fases-canonicas/${encodeURIComponent(id)}`,
+      command,
+      { context },
+    );
+  }
+
+  /** DELETE `/api/configuracao/admin/fases-canonicas/{id}` — remoção lógica (soft-delete). */
+  remover(id: string): Observable<ApiResult<void>> {
+    return this.http.delete<ApiResult<void>>(
+      `${this.basePath}/api/configuracao/admin/fases-canonicas/${encodeURIComponent(id)}`,
+    );
+  }
+}

--- a/libs/shared-data/src/lib/api/configuracao/index.ts
+++ b/libs/shared-data/src/lib/api/configuracao/index.ts
@@ -53,3 +53,22 @@ export {
   type TurnoOfertaOption,
   type UnidadeOfertanteDto,
 } from './ofertas-curso.api';
+export {
+  FasesCanonicasApi,
+  CODIGOS_FASE_CANONICA,
+  DONOS_TIPICOS_FASE,
+  type AtualizarFaseCanonicaCommand,
+  type CodigoFaseCanonica,
+  type CriarFaseCanonicaCommand,
+  type FaseCanonicaDto,
+  type FasesCanonicasQuery,
+} from './fases-canonicas.api';
+export {
+  TiposBancaApi,
+  CODIGOS_TIPO_BANCA,
+  type AtualizarTipoBancaCommand,
+  type CodigoTipoBanca,
+  type CriarTipoBancaCommand,
+  type TipoBancaDto,
+  type TiposBancaQuery,
+} from './tipos-banca.api';

--- a/libs/shared-data/src/lib/api/configuracao/tipos-banca.api.spec.ts
+++ b/libs/shared-data/src/lib/api/configuracao/tipos-banca.api.spec.ts
@@ -1,0 +1,108 @@
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  ApiResult,
+  apiResultInterceptor,
+  buildVendorMimeAccept,
+  isApiOk,
+  withIdempotencyKey,
+} from '@uniplus/shared-core/http';
+import { CriarTipoBancaCommand, TipoBancaDto, TiposBancaApi } from './tipos-banca.api';
+import { CONFIGURACAO_BASE_PATH } from './tokens';
+
+const BASE = 'http://localhost:5000';
+const ID = '01960000-0000-7000-0000-0000000000b2';
+
+const bancaSeed: TipoBancaDto = {
+  id: ID,
+  codigo: 'BANCA_ENTREVISTA',
+  nome: 'Banca de Entrevista',
+  faseTipica: 'Avaliação',
+  descricao: null,
+  criadoEm: '2026-06-10T12:00:00Z',
+};
+
+const criarCommand: CriarTipoBancaCommand = {
+  codigo: 'BANCA_ENTREVISTA',
+  nome: 'Banca de Entrevista',
+  faseTipica: 'Avaliação',
+  descricao: null,
+};
+
+describe('TiposBancaApi', () => {
+  let api: TiposBancaApi;
+  let controller: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([apiResultInterceptor])),
+        provideHttpClientTesting(),
+        { provide: CONFIGURACAO_BASE_PATH, useValue: BASE },
+      ],
+    });
+    api = TestBed.inject(TiposBancaApi);
+    controller = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => controller.verify());
+
+  it('listar() faz GET /api/configuracao/tipos-banca com limit e Accept versionado', async () => {
+    const promise = firstValueFrom(api.listar({ limit: 50 }));
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/tipos-banca`);
+    expect(req.request.params.get('limit')).toBe('50');
+    expect(req.request.headers.get('Accept')).toBe(buildVendorMimeAccept('tipo-banca', 1));
+    req.flush([bancaSeed]);
+    const result = (await promise) as ApiResult<readonly TipoBancaDto[]>;
+    expect(isApiOk(result)).toBe(true);
+  });
+
+  it('listar() com cursor envia cursor + direction e omite limit', async () => {
+    const promise = firstValueFrom(api.listar({ cursor: 'abc', direction: 'prev' }));
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/tipos-banca`);
+    expect(req.request.params.get('cursor')).toBe('abc');
+    expect(req.request.params.get('direction')).toBe('prev');
+    expect(req.request.params.has('limit')).toBe(false);
+    req.flush([bancaSeed]);
+    await promise;
+  });
+
+  it('criar() faz POST /api/configuracao/admin/tipos-banca com Idempotency-Key e Accept JSON', async () => {
+    const promise = firstValueFrom(api.criar(criarCommand, withIdempotencyKey('k')));
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/tipos-banca`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.headers.get('Idempotency-Key')).toBe('k');
+    expect(req.request.headers.get('Accept')).toBe('application/json');
+    req.flush(ID, { status: 201, statusText: 'Created' });
+    const result = (await promise) as ApiResult<string>;
+    expect(isApiOk(result)).toBe(true);
+  });
+
+  it('atualizar() faz PUT /api/configuracao/admin/tipos-banca/{id} sem o campo codigo', async () => {
+    const promise = firstValueFrom(
+      api.atualizar(
+        ID,
+        { id: ID, nome: 'Banca de Entrevista (revisada)', faseTipica: 'Avaliação', descricao: null },
+        withIdempotencyKey('k'),
+      ),
+    );
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/tipos-banca/${ID}`);
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).not.toHaveProperty('codigo');
+    req.flush(null, { status: 204, statusText: 'No Content' });
+    const result = (await promise) as ApiResult<void>;
+    expect(isApiOk(result)).toBe(true);
+  });
+
+  it('remover() faz DELETE /api/configuracao/admin/tipos-banca/{id}', async () => {
+    const promise = firstValueFrom(api.remover(ID));
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/tipos-banca/${ID}`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush(null, { status: 204, statusText: 'No Content' });
+    const result = (await promise) as ApiResult<void>;
+    expect(isApiOk(result)).toBe(true);
+  });
+});

--- a/libs/shared-data/src/lib/api/configuracao/tipos-banca.api.ts
+++ b/libs/shared-data/src/lib/api/configuracao/tipos-banca.api.ts
@@ -1,0 +1,97 @@
+import { HttpClient, HttpContext, HttpHeaders, HttpParams } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiResult, withVendorMime } from '@uniplus/shared-core/http';
+import type { components } from './schema';
+import { CONFIGURACAO_BASE_PATH } from './tokens';
+
+export type TipoBancaDto = components['schemas']['TipoBancaDto'];
+export type CriarTipoBancaCommand = components['schemas']['CriarTipoBancaCommand'];
+export type AtualizarTipoBancaCommand = components['schemas']['AtualizarTipoBancaCommand'];
+
+/** Filtro de listagem de Tipos de banca (cursor pagination, ADR-0026). */
+export interface TiposBancaQuery {
+  readonly cursor?: string;
+  readonly direction?: 'next' | 'prev';
+  readonly limit?: number;
+}
+
+/**
+ * Código canônico dos 4 tipos de banca fixos (UNI-REQ-0064). Roster fechado —
+ * usado só pelo `select` de criação; a edição trata `codigo` como imutável.
+ */
+export const CODIGOS_TIPO_BANCA = [
+  'BANCA_ANALISE_DOCUMENTAL',
+  'BANCA_ENTREVISTA',
+  'BANCA_CORRECAO_REDACOES',
+  'BANCA_ANALISE_RECURSOS',
+] as const;
+
+export type CodigoTipoBanca = (typeof CODIGOS_TIPO_BANCA)[number];
+
+/**
+ * Cliente Angular standalone do recurso Tipo de banca (módulo Configuração).
+ * Vocabulário fechado de cronograma — código imutável após a criação
+ * (`Atualizar*Command` não aceita `codigo`). `faseTipica` é texto livre
+ * orientativo, sem FK com Fase canônica (UNI-REQ-0064).
+ *
+ * API thin (ADR-0013): tipos do `schema.ts` gerado; resposta envelopada em
+ * `ApiResult<T>` (ADR-0011); versionamento por vendor MIME `tipo-banca v1`
+ * (ADR-0016). Espelha `FasesCanonicasApi`/`CampiApi`.
+ */
+@Injectable({ providedIn: 'root' })
+export class TiposBancaApi {
+  private readonly http = inject(HttpClient);
+  private readonly basePath = inject(CONFIGURACAO_BASE_PATH);
+
+  /** GET `/api/configuracao/tipos-banca` — lista paginada por cursor (ADR-0026). */
+  listar(query: TiposBancaQuery = {}): Observable<ApiResult<readonly TipoBancaDto[]>> {
+    let params = new HttpParams();
+    if (query.cursor !== undefined) {
+      params = params.set('cursor', query.cursor).set('direction', query.direction ?? 'next');
+    } else {
+      params = params.set('limit', String(query.limit ?? 100));
+    }
+    return this.http.get<ApiResult<readonly TipoBancaDto[]>>(
+      `${this.basePath}/api/configuracao/tipos-banca`,
+      { params, context: withVendorMime('tipo-banca', 1) },
+    );
+  }
+
+  /** GET `/api/configuracao/tipos-banca/{id}` — detalhe de um Tipo de banca. */
+  obter(id: string): Observable<ApiResult<TipoBancaDto>> {
+    return this.http.get<ApiResult<TipoBancaDto>>(
+      `${this.basePath}/api/configuracao/tipos-banca/${encodeURIComponent(id)}`,
+      { context: withVendorMime('tipo-banca', 1) },
+    );
+  }
+
+  /** POST `/api/configuracao/admin/tipos-banca` — cria. Idempotency-Key obrigatório. */
+  criar(command: CriarTipoBancaCommand, context: HttpContext): Observable<ApiResult<string>> {
+    return this.http.post<ApiResult<string>>(
+      `${this.basePath}/api/configuracao/admin/tipos-banca`,
+      command,
+      { context, headers: new HttpHeaders({ Accept: 'application/json' }) },
+    );
+  }
+
+  /** PUT `/api/configuracao/admin/tipos-banca/{id}` — atualiza (sem `codigo`, imutável). */
+  atualizar(
+    id: string,
+    command: AtualizarTipoBancaCommand,
+    context: HttpContext,
+  ): Observable<ApiResult<void>> {
+    return this.http.put<ApiResult<void>>(
+      `${this.basePath}/api/configuracao/admin/tipos-banca/${encodeURIComponent(id)}`,
+      command,
+      { context },
+    );
+  }
+
+  /** DELETE `/api/configuracao/admin/tipos-banca/{id}` — remoção lógica (soft-delete). */
+  remover(id: string): Observable<ApiResult<void>> {
+    return this.http.delete<ApiResult<void>>(
+      `${this.basePath}/api/configuracao/admin/tipos-banca/${encodeURIComponent(id)}`,
+    );
+  }
+}


### PR DESCRIPTION
## Resumo

Duas telas CRUD novas no app `configuracao`, espelhando o padrão já estabelecido pelas features irmãs (`campi`, `cursos`, `unidades`): lista com paginação por cursor, drawer de criação/edição, modal de inativação (soft-delete).

- **Fase Canônica** (`/fases-canonicas`) — vocabulário fechado das 14 fases do ciclo de vida do processo seletivo. Grupos condicionais no formulário: "Agrupa etapas" (só código `AVALIACAO`) e "Permite complementação" (só `HOMOLOGACAO`/`RECURSOS`).
- **Tipo de Banca** (`/tipos-banca`) — vocabulário fechado dos 4 tipos de banca. Campo "Fase típica" é texto livre com `datalist` de sugestões (sem FK com Fase canônica).

Em ambas, o código é imutável após a criação (`select` fechado na criação, `input readonly` na edição — os commands de atualização do contrato não aceitam o campo `codigo`).

Backend consumido: `uniplus-api#592` (já mergeado, UNI-REQ-0064).

## Desvios deliberados do texto original da issue

Registrados aqui porque não são óbvios a partir do diff:

1. **Sem chips de status "Ativas/Inativas"**: o contrato publicado (`GET /api/configuracao/fases-canonicas` e `/tipos-banca`) só aceita `cursor`/`limit`/`direction` e só retorna registros vivos — não há parâmetro de status nem forma de listar inativos hoje. Implementar o chip criaria uma opção "Inativas" que sempre voltaria vazia.
2. **Busca e filtro de "Dono típico" são client-side** sobre a página carregada — mesmo padrão já usado em `cursos.page.ts` (comentário `// Busca client-side... o backend só pagina por cursor`), porque o contrato não expõe filtro de texto/campo.
3. **Componentes reais do repo, não os nomes da issue**: o texto original menciona `<ui-page-header>`, `<ui-filter-bar>`, `<ui-data-table>`, `<ui-dialog>` — nenhum existe em `shared-ui` hoje. Usei o padrão real do app `configuracao` (header/filter-bar em markup nativo, `<ui-confirm-dialog>`, tabela `<table>` nativa em `.table-responsive`).
4. **Payload de atualização inclui `id`** (exigido por `AtualizarFaseCanonicaCommand`/`AtualizarTipoBancaCommand` no contrato publicado) mas nunca `codigo` — o texto da issue pedia omitir os dois; `id` é sistemático em todos os `Atualizar*Command` do contrato (mesmo padrão de `AtualizarCampusCommand`/`AtualizarUnidadeCommand`).
5. **409 de código duplicado mapeado no campo Código** (`FaseCanonica.CodigoJaExiste`/`TipoBanca.CodigoJaExiste` → `uniplus.configuracao.fase_canonica.codigo_ja_existe`/`.tipo_banca.codigo_ja_existe`), mesmo padrão de `CURSO_CODIGO_JA_EXISTE_CODE` em `cursos.page.ts` — confirmado direto no código-fonte do backend (`ConfiguracaoDomainErrorRegistration.cs`).

## Menu lateral

Habilita os dois itens que já existiam como placeholders desabilitados em `layout.ts` ("Fase Canônica", "Tipo de Banca").

## Test plan

- [x] `nx vite:test shared-data` — 191/191 (inclui 10 testes novos dos 2 API clients)
- [x] `nx vite:test configuracao` — 157/157 (inclui 24 testes novos das 2 páginas, incluindo um teste de interação real via DOM para o binding `[ngValue]` do select booleano)
- [x] `nx lint configuracao` / `nx lint shared-data` — limpo
- [x] `nx build configuracao` — build de produção OK, chunks lazy `fases-canonicas-page`/`tipos-banca-page` gerados
- [x] Revisão de diff via Codex CLI — 1 achado P2 real (409 de código duplicado caindo no banner genérico em vez do campo Código) corrigido nas duas páginas
- [ ] E2E (`fases-canonicas.flow.spec.ts`, `tipos-banca.flow.spec.ts`) escritos seguindo o padrão de `cursos.flow.spec.ts`, mas **não executados neste ambiente** (exigem stack Docker completa com Keycloak, conforme `docs/guia-testar-frontend-com-backend-local.md`)

Closes #393