### PR TITLE
feat(configuracao): adiciona cadastro de tipo de documento

### DIFF
--- a/apps/configuracao-e2e/src/specs/tipos-documento.flow.spec.ts
+++ b/apps/configuracao-e2e/src/specs/tipos-documento.flow.spec.ts
@@ -107,6 +107,18 @@ async function abrirPagina(page: Page): Promise<void> {
   await expect(page.getByRole('heading', { name: 'Tipo de Documento', level: 1 })).toBeVisible();
 }
 
+/**
+ * Locator de um chip de categoria pelo rótulo. `ui-filter-chips` sempre
+ * inclui o contador como texto visível dentro do próprio botão (ex.: "Saúde
+ * 1", "Todas 2") — o nome acessível nunca é só o rótulo isolado. A regex
+ * ancorada no início casa o rótulo seguido do contador sem colidir com
+ * outros botões da página que contenham o mesmo texto.
+ */
+function chipLocator(page: Page, rotulo: string) {
+  const escapado = rotulo.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+  return page.getByRole('button', { name: new RegExp(`^${escapado}\\b`, 'u') });
+}
+
 test.describe('Tipo de Documento — CRUD (#392)', () => {
   test.beforeEach(async ({ page }) => {
     await mockConfiguracaoRuntimeConfig(page);
@@ -122,17 +134,14 @@ test.describe('Tipo de Documento — CRUD (#392)', () => {
     await expect(page.getByText('RG')).toBeVisible();
     await expect(page.getByText('Laudo médico — PcD')).toBeVisible();
 
-    // Filtro por categoria (chip "Saúde")
-    await page.getByRole('button', { name: 'Saúde', exact: true }).click();
+    // Filtro por categoria (chip "Saúde 1" — ui-filter-chips inclui o contador no nome acessível)
+    await chipLocator(page, 'Saúde').click();
     await expect(page.locator('table tbody tr')).toHaveCount(1);
     await expect(page.getByText('Laudo médico — PcD')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Saúde', exact: true })).toHaveAttribute(
-      'aria-pressed',
-      'true',
-    );
+    await expect(chipLocator(page, 'Saúde')).toHaveAttribute('aria-pressed', 'true');
 
-    // Volta para "Todas"
-    await page.getByRole('button', { name: 'Todas', exact: true }).click();
+    // Volta para "Todas 2"
+    await chipLocator(page, 'Todas').click();
     await expect(page.locator('table tbody tr')).toHaveCount(2);
 
     // Criar

--- a/apps/configuracao-e2e/src/specs/tipos-documento.flow.spec.ts
+++ b/apps/configuracao-e2e/src/specs/tipos-documento.flow.spec.ts
@@ -1,0 +1,350 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test, type Page, type Route } from '@playwright/test';
+import { mockConfiguracaoRuntimeConfig } from '../support/runtime-config';
+
+/**
+ * E2E funcional do cadastro de Tipo de Documento (issue #392). Convenção do
+ * repo: runtime-config e API mockados por `page.route`; autenticação real
+ * (Keycloak) via projeto `fluxo-chromium` (auth-setup + storageState).
+ *
+ * Nomeado `tipos-documento.flow.spec.ts` (não `.e2e.ts`, conforme o mapa de
+ * testes da issue) para casar com `testMatch: /.*\.flow\.spec\.ts$/` do
+ * `playwright.config.ts` — é o padrão que roda com auth real mockando só a
+ * API, espelhando `cursos.flow.spec.ts`/`pesos-enem.flow.spec.ts`.
+ */
+
+const CORS_HEADERS = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'GET, POST, PUT, DELETE, OPTIONS',
+  'access-control-allow-headers': 'authorization, content-type, accept, idempotency-key',
+};
+
+const RG_ID = '01960000-0000-7000-0000-0000000000d1';
+const LAUDO_ID = '01960000-0000-7000-0000-0000000000d2';
+
+const rgSeed = {
+  id: RG_ID,
+  codigo: 'RG',
+  nome: 'Registro Geral',
+  descricao: 'Documento de identificação civil.',
+  categoria: 'IDENTIFICACAO',
+  formatosAceitos: 'pdf,jpg',
+  tamanhoMaximoMb: 10,
+  tipoEquivalente: 'CIN',
+  criadoEm: '2026-06-10T12:00:00Z',
+};
+
+const laudoSeed = {
+  id: LAUDO_ID,
+  codigo: 'LAUDO_MEDICO',
+  nome: 'Laudo médico — PcD',
+  descricao: null,
+  categoria: 'SAUDE',
+  formatosAceitos: null,
+  tamanhoMaximoMb: null,
+  tipoEquivalente: null,
+  criadoEm: '2026-06-11T12:00:00Z',
+};
+
+interface Capturado {
+  readonly posts: unknown[];
+  readonly deletedIds: string[];
+}
+
+function novoCapturado(): Capturado {
+  return { posts: [], deletedIds: [] };
+}
+
+async function mockApi(
+  page: Page,
+  capturado: Capturado,
+  lista: readonly unknown[],
+  opcoes: { readonly criarStatus?: number; readonly criarBody?: unknown } = {},
+): Promise<void> {
+  await page.route(/\/api\/configuracao\/admin\/tipos-documento\/[^/?]+$/, async (route) => {
+    if (route.request().method() === 'DELETE') {
+      const partes = route.request().url().split('/');
+      capturado.deletedIds.push(partes[partes.length - 1] ?? '');
+      await route.fulfill({ status: 204, headers: CORS_HEADERS });
+      return;
+    }
+    await route.fulfill({ status: 204, headers: CORS_HEADERS });
+  });
+  await page.route(/\/api\/configuracao\/admin\/tipos-documento(\?.*)?$/, async (route) => {
+    if (route.request().method() === 'POST') {
+      capturado.posts.push(route.request().postDataJSON());
+      const status = opcoes.criarStatus ?? 201;
+      await route.fulfill({
+        status,
+        contentType: status >= 400 ? 'application/problem+json' : 'application/json',
+        headers: CORS_HEADERS,
+        body: JSON.stringify(opcoes.criarBody ?? 'novo-tipo-documento-id'),
+      });
+      return;
+    }
+    await route.fulfill({ status: 204, headers: CORS_HEADERS });
+  });
+  await page.route(/\/api\/configuracao\/tipos-documento(\?.*)?$/, (route) =>
+    jsonRoute(route, lista),
+  );
+}
+
+async function jsonRoute(route: Route, body: unknown, status = 200): Promise<void> {
+  if (route.request().method() === 'OPTIONS') {
+    await route.fulfill({ status: 204, headers: CORS_HEADERS });
+    return;
+  }
+  await route.fulfill({
+    status,
+    contentType: 'application/json',
+    headers: CORS_HEADERS,
+    body: JSON.stringify(body),
+  });
+}
+
+async function abrirPagina(page: Page): Promise<void> {
+  await page.goto('/tipos-documento');
+  await expect(page.getByRole('heading', { name: 'Tipo de Documento', level: 1 })).toBeVisible();
+}
+
+test.describe('Tipo de Documento — CRUD (#392)', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockConfiguracaoRuntimeConfig(page);
+  });
+
+  test('CA-01: fluxo completo — criar, listar, filtrar por categoria e inativar', async ({
+    page,
+  }) => {
+    const capturado = novoCapturado();
+    await mockApi(page, capturado, [rgSeed, laudoSeed]);
+    await abrirPagina(page);
+
+    await expect(page.getByText('RG')).toBeVisible();
+    await expect(page.getByText('Laudo médico — PcD')).toBeVisible();
+
+    // Filtro por categoria (chip "Saúde")
+    await page.getByRole('button', { name: 'Saúde', exact: true }).click();
+    await expect(page.locator('table tbody tr')).toHaveCount(1);
+    await expect(page.getByText('Laudo médico — PcD')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Saúde', exact: true })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+
+    // Volta para "Todas"
+    await page.getByRole('button', { name: 'Todas', exact: true }).click();
+    await expect(page.locator('table tbody tr')).toHaveCount(2);
+
+    // Criar
+    await page.getByRole('button', { name: 'Novo tipo' }).first().click();
+    await page.locator('[formControlName="codigo"]').fill('DECL_LIDERANCA');
+    await page.locator('[formControlName="nome"]').fill('Declaração de liderança');
+    await page.locator('[formControlName="categoria"]').selectOption('OUTROS');
+    await page.getByRole('button', { name: 'Criar tipo de documento' }).click();
+
+    await expect.poll(() => capturado.posts.length).toBe(1);
+    expect(capturado.posts[0]).toMatchObject({ codigo: 'DECL_LIDERANCA', categoria: 'OUTROS' });
+
+    // Inativar
+    await page.getByRole('button', { name: 'Inativar' }).first().click();
+    const dialog = page.locator('dialog.uni-dialog');
+    await expect(dialog.getByText('RN08')).toBeVisible();
+    await dialog.getByRole('button', { name: 'Inativar' }).click();
+
+    await expect.poll(() => capturado.deletedIds.length).toBe(1);
+  });
+
+  test('CA-05: tipo equivalente igual ao código é rejeitado sem chamar o backend', async ({
+    page,
+  }) => {
+    const capturado = novoCapturado();
+    await mockApi(page, capturado, []);
+    await abrirPagina(page);
+
+    await page.getByRole('button', { name: 'Novo tipo' }).first().click();
+    await page.locator('[formControlName="codigo"]').fill('RG');
+    await page.locator('[formControlName="tipoEquivalente"]').fill('RG');
+    await page.locator('[formControlName="tipoEquivalente"]').blur();
+
+    await expect(
+      page.getByText('O tipo equivalente não pode ser igual ao próprio código.'),
+    ).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Criar tipo de documento' })).toBeDisabled();
+    expect(capturado.posts).toHaveLength(0);
+  });
+
+  test('CA-08: modal de inativação não exibe bloqueio por referência de outro módulo', async ({
+    page,
+  }) => {
+    const capturado = novoCapturado();
+    await mockApi(page, capturado, [rgSeed]);
+    await abrirPagina(page);
+
+    await page.getByRole('button', { name: 'Inativar' }).first().click();
+    const dialog = page.locator('dialog.uni-dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText(/bloque/i)).toHaveCount(0);
+  });
+});
+
+// Bloco `validacao`: rejeição de código duplicado — erro inline sem submit bem-sucedido.
+test.describe('Tipo de Documento — validação (#392)', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockConfiguracaoRuntimeConfig(page);
+  });
+
+  test('CA-03: código duplicado é rejeitado com erro inline sem fechar o drawer', async ({
+    page,
+  }) => {
+    await mockApi(page, novoCapturado(), [], {
+      criarStatus: 409,
+      criarBody: {
+        type: 'https://uniplus.dev/erros/uniplus.configuracao.tipo_documento.codigo_ja_existe',
+        title: 'Já existe um tipo de documento ativo com este código',
+        status: 409,
+        code: 'uniplus.configuracao.tipo_documento.codigo_ja_existe',
+      },
+    });
+    await abrirPagina(page);
+
+    await page.getByRole('button', { name: 'Novo tipo' }).first().click();
+    await page.locator('[formControlName="codigo"]').fill('RG');
+    await page.locator('[formControlName="nome"]').fill('Registro Geral (dup)');
+    await page.locator('[formControlName="categoria"]').selectOption('IDENTIFICACAO');
+    await page.getByRole('button', { name: 'Criar tipo de documento' }).click();
+
+    await expect(page.getByText('Já existe um tipo de documento ativo com este código')).toBeVisible();
+    await expect(page.locator('#cfg-tipo-documento-form')).toBeVisible();
+  });
+
+  test('CA-06: tamanho máximo zero ou negativo bloqueia o submit', async ({ page }) => {
+    const capturado = novoCapturado();
+    await mockApi(page, capturado, []);
+    await abrirPagina(page);
+
+    await page.getByRole('button', { name: 'Novo tipo' }).first().click();
+    await page.locator('[formControlName="codigo"]').fill('DECL');
+    await page.locator('[formControlName="nome"]').fill('Declaração');
+    await page.locator('[formControlName="categoria"]').selectOption('OUTROS');
+    await page.locator('[formControlName="tamanhoMaximoMb"]').fill('0');
+    await page.locator('[formControlName="tamanhoMaximoMb"]').blur();
+    await page.getByRole('button', { name: 'Criar tipo de documento' }).click();
+
+    expect(capturado.posts).toHaveLength(0);
+  });
+});
+
+// Bloco `axe`: acessibilidade WCAG 2.1 AA (sem violações serious/critical) na
+// lista, no drawer aberto e no modal aberto.
+test.describe('Tipo de Documento — acessibilidade axe-core (#392)', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockConfiguracaoRuntimeConfig(page);
+  });
+
+  async function violacoesGraves(page: Page): Promise<unknown[]> {
+    const resultado = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21aa'])
+      .analyze();
+    return resultado.violations.filter((v) => v.impact === 'serious' || v.impact === 'critical');
+  }
+
+  test('lista não tem violações serious/critical', async ({ page }) => {
+    await mockApi(page, novoCapturado(), [rgSeed, laudoSeed]);
+    await abrirPagina(page);
+    const graves = await violacoesGraves(page);
+    expect(graves, JSON.stringify(graves, null, 2)).toEqual([]);
+  });
+
+  test('drawer aberto não tem violações serious/critical', async ({ page }) => {
+    await mockApi(page, novoCapturado(), []);
+    await abrirPagina(page);
+    await page.getByRole('button', { name: 'Novo tipo' }).first().click();
+    await expect(page.locator('dialog.uni-drawer')).toBeVisible();
+    const graves = await violacoesGraves(page);
+    expect(graves, JSON.stringify(graves, null, 2)).toEqual([]);
+  });
+
+  test('modal de inativação aberto não tem violações serious/critical', async ({ page }) => {
+    await mockApi(page, novoCapturado(), [rgSeed]);
+    await abrirPagina(page);
+    await page.getByRole('button', { name: 'Inativar' }).first().click();
+    await expect(page.locator('dialog.uni-dialog')).toBeVisible();
+    const graves = await violacoesGraves(page);
+    expect(graves, JSON.stringify(graves, null, 2)).toEqual([]);
+  });
+});
+
+// Bloco `keyboard`: navegação por teclado sem mouse (e-MAG 3.1).
+test.describe('Tipo de Documento — navegação por teclado (#392)', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockConfiguracaoRuntimeConfig(page);
+  });
+
+  test('abre o drawer, preenche e salva sem usar o mouse', async ({ page }) => {
+    const capturado = novoCapturado();
+    await mockApi(page, capturado, []);
+    await abrirPagina(page);
+
+    await page.getByRole('button', { name: 'Novo tipo' }).first().focus();
+    await page.keyboard.press('Enter');
+    await expect(page.locator('dialog.uni-drawer')).toBeVisible();
+
+    await page.locator('[formControlName="codigo"]').fill('DECL_TECLADO');
+    await page.locator('[formControlName="nome"]').fill('Declaração via teclado');
+    await page.locator('[formControlName="categoria"]').selectOption('OUTROS');
+
+    await page.getByRole('button', { name: 'Criar tipo de documento' }).focus();
+    await page.keyboard.press('Enter');
+
+    await expect.poll(() => capturado.posts.length).toBe(1);
+  });
+});
+
+// Bloco `responsive`: lista e drawer em 375 px (mobile).
+test.describe('Tipo de Documento — responsividade 375px (#392)', () => {
+  test.use({ viewport: { width: 375, height: 812 } });
+
+  test.beforeEach(async ({ page }) => {
+    await mockConfiguracaoRuntimeConfig(page);
+  });
+
+  test('lista e drawer permanecem sem overflow horizontal em 375px', async ({ page }) => {
+    await mockApi(page, novoCapturado(), [rgSeed, laudoSeed]);
+    await abrirPagina(page);
+
+    const semOverflowLista = await page.evaluate(() => ({
+      clientWidth: document.documentElement.clientWidth,
+      scrollWidth: document.documentElement.scrollWidth,
+    }));
+    expect(semOverflowLista.scrollWidth).toBeLessThanOrEqual(semOverflowLista.clientWidth);
+
+    await page.getByRole('button', { name: 'Novo tipo' }).first().click();
+    await expect(page.locator('dialog.uni-drawer')).toBeVisible();
+
+    const semOverflowDrawer = await page.evaluate(() => ({
+      clientWidth: document.documentElement.clientWidth,
+      scrollWidth: document.documentElement.scrollWidth,
+    }));
+    expect(semOverflowDrawer.scrollWidth).toBeLessThanOrEqual(semOverflowDrawer.clientWidth);
+  });
+});
+
+// Bloco `a11y-focus`: drawer fecha com Esc e o foco retorna ao botão gatilho.
+test.describe('Tipo de Documento — foco e Esc (#392)', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockConfiguracaoRuntimeConfig(page);
+  });
+
+  test('drawer fecha com Esc e o foco retorna ao botão "Novo tipo"', async ({ page }) => {
+    await mockApi(page, novoCapturado(), []);
+    await abrirPagina(page);
+
+    const gatilho = page.getByRole('button', { name: 'Novo tipo' }).first();
+    await gatilho.click();
+    await expect(page.locator('dialog.uni-drawer')).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('dialog.uni-drawer')).toBeHidden();
+    await expect(gatilho).toBeFocused();
+  });
+});

