### PR TITLE
feat(configuracao): adiciona cadastro de Modalidade de concorrência

### DIFF
--- a/apps/configuracao-e2e/src/specs/modalidades.flow.spec.ts
+++ b/apps/configuracao-e2e/src/specs/modalidades.flow.spec.ts
@@ -1,0 +1,316 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test, type Page, type Route } from '@playwright/test';
+import { mockConfiguracaoRuntimeConfig } from '../support/runtime-config';
+
+/**
+ * E2E funcional do cadastro de Modalidade de concorrência (issue #390, Piloto B).
+ * Convenção do repo: runtime-config e API mockados por `page.route`; autenticação
+ * real (Keycloak) via storageState. Modalidade usa **tela dedicada** (rota própria)
+ * em vez de drawer, e `<ui-dialog>` para o bloqueio/confirmação de remoção.
+ */
+
+const CORS_HEADERS = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'GET, POST, PUT, DELETE, OPTIONS',
+  'access-control-allow-headers': 'authorization, content-type, accept, idempotency-key',
+};
+
+const AC_ID = '01960000-0000-7000-0000-0000000000a1';
+const V_ID = '01960000-0000-7000-0000-0000000000b1';
+
+const acSeed = {
+  id: AC_ID,
+  codigo: 'AC',
+  descricao: 'Ampla concorrência',
+  naturezaLegal: 'AMPLA',
+  composicaoVagas: 'RESIDUAL_DO_VO',
+  composicaoOrigem: null,
+  regraRemanejamento: null,
+  remanejamentoDestino: null,
+  remanejamentoPar: null,
+  remanejamentoFallback: null,
+  criteriosCumulativos: [],
+  acaoQuandoIndeferido: null,
+  baseLegal: null,
+  criadoEm: '2026-07-03T12:00:00Z',
+};
+
+// V retira suas vagas de AC e remaneja para AC — referencia AC (bloqueia a remoção de AC).
+const vSeed = {
+  ...acSeed,
+  id: V_ID,
+  codigo: 'V',
+  descricao: 'PcD ampla concorrência',
+  naturezaLegal: 'SUPLEMENTAR',
+  composicaoVagas: 'RETIRA_DE',
+  composicaoOrigem: 'AC',
+  regraRemanejamento: 'DESTINO_UNICO',
+  remanejamentoDestino: 'AC',
+  criteriosCumulativos: ['laudo'],
+};
+
+async function jsonRoute(route: Route, body: unknown, status = 200): Promise<void> {
+  if (route.request().method() === 'OPTIONS') {
+    await route.fulfill({ status: 204, headers: CORS_HEADERS });
+    return;
+  }
+  await route.fulfill({
+    status,
+    contentType: 'application/json',
+    headers: CORS_HEADERS,
+    body: JSON.stringify(body),
+  });
+}
+
+interface Capturado {
+  readonly posts: unknown[];
+  readonly puts: unknown[];
+  readonly deletedIds: string[];
+}
+
+function novoCapturado(): Capturado {
+  return { posts: [], puts: [], deletedIds: [] };
+}
+
+async function mockApi(
+  page: Page,
+  capturado: Capturado,
+  lista: readonly unknown[],
+  opcoes: { readonly removerStatus?: number; readonly removerBody?: unknown } = {},
+): Promise<void> {
+  await page.route(/\/api\/configuracao\/admin\/modalidades\/[^/?]+$/, async (route) => {
+    if (route.request().method() === 'DELETE') {
+      const partes = route.request().url().split('/');
+      capturado.deletedIds.push(partes[partes.length - 1] ?? '');
+      const status = opcoes.removerStatus ?? 204;
+      if (status >= 400) {
+        await route.fulfill({
+          status,
+          contentType: 'application/problem+json',
+          headers: CORS_HEADERS,
+          body: JSON.stringify(opcoes.removerBody ?? {}),
+        });
+        return;
+      }
+      await route.fulfill({ status: 204, headers: CORS_HEADERS });
+      return;
+    }
+    if (route.request().method() === 'PUT') {
+      capturado.puts.push(route.request().postDataJSON());
+      await route.fulfill({ status: 204, headers: CORS_HEADERS });
+      return;
+    }
+    await route.fulfill({ status: 204, headers: CORS_HEADERS });
+  });
+  await page.route(/\/api\/configuracao\/admin\/modalidades(\?.*)?$/, async (route) => {
+    if (route.request().method() === 'POST') {
+      capturado.posts.push(route.request().postDataJSON());
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        headers: CORS_HEADERS,
+        body: JSON.stringify('nova-modalidade-id'),
+      });
+      return;
+    }
+    await route.fulfill({ status: 204, headers: CORS_HEADERS });
+  });
+  // Detalhe por id (obter) — usado na edição.
+  await page.route(/\/api\/configuracao\/modalidades\/[^/?]+$/, (route) => {
+    const partes = route.request().url().split('/');
+    const id = (partes[partes.length - 1] ?? '').replace(/\?.*$/u, '');
+    const alvo = lista.find((m) => (m as { id: string }).id === id) ?? lista[0];
+    return jsonRoute(route, alvo);
+  });
+  await page.route(/\/api\/configuracao\/modalidades(\?.*)?$/, (route) => jsonRoute(route, lista));
+}
+
+async function abrirLista(page: Page): Promise<void> {
+  await page.goto('/modalidades');
+  await expect(page.getByRole('heading', { name: 'Modalidade de concorrência', level: 1 })).toBeVisible();
+}
+
+test.describe('Modalidade de concorrência — CRUD (#390)', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockConfiguracaoRuntimeConfig(page);
+  });
+
+  test('CA-01: lista modalidades com natureza, status e coluna "Referenciada por"', async ({ page }) => {
+    await mockApi(page, novoCapturado(), [acSeed, vSeed]);
+    await abrirLista(page);
+
+    await expect(page.locator('tbody tr')).toHaveCount(2);
+    const linhaAc = page.locator('tr[data-codigo="AC"]');
+    await expect(linhaAc.locator('td').first().locator('code')).toHaveText('AC');
+    await expect(linhaAc.locator('.tag--info')).toContainText('Ampla concorrência');
+    await expect(linhaAc.locator('.tag--success')).toHaveText('Ativa');
+    // A linha de AC mostra V como quem a referencia (mapa reverso).
+    await expect(linhaAc.locator('.cfg-ref-chip')).toHaveText('V');
+  });
+
+  test('CA-01: chips de natureza filtram a lista', async ({ page }) => {
+    await mockApi(page, novoCapturado(), [acSeed, vSeed]);
+    await abrirLista(page);
+
+    await page.getByRole('button', { name: /Suplementar/ }).click();
+    await expect(page.locator('tbody tr')).toHaveCount(1);
+    await expect(page.locator('tbody')).toContainText('PcD ampla concorrência');
+  });
+
+  test('CA-02: "Nova modalidade" navega para a tela dedicada com foco no título', async ({ page }) => {
+    await mockApi(page, novoCapturado(), [acSeed, vSeed]);
+    await abrirLista(page);
+
+    await page.getByRole('link', { name: 'Nova modalidade' }).first().click();
+    await expect(page).toHaveURL(/\/modalidades\/novo$/);
+    const titulo = page.getByRole('heading', { name: 'Nova modalidade', level: 1 });
+    await expect(titulo).toBeVisible();
+    await expect(titulo).toBeFocused();
+
+    await page.getByRole('link', { name: 'Voltar à lista' }).click();
+    await expect(page).toHaveURL(/\/modalidades$/);
+    await expect(page.getByRole('heading', { name: 'Modalidade de concorrência', level: 1 })).toBeVisible();
+  });
+
+  test('CA-03: AMPLA oculta remanejamento; COTA_RESERVADA fixa cascata; SUPLEMENTAR oferta destino/cruzado', async ({
+    page,
+  }) => {
+    await mockApi(page, novoCapturado(), [acSeed, vSeed]);
+    await page.goto('/modalidades/novo');
+
+    const natureza = page.locator('[formControlName="naturezaLegal"]');
+
+    await natureza.selectOption('AMPLA');
+    await expect(page.locator('#cfg-mod-remanejamento')).toBeHidden();
+
+    await natureza.selectOption('COTA_RESERVADA');
+    await expect(page.locator('#cfg-mod-remanejamento')).toBeVisible();
+    const regra = page.locator('[formControlName="regraRemanejamento"]');
+    await expect(regra).toHaveValue('SEGUE_CASCATA');
+    // Playwright toBeDisabled é instável em <option>; checa a propriedade DOM diretamente.
+    await expect(regra.locator('option[value="DESTINO_UNICO"]')).toHaveJSProperty('disabled', true);
+
+    await natureza.selectOption('SUPLEMENTAR');
+    await expect(regra.locator('option[value="SEGUE_CASCATA"]')).toHaveJSProperty('disabled', true);
+    await expect(regra.locator('option[value="DESTINO_UNICO"]')).toHaveJSProperty('disabled', false);
+    await expect(regra.locator('option[value="CRUZADO"]')).toHaveJSProperty('disabled', false);
+  });
+
+  test('CA-04: RETIRA_DE exige Origem; CRUZADO exige Par e Fallback', async ({ page }) => {
+    await mockApi(page, novoCapturado(), [acSeed, vSeed]);
+    await page.goto('/modalidades/novo');
+
+    await page.locator('[formControlName="composicaoVagas"]').selectOption('RETIRA_DE');
+    await expect(page.locator('[formControlName="composicaoOrigem"]')).toBeVisible();
+
+    await page.locator('[formControlName="naturezaLegal"]').selectOption('SUPLEMENTAR');
+    await page.locator('[formControlName="regraRemanejamento"]').selectOption('CRUZADO');
+    await expect(page.locator('[formControlName="remanejamentoPar"]')).toBeVisible();
+    await expect(page.locator('[formControlName="remanejamentoFallback"]')).toBeVisible();
+    await expect(page.locator('[formControlName="remanejamentoDestino"]')).toBeHidden();
+  });
+
+  test('CA-02 / CA-04: cria modalidade SUPLEMENTAR RETIRA_DE + DESTINO_UNICO', async ({ page }) => {
+    const capturado = novoCapturado();
+    await mockApi(page, capturado, [acSeed, vSeed]);
+    await page.goto('/modalidades/novo');
+
+    await page.locator('[formControlName="codigo"]').fill('LI_PPI');
+    await page.locator('[formControlName="descricao"]').fill('Cota PPI independente de renda');
+    await page.locator('[formControlName="composicaoVagas"]').selectOption('RETIRA_DE');
+    await page.locator('[formControlName="composicaoOrigem"]').selectOption('AC');
+    await page.locator('[formControlName="naturezaLegal"]').selectOption('SUPLEMENTAR');
+    await page.locator('[formControlName="regraRemanejamento"]').selectOption('DESTINO_UNICO');
+    await page.locator('[formControlName="remanejamentoDestino"]').selectOption('AC');
+    await page.getByRole('button', { name: 'Criar modalidade' }).click();
+
+    await expect.poll(() => capturado.posts.length).toBe(1);
+    expect(capturado.posts[0]).toMatchObject({
+      codigo: 'LI_PPI',
+      naturezaLegal: 'SUPLEMENTAR',
+      composicaoVagas: 'RETIRA_DE',
+      composicaoOrigem: 'AC',
+      regraRemanejamento: 'DESTINO_UNICO',
+      remanejamentoDestino: 'AC',
+    });
+    await expect(page).toHaveURL(/\/modalidades$/);
+  });
+
+  test('CA-05: código é somente leitura na edição', async ({ page }) => {
+    await mockApi(page, novoCapturado(), [acSeed, vSeed]);
+    await page.goto(`/modalidades/${V_ID}`);
+
+    const codigo = page.locator('[formControlName="codigo"]');
+    await expect(codigo).toHaveValue('V');
+    await expect(codigo).toBeDisabled();
+  });
+
+  test('CA-06: remoção bloqueada quando referenciada por outra viva', async ({ page }) => {
+    const capturado = novoCapturado();
+    await mockApi(page, capturado, [acSeed, vSeed]);
+    await abrirLista(page);
+
+    await page.getByRole('button', { name: 'Inativar modalidade AC' }).click();
+
+    const dialog = page.locator('dialog.uni-dialog');
+    await expect(dialog.getByText('Remoção bloqueada')).toBeVisible();
+    // V aparece como dependente na lista de referências.
+    await expect(dialog.locator('.cfg-refs-lista').getByText('V', { exact: true })).toBeVisible();
+    // Não deve haver botão de confirmação de inativação.
+    await expect(dialog.getByRole('button', { name: 'Inativar', exact: true })).toHaveCount(0);
+    await dialog.getByRole('button', { name: 'Entendi' }).click();
+    expect(capturado.deletedIds).toHaveLength(0);
+  });
+
+  test('CA-06: soft-delete quando a modalidade está livre', async ({ page }) => {
+    const capturado = novoCapturado();
+    await mockApi(page, capturado, [acSeed, vSeed]);
+    await abrirLista(page);
+
+    await page.getByRole('button', { name: 'Inativar modalidade V' }).click();
+
+    const dialog = page.locator('dialog.uni-dialog');
+    await dialog.getByRole('button', { name: 'Inativar', exact: true }).click();
+    await expect.poll(() => capturado.deletedIds.length).toBe(1);
+    expect(capturado.deletedIds[0]).toBe(V_ID);
+  });
+});
+
+// Bloco `axe`: acessibilidade WCAG 2.1 AA (sem violações serious/critical).
+test.describe('Modalidade — acessibilidade axe-core (#390)', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockConfiguracaoRuntimeConfig(page);
+  });
+
+  async function violacoesGraves(page: Page): Promise<unknown[]> {
+    const resultado = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21aa'])
+      .analyze();
+    return resultado.violations.filter((v) => v.impact === 'serious' || v.impact === 'critical');
+  }
+
+  test('lista não tem violações serious/critical', async ({ page }) => {
+    await mockApi(page, novoCapturado(), [acSeed, vSeed]);
+    await abrirLista(page);
+    const graves = await violacoesGraves(page);
+    expect(graves, JSON.stringify(graves, null, 2)).toEqual([]);
+  });
+
+  test('tela dedicada não tem violações serious/critical', async ({ page }) => {
+    await mockApi(page, novoCapturado(), [acSeed, vSeed]);
+    await page.goto('/modalidades/novo');
+    await page.locator('[formControlName="naturezaLegal"]').selectOption('SUPLEMENTAR');
+    await page.locator('[formControlName="regraRemanejamento"]').selectOption('CRUZADO');
+    const graves = await violacoesGraves(page);
+    expect(graves, JSON.stringify(graves, null, 2)).toEqual([]);
+  });
+
+  test('modal de bloqueio aberto não tem violações serious/critical', async ({ page }) => {
+    await mockApi(page, novoCapturado(), [acSeed, vSeed]);
+    await abrirLista(page);
+    await page.getByRole('button', { name: 'Inativar modalidade AC' }).click();
+    await expect(page.locator('dialog.uni-dialog')).toBeVisible();
+    const graves = await violacoesGraves(page);
+    expect(graves, JSON.stringify(graves, null, 2)).toEqual([]);
+  });
+});

--- a/apps/configuracao/src/app/app.routes.ts
+++ b/apps/configuracao/src/app/app.routes.ts
@@ -68,6 +68,14 @@ export const appRoutes: Routes = [
           ),
       },
       {
+        path: 'modalidades',
+        data: { breadcrumb: 'Modalidade' },
+        loadChildren: () =>
+          import('./features/modalidades/modalidades.routes').then(
+            (m) => m.MODALIDADES_ROUTES,
+          ),
+      },
+      {
         path: 'fases-canonicas',
         data: { breadcrumb: 'Fase Canônica' },
         loadChildren: () =>

--- a/apps/configuracao/src/app/features/modalidades/modalidade-form.page.spec.ts
+++ b/apps/configuracao/src/app/features/modalidades/modalidade-form.page.spec.ts
@@ -1,0 +1,276 @@
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/router';
+import { apiResultInterceptor } from '@uniplus/shared-core/http';
+import { CONFIGURACAO_BASE_PATH, ModalidadeDto } from '@uniplus/shared-data/configuracao';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ModalidadeFormPage } from './modalidade-form.page';
+
+const BASE = 'http://localhost:5000';
+const URL = `${BASE}/api/configuracao/modalidades`;
+
+function modalidade(over: Partial<ModalidadeDto>): ModalidadeDto {
+  return {
+    id: over.id ?? crypto.randomUUID(),
+    codigo: 'AC',
+    descricao: 'Ampla concorrência',
+    naturezaLegal: 'AMPLA',
+    composicaoVagas: 'RESIDUAL_DO_VO',
+    composicaoOrigem: null,
+    regraRemanejamento: null,
+    remanejamentoDestino: null,
+    remanejamentoPar: null,
+    remanejamentoFallback: null,
+    criteriosCumulativos: [],
+    acaoQuandoIndeferido: null,
+    baseLegal: null,
+    criadoEm: '2026-07-03T12:00:00Z',
+    ...over,
+  };
+}
+
+const AC = modalidade({ id: 'id-ac', codigo: 'AC' });
+const LB_PPI = modalidade({
+  id: 'id-lb',
+  codigo: 'LB_PPI',
+  descricao: 'Cota PPI baixa renda',
+  naturezaLegal: 'COTA_RESERVADA',
+  composicaoVagas: 'DENTRO_DO_VR',
+  regraRemanejamento: 'SEGUE_CASCATA',
+});
+
+describe('ModalidadeFormPage', () => {
+  let fixture: ComponentFixture<ModalidadeFormPage>;
+  let component: ModalidadeFormPage;
+  let controller: HttpTestingController;
+
+  beforeEach(() => {
+    // Modo criação por padrão (sem `id`); os testes de edição trocam a rota via `usarRota`.
+    TestBed.configureTestingModule({
+      imports: [ModalidadeFormPage],
+      providers: [
+        provideHttpClient(withInterceptors([apiResultInterceptor])),
+        provideHttpClientTesting(),
+        provideRouter([{ path: 'modalidades', children: [] }]),
+        { provide: CONFIGURACAO_BASE_PATH, useValue: BASE },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { paramMap: convertToParamMap({}) } },
+        },
+      ],
+    });
+  });
+
+  afterEach(() => controller.verify());
+
+  /** Instancia o componente e libera o GET das modalidades vivas (selects de FK). */
+  function montar(vivas: readonly ModalidadeDto[] = [AC, LB_PPI]): void {
+    fixture = TestBed.createComponent(ModalidadeFormPage);
+    component = fixture.componentInstance;
+    controller = TestBed.inject(HttpTestingController);
+    const req = controller.expectOne((r) => r.url === URL && r.params.get('limit') === '100');
+    req.flush([...vivas]);
+  }
+
+  /** Reconfigura a rota para modo edição antes de montar. */
+  function usarRota(id: string): void {
+    TestBed.overrideProvider(ActivatedRoute, {
+      useValue: { snapshot: { paramMap: convertToParamMap({ id }) } },
+    });
+  }
+
+  const setControl = (nome: string, valor: string): void => {
+    component['form'].get(nome)?.setValue(valor);
+  };
+
+  it('ModalidadeForm_Natureza_AmplaOcultaRemanejamento', () => {
+    montar();
+    setControl('naturezaLegal', 'AMPLA');
+    component['aoMudarNatureza']();
+    expect(component['mostraRemanejamento']()).toBe(false);
+    expect(component['form'].controls.regraRemanejamento.value).toBe('');
+  });
+
+  it('ModalidadeForm_Natureza_CotaFixaCascata', () => {
+    montar();
+    setControl('naturezaLegal', 'COTA_RESERVADA');
+    component['aoMudarNatureza']();
+    expect(component['form'].controls.regraRemanejamento.value).toBe('SEGUE_CASCATA');
+    expect(component['regraDesabilitada']('SEGUE_CASCATA')).toBe(false);
+    expect(component['regraDesabilitada']('DESTINO_UNICO')).toBe(true);
+    expect(component['regraDesabilitada']('CRUZADO')).toBe(true);
+  });
+
+  it('ModalidadeForm_Natureza_SuplementarOfertaDestinoOuCruzado', () => {
+    montar();
+    setControl('naturezaLegal', 'SUPLEMENTAR');
+    component['aoMudarNatureza']();
+    expect(component['regraDesabilitada']('SEGUE_CASCATA')).toBe(true);
+    expect(component['regraDesabilitada']('DESTINO_UNICO')).toBe(false);
+    expect(component['regraDesabilitada']('CRUZADO')).toBe(false);
+    // Regra passa a ser obrigatória.
+    expect(component['form'].controls.regraRemanejamento.invalid).toBe(true);
+  });
+
+  it('ModalidadeForm_RetiraDe_ExigeOrigem', () => {
+    montar();
+    setControl('composicaoVagas', 'RETIRA_DE');
+    component['aoMudarComposicao']();
+    expect(component['mostraOrigem']()).toBe(true);
+    expect(component['form'].controls.composicaoOrigem.invalid).toBe(true);
+    component['form'].controls.composicaoOrigem.setValue('AC');
+    expect(component['form'].controls.composicaoOrigem.valid).toBe(true);
+    // Voltar para outra composição limpa e desobriga a origem.
+    setControl('composicaoVagas', 'RESIDUAL_DO_VO');
+    component['aoMudarComposicao']();
+    expect(component['mostraOrigem']()).toBe(false);
+    expect(component['form'].controls.composicaoOrigem.value).toBe('');
+  });
+
+  it('ModalidadeForm_Args_PorRegra', () => {
+    montar();
+    setControl('naturezaLegal', 'SUPLEMENTAR');
+    component['aoMudarNatureza']();
+    setControl('regraRemanejamento', 'DESTINO_UNICO');
+    component['aoMudarRegra']();
+    expect(component['mostraDestino']()).toBe(true);
+    expect(component['mostraParFallback']()).toBe(false);
+    expect(component['form'].controls.remanejamentoDestino.invalid).toBe(true);
+
+    setControl('remanejamentoDestino', 'AC');
+    setControl('regraRemanejamento', 'CRUZADO');
+    component['aoMudarRegra']();
+    // Destino é limpo; par e fallback passam a ser exigidos.
+    expect(component['form'].controls.remanejamentoDestino.value).toBe('');
+    expect(component['mostraParFallback']()).toBe(true);
+    expect(component['form'].controls.remanejamentoPar.invalid).toBe(true);
+    expect(component['form'].controls.remanejamentoFallback.invalid).toBe(true);
+  });
+
+  it('ModalidadeForm_Codigo_RegexEUnicidade', () => {
+    montar();
+    const codigo = component['form'].controls.codigo;
+    codigo.setValue('AB-C');
+    expect(codigo.hasError('pattern')).toBe(true);
+    codigo.setValue('AB_C');
+    expect(codigo.valid).toBe(true);
+    // Unicidade entre vivas carregadas.
+    codigo.setValue('AC');
+    component['verificarCodigoDuplicado']();
+    expect(codigo.hasError('duplicado')).toBe(true);
+  });
+
+  it('ModalidadeForm_Codigo_ReadonlyNaEdicao', () => {
+    usarRota('id-lb');
+    montar();
+    const obter = controller.expectOne(`${URL}/id-lb`);
+    obter.flush(LB_PPI);
+    expect(component['modoEdicao']()).toBe(true);
+    expect(component['form'].controls.codigo.disabled).toBe(true);
+    expect(component['form'].controls.codigo.value).toBe('LB_PPI');
+  });
+
+  it('ModalidadeForm_TrocaNatureza_ResetaDependentes', () => {
+    montar();
+    setControl('naturezaLegal', 'SUPLEMENTAR');
+    component['aoMudarNatureza']();
+    setControl('regraRemanejamento', 'CRUZADO');
+    component['aoMudarRegra']();
+    component['form'].controls.remanejamentoPar.setValue('AC');
+    component['form'].controls.remanejamentoFallback.setValue('LB_PPI');
+
+    // Trocar para AMPLA com args preenchidos pede confirmação (§5).
+    setControl('naturezaLegal', 'AMPLA');
+    component['aoMudarNatureza']();
+    expect(component['confirmResetAberto']()).toBe(true);
+    expect(component['form'].controls.regraRemanejamento.value).toBe('CRUZADO');
+
+    component['confirmarResetNatureza']();
+    expect(component['confirmResetAberto']()).toBe(false);
+    expect(component['mostraRemanejamento']()).toBe(false);
+    expect(component['form'].controls.regraRemanejamento.value).toBe('');
+    expect(component['form'].controls.remanejamentoPar.value).toBe('');
+    expect(component['form'].controls.remanejamentoFallback.value).toBe('');
+  });
+
+  it('ModalidadeForm_TrocaNatureza_CancelarPreserva', () => {
+    montar();
+    setControl('naturezaLegal', 'SUPLEMENTAR');
+    component['aoMudarNatureza']();
+    setControl('regraRemanejamento', 'DESTINO_UNICO');
+    component['aoMudarRegra']();
+    component['form'].controls.remanejamentoDestino.setValue('AC');
+
+    setControl('naturezaLegal', 'COTA_RESERVADA');
+    component['aoMudarNatureza']();
+    expect(component['confirmResetAberto']()).toBe(true);
+
+    component['cancelarResetNatureza']();
+    // Reverte a natureza e preserva os campos.
+    expect(component['form'].controls.naturezaLegal.value).toBe('SUPLEMENTAR');
+    expect(component['form'].controls.remanejamentoDestino.value).toBe('AC');
+  });
+
+  it('ModalidadeForm_TrocaNatureza_CascataAutoNaoPrompt', () => {
+    montar();
+    setControl('naturezaLegal', 'COTA_RESERVADA');
+    component['aoMudarNatureza']();
+    // regra auto-preenchida SEGUE_CASCATA, sem argumentos digitados pelo usuário.
+    setControl('naturezaLegal', 'SUPLEMENTAR');
+    component['aoMudarNatureza']();
+    // Não pede confirmação (nada do usuário a descartar); aplica direto.
+    expect(component['confirmResetAberto']()).toBe(false);
+    expect(component['form'].controls.naturezaLegal.value).toBe('SUPLEMENTAR');
+    expect(component['form'].controls.regraRemanejamento.value).toBe('');
+    expect(component['regraDesabilitada']('SEGUE_CASCATA')).toBe(true);
+  });
+
+  it('montarComandoCriar anula campos inaplicáveis por coerência', () => {
+    montar();
+    setControl('codigo', 'AC2');
+    setControl('naturezaLegal', 'AMPLA');
+    component['aoMudarNatureza']();
+    setControl('composicaoVagas', 'RESIDUAL_DO_VO');
+    component['aoMudarComposicao']();
+    const cmd = component['montarComandoCriar']();
+    expect(cmd.codigo).toBe('AC2');
+    expect(cmd.regraRemanejamento).toBeNull();
+    expect(cmd.composicaoOrigem).toBeNull();
+    expect(cmd.remanejamentoDestino).toBeNull();
+    expect(cmd.remanejamentoPar).toBeNull();
+    expect(cmd.remanejamentoFallback).toBeNull();
+  });
+
+  it('CA-02: cria modalidade válida (POST com Idempotency-Key)', () => {
+    montar();
+    setControl('codigo', 'V');
+    setControl('descricao', 'PcD ampla concorrência');
+    setControl('naturezaLegal', 'SUPLEMENTAR');
+    component['aoMudarNatureza']();
+    setControl('composicaoVagas', 'RETIRA_DE');
+    component['aoMudarComposicao']();
+    setControl('composicaoOrigem', 'AC');
+    setControl('regraRemanejamento', 'DESTINO_UNICO');
+    component['aoMudarRegra']();
+    setControl('remanejamentoDestino', 'AC');
+
+    component['salvar']();
+    const post = controller.expectOne(`${BASE}/api/configuracao/admin/modalidades`);
+    expect(post.request.method).toBe('POST');
+    expect(post.request.headers.get('Idempotency-Key')).toBeTruthy();
+    expect(post.request.body.codigo).toBe('V');
+    expect(post.request.body.composicaoOrigem).toBe('AC');
+    expect(post.request.body.remanejamentoDestino).toBe('AC');
+    expect(post.request.body.regraRemanejamento).toBe('DESTINO_UNICO');
+    post.flush('novo-id', { status: 201, statusText: 'Created' });
+  });
+
+  it('CA-05: código inválido bloqueia o submit (sem POST)', () => {
+    montar();
+    setControl('codigo', '');
+    component['salvar']();
+    controller.expectNone(`${BASE}/api/configuracao/admin/modalidades`);
+    expect(component['form'].controls.codigo.invalid).toBe(true);
+  });
+});