--- a/apps/configuracao/src/app/app.routes.ts
+++ b/apps/configuracao/src/app/app.routes.ts
@@ -81,6 +81,14 @@ export const appRoutes: Routes = [
         loadChildren: () =>
           import('./features/tipos-banca/tipos-banca.routes').then((m) => m.TIPOS_BANCA_ROUTES),
       },
+      {
+        path: 'tipos-documento',
+        data: { breadcrumb: 'Tipo de Documento' },
+        loadChildren: () =>
+          import('./features/tipos-documento/tipos-documento.routes').then(
+            (m) => m.TIPOS_DOCUMENTO_ROUTES,
+          ),
+      },
     ],
   },
   { path: '**', redirectTo: '' },

--- a/apps/configuracao/src/app/features/tipos-documento/tipos-documento-list.page.spec.ts
+++ b/apps/configuracao/src/app/features/tipos-documento/tipos-documento-list.page.spec.ts
@@ -1,0 +1,389 @@
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ApplicationRef } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { apiResultInterceptor } from '@uniplus/shared-core/http';
+import { CONFIGURACAO_BASE_PATH, TipoDocumentoDto } from '@uniplus/shared-data/configuracao';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { TiposDocumentoListPage } from './tipos-documento-list.page';
+
+const BASE = 'http://localhost:5000';
+
+const rgSeed: TipoDocumentoDto = {
+  id: '01960000-0000-7000-0000-0000000000d1',
+  codigo: 'RG',
+  nome: 'Registro Geral',
+  descricao: 'Documento de identificação civil.',
+  categoria: 'IDENTIFICACAO',
+  formatosAceitos: 'pdf,jpg',
+  tamanhoMaximoMb: 10,
+  tipoEquivalente: 'CIN',
+  criadoEm: '2026-06-10T12:00:00Z',
+};
+
+const laudoSeed: TipoDocumentoDto = {
+  id: '01960000-0000-7000-0000-0000000000d2',
+  codigo: 'LAUDO_MEDICO',
+  nome: 'Laudo médico — PcD',
+  descricao: null,
+  categoria: 'SAUDE',
+  formatosAceitos: null,
+  tamanhoMaximoMb: null,
+  tipoEquivalente: null,
+  criadoEm: '2026-06-11T12:00:00Z',
+};
+
+describe('TiposDocumentoListPage', () => {
+  let fixture: ComponentFixture<TiposDocumentoListPage>;
+  let component: TiposDocumentoListPage;
+  let controller: HttpTestingController;
+  let appRef: ApplicationRef;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TiposDocumentoListPage],
+      providers: [
+        provideHttpClient(withInterceptors([apiResultInterceptor])),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        { provide: CONFIGURACAO_BASE_PATH, useValue: BASE },
+      ],
+    });
+    fixture = TestBed.createComponent(TiposDocumentoListPage);
+    component = fixture.componentInstance;
+    controller = TestBed.inject(HttpTestingController);
+    appRef = TestBed.inject(ApplicationRef);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => controller.verify());
+
+  const propagate = async (): Promise<void> => {
+    await Promise.resolve();
+    appRef.tick();
+  };
+
+  async function flushLista(itens: readonly TipoDocumentoDto[]): Promise<void> {
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/tipos-documento`);
+    req.flush(itens);
+    await propagate();
+  }
+
+  // TiposDocumentoListPage_Renderizacao
+  it('renderiza a lista com colunas, chips de categoria e paginador', async () => {
+    await flushLista([rgSeed, laudoSeed]);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('RG');
+    expect(fixture.nativeElement.textContent).toContain('Registro Geral');
+    expect(fixture.nativeElement.textContent).toContain('Equiv.:');
+    expect(fixture.nativeElement.textContent).toContain('CIN');
+    expect(component['categoriaChips']().length).toBe(8);
+  });
+
+  // TiposDocumentoListPage_FiltroPorCategoria
+  it('CA-01: chip de categoria filtra a lista e reflete o contador do conjunto atual', async () => {
+    await flushLista([rgSeed, laudoSeed]);
+
+    expect(component['documentosFiltrados']()).toHaveLength(2);
+    component['filtroCategoria'].set('SAUDE');
+    fixture.detectChanges();
+
+    expect(component['documentosFiltrados']()).toHaveLength(1);
+    expect(component['documentosFiltrados']()[0].codigo).toBe('LAUDO_MEDICO');
+    const chipSaude = component['categoriaChips']().find((c) => c.value === 'SAUDE');
+    expect(chipSaude?.count).toBe(1);
+  });
+
+  // TiposDocumentoListPage_BuscaPorTexto
+  it('busca por texto filtra registros por código e nome', async () => {
+    await flushLista([rgSeed, laudoSeed]);
+
+    component['termoBusca'].set('LAUDO');
+    fixture.detectChanges();
+
+    expect(component['documentosFiltrados']()).toHaveLength(1);
+    expect(component['documentosFiltrados']()[0].nome).toBe('Laudo médico — PcD');
+  });
+
+  // TiposDocumentoListPage_EmptyState
+  it('exibe empty-state quando a busca não retorna resultados', async () => {
+    await flushLista([rgSeed]);
+
+    component['termoBusca'].set('XYZNOTFOUND');
+    fixture.detectChanges();
+
+    expect(component['documentosFiltrados']()).toHaveLength(0);
+    expect(component['temFiltro']()).toBe(true);
+    expect(fixture.nativeElement.textContent).toContain('Nenhum tipo de documento encontrado');
+    expect(fixture.nativeElement.textContent).toContain('Limpar filtros');
+  });
+
+  it('exibe empty-state de cadastro inicial quando não há filtro ativo', async () => {
+    await flushLista([]);
+    fixture.detectChanges();
+
+    expect(component['temFiltro']()).toBe(false);
+    expect(fixture.nativeElement.textContent).toContain('Nenhum tipo de documento cadastrado');
+  });
+
+  // TipoDocumentoForm_CamposObrigatorios
+  it('bloqueia salvar com campos obrigatórios vazios', async () => {
+    await flushLista([]);
+    component['abrirCadastro']();
+    fixture.detectChanges();
+
+    component['salvar']();
+
+    controller.expectNone(`${BASE}/api/configuracao/admin/tipos-documento`);
+    expect(component['form'].controls.codigo.errors?.['required']).toBeTruthy();
+    expect(component['form'].controls.nome.errors?.['required']).toBeTruthy();
+    expect(component['form'].controls.categoria.errors?.['required']).toBeTruthy();
+  });
+
+  // TipoDocumentoForm_CodigoDuplicado_422MapeaCampo (via TiposDocumentoListPage_Erro422_MapeaCampo)
+  it('CA-03: código duplicado (409) é mapeado ao campo Código sem fechar o drawer', async () => {
+    await flushLista([]);
+    component['abrirCadastro']();
+    component['form'].patchValue({ codigo: 'RG', nome: 'Registro Geral (dup)', categoria: 'IDENTIFICACAO' });
+    component['salvar']();
+
+    const post = controller.expectOne(`${BASE}/api/configuracao/admin/tipos-documento`);
+    post.flush(
+      JSON.stringify({
+        type: 'https://uniplus.dev/erros/uniplus.configuracao.tipo_documento.codigo_ja_existe',
+        title: 'Já existe um tipo de documento ativo com este código',
+        status: 409,
+        code: 'uniplus.configuracao.tipo_documento.codigo_ja_existe',
+        traceId: 'test-trace',
+      }),
+      {
+        status: 409,
+        statusText: 'Conflict',
+        headers: { 'content-type': 'application/problem+json' },
+      },
+    );
+    await propagate();
+
+    expect(component['formOpen']()).toBe(true);
+    expect(component['form'].controls.codigo.errors?.['backend']).toBeTruthy();
+  });
+
+  // TipoDocumentoForm_TipoEquivalenteIgualCodigo_MarcaErro
+  it('CA-05: tipo equivalente igual ao código é rejeitado no cliente sem chamar o backend', async () => {
+    await flushLista([]);
+    component['abrirCadastro']();
+    component['form'].patchValue({ codigo: 'RG', tipoEquivalente: 'RG' });
+    fixture.detectChanges();
+
+    expect(component['tipoEquivalenteIgualCodigo']()).toBe(true);
+    expect(component['erroDoCampo']('tipoEquivalente')).toBe(
+      'O tipo equivalente não pode ser igual ao próprio código.',
+    );
+
+    component['salvar']();
+    controller.expectNone(`${BASE}/api/configuracao/admin/tipos-documento`);
+  });
+
+  it('tipo equivalente diferente do código não gera erro e permite salvar', async () => {
+    await flushLista([]);
+    component['abrirCadastro']();
+    component['form'].patchValue({ codigo: 'RG', tipoEquivalente: 'CIN' });
+    fixture.detectChanges();
+
+    expect(component['tipoEquivalenteIgualCodigo']()).toBe(false);
+    expect(component['erroDoCampo']('tipoEquivalente')).toBeNull();
+  });
+
+  // TipoDocumentoForm_TamanhoMaximoNaoPositivo_Invalido
+  it('CA-06: tamanho máximo zero ou negativo é inválido; valor positivo é aceito', async () => {
+    await flushLista([]);
+    component['abrirCadastro']();
+    component['form'].controls.tamanhoMaximoMb.setValue(0);
+    component['form'].controls.tamanhoMaximoMb.markAsTouched();
+    expect(component['form'].controls.tamanhoMaximoMb.invalid).toBe(true);
+
+    component['form'].controls.tamanhoMaximoMb.setValue(-5);
+    expect(component['form'].controls.tamanhoMaximoMb.invalid).toBe(true);
+
+    component['form'].controls.tamanhoMaximoMb.setValue(10);
+    expect(component['form'].controls.tamanhoMaximoMb.invalid).toBe(false);
+
+    component['form'].controls.tamanhoMaximoMb.setValue(null);
+    expect(component['form'].controls.tamanhoMaximoMb.invalid).toBe(false);
+  });
+
+  // TipoDocumentoForm_SerializaFormatosParaString
+  it('serializa checkboxes de formato marcados para a string "pdf,jpg,png"', async () => {
+    await flushLista([]);
+    component['abrirCadastro']();
+    component['form'].patchValue({
+      codigo: 'DECL',
+      nome: 'Declaração',
+      categoria: 'OUTROS',
+      formatoPdf: true,
+      formatoJpeg: true,
+      formatoPng: true,
+      formatoTiff: false,
+    });
+    component['salvar']();
+
+    const post = controller.expectOne(`${BASE}/api/configuracao/admin/tipos-documento`);
+    expect(post.request.body.formatosAceitos).toBe('pdf,jpg,png');
+    post.flush('new-id', { status: 201, statusText: 'Created' });
+    await propagate();
+    await flushLista([]);
+  });
+
+  it('nenhum formato marcado serializa para null', async () => {
+    await flushLista([]);
+    component['abrirCadastro']();
+    component['form'].patchValue({ codigo: 'DECL2', nome: 'Declaração 2', categoria: 'OUTROS' });
+    component['salvar']();
+
+    const post = controller.expectOne(`${BASE}/api/configuracao/admin/tipos-documento`);
+    expect(post.request.body.formatosAceitos).toBeNull();
+    post.flush('new-id-2', { status: 201, statusText: 'Created' });
+    await propagate();
+    await flushLista([]);
+  });
+
+  // TipoDocumentoForm_DesserializaStringParaCheckboxes
+  it('desserializa a string "pdf,jpg,png" para os checkboxes marcados ao abrir edição', async () => {
+    await flushLista([rgSeed]);
+    component['abrirEdicao'](rgSeed);
+    fixture.detectChanges();
+
+    expect(component['form'].controls.formatoPdf.value).toBe(true);
+    expect(component['form'].controls.formatoJpeg.value).toBe(true);
+    expect(component['form'].controls.formatoPng.value).toBe(false);
+    expect(component['form'].controls.formatoTiff.value).toBe(false);
+  });
+
+  // TiposDocumentoListPage_IdempotencyKeyFormScoped
+  it('abertura do drawer define nova idempotencyKey; fechar sem salvar não reseta a chave', async () => {
+    await flushLista([]);
+    component['abrirCadastro']();
+    const chaveInicial = component['idempotencyKeyAtual']();
+    expect(chaveInicial).toBeTruthy();
+
+    component['formOpen'].set(false);
+    expect(component['idempotencyKeyAtual']()).toBe(chaveInicial);
+  });
+
+  // TiposDocumentoListPage_CriarSucesso_FechaDrawerRecarregaLista
+  it('CA-02: sucesso no criar fecha o drawer e recarrega a lista', async () => {
+    await flushLista([]);
+    component['abrirCadastro']();
+    component['form'].patchValue({
+      codigo: 'DECL_LIDERANCA',
+      nome: 'Declaração de liderança',
+      categoria: 'OUTROS',
+    });
+    const key = component['idempotencyKeyAtual']();
+
+    component['salvar']();
+
+    const post = controller.expectOne(`${BASE}/api/configuracao/admin/tipos-documento`);
+    expect(post.request.method).toBe('POST');
+    expect(post.request.headers.get('Idempotency-Key')).toBe(key);
+    expect(post.request.body).toMatchObject({
+      codigo: 'DECL_LIDERANCA',
+      nome: 'Declaração de liderança',
+      categoria: 'OUTROS',
+    });
+    post.flush('new-id', { status: 201, statusText: 'Created' });
+    await propagate();
+
+    await flushLista([rgSeed]);
+    expect(component['formOpen']()).toBe(false);
+  });
+
+  // TiposDocumentoListPage_Erro422_MapeaCampo
+  it('erro 422 com errors[] é mapeado ao FormControl correto', async () => {
+    await flushLista([]);
+    component['abrirCadastro']();
+    component['form'].patchValue({ codigo: 'RG', nome: 'Registro Geral', categoria: 'IDENTIFICACAO' });
+    component['salvar']();
+
+    const post = controller.expectOne(`${BASE}/api/configuracao/admin/tipos-documento`);
+    post.flush(
+      JSON.stringify({
+        type: 'https://uniplus.dev/erros/uniplus.validacao',
+        title: 'Erro de validação',
+        status: 422,
+        code: 'uniplus.validacao',
+        traceId: 'test-trace',
+        errors: [{ field: 'Nome', code: 'MaximumLengthValidator', message: 'Nome muito longo.' }],
+      }),
+      {
+        status: 422,
+        statusText: 'Unprocessable Entity',
+        headers: { 'content-type': 'application/problem+json' },
+      },
+    );
+    await propagate();
+
+    expect(component['form'].controls.nome.errors?.['backend']).toMatchObject({
+      message: 'Nome muito longo.',
+    });
+  });
+
+  // TiposDocumentoListPage_Erro5xx_BannerGeral
+  it('erro 5xx exibe banner de alerta geral e notificação com traceId', async () => {
+    await flushLista([]);
+    component['abrirCadastro']();
+    component['form'].patchValue({ codigo: 'RG', nome: 'Registro Geral', categoria: 'IDENTIFICACAO' });
+    component['salvar']();
+
+    const post = controller.expectOne(`${BASE}/api/configuracao/admin/tipos-documento`);
+    post.flush(
+      JSON.stringify({
+        type: 'https://uniplus.dev/erros/uniplus.erro_interno',
+        title: 'Erro interno inesperado',
+        status: 500,
+        code: 'uniplus.erro_interno',
+        traceId: 'trace-500',
+      }),
+      {
+        status: 500,
+        statusText: 'Internal Server Error',
+        headers: { 'content-type': 'application/problem+json' },
+      },
+    );
+    await propagate();
+    fixture.detectChanges();
+
+    expect(component['formError']()).toBe('Erro interno inesperado');
+    expect(fixture.nativeElement.textContent).toContain('Erro interno inesperado');
+  });
+
+  // TiposDocumentoListPage_ModalInativacao_ExibeNomeENota
+  it('CA-07: modal de inativação exibe o nome do tipo e a nota de imunidade RN08', async () => {
+    await flushLista([rgSeed]);
+    component['pedirInativacao'](rgSeed);
+    fixture.detectChanges();
+
+    expect(component['confirmInativarMensagem']()).toContain('Registro Geral');
+    expect(component['confirmInativarMensagem']()).toContain('RG');
+    expect(component['confirmInativarMensagem']()).toContain(
+      'Editais já publicados que o referenciam não são afetados',
+    );
+    expect(component['confirmInativarMensagem']()).toContain('RN08');
+  });
+
+  // TiposDocumentoListPage_ModalInativacao_ConfirmaRemove
+  it('CA-07/CA-08: confirmação no modal dispara remover sem checagem prévia e atualiza a lista', async () => {
+    await flushLista([rgSeed]);
+    component['pedirInativacao'](rgSeed);
+    component['confirmarInativacao']();
+
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/tipos-documento/${rgSeed.id}`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush(null, { status: 204, statusText: 'No Content' });
+    await propagate();
+
+    await flushLista([]);
+    expect(component['confirmInativarAberto']()).toBe(false);
+  });
+});