--- a/apps/configuracao/src/app/features/modalidades/modalidade-form.page.ts
+++ b/apps/configuracao/src/app/features/modalidades/modalidade-form.page.ts
@@ -1,0 +1,958 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  ElementRef,
+  afterNextRender,
+  computed,
+  inject,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import {
+  AbstractControl,
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import {
+  ApiResult,
+  ProblemDetails,
+  ProblemI18nService,
+  ProblemValidationError,
+  idempotencyKey,
+  withIdempotencyKey,
+} from '@uniplus/shared-core/http';
+import { NotificationService } from '@uniplus/shared-core/notifications';
+import {
+  ACOES_QUANDO_INDEFERIDO,
+  AcaoQuandoIndeferidoToken,
+  AtualizarModalidadeCommand,
+  COMPOSICAO_RETIRA_DE,
+  COMPOSICAO_VAGAS_DEFAULT,
+  COMPOSICOES_VAGAS,
+  ComposicaoVagasToken,
+  CriarModalidadeCommand,
+  ModalidadeDto,
+  ModalidadesApi,
+  NATUREZA_LEGAL_DEFAULT,
+  NATUREZAS_LEGAIS,
+  NaturezaLegalToken,
+  REGRAS_REMANEJAMENTO,
+  RegraRemanejamentoToken,
+} from '@uniplus/shared-data/configuracao';
+import { AlertComponent, DialogComponent, SpinnerComponent } from '@uniplus/shared-ui/components';
+
+const CODIGO_REGEX = /^[A-Z0-9_]+$/u;
+const DESCRICAO_MAX = 300;
+const BASE_LEGAL_MAX = 500;
+const CODIGO_REFERENCIA_MAX = 60;
+
+type RegraSelecao = RegraRemanejamentoToken | '';
+type AcaoSelecao = AcaoQuandoIndeferidoToken | '';
+
+interface ModalidadeForm {
+  codigo: FormControl<string>;
+  descricao: FormControl<string>;
+  naturezaLegal: FormControl<NaturezaLegalToken>;
+  composicaoVagas: FormControl<ComposicaoVagasToken>;
+  composicaoOrigem: FormControl<string>;
+  regraRemanejamento: FormControl<RegraSelecao>;
+  remanejamentoDestino: FormControl<string>;
+  remanejamentoPar: FormControl<string>;
+  remanejamentoFallback: FormControl<string>;
+  acaoQuandoIndeferido: FormControl<AcaoSelecao>;
+  baseLegal: FormControl<string>;
+}
+
+@Component({
+  selector: 'cfg-modalidade-form-page',
+  standalone: true,
+  imports: [ReactiveFormsModule, RouterLink, AlertComponent, DialogComponent, SpinnerComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="page-header page-header--form">
+      <a class="btn btn--tertiary btn--sm btn--rect cfg-voltar" routerLink="/modalidades">
+        <i class="pi pi-chevron-left" aria-hidden="true"></i>
+        Voltar à lista
+      </a>
+      <div class="page-header__content">
+        <h1 #tituloPagina class="page-header__title" tabindex="-1">{{ titulo() }}</h1>
+        <p class="page-header__desc">
+          Configure a natureza legal, a composição das vagas e a cascata de remanejamento. As
+          escolhas se condicionam entre si — o resumo abaixo do formulário reflete o efeito atual.
+        </p>
+      </div>
+    </div>
+
+    @if (carregando()) {
+      <div class="cfg-form__loading" role="status">
+        <ui-spinner size="md" /> Carregando modalidade...
+      </div>
+    } @else {
+      @if (erroCarregar()) {
+        <ui-alert variant="danger" heading="Não foi possível carregar a modalidade">
+          {{ erroCarregar() }}
+        </ui-alert>
+      }
+
+      @if (formError()) {
+        <ui-alert variant="danger" heading="Não foi possível salvar">{{ formError() }}</ui-alert>
+      }
+
+      <form [formGroup]="form" id="cfg-modalidade-form" (ngSubmit)="salvar()" novalidate class="cfg-form">
+        <section aria-labelledby="cfg-mod-identificacao" class="form-section">
+          <h2 id="cfg-mod-identificacao" class="form-section__title">Identificação</h2>
+          <div class="form-grid">
+            <label class="field field--full" [class.is-error]="erroDoCampo('codigo')">
+              <span class="field__label is-required">Código</span>
+              <input
+                class="input"
+                type="text"
+                formControlName="codigo"
+                autocapitalize="characters"
+                [readonly]="modoEdicao()"
+                [attr.aria-invalid]="erroDoCampo('codigo') ? 'true' : null"
+                (input)="normalizarCodigo($event)"
+                (blur)="verificarCodigoDuplicado()"
+              />
+              <span class="field__hint">
+                Maiúsculas, dígitos e sublinhado (ex.: <code>LB_PPI</code>). Único entre as
+                modalidades vivas.
+                {{ modoEdicao() ? 'Não pode ser alterado após a criação.' : '' }}
+              </span>
+              @if (erroDoCampo('codigo')) {
+                <span class="field__error">{{ erroDoCampo('codigo') }}</span>
+              }
+            </label>
+
+            <label class="field field--full" [class.is-error]="erroDoCampo('descricao')">
+              <span class="field__label">Descrição</span>
+              <input
+                class="input"
+                type="text"
+                formControlName="descricao"
+                placeholder="Ex.: Cota PPI baixa renda"
+                [attr.aria-invalid]="erroDoCampo('descricao') ? 'true' : null"
+              />
+              <span class="field__hint">Rótulo legível da modalidade (até {{ descricaoMax }} caracteres).</span>
+              @if (erroDoCampo('descricao')) {
+                <span class="field__error">{{ erroDoCampo('descricao') }}</span>
+              }
+            </label>
+          </div>
+        </section>
+
+        <section aria-labelledby="cfg-mod-vagas" class="form-section">
+          <h2 id="cfg-mod-vagas" class="form-section__title">Composição de vagas</h2>
+          <div class="form-grid">
+            <label class="field field--full" [class.is-error]="erroDoCampo('naturezaLegal')">
+              <span class="field__label is-required">Natureza legal</span>
+              <select
+                class="select"
+                formControlName="naturezaLegal"
+                [attr.aria-invalid]="erroDoCampo('naturezaLegal') ? 'true' : null"
+                (change)="aoMudarNatureza()"
+              >
+                @for (op of naturezas; track op.value) {
+                  <option [value]="op.value">{{ op.label }}</option>
+                }
+              </select>
+              <span class="field__hint">Governa as regras de remanejamento disponíveis.</span>
+            </label>
+
+            <label class="field field--full" [class.is-error]="erroDoCampo('composicaoVagas')">
+              <span class="field__label is-required">Composição de vagas</span>
+              <select
+                class="select"
+                formControlName="composicaoVagas"
+                [attr.aria-invalid]="erroDoCampo('composicaoVagas') ? 'true' : null"
+                (change)="aoMudarComposicao()"
+              >
+                @for (op of composicoes; track op.value) {
+                  <option [value]="op.value">{{ op.label }}</option>
+                }
+              </select>
+              <span class="field__hint">"Retira de" exige informar a modalidade de origem.</span>
+            </label>
+
+            @if (mostraOrigem()) {
+              <label class="field field--full" [class.is-error]="erroDoCampo('composicaoOrigem')">
+                <span class="field__label is-required">Origem (modalidade)</span>
+                <select
+                  class="select"
+                  formControlName="composicaoOrigem"
+                  [attr.aria-invalid]="erroDoCampo('composicaoOrigem') ? 'true' : null"
+                >
+                  <option value="">Selecione uma modalidade</option>
+                  @for (op of opcoesReferencia(); track op.value) {
+                    <option [value]="op.value">{{ op.label }}</option>
+                  }
+                </select>
+                <span class="field__hint">De qual modalidade viva estas vagas são retiradas (por código).</span>
+                @if (erroDoCampo('composicaoOrigem')) {
+                  <span class="field__error">{{ erroDoCampo('composicaoOrigem') }}</span>
+                }
+              </label>
+            }
+          </div>
+        </section>
+
+        @if (mostraRemanejamento()) {
+          <section aria-labelledby="cfg-mod-remanejamento" class="form-section">
+            <h2 id="cfg-mod-remanejamento" class="form-section__title">Remanejamento</h2>
+            <div class="form-grid">
+              <label class="field field--full" [class.is-error]="erroDoCampo('regraRemanejamento')">
+                <span class="field__label is-required">Regra de remanejamento</span>
+                <select
+                  class="select"
+                  formControlName="regraRemanejamento"
+                  [attr.aria-invalid]="erroDoCampo('regraRemanejamento') ? 'true' : null"
+                  (change)="aoMudarRegra()"
+                >
+                  <option value="">Selecione uma regra</option>
+                  @for (op of regras; track op.value) {
+                    <option [value]="op.value" [disabled]="regraDesabilitada(op.value)">
+                      {{ op.label }}
+                    </option>
+                  }
+                </select>
+                <span class="field__hint">{{ dicaRegra() }}</span>
+                @if (erroDoCampo('regraRemanejamento')) {
+                  <span class="field__error">{{ erroDoCampo('regraRemanejamento') }}</span>
+                }
+              </label>
+
+              @if (mostraDestino()) {
+                <label class="field field--full" [class.is-error]="erroDoCampo('remanejamentoDestino')">
+                  <span class="field__label is-required">Destino</span>
+                  <select
+                    class="select"
+                    formControlName="remanejamentoDestino"
+                    [attr.aria-invalid]="erroDoCampo('remanejamentoDestino') ? 'true' : null"
+                  >
+                    <option value="">Selecione uma modalidade</option>
+                    @for (op of opcoesReferencia(); track op.value) {
+                      <option [value]="op.value">{{ op.label }}</option>
+                    }
+                  </select>
+                  @if (erroDoCampo('remanejamentoDestino')) {
+                    <span class="field__error">{{ erroDoCampo('remanejamentoDestino') }}</span>
+                  }
+                </label>
+              }
+
+              @if (mostraParFallback()) {
+                <div class="form-grid--pair">
+                  <label class="field" [class.is-error]="erroDoCampo('remanejamentoPar')">
+                    <span class="field__label is-required">Par</span>
+                    <select
+                      class="select"
+                      formControlName="remanejamentoPar"
+                      [attr.aria-invalid]="erroDoCampo('remanejamentoPar') ? 'true' : null"
+                    >
+                      <option value="">Selecione uma modalidade</option>
+                      @for (op of opcoesReferencia(); track op.value) {
+                        <option [value]="op.value">{{ op.label }}</option>
+                      }
+                    </select>
+                    @if (erroDoCampo('remanejamentoPar')) {
+                      <span class="field__error">{{ erroDoCampo('remanejamentoPar') }}</span>
+                    }
+                  </label>
+                  <label class="field" [class.is-error]="erroDoCampo('remanejamentoFallback')">
+                    <span class="field__label is-required">Fallback</span>
+                    <select
+                      class="select"
+                      formControlName="remanejamentoFallback"
+                      [attr.aria-invalid]="erroDoCampo('remanejamentoFallback') ? 'true' : null"
+                    >
+                      <option value="">Selecione uma modalidade</option>
+                      @for (op of opcoesReferencia(); track op.value) {
+                        <option [value]="op.value">{{ op.label }}</option>
+                      }
+                    </select>
+                    @if (erroDoCampo('remanejamentoFallback')) {
+                      <span class="field__error">{{ erroDoCampo('remanejamentoFallback') }}</span>
+                    }
+                  </label>
+                </div>
+              }
+            </div>
+          </section>
+        }
+
+        <section aria-labelledby="cfg-mod-criterios" class="form-section">
+          <h2 id="cfg-mod-criterios" class="form-section__title">Critérios e enquadramento</h2>
+          <div class="form-grid">
+            <div class="field field--full">
+              <span class="field__label" id="cfg-mod-criterios-label">Critérios cumulativos</span>
+              <div class="cfg-chips-input">
+                <input
+                  #criterioInput
+                  class="input"
+                  type="text"
+                  placeholder="Ex.: escola pública"
+                  aria-labelledby="cfg-mod-criterios-label"
+                  (keydown.enter)="adicionarCriterio(criterioInput); $event.preventDefault()"
+                />
+                <button
+                  type="button"
+                  class="btn btn--secondary btn--sm btn--rect"
+                  (click)="adicionarCriterio(criterioInput)"
+                >
+                  Adicionar
+                </button>
+              </div>
+              @if (criterios().length > 0) {
+                <ul class="cfg-chips" aria-label="Critérios cumulativos adicionados">
+                  @for (criterio of criterios(); track criterio) {
+                    <li class="cfg-chip">
+                      <span>{{ criterio }}</span>
+                      <button
+                        type="button"
+                        class="cfg-chip__remove"
+                        [attr.aria-label]="'Remover critério ' + criterio"
+                        (click)="removerCriterio(criterio)"
+                      >
+                        &times;
+                      </button>
+                    </li>
+                  }
+                </ul>
+              }
+              <span class="field__hint">Lista aberta (renda, autodeclaração, laudo, etc.).</span>
+            </div>
+
+            <label class="field field--full">
+              <span class="field__label">Ação quando indeferido</span>
+              <select class="select" formControlName="acaoQuandoIndeferido">
+                <option value="">Não se aplica</option>
+                @for (op of acoes; track op.value) {
+                  <option [value]="op.value">{{ op.label }}</option>
+                }
+              </select>
+              <span class="field__hint">Destino do candidato indeferido nesta modalidade (aplicável a cotas).</span>
+            </label>
+
+            <label class="field field--full" [class.is-error]="erroDoCampo('baseLegal')">
+              <span class="field__label">Base legal</span>
+              <input
+                class="input"
+                type="text"
+                formControlName="baseLegal"
+                placeholder="Ex.: Lei 12.711/2012, art. 1º"
+                [attr.aria-invalid]="erroDoCampo('baseLegal') ? 'true' : null"
+              />
+              @if (erroDoCampo('baseLegal')) {
+                <span class="field__error">{{ erroDoCampo('baseLegal') }}</span>
+              }
+            </label>
+          </div>
+        </section>
+
+        <aside class="cond-diagram" aria-label="Resumo das escolhas" aria-live="polite">
+          <h2 class="cond-diagram__title">Como estas vagas se comportam</h2>
+          <ul class="cond-diagram__list">
+            @for (clausula of resumoCondicional(); track clausula) {
+              <li class="cond-diagram__item">{{ clausula }}</li>
+            }
+          </ul>
+        </aside>
+      </form>
+
+      <div class="cfg-form-footer">
+        <a class="btn btn--tertiary btn--rect" routerLink="/modalidades">Cancelar</a>
+        <button type="submit" form="cfg-modalidade-form" class="btn btn--primary" [disabled]="salvando()">
+          @if (salvando()) {
+            <ui-spinner size="sm" />
+          }
+          {{ salvando() ? 'Salvando...' : modoEdicao() ? 'Salvar modalidade' : 'Criar modalidade' }}
+        </button>
+      </div>
+    }
+
+    <ui-dialog
+      [(visible)]="confirmResetAberto"
+      heading="Redefinir remanejamento?"
+      (closed)="cancelarResetNatureza()"
+    >
+      <p>
+        A natureza escolhida é incompatível com a regra de remanejamento atual. Se continuar, a
+        regra e seus argumentos (destino, par e fallback) serão limpos.
+      </p>
+      <div uiDialogFooter>
+        <button type="button" class="btn btn--tertiary btn--rect" (click)="cancelarResetNatureza()">
+          Manter natureza anterior
+        </button>
+        <button type="button" class="btn btn--danger btn--rect" (click)="confirmarResetNatureza()">
+          Redefinir campos
+        </button>
+      </div>
+    </ui-dialog>
+  `,
+})
+export class ModalidadeFormPage {
+  private readonly api = inject(ModalidadesApi);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly problemI18n = inject(ProblemI18nService);
+  private readonly notifications = inject(NotificationService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  protected readonly naturezas = NATUREZAS_LEGAIS;
+  protected readonly composicoes = COMPOSICOES_VAGAS;
+  protected readonly regras = REGRAS_REMANEJAMENTO;
+  protected readonly acoes = ACOES_QUANDO_INDEFERIDO;
+  protected readonly descricaoMax = DESCRICAO_MAX;
+
+  private readonly tituloPagina = viewChild<ElementRef<HTMLHeadingElement>>('tituloPagina');
+
+  private readonly id = signal<string | null>(this.route.snapshot.paramMap.get('id'));
+  protected readonly modoEdicao = computed(() => this.id() !== null);
+  protected readonly titulo = computed(() =>
+    this.modoEdicao() ? 'Editar modalidade' : 'Nova modalidade',
+  );
+
+  protected readonly carregando = signal(false);
+  protected readonly salvando = signal(false);
+  protected readonly erroCarregar = signal<string | null>(null);
+  protected readonly formError = signal<string | null>(null);
+  protected readonly tentouSalvar = signal(false);
+  protected readonly idempotencyKeyAtual = signal(idempotencyKey.create());
+  protected readonly criterios = signal<readonly string[]>([]);
+
+  /** Modalidades vivas para os selects de referência (origem/destino/par/fallback). */
+  private readonly modalidadesVivas = signal<readonly ModalidadeDto[]>([]);
+
+  /** Snapshot da modalidade em edição — usado para pré-checar unicidade excluindo a si mesma. */
+  private readonly codigoAtual = signal<string | null>(null);
+
+  /** Estado condicional (dirige visibilidade/validação) — derivado dos controles. */
+  private readonly natureza = signal<NaturezaLegalToken>(NATUREZA_LEGAL_DEFAULT);
+  private readonly composicao = signal<ComposicaoVagasToken>(COMPOSICAO_VAGAS_DEFAULT);
+  private readonly regra = signal<RegraSelecao>('');
+
+  private naturezaAnterior: NaturezaLegalToken = NATUREZA_LEGAL_DEFAULT;
+  private naturezaPendente: NaturezaLegalToken | null = null;
+  protected readonly confirmResetAberto = signal(false);
+
+  protected readonly form: FormGroup<ModalidadeForm> = new FormGroup<ModalidadeForm>({
+    codigo: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required, Validators.pattern(CODIGO_REGEX)],
+    }),
+    descricao: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.maxLength(DESCRICAO_MAX)],
+    }),
+    naturezaLegal: new FormControl<NaturezaLegalToken>(NATUREZA_LEGAL_DEFAULT, {
+      nonNullable: true,
+      validators: [Validators.required],
+    }),
+    composicaoVagas: new FormControl<ComposicaoVagasToken>(COMPOSICAO_VAGAS_DEFAULT, {
+      nonNullable: true,
+      validators: [Validators.required],
+    }),
+    composicaoOrigem: new FormControl('', { nonNullable: true }),
+    regraRemanejamento: new FormControl<RegraSelecao>('', { nonNullable: true }),
+    remanejamentoDestino: new FormControl('', { nonNullable: true }),
+    remanejamentoPar: new FormControl('', { nonNullable: true }),
+    remanejamentoFallback: new FormControl('', { nonNullable: true }),
+    acaoQuandoIndeferido: new FormControl<AcaoSelecao>('', { nonNullable: true }),
+    baseLegal: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.maxLength(BASE_LEGAL_MAX)],
+    }),
+  });
+
+  protected readonly mostraRemanejamento = computed(() => this.natureza() !== 'AMPLA');
+  protected readonly mostraOrigem = computed(() => this.composicao() === COMPOSICAO_RETIRA_DE);
+  protected readonly mostraDestino = computed(() => this.regra() === 'DESTINO_UNICO');
+  protected readonly mostraParFallback = computed(() => this.regra() === 'CRUZADO');
+
+  /** Opções de referência: modalidades vivas exceto a própria (por código). */
+  protected readonly opcoesReferencia = computed(() => {
+    const proprio = this.codigoAtual();
+    return this.modalidadesVivas()
+      .filter((m) => m.codigo !== proprio)
+      .map((m) => ({ value: m.codigo, label: m.descricao ? `${m.codigo} — ${m.descricao}` : m.codigo }));
+  });
+
+  protected readonly dicaRegra = computed(() => {
+    switch (this.natureza()) {
+      case 'COTA_RESERVADA':
+        return 'Cota reservada segue obrigatoriamente a cascata legal.';
+      case 'SUPLEMENTAR':
+      case 'OUTRA_MODALIDADE':
+        return 'Escolha destino único ou remanejamento cruzado.';
+      default:
+        return 'Selecione a regra de remanejamento aplicável.';
+    }
+  });
+
+  /** Snapshot reativo dos valores do form — dirige o mapa de condicionais (cond-diagram). */
+  private readonly valoresForm = toSignal(this.form.valueChanges, {
+    initialValue: this.form.getRawValue(),
+  });
+
+  protected readonly resumoCondicional = computed<readonly string[]>(() => {
+    const clausulas: string[] = [];
+    const natureza = this.natureza();
+    const composicao = this.composicao();
+    const regra = this.regra();
+    this.valoresForm();
+    const raw = this.form.getRawValue();
+
+    if (composicao === COMPOSICAO_RETIRA_DE) {
+      clausulas.push(
+        raw.composicaoOrigem
+          ? `As vagas são retiradas da modalidade ${raw.composicaoOrigem}.`
+          : 'As vagas são retiradas de outra modalidade (informe a origem).',
+      );
+    } else {
+      const label = COMPOSICOES_VAGAS.find((c) => c.value === composicao)?.label ?? composicao;
+      clausulas.push(`Composição das vagas: ${label.toLocaleLowerCase('pt-BR')}.`);
+    }
+
+    if (natureza === 'AMPLA') {
+      clausulas.push('Ampla concorrência não remaneja vagas ociosas.');
+    } else if (natureza === 'COTA_RESERVADA') {
+      clausulas.push('Cota reservada: vagas ociosas seguem a cascata legal de remanejamento.');
+    } else if (regra === 'DESTINO_UNICO') {
+      clausulas.push(
+        raw.remanejamentoDestino
+          ? `Vagas ociosas remanejam para ${raw.remanejamentoDestino}.`
+          : 'Vagas ociosas remanejam para um destino único (informe o destino).',
+      );
+    } else if (regra === 'CRUZADO') {
+      clausulas.push(
+        raw.remanejamentoPar && raw.remanejamentoFallback
+          ? `Remanejamento cruzado entre ${raw.remanejamentoPar} e ${raw.remanejamentoFallback}.`
+          : 'Remanejamento cruzado (informe o par e o fallback).',
+      );
+    } else {
+      clausulas.push('Selecione a regra de remanejamento para esta modalidade.');
+    }
+
+    return clausulas;
+  });
+
+  constructor() {
+    afterNextRender(() => this.tituloPagina()?.nativeElement.focus());
+    this.carregarModalidadesVivas();
+    if (this.id() !== null) {
+      this.carregarModalidade(this.id() as string);
+    } else {
+      this.reconciliarCondicionais();
+    }
+  }
+
+  protected normalizarCodigo(event: Event): void {
+    if (this.modoEdicao()) return;
+    const alvo = event.target;
+    if (!(alvo instanceof HTMLInputElement)) return;
+    const normalizado = alvo.value.toLocaleUpperCase('pt-BR');
+    if (normalizado !== alvo.value) {
+      this.form.controls.codigo.setValue(normalizado);
+    }
+  }
+
+  protected verificarCodigoDuplicado(): void {
+    if (this.modoEdicao()) return;
+    const control = this.form.controls.codigo;
+    const codigo = control.value.trim();
+    const duplicado =
+      codigo.length > 0 && this.modalidadesVivas().some((m) => m.codigo === codigo);
+    if (duplicado) {
+      control.setErrors({ ...(control.errors ?? {}), duplicado: true });
+      control.markAsTouched();
+      return;
+    }
+    if (control.hasError('duplicado')) {
+      const erros = { ...(control.errors ?? {}) };
+      delete erros['duplicado'];
+      control.setErrors(Object.keys(erros).length > 0 ? erros : null);
+    }
+  }
+
+  protected aoMudarComposicao(): void {
+    this.composicao.set(this.form.controls.composicaoVagas.value);
+    this.reconciliarCondicionais();
+  }
+
+  protected aoMudarRegra(): void {
+    this.regra.set(this.form.controls.regraRemanejamento.value);
+    this.reconciliarCondicionais();
+  }
+
+  protected aoMudarNatureza(): void {
+    const nova = this.form.controls.naturezaLegal.value;
+    if (nova === this.naturezaAnterior) return;
+    // Precisa resetar remanejamento e há dados preenchidos? Pede confirmação (§5).
+    if (this.remanejamentoPreenchido() && !this.naturezaCompativelComRegraAtual(nova)) {
+      this.naturezaPendente = nova;
+      this.confirmResetAberto.set(true);
+      return;
+    }
+    this.aplicarNatureza(nova);
+  }
+
+  protected confirmarResetNatureza(): void {
+    if (this.naturezaPendente !== null) {
+      this.aplicarNatureza(this.naturezaPendente);
+    }
+    this.naturezaPendente = null;
+    this.confirmResetAberto.set(false);
+  }
+
+  protected cancelarResetNatureza(): void {
+    // Reverte a seleção visual para a natureza anterior, preservando os campos.
+    this.form.controls.naturezaLegal.setValue(this.naturezaAnterior, { emitEvent: false });
+    this.natureza.set(this.naturezaAnterior);
+    this.naturezaPendente = null;
+    this.confirmResetAberto.set(false);
+  }
+
+  protected regraDesabilitada(valor: RegraRemanejamentoToken): boolean {
+    switch (this.natureza()) {
+      case 'COTA_RESERVADA':
+        return valor !== 'SEGUE_CASCATA';
+      case 'SUPLEMENTAR':
+      case 'OUTRA_MODALIDADE':
+        return valor === 'SEGUE_CASCATA';
+      default:
+        return false;
+    }
+  }
+
+  protected adicionarCriterio(input: HTMLInputElement): void {
+    const valor = input.value.trim();
+    if (valor.length === 0) return;
+    if (!this.criterios().some((c) => c.toLocaleLowerCase('pt-BR') === valor.toLocaleLowerCase('pt-BR'))) {
+      this.criterios.update((lista) => [...lista, valor]);
+    }
+    input.value = '';
+    input.focus();
+  }
+
+  protected removerCriterio(criterio: string): void {
+    this.criterios.update((lista) => lista.filter((c) => c !== criterio));
+  }
+
+  protected erroDoCampo(nome: keyof ModalidadeForm): string | null {
+    const control = this.form.controls[nome];
+    const mostrar = control.touched || control.dirty || this.tentouSalvar();
+    if (!mostrar || control.errors === null) {
+      return null;
+    }
+    if (control.errors['backend']) {
+      const backend = control.errors['backend'] as { code: string; message: string };
+      return backend.message;
+    }
+    if (control.errors['duplicado']) return 'Código já utilizado por outra modalidade viva.';
+    if (control.errors['required']) return 'Campo obrigatório.';
+    if (control.errors['pattern']) return 'Use apenas maiúsculas, dígitos e sublinhado.';
+    if (control.errors['maxlength']) return 'Valor acima do tamanho permitido.';
+    return 'Valor inválido.';
+  }
+
+  protected salvar(): void {
+    if (this.salvando()) return;
+    this.tentouSalvar.set(true);
+    this.verificarCodigoDuplicado();
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      this.focarPrimeiroErro();
+      return;
+    }
+    this.salvando.set(true);
+    this.formError.set(null);
+
+    if (this.modoEdicao()) {
+      this.api
+        .atualizar(this.id() as string, this.montarComandoAtualizar(), withIdempotencyKey(this.idempotencyKeyAtual()))
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe((result) => this.tratarResultado(result));
+      return;
+    }
+
+    this.api
+      .criar(this.montarComandoCriar(), withIdempotencyKey(this.idempotencyKeyAtual()))
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((result) => this.tratarResultado(result));
+  }
+
+  private aplicarNatureza(nova: NaturezaLegalToken): void {
+    this.natureza.set(nova);
+    this.naturezaAnterior = nova;
+    this.reconciliarCondicionais();
+  }
+
+  /**
+   * Reconcilia validação e valores condicionais espelhando as invariantes do
+   * agregado `Modalidade` (uniplus-api #589): coerência natureza↔regra, equivalência
+   * composição RETIRA_DE⟺origem e args por regra. Campos inaplicáveis são limpos aqui
+   * e também anulados no comando, evitando valores ocultos obsoletos.
+   */
+  private reconciliarCondicionais(): void {
+    const controls = this.form.controls;
+
+    // Composição ↔ Origem.
+    if (this.composicao() === COMPOSICAO_RETIRA_DE) {
+      controls.composicaoOrigem.setValidators([Validators.required, Validators.maxLength(CODIGO_REFERENCIA_MAX)]);
+    } else {
+      controls.composicaoOrigem.clearValidators();
+      controls.composicaoOrigem.setValue('', { emitEvent: false });
+    }
+    controls.composicaoOrigem.updateValueAndValidity({ emitEvent: false });
+
+    // Natureza ↔ Regra.
+    const natureza = this.natureza();
+    if (natureza === 'AMPLA') {
+      controls.regraRemanejamento.setValue('', { emitEvent: false });
+      controls.regraRemanejamento.clearValidators();
+    } else if (natureza === 'COTA_RESERVADA') {
+      controls.regraRemanejamento.setValue('SEGUE_CASCATA', { emitEvent: false });
+      controls.regraRemanejamento.setValidators([Validators.required]);
+    } else {
+      // SUPLEMENTAR / OUTRA_MODALIDADE: só DESTINO_UNICO/CRUZADO.
+      if (controls.regraRemanejamento.value === 'SEGUE_CASCATA') {
+        controls.regraRemanejamento.setValue('', { emitEvent: false });
+      }
+      controls.regraRemanejamento.setValidators([Validators.required]);
+    }
+    controls.regraRemanejamento.updateValueAndValidity({ emitEvent: false });
+    this.regra.set(controls.regraRemanejamento.value);
+
+    // Regra ↔ Args.
+    const regra = controls.regraRemanejamento.value;
+    this.configurarArg(controls.remanejamentoDestino, regra === 'DESTINO_UNICO');
+    this.configurarArg(controls.remanejamentoPar, regra === 'CRUZADO');
+    this.configurarArg(controls.remanejamentoFallback, regra === 'CRUZADO');
+  }
+
+  private configurarArg(control: AbstractControl, aplicavel: boolean): void {
+    if (aplicavel) {
+      control.setValidators([Validators.required, Validators.maxLength(CODIGO_REFERENCIA_MAX)]);
+    } else {
+      control.clearValidators();
+      control.setValue('', { emitEvent: false });
+    }
+    control.updateValueAndValidity({ emitEvent: false });
+  }
+
+  /**
+   * Indica se há **argumentos digitados pelo usuário** (destino/par/fallback) que
+   * seriam perdidos ao trocar a natureza — só então a confirmação faz sentido. A
+   * própria regra é auto-gerida por `reconciliarCondicionais` (ex.: o
+   * `SEGUE_CASCATA` que a cota preenche sozinha), então não conta como dado do
+   * usuário; considerá-la bloquearia trocas legítimas como COTA_RESERVADA →
+   * SUPLEMENTAR sem nada a descartar.
+   */
+  private remanejamentoPreenchido(): boolean {
+    const raw = this.form.getRawValue();
+    return (
+      raw.remanejamentoDestino !== '' ||
+      raw.remanejamentoPar !== '' ||
+      raw.remanejamentoFallback !== ''
+    );
+  }
+
+  private naturezaCompativelComRegraAtual(natureza: NaturezaLegalToken): boolean {
+    const regra = this.form.controls.regraRemanejamento.value;
+    switch (natureza) {
+      case 'AMPLA':
+        return regra === '';
+      case 'COTA_RESERVADA':
+        return regra === 'SEGUE_CASCATA';
+      default:
+        return regra === 'DESTINO_UNICO' || regra === 'CRUZADO';
+    }
+  }
+
+  private carregarModalidadesVivas(): void {
+    this.api
+      .listar({ limit: 100 })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((result) => {
+        if (result.ok) {
+          this.modalidadesVivas.set([...result.data]);
+        }
+      });
+  }
+
+  private carregarModalidade(id: string): void {
+    this.carregando.set(true);
+    this.api
+      .obter(id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((result) => {
+        this.carregando.set(false);
+        if (!result.ok) {
+          this.erroCarregar.set(this.problemI18n.resolve(result.problem).title);
+          return;
+        }
+        this.preencher(result.data);
+      });
+  }
+
+  private preencher(dto: ModalidadeDto): void {
+    const natureza = dto.naturezaLegal as NaturezaLegalToken;
+    this.codigoAtual.set(dto.codigo);
+    this.form.patchValue(
+      {
+        codigo: dto.codigo,
+        descricao: dto.descricao ?? '',
+        naturezaLegal: natureza,
+        composicaoVagas: dto.composicaoVagas as ComposicaoVagasToken,
+        composicaoOrigem: dto.composicaoOrigem ?? '',
+        regraRemanejamento: (dto.regraRemanejamento ?? '') as RegraSelecao,
+        remanejamentoDestino: dto.remanejamentoDestino ?? '',
+        remanejamentoPar: dto.remanejamentoPar ?? '',
+        remanejamentoFallback: dto.remanejamentoFallback ?? '',
+        acaoQuandoIndeferido: (dto.acaoQuandoIndeferido ?? '') as AcaoSelecao,
+        baseLegal: dto.baseLegal ?? '',
+      },
+      { emitEvent: false },
+    );
+    this.criterios.set([...dto.criteriosCumulativos]);
+    // Código é imutável na edição.
+    this.form.controls.codigo.disable({ emitEvent: false });
+    this.natureza.set(natureza);
+    this.composicao.set(dto.composicaoVagas as ComposicaoVagasToken);
+    this.regra.set((dto.regraRemanejamento ?? '') as RegraSelecao);
+    this.naturezaAnterior = natureza;
+    this.reconciliarCondicionais();
+  }
+
+  private tratarResultado(result: ApiResult<string | void>): void {
+    this.salvando.set(false);
+    if (result.ok) {
+      this.notifications.success(
+        this.modoEdicao() ? 'Modalidade atualizada' : 'Modalidade criada',
+        this.form.getRawValue().codigo,
+      );
+      this.idempotencyKeyAtual.set(idempotencyKey.create());
+      void this.router.navigate(['/modalidades']);
+      return;
+    }
+    this.aplicarFalha(result.problem);
+  }
+
+  private aplicarFalha(problem: ProblemDetails): void {
+    if (problem.status === 422 && problem.errors && problem.errors.length > 0) {
+      this.renovarIdempotencyKey();
+      this.aplicarErrosDeValidacao(problem.errors);
+      return;
+    }
+    // Unicidade de código (409).
+    if (problem.status === 409 || problem.code === 'Modalidade.CodigoJaExiste') {
+      this.renovarIdempotencyKey();
+      const control = this.form.controls.codigo;
+      control.setErrors({ backend: { code: problem.code, message: 'Código já utilizado por outra modalidade viva.' } });
+      control.markAsTouched();
+      this.formError.set(null);
+      return;
+    }
+    if (problem.code === 'uniplus.idempotency.body_mismatch') {
+      this.renovarIdempotencyKey();
+    }
+    this.formError.set(this.problemI18n.resolve(problem).title);
+    if (problem.status >= 500) {
+      this.notifications.errorFromProblem(problem);
+    }
+  }
+
+  private renovarIdempotencyKey(): void {
+    this.idempotencyKeyAtual.set(idempotencyKey.create());
+  }
+
+  private aplicarErrosDeValidacao(errors: ReadonlyArray<ProblemValidationError>): void {
+    let aplicouAlgum = false;
+    for (const erro of errors) {
+      const controlName = controlNameFromBackendField(erro.field);
+      if (controlName === null) continue;
+      const control = this.form.controls[controlName];
+      control.setErrors({ backend: { code: erro.code, message: erro.message } });
+      control.markAsTouched();
+      aplicouAlgum = true;
+    }
+    this.formError.set(
+      aplicouAlgum ? null : 'Não foi possível mapear os erros de validação. Revise os campos.',
+    );
+  }
+
+  /**
+   * Campos comuns aos comandos de criação e atualização (tudo exceto código/id),
+   * derivados **inteiramente** de `getRawValue()` (fonte única no submit). Campos
+   * inaplicáveis são anulados aqui espelhando as invariantes do agregado, evitando
+   * qualquer divergência entre o valor do form e o estado condicional em signals.
+   */
+  private montarCamposComuns(): Omit<CriarModalidadeCommand, 'codigo'> {
+    const raw = this.form.getRawValue();
+    const retiraDe = raw.composicaoVagas === COMPOSICAO_RETIRA_DE;
+    const regra: string | null =
+      raw.naturezaLegal === 'AMPLA' || raw.regraRemanejamento === '' ? null : raw.regraRemanejamento;
+    return {
+      descricao: normalizarOpcional(raw.descricao),
+      naturezaLegal: raw.naturezaLegal,
+      composicaoVagas: raw.composicaoVagas,
+      composicaoOrigem: retiraDe ? normalizarOpcional(raw.composicaoOrigem) : null,
+      regraRemanejamento: regra,
+      remanejamentoDestino: regra === 'DESTINO_UNICO' ? normalizarOpcional(raw.remanejamentoDestino) : null,
+      remanejamentoPar: regra === 'CRUZADO' ? normalizarOpcional(raw.remanejamentoPar) : null,
+      remanejamentoFallback: regra === 'CRUZADO' ? normalizarOpcional(raw.remanejamentoFallback) : null,
+      criteriosCumulativos: this.criterios().length > 0 ? [...this.criterios()] : null,
+      acaoQuandoIndeferido: normalizarOpcional(raw.acaoQuandoIndeferido),
+      baseLegal: normalizarOpcional(raw.baseLegal),
+    };
+  }
+
+  private montarComandoCriar(): CriarModalidadeCommand {
+    return { codigo: this.form.getRawValue().codigo.trim(), ...this.montarCamposComuns() };
+  }
+
+  private montarComandoAtualizar(): AtualizarModalidadeCommand {
+    // Código é imutável — não vai no comando de atualização.
+    return { id: this.id() as string, ...this.montarCamposComuns() };
+  }
+
+  private focarPrimeiroErro(): void {
+    const primeiro = document.querySelector<HTMLElement>('.cfg-form .is-error .input, .cfg-form .is-error .select');
+    primeiro?.focus();
+  }
+}
+
+function normalizarOpcional(valor: string | null | undefined): string | null {
+  if (valor === null || valor === undefined) return null;
+  const trimmed = valor.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+const MODALIDADE_CONTROL_NAMES: ReadonlySet<string> = new Set<keyof ModalidadeForm>([
+  'codigo',
+  'descricao',
+  'naturezaLegal',
+  'composicaoVagas',
+  'composicaoOrigem',
+  'regraRemanejamento',
+  'remanejamentoDestino',
+  'remanejamentoPar',
+  'remanejamentoFallback',
+  'acaoQuandoIndeferido',
+  'baseLegal',
+]);
+
+function controlNameFromBackendField(field: string): keyof ModalidadeForm | null {
+  const normalized =
+    field
+      .split('.')
+      .at(-1)
+      ?.replace(/\[\d+\]$/u, '') ?? field;
+  const camelCase = normalized.charAt(0).toLocaleLowerCase('pt-BR') + normalized.slice(1);
+  return MODALIDADE_CONTROL_NAMES.has(camelCase) ? (camelCase as keyof ModalidadeForm) : null;
+}

--- a/apps/configuracao/src/app/features/modalidades/modalidades-list.page.spec.ts
+++ b/apps/configuracao/src/app/features/modalidades/modalidades-list.page.spec.ts
@@ -1,0 +1,153 @@
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ApplicationRef } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { apiResultInterceptor } from '@uniplus/shared-core/http';
+import { CONFIGURACAO_BASE_PATH, ModalidadeDto } from '@uniplus/shared-data/configuracao';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ModalidadesListPage } from './modalidades-list.page';
+
+const BASE = 'http://localhost:5000';
+const URL = `${BASE}/api/configuracao/modalidades`;
+
+function modalidade(over: Partial<ModalidadeDto>): ModalidadeDto {
+  return {
+    id: over.id ?? crypto.randomUUID(),
+    codigo: 'AC',
+    descricao: 'Ampla concorrência',
+    naturezaLegal: 'AMPLA',
+    composicaoVagas: 'RESIDUAL_DO_VO',
+    composicaoOrigem: null,
+    regraRemanejamento: null,
+    remanejamentoDestino: null,
+    remanejamentoPar: null,
+    remanejamentoFallback: null,
+    criteriosCumulativos: [],
+    acaoQuandoIndeferido: null,
+    baseLegal: null,
+    criadoEm: '2026-07-03T12:00:00Z',
+    ...over,
+  };
+}
+
+const AC = modalidade({ id: 'id-ac', codigo: 'AC' });
+// V retira suas vagas de AC e remaneja para AC (referencia AC como origem e destino).
+const V = modalidade({
+  id: 'id-v',
+  codigo: 'V',
+  descricao: 'PcD ampla concorrência',
+  naturezaLegal: 'SUPLEMENTAR',
+  composicaoVagas: 'RETIRA_DE',
+  composicaoOrigem: 'AC',
+  regraRemanejamento: 'DESTINO_UNICO',
+  remanejamentoDestino: 'AC',
+});
+
+describe('ModalidadesListPage', () => {
+  let fixture: ComponentFixture<ModalidadesListPage>;
+  let component: ModalidadesListPage;
+  let controller: HttpTestingController;
+  let appRef: ApplicationRef;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ModalidadesListPage],
+      providers: [
+        provideHttpClient(withInterceptors([apiResultInterceptor])),
+        provideHttpClientTesting(),
+        provideRouter([{ path: 'modalidades', children: [] }]),
+        { provide: CONFIGURACAO_BASE_PATH, useValue: BASE },
+      ],
+    });
+    fixture = TestBed.createComponent(ModalidadesListPage);
+    component = fixture.componentInstance;
+    controller = TestBed.inject(HttpTestingController);
+    appRef = TestBed.inject(ApplicationRef);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => controller.verify());
+
+  const propagate = async (): Promise<void> => {
+    await Promise.resolve();
+    appRef.tick();
+  };
+
+  async function flushLista(itens: readonly ModalidadeDto[]): Promise<void> {
+    const req = controller.expectOne((r) => r.url === URL);
+    expect(req.request.params.get('limit')).toBe('100');
+    req.flush(itens);
+    await propagate();
+  }
+
+  it('CA-01: renderiza código, natureza e status Ativa', async () => {
+    await flushLista([AC, V]);
+    fixture.detectChanges();
+    const texto = fixture.nativeElement.textContent as string;
+    expect(component['modalidadesFiltradas']()).toHaveLength(2);
+    expect(texto).toContain('AC');
+    expect(texto).toContain('Ampla concorrência');
+    expect(texto).toContain('Ativa');
+  });
+
+  it('CA-01: chips de natureza contam por token e filtram client-side', async () => {
+    await flushLista([AC, V]);
+    const chips = component['chipsNatureza']();
+    expect(chips.find((c) => c.value === 'AMPLA')?.count).toBe(1);
+    expect(chips.find((c) => c.value === 'SUPLEMENTAR')?.count).toBe(1);
+
+    component['naturezaSelecionada'].set('SUPLEMENTAR');
+    expect(component['modalidadesFiltradas']().map((m) => m.codigo)).toEqual(['V']);
+  });
+
+  it('CA-01: busca casa código e descrição', async () => {
+    await flushLista([AC, V]);
+    component['busca'].set('pcd');
+    expect(component['modalidadesFiltradas']().map((m) => m.codigo)).toEqual(['V']);
+  });
+
+  it('CA-01: mapa reverso lista quem referencia a modalidade (AC referenciada por V)', async () => {
+    await flushLista([AC, V]);
+    expect(component['referenciadaPor']('AC').map((m) => m.codigo)).toEqual(['V']);
+    expect(component['referenciadaPor']('V')).toEqual([]);
+  });
+
+  it('ModalidadeRemocaoDialog_BloqueiaQuandoReferenciada: sem DELETE quando há dependente', async () => {
+    await flushLista([AC, V]);
+    component['pedirRemocao'](AC);
+    expect(component['remocaoBloqueada']()).toBe(true);
+    component['removerConfirmado']();
+    controller.expectNone(`${BASE}/api/configuracao/admin/modalidades/${AC.id}`);
+  });
+
+  it('ModalidadeRemocaoDialog_SoftDeleteQuandoLivre: DELETE e recarrega', async () => {
+    await flushLista([AC, V]);
+    component['pedirRemocao'](V);
+    expect(component['remocaoBloqueada']()).toBe(false);
+    component['removerConfirmado']();
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/modalidades/${V.id}`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush(null, { status: 204, statusText: 'No Content' });
+    await propagate();
+    expect(component['dialogAberto']()).toBe(false);
+    await flushLista([AC]);
+  });
+
+  it('ModalidadeRemocaoDialog_409Servidor: 409 mantém bloqueio autoritativo', async () => {
+    await flushLista([AC, V]);
+    component['pedirRemocao'](V);
+    component['removerConfirmado']();
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/modalidades/${V.id}`);
+    req.flush(
+      { type: 'about:blank', title: 'Conflito', status: 409, code: 'Modalidade.RemocaoBloqueadaPorReferencia' },
+      { status: 409, statusText: 'Conflict' },
+    );
+    await propagate();
+    expect(component['bloqueioServidor']()).toBe(true);
+    expect(component['remocaoBloqueada']()).toBe(true);
+    // A mensagem do servidor é capturada para exibição quando o referente não está na página.
+    expect(component['mensagemBloqueioServidor']()).toBeTruthy();
+    await flushLista([AC, V]);
+  });
+});

--- a/apps/configuracao/src/app/features/modalidades/modalidades-list.page.ts
+++ b/apps/configuracao/src/app/features/modalidades/modalidades-list.page.ts
@@ -1,0 +1,582 @@
+import { HttpParams } from '@angular/common/http';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  effect,
+  inject,
+  linkedSignal,
+  signal,
+  untracked,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { RouterLink } from '@angular/router';
+import {
+  ApiResult,
+  Cursor,
+  PaginationDirection,
+  ProblemI18nService,
+  cursorToString,
+  extractNextCursor,
+  extractPrevCursor,
+  useApiResource,
+  withVendorMime,
+} from '@uniplus/shared-core/http';
+import { NotificationService } from '@uniplus/shared-core/notifications';
+import {
+  COMPOSICOES_VAGAS,
+  CONFIGURACAO_BASE_PATH,
+  ModalidadeDto,
+  ModalidadesApi,
+  NATUREZAS_LEGAIS,
+  REGRAS_REMANEJAMENTO,
+} from '@uniplus/shared-data/configuracao';
+import {
+  AlertComponent,
+  DialogComponent,
+  EmptyStateComponent,
+  FilterChipsComponent,
+  PagerComponent,
+  SpinnerComponent,
+  TagComponent,
+  type UiFilterChipOption,
+  type UiTagVariant,
+} from '@uniplus/shared-ui/components';
+
+/** Tamanho da janela de cada página (cursor pagination, ADR-0026/0089). */
+const PAGE_SIZE = 100;
+
+/** Rótulo legível de um token de domínio fechado (fallback: o próprio token). */
+function rotulo(roster: readonly { value: string; label: string }[], token: string | null): string {
+  if (token === null) return '—';
+  return roster.find((o) => o.value === token)?.label ?? token;
+}
+
+/** Variante visual da tag de Natureza legal. */
+const NATUREZA_VARIANTE: Readonly<Record<string, UiTagVariant>> = {
+  AMPLA: 'info',
+  COTA_RESERVADA: 'success',
+  SUPLEMENTAR: 'warning',
+  OUTRA_MODALIDADE: 'neutral',
+};
+
+@Component({
+  selector: 'cfg-modalidades-list-page',
+  standalone: true,
+  imports: [
+    RouterLink,
+    AlertComponent,
+    DialogComponent,
+    EmptyStateComponent,
+    FilterChipsComponent,
+    PagerComponent,
+    SpinnerComponent,
+    TagComponent,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="page-header">
+      <div class="page-header__content">
+        <h1 class="page-header__title">Modalidade de concorrência</h1>
+        <p class="page-header__desc">
+          Formas de disputa de vagas de um processo — ampla concorrência e as cotas das ações
+          afirmativas (Lei 12.711/2012, atualizada pela Lei 14.723/2023), com composição e cascata
+          de remanejamento · UNI-REQ-0011.
+        </p>
+      </div>
+    </div>
+
+    <ui-alert variant="info" heading="Configuração viva — congelamento por snapshot" [dynamic]="false">
+      Mudanças neste cadastro não afetam processos já publicados, que congelam os dados no momento
+      da criação (RN08). Origem, destino, par e fallback referenciam outra modalidade pelo seu
+      código.
+    </ui-alert>
+
+    @if (errorMessage()) {
+      <ui-alert variant="danger" heading="Não foi possível carregar as modalidades">
+        {{ errorMessage() }}
+        <div class="cfg-list__retry">
+          <button
+            type="button"
+            class="btn btn--secondary btn--sm"
+            [disabled]="loading()"
+            (click)="tentarNovamente()"
+          >
+            Tentar novamente
+          </button>
+        </div>
+      </ui-alert>
+    }
+
+    <div data-scope class="cfg-modalidades-scope">
+      <div class="filter-bar" role="search" aria-label="Filtrar modalidades">
+        <div class="filter-bar__row">
+          <div class="input-group">
+            <span class="input-group__addon" aria-hidden="true"><i class="pi pi-search"></i></span>
+            <input
+              type="search"
+              class="input"
+              placeholder="Buscar por código ou descrição..."
+              aria-label="Buscar por código ou descrição"
+              [value]="busca()"
+              (input)="busca.set(inputValue($event))"
+            />
+          </div>
+          <button type="button" class="btn btn--tertiary btn--sm btn--rect" (click)="limparFiltros()">
+            Limpar
+          </button>
+        </div>
+        <div class="cfg-modalidades-filtro-grupo" role="group" aria-label="Filtrar por natureza legal">
+          <span class="cfg-filtro-legenda">Natureza</span>
+          <ui-filter-chips
+            [options]="chipsNatureza()"
+            [(selected)]="naturezaSelecionada"
+            ariaLabel="Natureza legal"
+          />
+        </div>
+      </div>
+
+      <section class="panel" aria-labelledby="cfg-modalidades-title">
+        <div class="panel-head">
+          <div class="panel-head__title">
+            <h2 id="cfg-modalidades-title">Modalidades</h2>
+            <span class="list-count" aria-label="Total de modalidades exibidas">
+              {{ modalidadesFiltradas().length }}
+            </span>
+            @if (loading()) {
+              <span class="cfg-list__loading"><ui-spinner size="sm" /> Carregando</span>
+            }
+          </div>
+          <a class="btn btn--primary" routerLink="novo">
+            <i class="pi pi-plus btn__icon" aria-hidden="true"></i>
+            Nova modalidade
+          </a>
+        </div>
+
+        @if (modalidadesFiltradas().length > 0) {
+          <div class="table-responsive">
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Código</th>
+                  <th scope="col">Natureza</th>
+                  <th scope="col">Composição de vagas</th>
+                  <th scope="col">Remanejamento</th>
+                  <th scope="col">Referenciada por</th>
+                  <th scope="col">Status</th>
+                  <th scope="col"><span class="sr-only">Ações</span></th>
+                </tr>
+              </thead>
+              <tbody>
+                @for (m of modalidadesFiltradas(); track m.id) {
+                  <tr [attr.data-codigo]="m.codigo">
+                    <td data-label="Código">
+                      <code>{{ m.codigo }}</code>
+                      @if (m.descricao) {
+                        <span class="cfg-meta">{{ m.descricao }}</span>
+                      }
+                    </td>
+                    <td data-label="Natureza">
+                      <ui-tag [variant]="naturezaVariante(m.naturezaLegal)">
+                        {{ naturezaLabel(m.naturezaLegal) }}
+                      </ui-tag>
+                    </td>
+                    <td data-label="Composição de vagas">
+                      {{ composicaoLabel(m.composicaoVagas) }}
+                      @if (m.composicaoOrigem) {
+                        <span class="cfg-meta">de <code>{{ m.composicaoOrigem }}</code></span>
+                      }
+                    </td>
+                    <td data-label="Remanejamento">{{ remanejamentoResumo(m) }}</td>
+                    <td data-label="Referenciada por">
+                      @if (referenciadaPor(m.codigo); as refs) {
+                        @if (refs.length > 0) {
+                          <span class="cfg-refs">
+                            @for (r of refs; track r.id) {
+                              <code class="cfg-ref-chip">{{ r.codigo }}</code>
+                            }
+                          </span>
+                        } @else {
+                          <span class="cfg-meta">Nenhuma</span>
+                        }
+                      }
+                    </td>
+                    <td data-label="Status"><span class="tag tag--success">Ativa</span></td>
+                    <td class="table-responsive__actions" data-label="Ações">
+                      <a
+                        class="btn btn--tertiary btn--sm btn--rect"
+                        [routerLink]="m.id"
+                        [attr.aria-label]="'Editar modalidade ' + m.codigo"
+                      >
+                        Editar
+                      </a>
+                      <button
+                        type="button"
+                        class="btn btn--tertiary btn--sm btn--rect"
+                        [disabled]="loading()"
+                        [attr.aria-label]="'Inativar modalidade ' + m.codigo"
+                        (click)="pedirRemocao(m)"
+                      >
+                        Inativar
+                      </button>
+                    </td>
+                  </tr>
+                }
+              </tbody>
+            </table>
+          </div>
+        } @else if (!loading() && !errorMessage()) {
+          @if (temFiltroAtivo()) {
+            <ui-empty-state
+              heading="Nenhuma modalidade encontrada"
+              description="Ajuste a busca ou os filtros de natureza para ver resultados."
+            >
+              <button type="button" class="btn btn--secondary" (click)="limparFiltros()">
+                Limpar filtros
+              </button>
+            </ui-empty-state>
+          } @else {
+            <ui-empty-state
+              heading="Nenhuma modalidade cadastrada"
+              description="Cadastre a primeira modalidade para configurar a disputa de vagas dos processos."
+            >
+              <a class="btn btn--primary" routerLink="novo">Nova modalidade</a>
+            </ui-empty-state>
+          }
+        }
+
+        @if (prevCursor() !== null || nextCursor() !== null) {
+          <ui-pager
+            statusText="Navegação por páginas"
+            navigationLabel="Paginação de modalidades"
+            [hasPrevious]="prevCursor() !== null"
+            [hasNext]="nextCursor() !== null"
+            [isDisabled]="loading()"
+            (previous)="paginaAnterior()"
+            (next)="proximaPagina()"
+          />
+        }
+      </section>
+    </div>
+
+    <ui-dialog
+      [(visible)]="dialogAberto"
+      [heading]="remocaoBloqueada() ? 'Remoção bloqueada' : 'Inativar modalidade'"
+      (closed)="aoFecharDialog()"
+    >
+      @if (modalidadeParaRemover(); as alvo) {
+        @if (remocaoBloqueada()) {
+          <ui-alert variant="warning" heading="Modalidade referenciada por outra viva" [dynamic]="false">
+            @if (referenciadaPor(alvo.codigo).length > 0) {
+              A modalidade <code>{{ alvo.codigo }}</code> não pode ser inativada porque é usada como
+              origem, destino, par ou fallback das seguintes modalidades vivas:
+              <ul class="cfg-refs-lista">
+                @for (r of referenciadaPor(alvo.codigo); track r.id) {
+                  <li><code>{{ r.codigo }}</code>@if (r.descricao) { — {{ r.descricao }} }</li>
+                }
+              </ul>
+              Ajuste ou remova essas referências antes de inativar.
+            } @else {
+              {{ mensagemBloqueioServidor() ?? mensagemBloqueioPadrao }}
+            }
+          </ui-alert>
+        } @else {
+          <p>
+            A modalidade <code>{{ alvo.codigo }}</code> é inativada (soft-delete) e mantida na trilha
+            de auditoria. Cópias congeladas por snapshot em processos publicados não são afetadas
+            (RN08). Confirma?
+          </p>
+        }
+      }
+
+      <div uiDialogFooter>
+        @if (remocaoBloqueada()) {
+          <button type="button" class="btn btn--primary btn--rect" (click)="dialogAberto.set(false)">
+            Entendi
+          </button>
+        } @else {
+          <button type="button" class="btn btn--tertiary btn--rect" (click)="dialogAberto.set(false)">
+            Cancelar
+          </button>
+          <button
+            type="button"
+            class="btn btn--danger btn--rect"
+            [disabled]="removendo()"
+            (click)="removerConfirmado()"
+          >
+            @if (removendo()) {
+              <ui-spinner size="sm" />
+            }
+            {{ removendo() ? 'Inativando...' : 'Inativar' }}
+          </button>
+        }
+      </div>
+    </ui-dialog>
+  `,
+})
+export class ModalidadesListPage {
+  private readonly api = inject(ModalidadesApi);
+  private readonly problemI18n = inject(ProblemI18nService);
+  private readonly notifications = inject(NotificationService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly basePath = inject(CONFIGURACAO_BASE_PATH);
+
+  protected readonly busca = signal('');
+  protected readonly naturezaSelecionada = signal<string | null>(null);
+  protected readonly dialogAberto = signal(false);
+  protected readonly removendo = signal(false);
+  protected readonly modalidadeParaRemover = signal<ModalidadeDto | null>(null);
+  /** Bloqueio autoritativo do servidor (409) além do pré-cheque client-side. */
+  protected readonly bloqueioServidor = signal(false);
+  /** Mensagem do `ProblemDetails` do 409 — usada quando a referência viva não está na página carregada. */
+  protected readonly mensagemBloqueioServidor = signal<string | null>(null);
+  /** Fallback quando o servidor bloqueia sem título e o mapa reverso local está vazio. */
+  protected readonly mensagemBloqueioPadrao =
+    'Esta modalidade não pode ser inativada porque outra modalidade viva a referencia ' +
+    '(possivelmente fora desta página). Ajuste ou remova essas referências antes de inativar.';
+
+  private readonly pagina = signal<
+    { readonly cursor: Cursor; readonly direction: PaginationDirection } | undefined
+  >(undefined);
+
+  private readonly lista = useApiResource<readonly ModalidadeDto[]>(() => ({
+    url: `${this.basePath}/api/configuracao/modalidades`,
+    params: this.montarParams(),
+    context: withVendorMime('modalidade', 1),
+  }));
+
+  protected readonly loading = this.lista.isLoading;
+
+  private readonly cursores = linkedSignal<
+    ApiResult<readonly ModalidadeDto[]> | undefined,
+    { readonly prev: Cursor | null; readonly next: Cursor | null }
+  >({
+    source: () => this.lista.value(),
+    computation: (envelope, previous) => {
+      const atual = previous?.value ?? { prev: null, next: null };
+      if (envelope === undefined) {
+        return atual;
+      }
+      const primeiraPagina = untracked(() => this.pagina() === undefined);
+      if (!envelope.ok) {
+        return primeiraPagina ? { prev: null, next: null } : atual;
+      }
+      const link = untracked(() => this.lista.headers()?.get('Link') ?? null);
+      return { prev: extractPrevCursor(link), next: extractNextCursor(link) };
+    },
+  });
+
+  protected readonly prevCursor = computed(() => this.cursores().prev);
+  protected readonly nextCursor = computed(() => this.cursores().next);
+
+  protected readonly modalidades = linkedSignal<
+    ApiResult<readonly ModalidadeDto[]> | undefined,
+    readonly ModalidadeDto[]
+  >({
+    source: () => this.lista.value(),
+    computation: (envelope, previous) => {
+      const atual = previous?.value ?? [];
+      if (envelope === undefined) {
+        return atual;
+      }
+      const primeiraPagina = untracked(() => this.pagina() === undefined);
+      if (!envelope.ok) {
+        return primeiraPagina ? [] : atual;
+      }
+      return [...envelope.data];
+    },
+  });
+
+  /**
+   * Mapa reverso código → modalidades vivas que o referenciam (origem/destino/par/
+   * fallback). Calculado sobre a página carregada — é uma DICA de UX (coluna
+   * "Referenciada por" e pré-bloqueio de remoção); o backend é a fonte autoritativa
+   * do bloqueio (409). Domínio pequeno e fechado: uma página cobre as vivas na prática.
+   */
+  private readonly referenciasReversas = computed(() => {
+    const mapa = new Map<string, ModalidadeDto[]>();
+    for (const m of this.modalidades()) {
+      const alvos = [
+        m.composicaoOrigem,
+        m.remanejamentoDestino,
+        m.remanejamentoPar,
+        m.remanejamentoFallback,
+      ];
+      for (const alvo of alvos) {
+        if (!alvo || alvo === m.codigo) continue;
+        const lista = mapa.get(alvo) ?? [];
+        if (!lista.some((x) => x.id === m.id)) lista.push(m);
+        mapa.set(alvo, lista);
+      }
+    }
+    return mapa;
+  });
+
+  protected readonly chipsNatureza = computed<readonly UiFilterChipOption[]>(() => {
+    const todas = this.modalidades();
+    return NATUREZAS_LEGAIS.map((n) => ({
+      value: n.value,
+      label: n.label,
+      count: todas.filter((m) => m.naturezaLegal === n.value).length,
+    }));
+  });
+
+  protected readonly modalidadesFiltradas = computed(() => {
+    const termo = this.busca().trim().toLocaleLowerCase('pt-BR');
+    const natureza = this.naturezaSelecionada();
+    return this.modalidades().filter((m) => {
+      const casaBusca =
+        termo.length === 0 ||
+        m.codigo.toLocaleLowerCase('pt-BR').includes(termo) ||
+        (m.descricao ?? '').toLocaleLowerCase('pt-BR').includes(termo);
+      const casaNatureza = natureza === null || m.naturezaLegal === natureza;
+      return casaBusca && casaNatureza;
+    });
+  });
+
+  protected readonly temFiltroAtivo = computed(
+    () => this.busca().trim().length > 0 || this.naturezaSelecionada() !== null,
+  );
+
+  protected readonly remocaoBloqueada = computed(() => {
+    if (this.bloqueioServidor()) return true;
+    const alvo = this.modalidadeParaRemover();
+    return alvo !== null && (this.referenciasReversas().get(alvo.codigo)?.length ?? 0) > 0;
+  });
+
+  protected readonly errorMessage = computed<string | null>(() => {
+    const problem = this.lista.problem();
+    if (problem) {
+      return this.problemI18n.resolve(problem).title;
+    }
+    return this.lista.error() ? 'Erro inesperado ao carregar modalidades.' : null;
+  });
+
+  constructor() {
+    effect(() => {
+      const problem = this.lista.problem();
+      if (problem && problem.status >= 500) {
+        const titulo = this.problemI18n.resolve(problem).title;
+        untracked(() => this.notifications.errorFromProblem(problem, { title: titulo }));
+      }
+    });
+  }
+
+  protected inputValue(event: Event): string {
+    return event.target instanceof HTMLInputElement ? event.target.value : '';
+  }
+
+  protected naturezaLabel(token: string): string {
+    return rotulo(NATUREZAS_LEGAIS, token);
+  }
+
+  protected naturezaVariante(token: string): UiTagVariant {
+    return NATUREZA_VARIANTE[token] ?? 'neutral';
+  }
+
+  protected composicaoLabel(token: string): string {
+    return rotulo(COMPOSICOES_VAGAS, token);
+  }
+
+  protected referenciadaPor(codigo: string): readonly ModalidadeDto[] {
+    return this.referenciasReversas().get(codigo) ?? [];
+  }
+
+  protected remanejamentoResumo(m: ModalidadeDto): string {
+    if (m.regraRemanejamento === null) return '—';
+    const regra = rotulo(REGRAS_REMANEJAMENTO, m.regraRemanejamento);
+    if (m.remanejamentoDestino) return `${regra} → ${m.remanejamentoDestino}`;
+    if (m.remanejamentoPar || m.remanejamentoFallback) {
+      return `${regra} (${m.remanejamentoPar ?? '—'} / ${m.remanejamentoFallback ?? '—'})`;
+    }
+    return regra;
+  }
+
+  protected proximaPagina(): void {
+    const proximo = this.nextCursor();
+    if (proximo !== null && !this.loading()) {
+      this.pagina.set({ cursor: proximo, direction: 'next' });
+    }
+  }
+
+  protected paginaAnterior(): void {
+    const anterior = this.prevCursor();
+    if (anterior !== null && !this.loading()) {
+      this.pagina.set({ cursor: anterior, direction: 'prev' });
+    }
+  }
+
+  protected tentarNovamente(): void {
+    if (!this.loading()) {
+      this.lista.reload();
+    }
+  }
+
+  protected limparFiltros(): void {
+    this.busca.set('');
+    this.naturezaSelecionada.set(null);
+  }
+
+  protected pedirRemocao(m: ModalidadeDto): void {
+    this.modalidadeParaRemover.set(m);
+    this.bloqueioServidor.set(false);
+    this.mensagemBloqueioServidor.set(null);
+    this.dialogAberto.set(true);
+  }
+
+  protected aoFecharDialog(): void {
+    this.modalidadeParaRemover.set(null);
+    this.bloqueioServidor.set(false);
+    this.mensagemBloqueioServidor.set(null);
+  }
+
+  protected removerConfirmado(): void {
+    const alvo = this.modalidadeParaRemover();
+    if (alvo === null || this.removendo() || this.remocaoBloqueada()) {
+      return;
+    }
+    this.removendo.set(true);
+    this.api
+      .remover(alvo.id)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((result) => {
+        this.removendo.set(false);
+        if (result.ok) {
+          this.notifications.success('Modalidade inativada', alvo.codigo);
+          this.dialogAberto.set(false);
+          this.recarregar();
+          return;
+        }
+        // 409 = bloqueio autoritativo do servidor (corrida ou referência fora da página):
+        // mantém o diálogo em modo bloqueio e mostra a mensagem do servidor.
+        if (result.problem.status === 409) {
+          this.bloqueioServidor.set(true);
+          this.mensagemBloqueioServidor.set(this.problemI18n.resolve(result.problem).title);
+          this.recarregar();
+          return;
+        }
+        this.notifications.errorFromProblem(result.problem, {
+          title: this.problemI18n.resolve(result.problem).title,
+        });
+      });
+  }
+
+  private montarParams(): HttpParams {
+    const pagina = this.pagina();
+    if (pagina === undefined) {
+      return new HttpParams().set('limit', String(PAGE_SIZE));
+    }
+    return new HttpParams()
+      .set('cursor', cursorToString(pagina.cursor))
+      .set('direction', pagina.direction);
+  }
+
+  private recarregar(): void {
+    if (this.pagina() === undefined) {
+      this.lista.reload();
+    } else {
+      this.pagina.set(undefined);
+    }
+  }
+}

--- a/apps/configuracao/src/app/features/modalidades/modalidades.routes.ts
+++ b/apps/configuracao/src/app/features/modalidades/modalidades.routes.ts
@@ -1,0 +1,26 @@
+import { Routes } from '@angular/router';
+
+/**
+ * Rotas da feature Modalidade de concorrência (Piloto B — lista + tela dedicada).
+ * A lista é a tela primária; a criação/edição usa **tela dedicada** (rota própria),
+ * não drawer, por causa dos condicionais cruzados (natureza↔regra↔args, composição↔origem).
+ */
+export const MODALIDADES_ROUTES: Routes = [
+  {
+    path: '',
+    loadComponent: () =>
+      import('./modalidades-list.page').then((m) => m.ModalidadesListPage),
+  },
+  {
+    path: 'novo',
+    data: { breadcrumb: 'Nova modalidade' },
+    loadComponent: () =>
+      import('./modalidade-form.page').then((m) => m.ModalidadeFormPage),
+  },
+  {
+    path: ':id',
+    data: { breadcrumb: 'Editar modalidade' },
+    loadComponent: () =>
+      import('./modalidade-form.page').then((m) => m.ModalidadeFormPage),
+  },
+];

--- a/apps/configuracao/src/app/layout/layout.ts
+++ b/apps/configuracao/src/app/layout/layout.ts
@@ -241,7 +241,7 @@ export class LayoutComponent {
           routerLink: '/ofertas-curso',
           exact: true,
         },
-        { label: 'Modalidade', icon: 'pi-users' },
+        { label: 'Modalidade', icon: 'pi-users', routerLink: '/modalidades' },
         {
           label: 'Tipo de Documento',
           icon: 'pi-id-card',

--- a/apps/configuracao/src/styles.css
+++ b/apps/configuracao/src/styles.css
@@ -920,3 +920,173 @@ cfg-pesos-enem-page {
   border-top: 1px solid var(--border-subtle);
   margin: 0;
 }
+
+/* ── Modalidade de concorrência (Piloto B — lista + tela dedicada) ────────── */
+
+.cfg-modalidades-scope {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.cfg-modalidades-filtro-grupo {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.cfg-filtro-legenda {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.cfg-meta {
+  display: block;
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+}
+
+.cfg-refs {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+
+.cfg-ref-chip {
+  font-size: var(--text-xs);
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  background: var(--surface-subtle);
+  border: 1px solid var(--border-subtle);
+}
+
+.cfg-refs-lista {
+  margin: var(--space-2) 0 0;
+  padding-left: var(--space-5);
+}
+
+.cfg-list__retry {
+  margin-top: var(--space-3);
+}
+
+.cfg-list__loading {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+}
+
+/* Tela dedicada de formulário */
+
+.page-header--form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.cfg-voltar {
+  align-self: flex-start;
+}
+
+.form-section {
+  margin-bottom: var(--space-6);
+}
+
+.cfg-form__loading {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-6);
+  color: var(--text-secondary);
+}
+
+/* Entrada de critérios cumulativos (chips) */
+
+.cfg-chips-input {
+  display: flex;
+  gap: var(--space-2);
+  align-items: stretch;
+}
+
+.cfg-chips-input .input {
+  flex: 1 1 auto;
+}
+
+.cfg-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  list-style: none;
+  margin: var(--space-2) 0 0;
+  padding: 0;
+}
+
+.cfg-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 2px 6px 2px 10px;
+  border-radius: var(--radius-md);
+  background: var(--surface-subtle);
+  border: 1px solid var(--border-subtle);
+  font-size: var(--text-sm);
+}
+
+.cfg-chip__remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: var(--text-md);
+  line-height: 1;
+}
+
+.cfg-chip__remove:hover {
+  color: var(--color-danger);
+}
+
+.cfg-chip__remove:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring-color);
+  outline-offset: var(--focus-ring-offset);
+}
+
+/* Mapa de condicionais — reflete o efeito das escolhas ao operador */
+
+.cond-diagram {
+  margin-top: var(--space-5);
+  padding: var(--space-4) var(--space-5);
+  border: 1px solid var(--border-default);
+  border-left: 3px solid var(--color-primary);
+  border-radius: var(--radius-md);
+  background: var(--surface-subtle);
+}
+
+.cond-diagram__title {
+  margin: 0 0 var(--space-2);
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-heading);
+}
+
+.cond-diagram__list {
+  margin: 0;
+  padding-left: var(--space-5);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.cond-diagram__item {
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+}

--- a/libs/shared-data/src/lib/api/configuracao/index.ts
+++ b/libs/shared-data/src/lib/api/configuracao/index.ts
@@ -81,3 +81,22 @@ export {
   type TipoDocumentoDto,
   type TiposDocumentoQuery,
 } from './tipos-documento.api';
+export {
+  ModalidadesApi,
+  ACOES_QUANDO_INDEFERIDO,
+  COMPOSICAO_RETIRA_DE,
+  COMPOSICAO_VAGAS_DEFAULT,
+  COMPOSICOES_VAGAS,
+  NATUREZA_LEGAL_DEFAULT,
+  NATUREZAS_LEGAIS,
+  REGRAS_REMANEJAMENTO,
+  type AcaoQuandoIndeferidoToken,
+  type AtualizarModalidadeCommand,
+  type ComposicaoVagasToken,
+  type CriarModalidadeCommand,
+  type DominioOption,
+  type ModalidadeDto,
+  type ModalidadesQuery,
+  type NaturezaLegalToken,
+  type RegraRemanejamentoToken,
+} from './modalidades.api';

--- a/libs/shared-data/src/lib/api/configuracao/modalidades.api.spec.ts
+++ b/libs/shared-data/src/lib/api/configuracao/modalidades.api.spec.ts
@@ -1,0 +1,171 @@
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  ApiResult,
+  apiResultInterceptor,
+  buildVendorMimeAccept,
+  isApiOk,
+  withIdempotencyKey,
+} from '@uniplus/shared-core/http';
+import {
+  CriarModalidadeCommand,
+  ModalidadeDto,
+  ModalidadesApi,
+} from './modalidades.api';
+import { CONFIGURACAO_BASE_PATH } from './tokens';
+
+const BASE = 'http://localhost:5000';
+const ID = '01960000-0000-7000-0000-0000000000a1';
+
+const modalidadeSeed: ModalidadeDto = {
+  id: ID,
+  codigo: 'LB_PPI',
+  descricao: 'Cota PPI baixa renda',
+  naturezaLegal: 'COTA_RESERVADA',
+  composicaoVagas: 'DENTRO_DO_VR',
+  composicaoOrigem: null,
+  regraRemanejamento: 'SEGUE_CASCATA',
+  remanejamentoDestino: null,
+  remanejamentoPar: null,
+  remanejamentoFallback: null,
+  criteriosCumulativos: ['escola pública', 'renda ≤ 1 SM'],
+  acaoQuandoIndeferido: 'RECLASSIFICAR_AC',
+  baseLegal: 'Lei 12.711/2012, art. 1º',
+  criadoEm: '2026-07-03T12:00:00Z',
+};
+
+const criarCommand: CriarModalidadeCommand = {
+  codigo: 'V',
+  descricao: 'PcD ampla concorrência',
+  naturezaLegal: 'SUPLEMENTAR',
+  composicaoVagas: 'RETIRA_DE',
+  composicaoOrigem: 'AC',
+  regraRemanejamento: 'DESTINO_UNICO',
+  remanejamentoDestino: 'AC',
+  remanejamentoPar: null,
+  remanejamentoFallback: null,
+  criteriosCumulativos: ['laudo'],
+  acaoQuandoIndeferido: 'RECLASSIFICAR_AC',
+  baseLegal: 'Lei 14.723/2023',
+};
+
+describe('ModalidadesApi', () => {
+  let api: ModalidadesApi;
+  let controller: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([apiResultInterceptor])),
+        provideHttpClientTesting(),
+        { provide: CONFIGURACAO_BASE_PATH, useValue: BASE },
+      ],
+    });
+    api = TestBed.inject(ModalidadesApi);
+    controller = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => controller.verify());
+
+  it('listar() faz GET /api/configuracao/modalidades com limit e Accept versionado', async () => {
+    const promise = firstValueFrom(api.listar({ limit: 50 }));
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/modalidades`);
+    expect(req.request.params.get('limit')).toBe('50');
+    expect(req.request.headers.get('Accept')).toBe(buildVendorMimeAccept('modalidade', 1));
+    req.flush([modalidadeSeed]);
+    const result = (await promise) as ApiResult<readonly ModalidadeDto[]>;
+    expect(isApiOk(result)).toBe(true);
+  });
+
+  it('listar() com cursor envia cursor + direction e omite limit', async () => {
+    const promise = firstValueFrom(api.listar({ cursor: 'abc', direction: 'prev' }));
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/modalidades`);
+    expect(req.request.params.get('cursor')).toBe('abc');
+    expect(req.request.params.get('direction')).toBe('prev');
+    expect(req.request.params.has('limit')).toBe(false);
+    req.flush([modalidadeSeed]);
+    await promise;
+  });
+
+  it('obter() faz GET /api/configuracao/modalidades/{id} com Accept versionado', async () => {
+    const promise = firstValueFrom(api.obter(ID));
+    const req = controller.expectOne(`${BASE}/api/configuracao/modalidades/${ID}`);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.headers.get('Accept')).toBe(buildVendorMimeAccept('modalidade', 1));
+    req.flush(modalidadeSeed);
+    const result = (await promise) as ApiResult<ModalidadeDto>;
+    expect(isApiOk(result)).toBe(true);
+  });
+
+  it('criar() faz POST /api/configuracao/admin/modalidades com Idempotency-Key e Accept JSON', async () => {
+    const promise = firstValueFrom(api.criar(criarCommand, withIdempotencyKey('k')));
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/modalidades`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body.codigo).toBe('V');
+    expect(req.request.body.composicaoOrigem).toBe('AC');
+    expect(req.request.headers.get('Idempotency-Key')).toBe('k');
+    expect(req.request.headers.get('Accept')).toBe('application/json');
+    req.flush(ID, { status: 201, statusText: 'Created' });
+    const result = (await promise) as ApiResult<string>;
+    expect(isApiOk(result)).toBe(true);
+  });
+
+  it('atualizar() faz PUT /api/configuracao/admin/modalidades/{id} sem enviar codigo (imutável)', async () => {
+    const promise = firstValueFrom(
+      api.atualizar(
+        ID,
+        {
+          id: ID,
+          descricao: 'Cota PPI baixa renda',
+          naturezaLegal: 'COTA_RESERVADA',
+          composicaoVagas: 'DENTRO_DO_VR',
+          composicaoOrigem: null,
+          regraRemanejamento: 'SEGUE_CASCATA',
+          remanejamentoDestino: null,
+          remanejamentoPar: null,
+          remanejamentoFallback: null,
+          criteriosCumulativos: ['escola pública'],
+          acaoQuandoIndeferido: 'RECLASSIFICAR_AC',
+          baseLegal: 'Lei 12.711/2012',
+        },
+        withIdempotencyKey('k'),
+      ),
+    );
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/modalidades/${ID}`);
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body.codigo).toBeUndefined();
+    expect(req.request.headers.get('Idempotency-Key')).toBe('k');
+    req.flush(null, { status: 204, statusText: 'No Content' });
+    const result = (await promise) as ApiResult<void>;
+    expect(isApiOk(result)).toBe(true);
+  });
+
+  it('remover() faz DELETE /api/configuracao/admin/modalidades/{id} sem Idempotency-Key', async () => {
+    const promise = firstValueFrom(api.remover(ID));
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/modalidades/${ID}`);
+    expect(req.request.method).toBe('DELETE');
+    expect(req.request.headers.has('Idempotency-Key')).toBe(false);
+    req.flush(null, { status: 204, statusText: 'No Content' });
+    const result = (await promise) as ApiResult<void>;
+    expect(isApiOk(result)).toBe(true);
+  });
+
+  it('remover() propaga 409 de bloqueio por referência como problem', async () => {
+    const promise = firstValueFrom(api.remover(ID));
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/modalidades/${ID}`);
+    req.flush(
+      {
+        type: 'about:blank',
+        title: 'Conflito',
+        status: 409,
+        code: 'Modalidade.RemocaoBloqueadaPorReferencia',
+      },
+      { status: 409, statusText: 'Conflict' },
+    );
+    const result = (await promise) as ApiResult<void>;
+    expect(isApiOk(result)).toBe(false);
+  });
+});