--- a/apps/configuracao/src/app/features/tipos-documento/tipos-documento-list.page.ts
+++ b/apps/configuracao/src/app/features/tipos-documento/tipos-documento-list.page.ts
@@ -1,0 +1,975 @@
+import { HttpParams } from '@angular/common/http';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  effect,
+  inject,
+  linkedSignal,
+  signal,
+  untracked,
+} from '@angular/core';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { map } from 'rxjs';
+import {
+  ApiResult,
+  Cursor,
+  PaginationDirection,
+  ProblemDetails,
+  ProblemI18nService,
+  ProblemValidationError,
+  cursorToString,
+  extractNextCursor,
+  extractPrevCursor,
+  idempotencyKey,
+  useApiResource,
+  withIdempotencyKey,
+  withVendorMime,
+} from '@uniplus/shared-core/http';
+import { NotificationService } from '@uniplus/shared-core/notifications';
+import {
+  AtualizarTipoDocumentoCommand,
+  CATEGORIAS_DOCUMENTO,
+  CONFIGURACAO_BASE_PATH,
+  CriarTipoDocumentoCommand,
+  TipoDocumentoDto,
+  TiposDocumentoApi,
+} from '@uniplus/shared-data/configuracao';
+import {
+  AlertComponent,
+  ConfirmDialogComponent,
+  DrawerComponent,
+  EmptyStateComponent,
+  FilterChipsComponent,
+  PagerComponent,
+  SpinnerComponent,
+  TagComponent,
+  type UiFilterChipOption,
+} from '@uniplus/shared-ui/components';
+
+/** Tamanho da janela de cada página (cursor pagination, ADR-0026). */
+const PAGE_SIZE = 50;
+
+/** Vendor code do DomainError `TipoDocumento.CodigoJaExiste` (uniplus-api, 409 Conflict). */
+const TIPO_DOCUMENTO_CODIGO_JA_EXISTE_CODE = 'uniplus.configuracao.tipo_documento.codigo_ja_existe';
+
+/** Teto do campo `tamanhoMaximoMb` — o backend só exige `> 0`; sem teto superior no contrato. */
+const TAMANHO_MAXIMO_MB_MINIMO = 1;
+
+type ModoFormulario = 'criar' | 'editar';
+type FormatoAceitoChave = 'formatoPdf' | 'formatoJpeg' | 'formatoPng' | 'formatoTiff';
+
+interface FormatoAceitoOpcao {
+  readonly key: FormatoAceitoChave;
+  readonly extensao: string;
+  readonly label: string;
+}
+
+/**
+ * Roster fechado de formatos de arquivo aceitos (checkboxes do drawer,
+ * serializados para a string orientativa `"pdf,jpg,png"` que o backend
+ * persiste em `formatosAceitos`). A extensão `jpg` (não `jpeg`) é a canônica
+ * de serialização — espelha o exemplo da issue #392.
+ */
+const FORMATOS_ACEITOS_OPCOES: readonly FormatoAceitoOpcao[] = [
+  { key: 'formatoPdf', extensao: 'pdf', label: 'PDF' },
+  { key: 'formatoJpeg', extensao: 'jpg', label: 'JPEG' },
+  { key: 'formatoPng', extensao: 'png', label: 'PNG' },
+  { key: 'formatoTiff', extensao: 'tiff', label: 'TIFF' },
+];
+
+interface TipoDocumentoForm {
+  codigo: FormControl<string>;
+  categoria: FormControl<string>;
+  nome: FormControl<string>;
+  descricao: FormControl<string>;
+  tipoEquivalente: FormControl<string>;
+  formatoPdf: FormControl<boolean>;
+  formatoJpeg: FormControl<boolean>;
+  formatoPng: FormControl<boolean>;
+  formatoTiff: FormControl<boolean>;
+  tamanhoMaximoMb: FormControl<number | null>;
+}
+
+@Component({
+  selector: 'cfg-tipos-documento-list-page',
+  standalone: true,
+  imports: [
+    ReactiveFormsModule,
+    AlertComponent,
+    ConfirmDialogComponent,
+    DrawerComponent,
+    EmptyStateComponent,
+    FilterChipsComponent,
+    PagerComponent,
+    SpinnerComponent,
+    TagComponent,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="page-header">
+      <div class="page-header__content">
+        <h1 class="page-header__title">Tipo de Documento</h1>
+        <p class="page-header__desc">
+          Cadastro classificatório dos documentos que um candidato pode anexar a uma inscrição —
+          código, nome, categoria, formatos aceitos e tamanho máximo. Não define regra material
+          sobre o documento (validade, assinatura, idade de emissão); isso pertence à exigência
+          documental do edital. UNI-REQ-0013.
+        </p>
+      </div>
+    </div>
+
+    @if (errorMessage()) {
+      <ui-alert variant="danger" heading="Não foi possível carregar os tipos de documento">
+        {{ errorMessage() }}
+        <div class="cfg-tipos-documento__retry">
+          <button
+            type="button"
+            class="btn btn--secondary btn--sm"
+            [disabled]="loading()"
+            (click)="tentarNovamente()"
+          >
+            Tentar novamente
+          </button>
+        </div>
+      </ui-alert>
+    }
+
+    <div class="filter-bar" role="search" aria-label="Filtrar tipos de documento">
+      <div class="filter-bar__row">
+        <div class="input-group">
+          <span class="input-group__addon" aria-hidden="true">
+            <i class="pi pi-search"></i>
+          </span>
+          <input
+            type="search"
+            class="input"
+            placeholder="Buscar por código ou nome…"
+            aria-label="Buscar tipo de documento"
+            [value]="termoBusca()"
+            (input)="termoBusca.set(inputValue($event))"
+          />
+        </div>
+      </div>
+      <div class="filter-bar__group">
+        <span class="u-eyebrow">Categoria</span>
+        <ui-filter-chips
+          [options]="categoriaChips()"
+          [selected]="filtroCategoria()"
+          (selectedChange)="filtroCategoria.set($event ?? '')"
+          ariaLabel="Filtrar por categoria"
+        />
+      </div>
+    </div>
+
+    <section class="panel" aria-labelledby="cfg-tipos-documento-list-title">
+      <div class="panel-head">
+        <div class="panel-head__title">
+          <h2 id="cfg-tipos-documento-list-title">Tipos de documento</h2>
+          @if (loading()) {
+            <span class="cfg-tipos-documento__loading"><ui-spinner size="sm" /> Carregando</span>
+          }
+        </div>
+        <button type="button" class="btn btn--primary" (click)="abrirCadastro()">
+          <i class="pi pi-plus btn__icon" aria-hidden="true"></i>
+          Novo tipo
+        </button>
+      </div>
+
+      @if (documentosFiltrados().length > 0) {
+        <div class="table-responsive">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Código</th>
+                <th scope="col">Nome</th>
+                <th scope="col">Categoria</th>
+                <th scope="col">Formatos aceitos</th>
+                <th scope="col">Tam. máx.</th>
+                <th scope="col"><span class="sr-only">Ações</span></th>
+              </tr>
+            </thead>
+            <tbody>
+              @for (tipo of documentosFiltrados(); track tipo.id) {
+                <tr>
+                  <td data-label="Código"><code>{{ tipo.codigo }}</code></td>
+                  <td data-label="Nome">
+                    {{ tipo.nome }}
+                    @if (tipo.tipoEquivalente) {
+                      <div class="table-responsive__meta">Equiv.: <code>{{ tipo.tipoEquivalente }}</code></div>
+                    }
+                  </td>
+                  <td data-label="Categoria"><ui-tag>{{ categoriaLabel(tipo.categoria) }}</ui-tag></td>
+                  <td data-label="Formatos aceitos" class="u-caption">{{ tipo.formatosAceitos || '—' }}</td>
+                  <td data-label="Tam. máx." class="u-caption">{{ tamanhoLabel(tipo.tamanhoMaximoMb) }}</td>
+                  <td class="table-responsive__actions" data-label="Ações">
+                    <button
+                      type="button"
+                      class="btn btn--tertiary btn--sm btn--rect"
+                      [disabled]="loading()"
+                      (click)="abrirEdicao(tipo)"
+                    >
+                      Editar
+                    </button>
+                    <button
+                      type="button"
+                      class="btn btn--tertiary btn--sm btn--rect"
+                      [disabled]="loading()"
+                      (click)="pedirInativacao(tipo)"
+                    >
+                      Inativar
+                    </button>
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+      } @else if (!loading() && !errorMessage()) {
+        @if (temFiltro()) {
+          <ui-empty-state
+            heading="Nenhum tipo de documento encontrado"
+            description="Ajuste a busca ou a categoria para ver resultados."
+          >
+            <button type="button" class="btn btn--secondary" (click)="limparFiltros()">
+              Limpar filtros
+            </button>
+          </ui-empty-state>
+        } @else {
+          <ui-empty-state
+            heading="Nenhum tipo de documento cadastrado"
+            description="Cadastre o primeiro tipo de documento para compor exigências documentais de editais."
+          >
+            <button type="button" class="btn btn--primary" (click)="abrirCadastro()">
+              Novo tipo
+            </button>
+          </ui-empty-state>
+        }
+      }
+
+      @if (prevCursor() !== null || nextCursor() !== null) {
+        <ui-pager
+          statusText="Navegação por páginas"
+          navigationLabel="Paginação de tipos de documento"
+          [hasPrevious]="prevCursor() !== null"
+          [hasNext]="nextCursor() !== null"
+          [isDisabled]="loading()"
+          (previous)="paginaAnterior()"
+          (next)="proximaPagina()"
+        />
+      }
+    </section>
+
+    <ui-drawer
+      class="cfg-form-drawer"
+      [(visible)]="formOpen"
+      [heading]="formHeading()"
+      ariaLabel="Formulário de tipo de documento"
+      position="right"
+    >
+      @if (formError()) {
+        <ui-alert variant="danger" heading="Não foi possível salvar">{{ formError() }}</ui-alert>
+      }
+
+      <form
+        [formGroup]="form"
+        id="cfg-tipo-documento-form"
+        (ngSubmit)="salvar()"
+        novalidate
+        class="cfg-form"
+      >
+        <div class="form-grid form-grid--pair">
+          <label class="field" [class.is-error]="erroDoCampo('codigo')">
+            <span class="field__label is-required">Código</span>
+            <input
+              class="input cfg-input-uppercase"
+              type="text"
+              formControlName="codigo"
+              [attr.aria-invalid]="erroDoCampo('codigo') ? 'true' : null"
+            />
+            <span class="field__hint">
+              Editável. A unicidade entre tipos ativos é validada ao salvar.
+            </span>
+            @if (erroDoCampo('codigo')) {
+              <span class="field__error">{{ erroDoCampo('codigo') }}</span>
+            }
+          </label>
+          <label class="field" [class.is-error]="erroDoCampo('categoria')">
+            <span class="field__label is-required">Categoria</span>
+            <select class="select" formControlName="categoria">
+              <option value="">Selecione…</option>
+              @for (opcao of categoriasDocumento; track opcao.value) {
+                <option [value]="opcao.value">{{ opcao.label }}</option>
+              }
+            </select>
+            <span class="field__hint">Domínio fechado. Congelada no snapshot do edital (RN08).</span>
+            @if (erroDoCampo('categoria')) {
+              <span class="field__error">{{ erroDoCampo('categoria') }}</span>
+            }
+          </label>
+        </div>
+
+        <label class="field field--full" [class.is-error]="erroDoCampo('nome')">
+          <span class="field__label is-required">Nome</span>
+          <input
+            class="input"
+            type="text"
+            formControlName="nome"
+            [attr.aria-invalid]="erroDoCampo('nome') ? 'true' : null"
+          />
+          @if (erroDoCampo('nome')) {
+            <span class="field__error">{{ erroDoCampo('nome') }}</span>
+          }
+        </label>
+
+        <label class="field field--full" [class.is-error]="erroDoCampo('descricao')">
+          <span class="field__label">Descrição</span>
+          <textarea class="textarea" rows="3" formControlName="descricao"></textarea>
+          <span class="field__hint">
+            Observação classificatória — não inclui regra material (validade, assinatura, idade de
+            emissão).
+          </span>
+          @if (erroDoCampo('descricao')) {
+            <span class="field__error">{{ erroDoCampo('descricao') }}</span>
+          }
+        </label>
+
+        <label class="field field--full" [class.is-error]="erroDoCampo('tipoEquivalente')">
+          <span class="field__label">Tipo equivalente</span>
+          <input
+            class="input cfg-input-uppercase"
+            type="text"
+            formControlName="tipoEquivalente"
+            [attr.aria-invalid]="erroDoCampo('tipoEquivalente') ? 'true' : null"
+          />
+          <span class="field__hint">
+            Código de outro tipo equivalente (apenas rótulo classificatório, sem vínculo). Não pode
+            ser igual ao próprio código.
+          </span>
+          @if (erroDoCampo('tipoEquivalente')) {
+            <span class="field__error">{{ erroDoCampo('tipoEquivalente') }}</span>
+          }
+        </label>
+
+        <fieldset class="field field--full">
+          <legend class="field__label">Formatos aceitos</legend>
+          <div class="cfg-tipo-documento-formatos">
+            @for (opcao of formatosAceitosOpcoes; track opcao.key) {
+              <label class="checkbox">
+                <input type="checkbox" [formControlName]="opcao.key" />
+                <span class="checkbox__box"></span>
+                {{ opcao.label }}
+              </label>
+            }
+          </div>
+          <span class="field__hint">
+            Orientativo — extensões de arquivo aceitas para o upload deste documento.
+          </span>
+        </fieldset>
+
+        <label class="field" [class.is-error]="erroDoCampo('tamanhoMaximoMb')">
+          <span class="field__label">Tamanho máximo (MB)</span>
+          <input
+            class="input"
+            type="number"
+            min="1"
+            step="1"
+            formControlName="tamanhoMaximoMb"
+            [attr.aria-invalid]="erroDoCampo('tamanhoMaximoMb') ? 'true' : null"
+          />
+          <span class="field__hint">Quando informado, deve ser um inteiro positivo (≥ 1).</span>
+          @if (erroDoCampo('tamanhoMaximoMb')) {
+            <span class="field__error">{{ erroDoCampo('tamanhoMaximoMb') }}</span>
+          }
+        </label>
+      </form>
+
+      <div class="cfg-form-footer">
+        <button type="button" class="btn btn--tertiary btn--rect" (click)="formOpen.set(false)">
+          Cancelar
+        </button>
+        <button
+          type="submit"
+          form="cfg-tipo-documento-form"
+          class="btn btn--primary"
+          [disabled]="saving() || tipoEquivalenteIgualCodigo()"
+        >
+          @if (saving()) {
+            <ui-spinner size="sm" />
+          }
+          {{
+            saving()
+              ? 'Salvando...'
+              : modo() === 'criar'
+                ? 'Criar tipo de documento'
+                : 'Salvar tipo de documento'
+          }}
+        </button>
+      </div>
+    </ui-drawer>
+
+    <ui-confirm-dialog
+      [(visible)]="confirmInativarAberto"
+      heading="Inativar tipo de documento"
+      [message]="confirmInativarMensagem()"
+      confirmLabel="Inativar"
+      confirmVariant="danger"
+      (confirmed)="confirmarInativacao()"
+    />
+  `,
+})
+export class TiposDocumentoListPage {
+  private readonly api = inject(TiposDocumentoApi);
+  private readonly problemI18n = inject(ProblemI18nService);
+  private readonly notifications = inject(NotificationService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly basePath = inject(CONFIGURACAO_BASE_PATH);
+
+  protected readonly categoriasDocumento = CATEGORIAS_DOCUMENTO;
+  protected readonly formatosAceitosOpcoes = FORMATOS_ACEITOS_OPCOES;
+
+  protected readonly saving = signal(false);
+  protected readonly formOpen = signal(false);
+  protected readonly formError = signal<string | null>(null);
+  protected readonly modo = signal<ModoFormulario>('criar');
+  protected readonly tipoEmEdicaoId = signal<string | null>(null);
+  protected readonly idempotencyKeyAtual = signal(idempotencyKey.create());
+  protected readonly termoBusca = signal('');
+  protected readonly filtroCategoria = signal('');
+
+  protected readonly confirmInativarAberto = signal(false);
+  protected readonly tipoParaInativar = signal<TipoDocumentoDto | null>(null);
+  protected readonly confirmError = signal<string | null>(null);
+
+  private readonly pagina = signal<
+    { readonly cursor: Cursor; readonly direction: PaginationDirection } | undefined
+  >(undefined);
+
+  private readonly lista = useApiResource<readonly TipoDocumentoDto[]>(() => ({
+    url: `${this.basePath}/api/configuracao/tipos-documento`,
+    params: this.montarParams(),
+    context: withVendorMime('tipo-documento', 1),
+  }));
+
+  protected readonly loading = this.lista.isLoading;
+
+  private readonly cursores = linkedSignal<
+    ApiResult<readonly TipoDocumentoDto[]> | undefined,
+    { readonly prev: Cursor | null; readonly next: Cursor | null }
+  >({
+    source: () => this.lista.value(),
+    computation: (envelope, previous) => {
+      const atual = previous?.value ?? { prev: null, next: null };
+      if (envelope === undefined) {
+        return atual;
+      }
+      const primeiraPagina = untracked(() => this.pagina() === undefined);
+      if (!envelope.ok) {
+        return primeiraPagina ? { prev: null, next: null } : atual;
+      }
+      const link = untracked(() => this.lista.headers()?.get('Link') ?? null);
+      return { prev: extractPrevCursor(link), next: extractNextCursor(link) };
+    },
+  });
+
+  protected readonly prevCursor = computed(() => this.cursores().prev);
+  protected readonly nextCursor = computed(() => this.cursores().next);
+
+  protected readonly tiposDocumento = linkedSignal<
+    ApiResult<readonly TipoDocumentoDto[]> | undefined,
+    readonly TipoDocumentoDto[]
+  >({
+    source: () => this.lista.value(),
+    computation: (envelope, previous) => {
+      const atual = previous?.value ?? [];
+      if (envelope === undefined) {
+        return atual;
+      }
+      const primeiraPagina = untracked(() => this.pagina() === undefined);
+      if (!envelope.ok) {
+        return primeiraPagina ? [] : atual;
+      }
+      return [...envelope.data];
+    },
+  });
+
+  // Busca client-side sobre a página carregada: o backend só pagina por
+  // cursor, sem filtro de texto/categoria no contrato (issue #392 §4).
+  protected readonly registrosBuscados = computed(() => {
+    const termo = this.termoBusca().trim().toLocaleLowerCase('pt-BR');
+    const registros = this.tiposDocumento();
+    if (termo.length === 0) {
+      return registros;
+    }
+    return registros.filter(
+      (tipo) =>
+        tipo.codigo.toLocaleLowerCase('pt-BR').includes(termo) ||
+        tipo.nome.toLocaleLowerCase('pt-BR').includes(termo),
+    );
+  });
+
+  /**
+   * Chips de categoria com contador dinâmico sobre o conjunto já filtrado por
+   * busca textual (CA-01) — refletem quantos registros de cada categoria
+   * casam com o termo digitado, antes de aplicar o próprio filtro de chip.
+   */
+  protected readonly categoriaChips = computed<readonly UiFilterChipOption[]>(() => {
+    const registros = this.registrosBuscados();
+    const contagem = new Map<string, number>();
+    for (const registro of registros) {
+      contagem.set(registro.categoria, (contagem.get(registro.categoria) ?? 0) + 1);
+    }
+    return [
+      { value: '', label: 'Todas', count: registros.length },
+      ...CATEGORIAS_DOCUMENTO.map((categoria) => ({
+        value: categoria.value,
+        label: categoria.label,
+        count: contagem.get(categoria.value) ?? 0,
+      })),
+    ];
+  });
+
+  protected readonly documentosFiltrados = computed(() => {
+    const categoria = this.filtroCategoria();
+    const registros = this.registrosBuscados();
+    if (categoria === '') {
+      return registros;
+    }
+    return registros.filter((tipo) => tipo.categoria === categoria);
+  });
+
+  protected readonly temFiltro = computed(
+    () => this.termoBusca().trim().length > 0 || this.filtroCategoria() !== '',
+  );
+
+  protected readonly errorMessage = computed<string | null>(() => {
+    const problem = this.lista.problem();
+    if (problem) {
+      return this.problemI18n.resolve(problem).title;
+    }
+    return this.lista.error() ? 'Erro inesperado ao carregar tipos de documento.' : null;
+  });
+
+  protected readonly formHeading = computed(() =>
+    this.modo() === 'criar' ? 'Novo tipo de documento' : 'Editar tipo de documento',
+  );
+
+  protected readonly confirmInativarMensagem = computed(() => {
+    const erro = this.confirmError();
+    if (erro !== null) {
+      return erro;
+    }
+    const tipo = this.tipoParaInativar();
+    return tipo
+      ? `Deseja inativar "${tipo.nome}" (${tipo.codigo})? O tipo é inativado e mantido na ` +
+          'trilha de auditoria. Editais já publicados que o referenciam não são afetados — os ' +
+          'parâmetros foram congelados na configuração do edital (RN08).'
+      : 'Deseja inativar este tipo de documento?';
+  });
+
+  protected readonly form: FormGroup<TipoDocumentoForm> = new FormGroup<TipoDocumentoForm>({
+    codigo: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required, Validators.maxLength(60)],
+    }),
+    categoria: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
+    nome: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required, Validators.minLength(2), Validators.maxLength(200)],
+    }),
+    descricao: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.maxLength(1000)],
+    }),
+    tipoEquivalente: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.maxLength(60)],
+    }),
+    formatoPdf: new FormControl(false, { nonNullable: true }),
+    formatoJpeg: new FormControl(false, { nonNullable: true }),
+    formatoPng: new FormControl(false, { nonNullable: true }),
+    formatoTiff: new FormControl(false, { nonNullable: true }),
+    tamanhoMaximoMb: new FormControl<number | null>(null, {
+      validators: [Validators.min(TAMANHO_MAXIMO_MB_MINIMO)],
+    }),
+  });
+
+  // Valor reativo do formulário — só para a checagem de auto-equivalência
+  // client-side (§5.2 da issue #392), que precisa reagir a cada tecla/blur
+  // sem depender de round-trip ao backend. `getRawValue()` (não `.value` do
+  // próprio `valueChanges`) preserva os campos como não-opcionais mesmo com
+  // nenhum control desabilitado.
+  private readonly formValue = toSignal(
+    this.form.valueChanges.pipe(map(() => this.form.getRawValue())),
+    { initialValue: this.form.getRawValue() },
+  );
+
+  /**
+   * `tipoEquivalente` igual ao próprio `codigo` (trim, case-sensitive —
+   * espelha o guard `StringComparison.Ordinal` do backend). Gate do botão
+   * Salvar e fonte do erro inline — sem chamada de rede (§5.2).
+   */
+  protected readonly tipoEquivalenteIgualCodigo = computed(() => {
+    const valor = this.formValue();
+    const equivalente = valor.tipoEquivalente.trim();
+    const codigo = valor.codigo.trim();
+    return equivalente.length > 0 && equivalente === codigo;
+  });
+
+  constructor() {
+    effect(() => {
+      const problem = this.lista.problem();
+      if (problem && problem.status >= 500) {
+        const titulo = this.problemI18n.resolve(problem).title;
+        untracked(() => this.notifications.errorFromProblem(problem, { title: titulo }));
+      }
+    });
+
+    // Sincroniza o erro inline de auto-equivalência no próprio FormControl —
+    // mesmo mecanismo de `erroDoCampo()` usado para erros required/backend,
+    // sem duplicar a lógica de exibição.
+    effect(() => {
+      const invalido = this.tipoEquivalenteIgualCodigo();
+      untracked(() => {
+        const control = this.form.controls.tipoEquivalente;
+        if (invalido) {
+          control.setErrors({ ...control.errors, igualAoCodigo: true });
+          control.markAsTouched();
+          return;
+        }
+        if (control.errors?.['igualAoCodigo']) {
+          const resto = { ...control.errors };
+          delete resto['igualAoCodigo'];
+          control.setErrors(Object.keys(resto).length > 0 ? resto : null);
+        }
+      });
+    });
+  }
+
+  protected inputValue(event: Event): string {
+    return event.target instanceof HTMLInputElement ? event.target.value : '';
+  }
+
+  protected limparFiltros(): void {
+    this.termoBusca.set('');
+    this.filtroCategoria.set('');
+  }
+
+  protected categoriaLabel(valor: string): string {
+    return CATEGORIAS_DOCUMENTO.find((categoria) => categoria.value === valor)?.label ?? valor;
+  }
+
+  protected tamanhoLabel(valor: number | string | null): string {
+    const normalizado = normalizarTamanhoMaximo(valor);
+    return normalizado === null ? '—' : `${normalizado} MB`;
+  }
+
+  protected proximaPagina(): void {
+    const proximo = this.nextCursor();
+    if (proximo !== null && !this.loading()) {
+      this.pagina.set({ cursor: proximo, direction: 'next' });
+    }
+  }
+
+  protected paginaAnterior(): void {
+    const anterior = this.prevCursor();
+    if (anterior !== null && !this.loading()) {
+      this.pagina.set({ cursor: anterior, direction: 'prev' });
+    }
+  }
+
+  protected tentarNovamente(): void {
+    if (!this.loading()) {
+      this.lista.reload();
+    }
+  }
+
+  protected abrirCadastro(): void {
+    this.modo.set('criar');
+    this.tipoEmEdicaoId.set(null);
+    this.form.reset({
+      codigo: '',
+      categoria: '',
+      nome: '',
+      descricao: '',
+      tipoEquivalente: '',
+      formatoPdf: false,
+      formatoJpeg: false,
+      formatoPng: false,
+      formatoTiff: false,
+      tamanhoMaximoMb: null,
+    });
+    this.formError.set(null);
+    this.idempotencyKeyAtual.set(idempotencyKey.create());
+    this.formOpen.set(true);
+  }
+
+  protected abrirEdicao(tipo: TipoDocumentoDto): void {
+    this.modo.set('editar');
+    this.tipoEmEdicaoId.set(tipo.id);
+    const formatos = desserializarFormatosAceitos(tipo.formatosAceitos);
+    this.form.reset({
+      codigo: tipo.codigo,
+      categoria: tipo.categoria,
+      nome: tipo.nome,
+      descricao: tipo.descricao ?? '',
+      tipoEquivalente: tipo.tipoEquivalente ?? '',
+      formatoPdf: formatos.formatoPdf,
+      formatoJpeg: formatos.formatoJpeg,
+      formatoPng: formatos.formatoPng,
+      formatoTiff: formatos.formatoTiff,
+      tamanhoMaximoMb: normalizarTamanhoMaximo(tipo.tamanhoMaximoMb),
+    });
+    this.formError.set(null);
+    this.idempotencyKeyAtual.set(idempotencyKey.create());
+    this.formOpen.set(true);
+  }
+
+  protected pedirInativacao(tipo: TipoDocumentoDto): void {
+    this.tipoParaInativar.set(tipo);
+    this.confirmError.set(null);
+    this.confirmInativarAberto.set(true);
+  }
+
+  protected confirmarInativacao(): void {
+    const tipo = this.tipoParaInativar();
+    if (tipo === null || this.saving()) {
+      return;
+    }
+    this.saving.set(true);
+    this.api
+      .remover(tipo.id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((result) => {
+        this.saving.set(false);
+        if (result.ok) {
+          this.notifications.success('Tipo de documento inativado', tipo.codigo);
+          this.confirmInativarAberto.set(false);
+          this.tipoParaInativar.set(null);
+          this.recarregar();
+          return;
+        }
+        // O `ui-confirm-dialog` fecha a si mesmo de forma síncrona ao emitir
+        // `confirmed` (antes desta resposta HTTP assíncrona chegar) — reabrir
+        // explicitamente com a mensagem de erro mantém o fluxo visível.
+        const titulo = this.problemI18n.resolve(result.problem).title;
+        this.confirmError.set(titulo);
+        this.confirmInativarAberto.set(true);
+        if (result.problem.status >= 500) {
+          this.notifications.errorFromProblem(result.problem, { title: titulo });
+        }
+      });
+  }
+
+  protected salvar(): void {
+    if (this.saving() || this.tipoEquivalenteIgualCodigo()) {
+      return;
+    }
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    this.saving.set(true);
+    this.formError.set(null);
+
+    if (this.modo() === 'criar') {
+      this.api
+        .criar(this.criarCommand(), withIdempotencyKey(this.idempotencyKeyAtual()))
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe((result) => this.handleSalvarResult(result));
+      return;
+    }
+
+    this.api
+      .atualizar(
+        this.tipoEmEdicaoId() ?? '',
+        this.atualizarCommand(),
+        withIdempotencyKey(this.idempotencyKeyAtual()),
+      )
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((result) => this.handleSalvarResult(result));
+  }
+
+  protected erroDoCampo(nome: keyof TipoDocumentoForm): string | null {
+    const control = this.form.controls[nome];
+    const shouldShowError = control.touched || control.dirty;
+    if (!shouldShowError || control.errors === null) {
+      return null;
+    }
+    if (control.errors['backend']) {
+      const backend = control.errors['backend'] as { code: string; message: string };
+      return backend.message;
+    }
+    if (control.errors['igualAoCodigo']) {
+      return 'O tipo equivalente não pode ser igual ao próprio código.';
+    }
+    if (control.errors['required']) return 'Campo obrigatório.';
+    if (control.errors['maxlength']) return 'Valor acima do tamanho permitido.';
+    if (control.errors['minlength']) return 'Valor abaixo do tamanho mínimo.';
+    if (control.errors['min']) return 'Deve ser um inteiro positivo (≥ 1).';
+    return 'Valor inválido.';
+  }
+
+  private montarParams(): HttpParams {
+    const pagina = this.pagina();
+    if (pagina === undefined) {
+      return new HttpParams().set('limit', String(PAGE_SIZE));
+    }
+    return new HttpParams()
+      .set('cursor', cursorToString(pagina.cursor))
+      .set('direction', pagina.direction);
+  }
+
+  private recarregar(): void {
+    if (this.pagina() === undefined) {
+      this.lista.reload();
+    } else {
+      this.pagina.set(undefined);
+    }
+  }
+
+  private handleSalvarResult(result: ApiResult<string | void>): void {
+    this.saving.set(false);
+    if (result.ok) {
+      this.notifications.success(
+        this.modo() === 'criar' ? 'Tipo de documento criado' : 'Tipo de documento atualizado',
+      );
+      this.formOpen.set(false);
+      this.idempotencyKeyAtual.set(idempotencyKey.create());
+      this.recarregar();
+      return;
+    }
+    this.aplicarFalha(result.problem);
+  }
+
+  private aplicarFalha(problem: ProblemDetails): void {
+    if (problem.status === 422 && problem.errors && problem.errors.length > 0) {
+      this.renovarIdempotencyKey();
+      this.aplicarErrosDeValidacao(problem.errors);
+      return;
+    }
+    // TipoDocumento.CodigoJaExiste é um DomainError único (409, sem
+    // `errors[]` — esse array só existe no pipeline FluentValidation/422);
+    // mapeado ao campo manualmente para exibir o erro inline exigido pelo CA-03.
+    if (problem.code === TIPO_DOCUMENTO_CODIGO_JA_EXISTE_CODE) {
+      this.renovarIdempotencyKey();
+      this.form.controls.codigo.setErrors({
+        backend: { code: problem.code, message: this.problemI18n.resolve(problem).title },
+      });
+      this.form.controls.codigo.markAsTouched();
+      return;
+    }
+    if (problem.status === 409 || problem.code === 'uniplus.idempotency.body_mismatch') {
+      this.renovarIdempotencyKey();
+    }
+    this.formError.set(this.problemI18n.resolve(problem).title);
+    if (problem.status >= 500) {
+      this.notifications.errorFromProblem(problem);
+    }
+  }
+
+  private renovarIdempotencyKey(): void {
+    this.idempotencyKeyAtual.set(idempotencyKey.create());
+  }
+
+  private aplicarErrosDeValidacao(errors: ReadonlyArray<ProblemValidationError>): void {
+    let aplicouAlgum = false;
+    for (const erro of errors) {
+      const controlName = controlNameFromBackendField(erro.field);
+      if (controlName === null) continue;
+      const control = this.form.controls[controlName];
+      control.setErrors({ backend: { code: erro.code, message: erro.message } });
+      control.markAsTouched();
+      aplicouAlgum = true;
+    }
+
+    if (aplicouAlgum) {
+      this.formError.set(null);
+      return;
+    }
+    this.formError.set('Não foi possível mapear os erros de validação. Revise os campos.');
+  }
+
+  private criarCommand(): CriarTipoDocumentoCommand {
+    const raw = this.form.getRawValue();
+    return {
+      codigo: raw.codigo.trim(),
+      nome: raw.nome.trim(),
+      categoria: raw.categoria,
+      descricao: nullIfBlank(raw.descricao),
+      formatosAceitos: serializarFormatosAceitos(raw),
+      tamanhoMaximoMb: raw.tamanhoMaximoMb,
+      tipoEquivalente: nullIfBlank(raw.tipoEquivalente),
+    };
+  }
+
+  private atualizarCommand(): AtualizarTipoDocumentoCommand {
+    return { id: this.tipoEmEdicaoId() ?? '', ...this.criarCommand() };
+  }
+}
+
+const TIPO_DOCUMENTO_CONTROL_NAMES: ReadonlySet<string> = new Set<keyof TipoDocumentoForm>([
+  'codigo',
+  'categoria',
+  'nome',
+  'descricao',
+  'tipoEquivalente',
+  'tamanhoMaximoMb',
+]);
+
+function controlNameFromBackendField(field: string): keyof TipoDocumentoForm | null {
+  const normalized =
+    field
+      .split('.')
+      .at(-1)
+      ?.replace(/\[\d+\]$/u, '') ?? field;
+  const camelCase = normalized.charAt(0).toLocaleLowerCase('pt-BR') + normalized.slice(1);
+  return TIPO_DOCUMENTO_CONTROL_NAMES.has(camelCase)
+    ? (camelCase as keyof TipoDocumentoForm)
+    : null;
+}
+
+function nullIfBlank(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+// `tamanhoMaximoMb` é `int32` no contrato, mas o `schema.ts` gerado tipa como
+// `number | string | null` (mesmo padrão de `OfertaCursoDto.vagasAnuaisAutorizadas`)
+// — o form (`FormControl<number | null>`) preserva o valor mesmo quando o
+// backend serializa como string.
+function normalizarTamanhoMaximo(valor: number | string | null | undefined): number | null {
+  if (valor === null || valor === undefined) {
+    return null;
+  }
+  const numero = typeof valor === 'number' ? valor : Number(valor);
+  return Number.isFinite(numero) ? numero : null;
+}
+
+/** Serializa os checkboxes marcados para a string orientativa `"pdf,jpg,png"` (§5.5 da issue #392). */
+function serializarFormatosAceitos(raw: Record<FormatoAceitoChave, boolean>): string | null {
+  const extensoes = FORMATOS_ACEITOS_OPCOES.filter((opcao) => raw[opcao.key]).map(
+    (opcao) => opcao.extensao,
+  );
+  return extensoes.length > 0 ? extensoes.join(',') : null;
+}
+
+/** Desserializa a string persistida (ex.: `"pdf,jpg,png"`) para o estado dos 4 checkboxes. */
+function desserializarFormatosAceitos(
+  valor: string | null | undefined,
+): Record<FormatoAceitoChave, boolean> {
+  const extensoes = new Set(
+    (valor ?? '')
+      .split(',')
+      .map((item) => item.trim().toLocaleLowerCase('pt-BR'))
+      .filter((item) => item.length > 0),
+  );
+  return {
+    formatoPdf: extensoes.has('pdf'),
+    formatoJpeg: extensoes.has('jpg') || extensoes.has('jpeg'),
+    formatoPng: extensoes.has('png'),
+    formatoTiff: extensoes.has('tiff') || extensoes.has('tif'),
+  };
+}

--- a/apps/configuracao/src/app/features/tipos-documento/tipos-documento.routes.ts
+++ b/apps/configuracao/src/app/features/tipos-documento/tipos-documento.routes.ts
@@ -1,0 +1,9 @@
+import { Routes } from '@angular/router';
+
+export const TIPOS_DOCUMENTO_ROUTES: Routes = [
+  {
+    path: '',
+    loadComponent: () =>
+      import('./tipos-documento-list.page').then((m) => m.TiposDocumentoListPage),
+  },
+];

--- a/apps/configuracao/src/app/layout/layout.ts
+++ b/apps/configuracao/src/app/layout/layout.ts
@@ -242,7 +242,12 @@ export class LayoutComponent {
           exact: true,
         },
         { label: 'Modalidade', icon: 'pi-users' },
-        { label: 'Tipo de Documento', icon: 'pi-id-card' },
+        {
+          label: 'Tipo de Documento',
+          icon: 'pi-id-card',
+          routerLink: '/tipos-documento',
+          exact: true,
+        },
         { label: 'Condição de Atendimento', icon: 'pi-heart' },
         { label: 'Recurso de Acessibilidade', icon: 'pi-universal-access' },
         { label: 'Tipo de Deficiência', icon: 'pi-eye' },

--- a/apps/configuracao/src/styles.css
+++ b/apps/configuracao/src/styles.css
@@ -670,6 +670,19 @@ cfg-pesos-enem-page {
   grid-column: 1 / -1;
 }
 
+/* Realce visual (não normativo) para campos de código curto — o valor
+   digitado não é forçado a maiúsculas, só exibido assim (Tipo de Documento,
+   issue #392 §3.1). */
+.cfg-input-uppercase {
+  text-transform: uppercase;
+}
+
+.cfg-tipo-documento-formatos {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+}
+
 .field__readonly {
   display: flex;
   align-items: center;

--- a/libs/shared-data/src/lib/api/configuracao/index.ts
+++ b/libs/shared-data/src/lib/api/configuracao/index.ts
@@ -72,3 +72,12 @@ export {
   type TipoBancaDto,
   type TiposBancaQuery,
 } from './tipos-banca.api';
+export {
+  TiposDocumentoApi,
+  CATEGORIAS_DOCUMENTO,
+  type AtualizarTipoDocumentoCommand,
+  type CategoriaDocumentoOption,
+  type CriarTipoDocumentoCommand,
+  type TipoDocumentoDto,
+  type TiposDocumentoQuery,
+} from './tipos-documento.api';

--- a/libs/shared-data/src/lib/api/configuracao/tipos-documento.api.spec.ts
+++ b/libs/shared-data/src/lib/api/configuracao/tipos-documento.api.spec.ts
@@ -1,0 +1,117 @@
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  ApiResult,
+  apiResultInterceptor,
+  buildVendorMimeAccept,
+  isApiOk,
+  withIdempotencyKey,
+} from '@uniplus/shared-core/http';
+import { AtualizarTipoDocumentoCommand, CriarTipoDocumentoCommand, TipoDocumentoDto, TiposDocumentoApi } from './tipos-documento.api';
+import { CONFIGURACAO_BASE_PATH } from './tokens';
+
+const BASE = 'http://localhost:5000';
+const ID = '01960000-0000-7000-0000-0000000000d1';
+
+const tipoDocumentoSeed: TipoDocumentoDto = {
+  id: ID,
+  codigo: 'RG',
+  nome: 'Registro Geral',
+  descricao: 'Documento de identificação civil.',
+  categoria: 'IDENTIFICACAO',
+  formatosAceitos: 'pdf,jpg,png',
+  tamanhoMaximoMb: 10,
+  tipoEquivalente: 'CIN',
+  criadoEm: '2026-06-10T12:00:00Z',
+};
+
+const criarCommand: CriarTipoDocumentoCommand = {
+  codigo: 'RG',
+  nome: 'Registro Geral',
+  categoria: 'IDENTIFICACAO',
+  descricao: 'Documento de identificação civil.',
+  formatosAceitos: 'pdf,jpg,png',
+  tamanhoMaximoMb: 10,
+  tipoEquivalente: 'CIN',
+};
+
+describe('TiposDocumentoApi', () => {
+  let api: TiposDocumentoApi;
+  let controller: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([apiResultInterceptor])),
+        provideHttpClientTesting(),
+        { provide: CONFIGURACAO_BASE_PATH, useValue: BASE },
+      ],
+    });
+    api = TestBed.inject(TiposDocumentoApi);
+    controller = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => controller.verify());
+
+  it('listar() faz GET /api/configuracao/tipos-documento com limit e Accept versionado', async () => {
+    const promise = firstValueFrom(api.listar({ limit: 50 }));
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/tipos-documento`);
+    expect(req.request.params.get('limit')).toBe('50');
+    expect(req.request.headers.get('Accept')).toBe(buildVendorMimeAccept('tipo-documento', 1));
+    req.flush([tipoDocumentoSeed]);
+    const result = (await promise) as ApiResult<readonly TipoDocumentoDto[]>;
+    expect(isApiOk(result)).toBe(true);
+  });
+
+  it('listar() com cursor envia cursor + direction e omite limit', async () => {
+    const promise = firstValueFrom(api.listar({ cursor: 'abc', direction: 'prev' }));
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/tipos-documento`);
+    expect(req.request.params.get('cursor')).toBe('abc');
+    expect(req.request.params.get('direction')).toBe('prev');
+    expect(req.request.params.has('limit')).toBe(false);
+    req.flush([tipoDocumentoSeed]);
+    await promise;
+  });
+
+  it('obter() faz GET /api/configuracao/tipos-documento/{id}', async () => {
+    const promise = firstValueFrom(api.obter(ID));
+    const req = controller.expectOne(`${BASE}/api/configuracao/tipos-documento/${ID}`);
+    expect(req.request.method).toBe('GET');
+    req.flush(tipoDocumentoSeed);
+    const result = (await promise) as ApiResult<TipoDocumentoDto>;
+    expect(isApiOk(result)).toBe(true);
+  });
+
+  it('criar() faz POST /api/configuracao/admin/tipos-documento com Idempotency-Key e Accept JSON', async () => {
+    const promise = firstValueFrom(api.criar(criarCommand, withIdempotencyKey('k')));
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/tipos-documento`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.headers.get('Idempotency-Key')).toBe('k');
+    expect(req.request.headers.get('Accept')).toBe('application/json');
+    req.flush(ID, { status: 201, statusText: 'Created' });
+    const result = (await promise) as ApiResult<string>;
+    expect(isApiOk(result)).toBe(true);
+  });
+
+  it('atualizar() faz PUT /api/configuracao/admin/tipos-documento/{id}', async () => {
+    const command: AtualizarTipoDocumentoCommand = { id: ID, ...criarCommand };
+    const promise = firstValueFrom(api.atualizar(ID, command, withIdempotencyKey('k')));
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/tipos-documento/${ID}`);
+    expect(req.request.method).toBe('PUT');
+    req.flush(null, { status: 204, statusText: 'No Content' });
+    const result = (await promise) as ApiResult<void>;
+    expect(isApiOk(result)).toBe(true);
+  });
+
+  it('remover() faz DELETE /api/configuracao/admin/tipos-documento/{id}', async () => {
+    const promise = firstValueFrom(api.remover(ID));
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/tipos-documento/${ID}`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush(null, { status: 204, statusText: 'No Content' });
+    const result = (await promise) as ApiResult<void>;
+    expect(isApiOk(result)).toBe(true);
+  });
+});