--- a/libs/shared-data/src/lib/api/configuracao/modalidades.api.ts
+++ b/libs/shared-data/src/lib/api/configuracao/modalidades.api.ts
@@ -1,0 +1,158 @@
+import { HttpClient, HttpContext, HttpHeaders, HttpParams } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiResult, withVendorMime } from '@uniplus/shared-core/http';
+import type { components } from './schema';
+import { CONFIGURACAO_BASE_PATH } from './tokens';
+
+export type ModalidadeDto = components['schemas']['ModalidadeDto'];
+export type CriarModalidadeCommand = components['schemas']['CriarModalidadeCommand'];
+export type AtualizarModalidadeCommand = components['schemas']['AtualizarModalidadeCommand'];
+
+/**
+ * Rosters dos domínios fechados de Modalidade de concorrência — tokens
+ * UPPER_SNAKE persistidos e aceitos pelo contrato (ver `NaturezasLegais`,
+ * `ComposicoesVagas`, `RegrasRemanejamento` e `AcoesQuandoIndeferido` em
+ * `Unifesspa.UniPlus.Configuracao.Domain.Enums`, uniplus-api #589). Não são enums
+ * gerados pelo `openapi-typescript` — os campos chegam como `string` no
+ * `schema.ts`; os tokens abaixo são copiados 1:1 do código-fonte do backend e o
+ * domínio é a fonte de verdade das invariantes de coerência.
+ */
+export interface DominioOption<T extends string = string> {
+  readonly value: T;
+  readonly label: string;
+}
+
+export type NaturezaLegalToken = 'AMPLA' | 'COTA_RESERVADA' | 'SUPLEMENTAR' | 'OUTRA_MODALIDADE';
+
+export const NATUREZAS_LEGAIS: readonly DominioOption<NaturezaLegalToken>[] = [
+  { value: 'AMPLA', label: 'Ampla concorrência' },
+  { value: 'COTA_RESERVADA', label: 'Cota reservada' },
+  { value: 'SUPLEMENTAR', label: 'Suplementar' },
+  { value: 'OUTRA_MODALIDADE', label: 'Outra modalidade' },
+] as const;
+
+/** Natureza legal default de uma nova modalidade (§3 da story). */
+export const NATUREZA_LEGAL_DEFAULT: NaturezaLegalToken = 'AMPLA';
+
+export type ComposicaoVagasToken =
+  | 'RESIDUAL_DO_VO'
+  | 'DENTRO_DO_VR'
+  | 'RETIRA_DE'
+  | 'SUPLEMENTAR_AO_TOTAL';
+
+export const COMPOSICOES_VAGAS: readonly DominioOption<ComposicaoVagasToken>[] = [
+  { value: 'RESIDUAL_DO_VO', label: 'Residual do VO' },
+  { value: 'DENTRO_DO_VR', label: 'Dentro do VR' },
+  { value: 'RETIRA_DE', label: 'Retira de' },
+  { value: 'SUPLEMENTAR_AO_TOTAL', label: 'Suplementar ao total' },
+] as const;
+
+/** Composição default de uma nova modalidade (§3 da story). */
+export const COMPOSICAO_VAGAS_DEFAULT: ComposicaoVagasToken = 'RESIDUAL_DO_VO';
+
+/** Única composição que exige `composicaoOrigem` (equivalência exata, invariante do agregado). */
+export const COMPOSICAO_RETIRA_DE: ComposicaoVagasToken = 'RETIRA_DE';
+
+export type RegraRemanejamentoToken = 'SEGUE_CASCATA' | 'DESTINO_UNICO' | 'CRUZADO';
+
+export const REGRAS_REMANEJAMENTO: readonly DominioOption<RegraRemanejamentoToken>[] = [
+  { value: 'SEGUE_CASCATA', label: 'Segue cascata' },
+  { value: 'DESTINO_UNICO', label: 'Destino único' },
+  { value: 'CRUZADO', label: 'Cruzado' },
+] as const;
+
+export type AcaoQuandoIndeferidoToken = 'RECLASSIFICAR_AC' | 'RECLASSIFICAR_REGRA_EDITAL';
+
+export const ACOES_QUANDO_INDEFERIDO: readonly DominioOption<AcaoQuandoIndeferidoToken>[] = [
+  { value: 'RECLASSIFICAR_AC', label: 'Reclassificar em ampla concorrência' },
+  { value: 'RECLASSIFICAR_REGRA_EDITAL', label: 'Reclassificar conforme regra do edital' },
+] as const;
+
+/**
+ * Filtro de listagem de Modalidades (cursor pagination bidirecional, ADR-0026/0089).
+ * A filtragem por Natureza/busca é client-side sobre a página carregada — o
+ * contrato de listagem não expõe filtros de query além de cursor/limit/direction.
+ */
+export interface ModalidadesQuery {
+  readonly cursor?: string;
+  readonly direction?: 'next' | 'prev';
+  readonly limit?: number;
+}
+
+/**
+ * Cliente Angular standalone do recurso Modalidade de concorrência (módulo
+ * Configuração, UNI-REQ-0011). A entidade mais rica do módulo: natureza legal,
+ * composição de vagas, cascata de remanejamento e auto-referência por **código**
+ * de outra modalidade viva (origem/destino/par/fallback são códigos, não ids).
+ *
+ * API thin (ADR-0013): tipos do `schema.ts` gerado; resposta envelopada em
+ * `ApiResult<T>` (ADR-0011); versionamento por vendor MIME `modalidade v1`
+ * (ADR-0016/0028) nos GET; mutação com `Idempotency-Key` (ADR-0027) via
+ * `HttpContext`. Espelha `OfertasCursoApi`.
+ *
+ * O `Codigo` é imutável pós-criação (o comando de atualização não o aceita) e a
+ * remoção é soft-delete, podendo ser bloqueada (409) quando outra modalidade viva
+ * a referencia — o backend é a fonte autoritativa desse bloqueio.
+ */
+@Injectable({ providedIn: 'root' })
+export class ModalidadesApi {
+  private readonly http = inject(HttpClient);
+  private readonly basePath = inject(CONFIGURACAO_BASE_PATH);
+
+  /** GET `/api/configuracao/modalidades` — lista paginada por cursor (ADR-0026/0089). */
+  listar(query: ModalidadesQuery = {}): Observable<ApiResult<readonly ModalidadeDto[]>> {
+    let params = new HttpParams();
+    if (query.cursor !== undefined) {
+      params = params.set('cursor', query.cursor).set('direction', query.direction ?? 'next');
+    } else {
+      params = params.set('limit', String(query.limit ?? 100));
+    }
+    return this.http.get<ApiResult<readonly ModalidadeDto[]>>(
+      `${this.basePath}/api/configuracao/modalidades`,
+      { params, context: withVendorMime('modalidade', 1) },
+    );
+  }
+
+  /** GET `/api/configuracao/modalidades/{id}` — detalhe de uma Modalidade. */
+  obter(id: string): Observable<ApiResult<ModalidadeDto>> {
+    return this.http.get<ApiResult<ModalidadeDto>>(
+      `${this.basePath}/api/configuracao/modalidades/${encodeURIComponent(id)}`,
+      { context: withVendorMime('modalidade', 1) },
+    );
+  }
+
+  /** POST `/api/configuracao/admin/modalidades` — cria. Idempotency-Key obrigatório (ADR-0027). */
+  criar(command: CriarModalidadeCommand, context: HttpContext): Observable<ApiResult<string>> {
+    return this.http.post<ApiResult<string>>(
+      `${this.basePath}/api/configuracao/admin/modalidades`,
+      command,
+      { context, headers: new HttpHeaders({ Accept: 'application/json' }) },
+    );
+  }
+
+  /** PUT `/api/configuracao/admin/modalidades/{id}` — atualiza os atributos editáveis (código imutável). */
+  atualizar(
+    id: string,
+    command: AtualizarModalidadeCommand,
+    context: HttpContext,
+  ): Observable<ApiResult<void>> {
+    return this.http.put<ApiResult<void>>(
+      `${this.basePath}/api/configuracao/admin/modalidades/${encodeURIComponent(id)}`,
+      command,
+      { context },
+    );
+  }
+
+  /**
+   * DELETE `/api/configuracao/admin/modalidades/{id}` — remoção lógica (soft-delete).
+   * Sem `Idempotency-Key` (o contrato não o exige). Pode responder 409 quando a
+   * modalidade é referenciada por outra viva (origem/destino/par/fallback) — o
+   * chamador trata o 409 como bloqueio autoritativo.
+   */
+  remover(id: string): Observable<ApiResult<void>> {
+    return this.http.delete<ApiResult<void>>(
+      `${this.basePath}/api/configuracao/admin/modalidades/${encodeURIComponent(id)}`,
+    );
+  }
+}


### PR DESCRIPTION
## Contexto

Implementa o **cadastro de Modalidade de concorrência** no painel administrativo (app `configuracao`), **Piloto B** do padrão CRUD do módulo Configuração — o único cadastro cuja complexidade (condicionais cruzados + auto-referência) exige **tela dedicada** em vez de drawer. Espelha o backend `uniplus-api #589` (UNI-REQ-0011), cujo contrato já está publicado no `schema.ts` gerado.

Closes #390

## O que foi entregue

**Camada de dados** (`libs/shared-data`)
- `modalidades.api.ts` — client thin espelhando `OfertasCursoApi`: `listar`/`obter` (vendor MIME `modalidade` v1, cursor bidirecional), `criar`/`atualizar` (Idempotency-Key), `remover` (soft-delete, sem key). Rosters dos 4 domínios fechados (natureza, composição, regra, ação) com tokens `UPPER_SNAKE` copiados 1:1 do domínio do backend.

**Feature** (`apps/configuracao/.../features/modalidades`)
- `modalidades.routes.ts` — rotas lazy: `''` (lista), `novo` e `:id` (tela dedicada).
- `modalidades-list.page.ts` — busca + chips de natureza (client-side sobre a página), coluna **"Referenciada por"** (mapa reverso das dependências), paginação por cursor, e `ui-dialog` de remoção com dois estados: **bloqueio** (quando referenciada por outra viva) e **confirmação de soft-delete** (quando livre). O `409` do backend é tratado como bloqueio autoritativo.
- `modalidade-form.page.ts` — tela dedicada com os condicionais cruzados espelhando as invariantes do agregado `Modalidade`, mapa de condicionais (`cond-diagram`) em região `aria-live`, foco no `<h1>` ao entrar e código imutável na edição.
- Registro no `app.routes.ts` e habilitação do item **Modalidade** na navegação.