--- a/libs/shared-data/src/lib/api/configuracao/tipos-documento.api.ts
+++ b/libs/shared-data/src/lib/api/configuracao/tipos-documento.api.ts
@@ -1,0 +1,106 @@
+import { HttpClient, HttpContext, HttpHeaders, HttpParams } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiResult, withVendorMime } from '@uniplus/shared-core/http';
+import type { components } from './schema';
+import { CONFIGURACAO_BASE_PATH } from './tokens';
+
+export type TipoDocumentoDto = components['schemas']['TipoDocumentoDto'];
+export type CriarTipoDocumentoCommand = components['schemas']['CriarTipoDocumentoCommand'];
+export type AtualizarTipoDocumentoCommand = components['schemas']['AtualizarTipoDocumentoCommand'];
+
+/** Opção de categoria de documento (domínio fechado, 7 valores). */
+export interface CategoriaDocumentoOption {
+  readonly value: string;
+  readonly label: string;
+}
+
+/**
+ * As 7 categorias de `CategoriaDocumento` — vocabulário de referência (enum
+ * fechado no backend, exposto como `string` no contrato). Espelha
+ * `GRUPOS_AREA_ENEM` de `CursosApi`.
+ */
+export const CATEGORIAS_DOCUMENTO: readonly CategoriaDocumentoOption[] = [
+  { value: 'IDENTIFICACAO', label: 'Identificação' },
+  { value: 'ESCOLARIDADE', label: 'Escolaridade' },
+  { value: 'RENDA', label: 'Renda' },
+  { value: 'RACA_ETNIA', label: 'Raça/etnia' },
+  { value: 'SAUDE', label: 'Saúde' },
+  { value: 'RESIDENCIA', label: 'Residência' },
+  { value: 'OUTROS', label: 'Outros' },
+] as const;
+
+/** Filtro de listagem de Tipos de Documento (cursor pagination, ADR-0026). */
+export interface TiposDocumentoQuery {
+  readonly cursor?: string;
+  readonly direction?: 'next' | 'prev';
+  readonly limit?: number;
+}
+
+/**
+ * Cliente Angular standalone do recurso Tipo de Documento (módulo
+ * Configuração). Cadastro classificatório puro — sem FK para outras
+ * entidades cadastrais; `tipoEquivalente` é só um rótulo textual (não
+ * referência), congelado por snapshot na configuração de exigência
+ * documental do edital (RN08, fora desta tela).
+ *
+ * API thin (ADR-0013): tipos do `schema.ts` gerado; resposta envelopada em
+ * `ApiResult<T>` (ADR-0011); versionamento por vendor MIME `tipo-documento
+ * v1` (ADR-0016/0028). Espelha `CursosApi`/`CampiApi`.
+ */
+@Injectable({ providedIn: 'root' })
+export class TiposDocumentoApi {
+  private readonly http = inject(HttpClient);
+  private readonly basePath = inject(CONFIGURACAO_BASE_PATH);
+
+  /** GET `/api/configuracao/tipos-documento` — lista paginada por cursor (ADR-0026). */
+  listar(query: TiposDocumentoQuery = {}): Observable<ApiResult<readonly TipoDocumentoDto[]>> {
+    let params = new HttpParams();
+    if (query.cursor !== undefined) {
+      params = params.set('cursor', query.cursor).set('direction', query.direction ?? 'next');
+    } else {
+      params = params.set('limit', String(query.limit ?? 100));
+    }
+    return this.http.get<ApiResult<readonly TipoDocumentoDto[]>>(
+      `${this.basePath}/api/configuracao/tipos-documento`,
+      { params, context: withVendorMime('tipo-documento', 1) },
+    );
+  }
+
+  /** GET `/api/configuracao/tipos-documento/{id}` — detalhe de um Tipo de Documento. */
+  obter(id: string): Observable<ApiResult<TipoDocumentoDto>> {
+    return this.http.get<ApiResult<TipoDocumentoDto>>(
+      `${this.basePath}/api/configuracao/tipos-documento/${encodeURIComponent(id)}`,
+      { context: withVendorMime('tipo-documento', 1) },
+    );
+  }
+
+  /** POST `/api/configuracao/admin/tipos-documento` — cria um Tipo de Documento. Idempotency-Key obrigatório (ADR-0027). */
+  criar(command: CriarTipoDocumentoCommand, context: HttpContext): Observable<ApiResult<string>> {
+    return this.http.post<ApiResult<string>>(
+      `${this.basePath}/api/configuracao/admin/tipos-documento`,
+      command,
+      { context, headers: new HttpHeaders({ Accept: 'application/json' }) },
+    );
+  }
+
+  /** PUT `/api/configuracao/admin/tipos-documento/{id}` — atualiza um Tipo de Documento (código reeditável). */
+  atualizar(
+    id: string,
+    command: AtualizarTipoDocumentoCommand,
+    context: HttpContext,
+  ): Observable<ApiResult<void>> {
+    return this.http.put<ApiResult<void>>(
+      `${this.basePath}/api/configuracao/admin/tipos-documento/${encodeURIComponent(id)}`,
+      command,
+      { context },
+    );
+  }
+
+  /** DELETE `/api/configuracao/admin/tipos-documento/{id}` — inativação (soft-delete); sem bloqueio por referência externa (RN08/ADR-0061). */
+  remover(id: string): Observable<ApiResult<void>> {
+    return this.http.delete<ApiResult<void>>(
+      `${this.basePath}/api/configuracao/admin/tipos-documento/${encodeURIComponent(id)}`,
+    );
+  }
+}


### PR DESCRIPTION
## Contexto

Cadastro de **Tipo de Documento** no painel Configuração — cadastro classificatório puro que define *o que um documento é* (RG, laudo médico, autodeclaração PPI etc.), sem regra material sobre o documento. Espelha `uniplus-api#591` (UNI-REQ-0013). Segue o padrão CRUD lista→drawer→modal da spec macro `web-configuracao-arquitetura.md`, usando `CursosApi`/`CursosPage` como referência estrutural e `UnidadesPage` como referência de filtro por chips.

Closes #392

## O que foi feito

### API client (`libs/shared-data/src/lib/api/configuracao/`)
- `TiposDocumentoApi`: `listar` (cursor pagination), `obter`, `criar`, `atualizar`, `remover` — vendor MIME `tipo-documento` v1, `Idempotency-Key` em POST/PUT (não em DELETE, confirmado contra o controller real do backend).
- `CATEGORIAS_DOCUMENTO`: roster fechado das 7 categorias (`IDENTIFICACAO`, `ESCOLARIDADE`, `RENDA`, `RACA_ETNIA`, `SAUDE`, `RESIDENCIA`, `OUTROS`).

### Feature (`apps/configuracao/src/app/features/tipos-documento/`)
- `TiposDocumentoListPage`: lista paginada por cursor com busca client-side (código/nome) e filtro por categoria via `ui-filter-chips` com contador dinâmico sobre o conjunto já filtrado pela busca.
- Drawer único de criar/editar (form-grid 1 coluna, par Código+Categoria); modal de inativação com nota de imunidade pós-publicação (RN08).
- Rota registrada em `app.routes.ts` (`/tipos-documento`, breadcrumb "Tipo de Documento").