## Espelhamento das invariantes do backend (#589)

| Regra | Frontend |
|---|---|
| `AMPLA` ⇒ sem remanejamento | seção de remanejamento oculta; regra nula no comando |
| `COTA_RESERVADA` ⇒ `SEGUE_CASCATA` | regra fixada; demais opções desabilitadas |
| `SUPLEMENTAR`/`OUTRA_MODALIDADE` ⇒ `DESTINO_UNICO`/`CRUZADO` | `SEGUE_CASCATA` desabilitado; regra obrigatória |
| `RETIRA_DE` ⟺ `composicaoOrigem` | equivalência both-way (visibilidade + validação + anulação no comando) |
| `DESTINO_UNICO` ⇒ só `destino`; `CRUZADO` ⇒ `par`+`fallback` | args exigidos/anulados por regra |

O comando é derivado **inteiramente** de `getRawValue()` no submit, anulando campos inaplicáveis — sem divergência entre o valor do formulário e o estado condicional.

## Critérios de aceite

- [x] **CA-01** lista com filtro (chips de natureza), paginação por cursor, contador e coluna "Referenciada por"; empty-state.
- [x] **CA-02** navegação para a tela dedicada com foco no título; "‹ Voltar" retorna à lista.
- [x] **CA-03** condicionais de natureza (oculta/fixa/oferta).
- [x] **CA-04** condicionais de composição/args + reset ao trocar natureza (com confirmação).
- [x] **CA-05** código com regex + unicidade na criação; read-only na edição.
- [x] **CA-06** modal bloqueia quando referenciada (lista as referências) e confirma soft-delete quando livre; nota de imunidade pós-publicação (RN08).
- [x] **CA-07** a11y: `<dialog>` nativo (foco/Esc/trap), chips `aria-pressed`, axe sem serious/critical (lista, tela dedicada, modal).
- [x] **CA-08** LGPD inaplicável — dado institucional de configuração, sem PII.