### Reconciliação issue vs. contrato real do backend

O rascunho da issue tinha alguns valores aproximados; onde divergiam do código real do `uniplus-api` (`TipoDocumento.cs`, `CriarTipoDocumentoCommandValidator.cs`, `TiposDocumentoController.cs`, já presentes localmente em `repositories/uniplus-api`), segui o contrato real:

| Campo | Rascunho da issue | Contrato real (usado) |
|---|---|---|
| Vendor MIME resource | `tipos-documento` (plural) | `tipo-documento` (singular) — confirmado no `[VendorMediaType]` do controller |
| `codigo` maxLength | ~40 | 60 |
| `nome` | até 255, sem mínimo | 2–200 (`NomeMinLength=2` na entidade) |
| `tipoEquivalente` == `codigo` | não especificava case-sensitivity | case-sensitive (`StringComparison.Ordinal`), trim — replicado no client |
| `tamanhoMaximoMb` | "máximo global do sistema: 50 MB" | sem teto no backend (`GreaterThan(0)` apenas) — não adicionei `Validators.max` para não rejeitar client-side algo que o backend aceita |
| `remover(id, ctx)` com Idempotency-Key | citava ADR-0014 | `DELETE` não tem `[RequiresIdempotencyKey]` no controller — `remover(id)` sem contexto, igual a `CursosApi`/`CampiApi` |

### Regras de UX implementadas
- **CA-01** — lista + filtro por categoria (chips com contador dinâmico) + busca por código/nome + paginação cursor prev/next.
- **CA-02** — criar tipo válido fecha o drawer, adiciona à lista, notifica sucesso.
- **CA-03/CA-04** — código duplicado (409, `codigo_ja_existe`) mapeado inline ao campo `codigo`; edição revalida excluindo o próprio registro (o backend já ignora o próprio id).
- **CA-05** — `tipoEquivalente == codigo` validado 100% client-side (sem round-trip), botão Salvar desabilitado nesse estado.
- **CA-06** — `tamanhoMaximoMb` ≤ 0 rejeitado via `Validators.min(1)`.
- **CA-07/CA-08** — modal de inativação mostra nome + nota RN08; sem checagem prévia de referência externa (soft-delete simples).
- **CA-09** — `role="search"` na busca, `aria-pressed` nos chips (via `ui-filter-chips`), `aria-describedby` nos erros (via padrão `field__error`/`field__hint`).
- **CA-10** — inaplicável (sem PII).
- **CA-11** — zero `any`, fitness `no-direct-http-in-pages` verde, lint/build/test limpos.

## Testes

- **Vitest**: 19 testes em `tipos-documento-list.page.spec.ts` (mapa da issue previa 16 — adicionei 3 casos extra: empty-state sem filtro, tipo equivalente válido, nenhum formato marcado) + 6 testes em `tipos-documento.api.spec.ts`.
- **Playwright**: 12 cenários em `tipos-documento.flow.spec.ts` cobrindo CRUD completo, validação client-side, ausência de bloqueio na inativação, axe-core (lista/drawer/modal, tags `wcag2a`+`wcag2aa`+`wcag21aa`), navegação por teclado sem mouse, e foco/Esc no drawer.
  - Nomeado `*.flow.spec.ts` (não `*.e2e.ts` do mapa da issue) para casar com o `testMatch` real do `playwright.config.ts` (projeto `fluxo-chromium`, auth real via storageState + API mockada) — mesma convenção de `cursos.flow.spec.ts`/`pesos-enem.flow.spec.ts`.
  - **Limitação conhecida**: não executei os testes Playwright ponta-a-ponta neste ambiente. A stack Docker compartilhada tem um `configuracao-web` já rodando na porta 4203 servindo uma imagem nginx estática (build antigo, sem a rota nova) — usar essa stack teria testado código desatualizado, e rebuildar/derrubar o container arriscava impactar outros worktrees em paralelo. Validei a suíte estruturalmente via `npx playwright test --list` (12 testes reconhecidos corretamente sob `fluxo-chromium`) e lint limpo.

### Suíte completa local
- `npx nx run-many --target=vite:test --all` — 9 projetos, todos verdes.
- `npx nx run-many --target=lint --all` — 15 projetos, todos limpos.
- `npx nx run-many --target=build --all` — 9 projetos, build OK.
- `npx nx run shared-data:codegen-api-check` — sem drift (não toquei `schema.ts`/`openapi.json`).

## Riscos / limitações remanescentes

- E2E Playwright não executado ponta-a-ponta neste ambiente (ver acima) — recomendo rodar `npx nx e2e configuracao-e2e --grep tipos-documento` em ambiente com Keycloak + dev server locais antes do merge, ou confiar no CI se ele reconstrói a stack.
- `tamanhoMaximoMb` sem teto máximo client-side, de propósito — o backend não impõe um hoje; se um teto de negócio for definido depois, é um `Validators.max` de 1 linha.