## Testes

- **Vitest:** `modalidades.api.spec.ts` (7), `modalidade-form.page.spec.ts` (12 — condicionais, código, reset, comando), `modalidades-list.page.spec.ts` (7 — chips, mapa reverso, bloqueio vs soft-delete, 409). Suíte `configuracao` 195/195 e `shared-data` 212/212 verdes.
- **Playwright + axe:** `modalidades.flow.spec.ts` — fluxo lista→tela dedicada→salvar→voltar, condicionais, bloqueio de remoção e acessibilidade (WCAG 2.1 AA).
- `build`, `lint` e o fitness `no-direct-http-in-pages` verdes nos projetos afetados.

## Decisões e notas

- **Mapa reverso ("Referenciada por" + pré-bloqueio)** é uma dica de UX computada sobre a página carregada (domínio pequeno e fechado); o backend permanece a fonte autoritativa do bloqueio via `409`.
- **Filtro por Status** foi omitido: o `ModalidadeDto` não expõe status e a listagem retorna apenas vivas — mantida apenas a coluna "Ativa" (consistente com Reserva demográfica). Filtro apenas por Natureza.
- **Selects nativos** (`<select class="select">`) seguindo o idioma do app (Cursos/Reserva), com `[disabled]` por opção para a habilitação condicional da regra.
