### PR TITLE
feat(configuracao): exibe ofertas vivas por curso na tela de Curso

### DIFF
--- a/apps/configuracao-e2e/src/specs/cursos.flow.spec.ts
+++ b/apps/configuracao-e2e/src/specs/cursos.flow.spec.ts
@@ -25,6 +25,27 @@ const cursoSeed = {
   criadoEm: '2026-06-10T12:00:00Z',
 };
 
+const ofertaSeed = {
+  id: '01960000-0000-7000-0000-0000000000f1',
+  cursoId: CURSO_ID,
+  localOfertaId: '01960000-0000-7000-0000-0000000000d1',
+  unidadeOfertante: {
+    origemId: '01960000-0000-7000-0000-0000000000e1',
+    sigla: 'IGE',
+    nome: 'Instituto de Geociências e Engenharias',
+    tipo: 'Instituto',
+  },
+  programaDeOferta: 'REGULAR',
+  formatoPedagogico: 'PRESENCIAL',
+  turno: 'MATUTINO',
+  eMecCodigo: '123456',
+  codigoSga: null,
+  vagasAnuaisAutorizadas: 40,
+  baseLegal: null,
+  atoAutorizacaoMec: null,
+  criadoEm: '2026-06-10T12:00:00Z',
+};
+
 async function jsonRoute(route: Route, body: unknown, status = 200): Promise<void> {
   if (route.request().method() === 'OPTIONS') {
     await route.fulfill({ status: 204, headers: CORS_HEADERS });
@@ -41,17 +62,24 @@ async function jsonRoute(route: Route, body: unknown, status = 200): Promise<voi
 interface Capturado {
   readonly posts: unknown[];
   readonly deletedIds: string[];
+  readonly ofertaCursoIds: string[];
 }
 
 function novoCapturado(): Capturado {
-  return { posts: [], deletedIds: [] };
+  return { posts: [], deletedIds: [], ofertaCursoIds: [] };
 }
 
 async function mockApi(
   page: Page,
   capturado: Capturado,
   lista: readonly unknown[],
-  opcoes: { readonly criarStatus?: number; readonly criarBody?: unknown; readonly deleteStatus?: number; readonly deleteBody?: unknown } = {},
+  opcoes: {
+    readonly criarStatus?: number;
+    readonly criarBody?: unknown;
+    readonly deleteStatus?: number;
+    readonly deleteBody?: unknown;
+    readonly ofertas?: readonly unknown[];
+  } = {},
 ): Promise<void> {
   await page.route(/\/api\/configuracao\/admin\/cursos\/[^/?]+$/, async (route) => {
     if (route.request().method() === 'DELETE') {
@@ -80,6 +108,13 @@ async function mockApi(
       return;
     }
     await route.fulfill({ status: 204, headers: CORS_HEADERS });
+  });
+  await page.route(/\/api\/configuracao\/ofertas-curso(\?.*)?$/, async (route) => {
+    const cursoId = new URL(route.request().url()).searchParams.get('cursoId');
+    if (cursoId !== null) {
+      capturado.ofertaCursoIds.push(cursoId);
+    }
+    await jsonRoute(route, opcoes.ofertas ?? []);
   });
   await page.route(/\/api\/configuracao\/cursos(\?.*)?$/, (route) => jsonRoute(route, lista));
 }
@@ -143,7 +178,7 @@ test.describe('Curso — CRUD (#389)', () => {
     await expect(page.locator('#cfg-curso-form')).toBeVisible();
   });
 
-  test('CA-08: remoção bloqueada por oferta viva reabre o modal com a mensagem de erro', async ({
+  test('CA-08/#435: remoção bloqueada (409) abre o drawer de Ofertas com o preview do bloqueio', async ({
     page,
   }) => {
     const capturado = novoCapturado();
@@ -155,22 +190,40 @@ test.describe('Curso — CRUD (#389)', () => {
         status: 409,
         code: 'uniplus.configuracao.curso.remocao_bloqueada_por_oferta_curso',
       },
+      ofertas: [ofertaSeed],
     });
     await abrirPagina(page);
 
     await page.getByRole('button', { name: 'Remover' }).first().click();
-    const dialog = page.locator('dialog.uni-dialog');
-    await dialog.getByRole('button', { name: 'Remover' }).click();
+    const confirm = page.locator('dialog.uni-dialog');
+    await confirm.getByRole('button', { name: 'Remover' }).click();
 
-    // O ui-confirm-dialog fecha a si mesmo de forma síncrona ao confirmar,
-    // antes da resposta HTTP chegar — a asserção real precisa ser que o
-    // modal REABRE com a mensagem de erro, não apenas que a mensagem exista
-    // em algum lugar da página (um toast, por exemplo, também satisfaria
-    // isso sem provar que o modal permaneceu no fluxo).
-    await expect(dialog).toBeVisible();
+    // Em vez de reabrir o confirm, o fluxo abre o drawer de Ofertas com a
+    // mensagem que a API retornou e lista a oferta que bloqueia a remoção — o
+    // operador vê exatamente o que impede a exclusão (#435, CA2).
+    const drawer = page.locator('dialog.uni-drawer');
+    await expect(drawer.getByRole('heading', { name: 'Ofertas de ENG-CIV' })).toBeVisible();
+    await expect(drawer.getByText('Remoção bloqueada')).toBeVisible();
     await expect(
-      dialog.getByText('Não é possível remover um curso referenciado por uma oferta de curso ativa'),
+      drawer.getByText('Não é possível remover um curso referenciado por uma oferta de curso ativa'),
     ).toBeVisible();
+    await expect(drawer.getByText('Instituto de Geociências e Engenharias')).toBeVisible();
+    await expect.poll(() => capturado.ofertaCursoIds).toContain(CURSO_ID);
+  });
+
+  test('#435: ação "Ofertas" abre o drawer e lista as ofertas vivas do curso via cursoId', async ({
+    page,
+  }) => {
+    const capturado = novoCapturado();
+    await mockApi(page, capturado, [cursoSeed], { ofertas: [ofertaSeed] });
+    await abrirPagina(page);
+
+    await page.getByRole('button', { name: 'Ofertas' }).first().click();
+
+    const drawer = page.locator('dialog.uni-drawer');
+    await expect(drawer.getByRole('heading', { name: 'Ofertas de ENG-CIV' })).toBeVisible();
+    await expect(drawer.getByText('Instituto de Geociências e Engenharias')).toBeVisible();
+    await expect.poll(() => capturado.ofertaCursoIds).toContain(CURSO_ID);
   });
 
   test('remove um curso sem oferta viva após confirmação', async ({ page }) => {

--- a/apps/configuracao/src/app/features/cursos/cursos.page.spec.ts
+++ b/apps/configuracao/src/app/features/cursos/cursos.page.spec.ts
@@ -4,11 +4,16 @@ import { ApplicationRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { apiResultInterceptor } from '@uniplus/shared-core/http';
-import { CONFIGURACAO_BASE_PATH, CursoDto } from '@uniplus/shared-data/configuracao';
+import {
+  CONFIGURACAO_BASE_PATH,
+  CursoDto,
+  OfertaCursoDto,
+} from '@uniplus/shared-data/configuracao';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { CursosPage } from './cursos.page';
 
 const BASE = 'http://localhost:5000';
+const OFERTAS_URL = `${BASE}/api/configuracao/ofertas-curso`;
 
 const cursoSeed: CursoDto = {
   id: '01960000-0000-7000-0000-0000000000c1',
@@ -17,6 +22,27 @@ const cursoSeed: CursoDto = {
   grau: 'Bacharelado',
   nivelEnsino: 'Graduação',
   grupoAreaEnem: 'Tecnológica',
+  criadoEm: '2026-06-10T12:00:00Z',
+};
+
+const ofertaSeed: OfertaCursoDto = {
+  id: '01960000-0000-7000-0000-0000000000f1',
+  cursoId: cursoSeed.id,
+  localOfertaId: '01960000-0000-7000-0000-0000000000d1',
+  unidadeOfertante: {
+    origemId: '01960000-0000-7000-0000-0000000000e1',
+    sigla: 'IGE',
+    nome: 'Instituto de Geociências e Engenharias',
+    tipo: 'Instituto',
+  },
+  programaDeOferta: 'REGULAR',
+  formatoPedagogico: 'PRESENCIAL',
+  turno: 'MATUTINO',
+  eMecCodigo: '123456',
+  codigoSga: null,
+  vagasAnuaisAutorizadas: 40,
+  baseLegal: null,
+  atoAutorizacaoMec: null,
   criadoEm: '2026-06-10T12:00:00Z',
 };
 
@@ -164,7 +190,7 @@ describe('CursosPage', () => {
     expect(component['form'].controls.codigo.errors?.['backend']).toBeTruthy();
   });
 
-  it('CA-08: remoção bloqueada por oferta viva (409) reabre o modal com a mensagem de erro', async () => {
+  it('CA-08/CA2: remoção bloqueada (409) fecha o confirm e abre o drawer de Ofertas com o preview do bloqueio', async () => {
     await flushLista([cursoSeed]);
     component['pedirRemocao'](cursoSeed);
     component['removerConfirmado']();
@@ -189,10 +215,107 @@ describe('CursosPage', () => {
     );
     await propagate();
 
-    expect(component['confirmOpen']()).toBe(true);
-    expect(component['confirmMessage']()).toBe(
+    // O confirm não reabre; abre o drawer de Ofertas com a mensagem que a API
+    // devolveu (sem acoplar a UI ao vendor code — ramifica por status 409).
+    expect(component['confirmOpen']()).toBe(false);
+    expect(component['ofertasOpen']()).toBe(true);
+    expect(component['ofertasBloqueio']()).toBe(
       'Não é possível remover um curso referenciado por uma oferta de curso ativa',
     );
+
+    // E consulta as ofertas do curso via ?cursoId para o preview do bloqueio.
+    const ofertas = controller.expectOne((r) => r.url === OFERTAS_URL);
+    expect(ofertas.request.params.get('cursoId')).toBe(cursoSeed.id);
+    ofertas.flush([ofertaSeed]);
+    await propagate();
+    expect(component['ofertas']()).toHaveLength(1);
+  });
+
+  it('CA1: abrir "Ofertas" lista as ofertas do curso filtrando por cursoId', async () => {
+    await flushLista([cursoSeed]);
+
+    component['abrirOfertas'](cursoSeed);
+    await propagate();
+
+    const req = controller.expectOne((r) => r.url === OFERTAS_URL);
+    expect(req.request.params.get('cursoId')).toBe(cursoSeed.id);
+    expect(req.request.params.get('limit')).toBe('50');
+    req.flush([ofertaSeed]);
+    await propagate();
+
+    expect(component['ofertasOpen']()).toBe(true);
+    expect(component['ofertas']()).toHaveLength(1);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('IGE');
+    expect(fixture.nativeElement.textContent).toContain('Regular');
+  });
+
+  it('CA1: drawer mostra empty-state quando o curso não tem ofertas vivas', async () => {
+    await flushLista([cursoSeed]);
+
+    component['abrirOfertas'](cursoSeed);
+    await propagate();
+    controller.expectOne((r) => r.url === OFERTAS_URL).flush([]);
+    await propagate();
+
+    expect(component['ofertas']()).toHaveLength(0);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('Nenhuma oferta ativa');
+  });
+
+  it('CA1: trocar de curso não vaza as ofertas do curso anterior enquanto o novo GET não resolve', async () => {
+    const cursoB: CursoDto = {
+      ...cursoSeed,
+      id: '01960000-0000-7000-0000-0000000000c2',
+      codigo: 'ADM',
+      nome: 'Administração',
+    };
+    await flushLista([cursoSeed, cursoB]);
+
+    component['abrirOfertas'](cursoSeed);
+    await propagate();
+    controller.expectOne((r) => r.url === OFERTAS_URL).flush([ofertaSeed]);
+    await propagate();
+    expect(component['ofertas']()).toHaveLength(1);
+
+    // Fecha A e abre B: a lista precisa zerar de imediato (antes do GET de B),
+    // senão o drawer mostraria a oferta de A sob o cabeçalho de B.
+    component['aoFecharOfertas']();
+    component['abrirOfertas'](cursoB);
+    expect(component['ofertas']()).toHaveLength(0);
+    expect(component['ofertasNextCursor']()).toBeNull();
+
+    await propagate();
+    const reqB = controller.expectOne((r) => r.url === OFERTAS_URL);
+    expect(reqB.request.params.get('cursoId')).toBe(cursoB.id);
+    reqB.flush([]);
+    await propagate();
+    expect(component['ofertas']()).toHaveLength(0);
+  });
+
+  it('CA3: navegar para a próxima página reanexa cursoId e envia cursor/direction sem limit', async () => {
+    await flushLista([cursoSeed]);
+
+    component['abrirOfertas'](cursoSeed);
+    await propagate();
+
+    const p1 = controller.expectOne((r) => r.url === OFERTAS_URL);
+    p1.flush([ofertaSeed], {
+      headers: { Link: `<${OFERTAS_URL}?cursor=pagina-2&direction=next>; rel="next"` },
+    });
+    await propagate();
+    expect(component['ofertasNextCursor']()).not.toBeNull();
+
+    component['proximaPaginaOfertas']();
+    await propagate();
+
+    const p2 = controller.expectOne((r) => r.url === OFERTAS_URL);
+    expect(p2.request.params.get('cursoId')).toBe(cursoSeed.id);
+    expect(p2.request.params.get('cursor')).toBe('pagina-2');
+    expect(p2.request.params.get('direction')).toBe('next');
+    expect(p2.request.params.has('limit')).toBe(false);
+    p2.flush([{ ...ofertaSeed, id: '01960000-0000-7000-0000-0000000000f2' }]);
+    await propagate();
   });
 
   it('remove um curso sem oferta viva após confirmação', async () => {

--- a/apps/configuracao/src/app/features/cursos/cursos.page.ts
+++ b/apps/configuracao/src/app/features/cursos/cursos.page.ts
@@ -35,6 +35,9 @@ import {
   CursoDto,
   CursosApi,
   GRUPOS_AREA_ENEM,
+  OfertaCursoDto,
+  PROGRAMAS_DE_OFERTA,
+  TURNOS_OFERTA,
 } from '@uniplus/shared-data/configuracao';
 import {
   AlertComponent,
@@ -50,6 +53,10 @@ const PAGE_SIZE = 50;
 
 /** Vendor code do DomainError `Curso.CodigoJaExiste` (uniplus-api, 409 Conflict). */
 const CURSO_CODIGO_JA_EXISTE_CODE = 'uniplus.configuracao.curso.codigo_ja_existe';
+
+/** Rótulos dos tokens de programa/turno da oferta (domínios fechados, ofertas-curso.api). */
+const PROGRAMA_LABELS = new Map(PROGRAMAS_DE_OFERTA.map((opcao) => [opcao.value, opcao.label]));
+const TURNO_LABELS = new Map(TURNOS_OFERTA.map((opcao) => [opcao.value, opcao.label]));
 
 type ModoFormulario = 'criar' | 'editar';
 
@@ -152,6 +159,14 @@ interface CursoForm {
                   <td data-label="Nível">{{ curso.nivelEnsino }}</td>
                   <td data-label="Grupo ENEM">{{ curso.grupoAreaEnem || '—' }}</td>
                   <td class="table-responsive__actions" data-label="Ações">
+                    <button
+                      type="button"
+                      class="btn btn--tertiary btn--sm btn--rect"
+                      [disabled]="loading()"
+                      (click)="abrirOfertas(curso)"
+                    >
+                      Ofertas
+                    </button>
                     <button
                       type="button"
                       class="btn btn--tertiary btn--sm btn--rect"
@@ -325,6 +340,79 @@ interface CursoForm {
       confirmVariant="danger"
       (confirmed)="removerConfirmado()"
     />
+
+    <ui-drawer
+      class="cfg-ofertas-drawer"
+      [(visible)]="ofertasOpen"
+      [heading]="ofertasHeading()"
+      ariaLabel="Ofertas de curso do curso selecionado"
+      position="right"
+      (closed)="aoFecharOfertas()"
+    >
+      @if (ofertasBloqueio()) {
+        <ui-alert variant="danger" heading="Remoção bloqueada">
+          {{ ofertasBloqueio() }} Remova as ofertas abaixo antes de excluir o curso.
+        </ui-alert>
+      } @else {
+        <ui-alert variant="info" [dynamic]="false" heading="Ofertas vivas deste curso">
+          Instâncias regulatórias (Oferta de curso) que referenciam este curso. Enquanto houver
+          ofertas ativas, a remoção do curso é bloqueada.
+        </ui-alert>
+      }
+
+      @if (ofertasErrorMessage()) {
+        <ui-alert variant="danger" heading="Não foi possível carregar as ofertas">
+          {{ ofertasErrorMessage() }}
+          <div class="cfg-ofertas__retry">
+            <button
+              type="button"
+              class="btn btn--secondary btn--sm"
+              [disabled]="ofertasLoading()"
+              (click)="recarregarOfertas()"
+            >
+              Tentar novamente
+            </button>
+          </div>
+        </ui-alert>
+      }
+
+      @if (ofertasLoading()) {
+        <p class="cfg-ofertas__loading"><ui-spinner size="sm" /> Carregando ofertas…</p>
+      }
+
+      @if (ofertas().length > 0) {
+        <ul class="cfg-ofertas-list">
+          @for (oferta of ofertas(); track oferta.id) {
+            <li class="cfg-ofertas-list__item">
+              <p class="cfg-ofertas-list__unidade">
+                {{ oferta.unidadeOfertante.sigla }} — {{ oferta.unidadeOfertante.nome }}
+              </p>
+              <p class="cfg-ofertas-list__meta">
+                <span class="tag">{{ programaLabel(oferta.programaDeOferta) }}</span>
+                <span>{{ turnoLabel(oferta.turno) }}</span>
+              </p>
+            </li>
+          }
+        </ul>
+      } @else if (!ofertasLoading() && !ofertasErrorMessage()) {
+        <ui-empty-state
+          heading="Nenhuma oferta ativa"
+          description="Este curso não possui ofertas de curso vivas — a remoção não será bloqueada."
+        />
+      }
+
+      @if (ofertasPrevCursor() !== null || ofertasNextCursor() !== null) {
+        <ui-pager
+          statusText="Navegação por páginas"
+          navigationLabel="Paginação de ofertas do curso"
+          [hasPrevious]="ofertasPrevCursor() !== null"
+          [hasNext]="ofertasNextCursor() !== null"
+          [isDisabled]="ofertasLoading()"
+          (previous)="paginaAnteriorOfertas()"
+          (next)="proximaPaginaOfertas()"
+        />
+      }
+    </ui-drawer>
   `,
 })
 export class CursosPage {
@@ -346,6 +434,15 @@ export class CursosPage {
   protected readonly confirmError = signal<string | null>(null);
   protected readonly idempotencyKeyAtual = signal(idempotencyKey.create());
   protected readonly termoBusca = signal('');
+
+  // Drawer "Ofertas do curso" — inspeção sob demanda das ofertas vivas de um
+  // curso via filtro `?cursoId` (api#755, issue #435).
+  protected readonly ofertasOpen = signal(false);
+  protected readonly cursoParaOfertas = signal<CursoDto | null>(null);
+  protected readonly ofertasBloqueio = signal<string | null>(null);
+  private readonly ofertasPagina = signal<
+    { readonly cursor: Cursor; readonly direction: PaginationDirection } | undefined
+  >(undefined);
 
   private readonly pagina = signal<
     { readonly cursor: Cursor; readonly direction: PaginationDirection } | undefined
@@ -397,6 +494,76 @@ export class CursosPage {
       }
       return [...envelope.data];
     },
+  });
+
+  // Ofertas vivas do curso selecionado — só dispara quando o drawer tem um
+  // curso (request fn `undefined` = sem fetch). Filtro `?cursoId` reanexado a
+  // cada página; prev/next lidos do header Link (ADR-0026 web + api#755).
+  private readonly listaOfertas = useApiResource<readonly OfertaCursoDto[]>(() => {
+    const curso = this.cursoParaOfertas();
+    if (curso === null) {
+      return undefined;
+    }
+    return {
+      url: `${this.basePath}/api/configuracao/ofertas-curso`,
+      params: this.montarParamsOfertas(curso.id),
+      context: withVendorMime('oferta-curso', 1),
+    };
+  });
+
+  protected readonly ofertasLoading = this.listaOfertas.isLoading;
+
+  private readonly ofertasCursores = linkedSignal<
+    ApiResult<readonly OfertaCursoDto[]> | undefined,
+    { readonly prev: Cursor | null; readonly next: Cursor | null }
+  >({
+    source: () => this.listaOfertas.value(),
+    computation: (envelope, previous) => {
+      const atual = previous?.value ?? { prev: null, next: null };
+      if (envelope === undefined) {
+        return atual;
+      }
+      const primeiraPagina = untracked(() => this.ofertasPagina() === undefined);
+      if (!envelope.ok) {
+        return primeiraPagina ? { prev: null, next: null } : atual;
+      }
+      const link = untracked(() => this.listaOfertas.headers()?.get('Link') ?? null);
+      return { prev: extractPrevCursor(link), next: extractNextCursor(link) };
+    },
+  });
+
+  protected readonly ofertasPrevCursor = computed(() => this.ofertasCursores().prev);
+  protected readonly ofertasNextCursor = computed(() => this.ofertasCursores().next);
+
+  protected readonly ofertas = linkedSignal<
+    ApiResult<readonly OfertaCursoDto[]> | undefined,
+    readonly OfertaCursoDto[]
+  >({
+    source: () => this.listaOfertas.value(),
+    computation: (envelope, previous) => {
+      const atual = previous?.value ?? [];
+      if (envelope === undefined) {
+        return atual;
+      }
+      const primeiraPagina = untracked(() => this.ofertasPagina() === undefined);
+      if (!envelope.ok) {
+        return primeiraPagina ? [] : atual;
+      }
+      return [...envelope.data];
+    },
+  });
+
+  protected readonly ofertasErrorMessage = computed<string | null>(() => {
+    const problem = this.listaOfertas.problem();
+    if (problem) {
+      return this.problemI18n.resolve(problem).title;
+    }
+    return this.listaOfertas.error() ? 'Erro inesperado ao carregar as ofertas do curso.' : null;
+  });
+
+  protected readonly ofertasHeading = computed(() => {
+    const curso = this.cursoParaOfertas();
+    return curso ? `Ofertas de ${curso.codigo}` : 'Ofertas do curso';
   });
 
   // Busca client-side sobre a página carregada: o backend (api#588) só pagina
@@ -480,6 +647,67 @@ export class CursosPage {
     }
   }
 
+  /** Abre o drawer com as ofertas vivas do curso (inspeção proativa, sem contexto de bloqueio). */
+  protected abrirOfertas(curso: CursoDto): void {
+    this.ofertasBloqueio.set(null);
+    this.exibirOfertas(curso);
+  }
+
+  private exibirOfertas(curso: CursoDto): void {
+    // Zera lista e cursores ANTES de trocar o curso: os linkedSignals preservam
+    // o valor anterior enquanto o envelope é `undefined` (loading), então sem
+    // este reset o drawer exibiria as ofertas do curso anterior sob o cabeçalho
+    // do novo até o GET resolver (cabeçalho ≠ corpo).
+    this.limparOfertas();
+    this.ofertasPagina.set(undefined);
+    this.cursoParaOfertas.set(curso);
+    this.ofertasOpen.set(true);
+  }
+
+  protected aoFecharOfertas(): void {
+    // Limpa o curso (a request fn passa a retornar `undefined`) para que a
+    // próxima abertura refaça a busca do zero, sempre com dados frescos.
+    this.cursoParaOfertas.set(null);
+    this.ofertasBloqueio.set(null);
+    this.limparOfertas();
+  }
+
+  private limparOfertas(): void {
+    this.ofertas.set([]);
+    this.ofertasCursores.set({ prev: null, next: null });
+  }
+
+  protected recarregarOfertas(): void {
+    if (!this.ofertasLoading()) {
+      this.listaOfertas.reload();
+    }
+  }
+
+  protected proximaPaginaOfertas(): void {
+    const proximo = this.ofertasNextCursor();
+    if (proximo !== null && !this.ofertasLoading()) {
+      this.ofertasPagina.set({ cursor: proximo, direction: 'next' });
+    }
+  }
+
+  protected paginaAnteriorOfertas(): void {
+    const anterior = this.ofertasPrevCursor();
+    if (anterior !== null && !this.ofertasLoading()) {
+      this.ofertasPagina.set({ cursor: anterior, direction: 'prev' });
+    }
+  }
+
+  protected programaLabel(token: string): string {
+    return PROGRAMA_LABELS.get(token) ?? token;
+  }
+
+  protected turnoLabel(token: string | null): string {
+    if (token === null) {
+      return '—';
+    }
+    return TURNO_LABELS.get(token) ?? token;
+  }
+
   protected tentarNovamente(): void {
     if (!this.loading()) {
       this.lista.reload();
@@ -534,11 +762,23 @@ export class CursosPage {
           this.recarregar();
           return;
         }
-        // `ui-confirm-dialog` fecha a si mesmo de forma síncrona ao emitir
-        // `confirmed` (antes desta resposta HTTP assíncrona chegar) — reabrir
-        // explicitamente com a mensagem de erro é o único jeito de manter o
-        // fluxo de bloqueio visível para o operador (CA-08).
+        // A mensagem exibida é a que a API já devolve no ProblemDetails (title),
+        // sem acoplar a UI ao vendor code do erro.
         const titulo = this.problemI18n.resolve(result.problem).title;
+        // 409 é o único conflito possível no DELETE do curso: referenciado por
+        // oferta viva. Em vez de só reexibir o texto, fecha o confirm e abre o
+        // drawer de Ofertas com o preview das ofertas que bloqueiam a remoção
+        // (issue #435, CA2) — o operador vê exatamente o que impede a exclusão.
+        if (result.problem.status === 409) {
+          this.confirmOpen.set(false);
+          this.cursoParaRemover.set(null);
+          this.ofertasBloqueio.set(titulo);
+          this.exibirOfertas(curso);
+          return;
+        }
+        // Demais falhas (5xx, rede): mantém o confirm aberto com a mensagem. O
+        // `ui-confirm-dialog` fecha a si mesmo de forma síncrona ao emitir
+        // `confirmed`; reabrir explicitamente mantém o erro visível ao operador.
         this.confirmError.set(titulo);
         this.confirmOpen.set(true);
         if (result.problem.status >= 500) {
@@ -599,6 +839,18 @@ export class CursosPage {
     return new HttpParams()
       .set('cursor', cursorToString(pagina.cursor))
       .set('direction', pagina.direction);
+  }
+
+  /** Params da listagem de ofertas do curso — `cursoId` reanexado em toda página (api#755). */
+  private montarParamsOfertas(cursoId: string): HttpParams {
+    const pagina = this.ofertasPagina();
+    if (pagina === undefined) {
+      return new HttpParams().set('limit', String(PAGE_SIZE)).set('cursoId', cursoId);
+    }
+    return new HttpParams()
+      .set('cursor', cursorToString(pagina.cursor))
+      .set('direction', pagina.direction)
+      .set('cursoId', cursoId);
   }
 
   private recarregar(): void {

--- a/libs/shared-data/openapi/configuracao.openapi.json
+++ b/libs/shared-data/openapi/configuracao.openapi.json
@@ -2999,6 +2999,14 @@
         ],
         "parameters": [
           {
+            "name": "cursoId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
             "name": "cursor",
             "in": "query",
             "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",

--- a/libs/shared-data/src/lib/api/configuracao/ofertas-curso.api.spec.ts
+++ b/libs/shared-data/src/lib/api/configuracao/ofertas-curso.api.spec.ts
@@ -84,6 +84,27 @@ describe('OfertasCursoApi', () => {
     await promise;
   });
 
+  it('listar({ cursoId }) inclui o filtro cursoId na 1ª página (api#755)', async () => {
+    const promise = firstValueFrom(api.listar({ cursoId: CURSO_ID, limit: 50 }));
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/ofertas-curso`);
+    expect(req.request.params.get('cursoId')).toBe(CURSO_ID);
+    expect(req.request.params.get('limit')).toBe('50');
+    req.flush([ofertaSeed]);
+    await promise;
+  });
+
+  it('listar({ cursoId, cursor }) reanexa cursoId junto do cursor', async () => {
+    const promise = firstValueFrom(
+      api.listar({ cursoId: CURSO_ID, cursor: 'abc', direction: 'next' }),
+    );
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/ofertas-curso`);
+    expect(req.request.params.get('cursoId')).toBe(CURSO_ID);
+    expect(req.request.params.get('cursor')).toBe('abc');
+    expect(req.request.params.get('direction')).toBe('next');
+    req.flush([ofertaSeed]);
+    await promise;
+  });
+
   it('obter() faz GET /api/configuracao/ofertas-curso/{id}', async () => {
     const promise = firstValueFrom(api.obter(ID));
     const req = controller.expectOne(`${BASE}/api/configuracao/ofertas-curso/${ID}`);

--- a/libs/shared-data/src/lib/api/configuracao/ofertas-curso.api.ts
+++ b/libs/shared-data/src/lib/api/configuracao/ofertas-curso.api.ts
@@ -58,11 +58,16 @@ export const TURNOS_OFERTA: readonly TurnoOfertaOption[] = [
   { value: 'INTEGRAL', label: 'Integral' },
 ] as const;
 
-/** Filtro de listagem de Ofertas de Curso (cursor pagination, ADR-0026). Sem filtro por `cursoId` no contrato atual. */
+/**
+ * Filtro de listagem de Ofertas de Curso (cursor pagination, ADR-0026).
+ * `cursoId` (opcional, api#755) restringe às ofertas vivas de um curso; viaja
+ * como query param e combina com o cursor — reanexado a cada página.
+ */
 export interface OfertasCursoQuery {
   readonly cursor?: string;
   readonly direction?: 'next' | 'prev';
   readonly limit?: number;
+  readonly cursoId?: string;
 }
 
 /**
@@ -89,6 +94,9 @@ export class OfertasCursoApi {
       params = params.set('cursor', query.cursor).set('direction', query.direction ?? 'next');
     } else {
       params = params.set('limit', String(query.limit ?? 100));
+    }
+    if (query.cursoId !== undefined) {
+      params = params.set('cursoId', query.cursoId);
     }
     return this.http.get<ApiResult<readonly OfertaCursoDto[]>>(
       `${this.basePath}/api/configuracao/ofertas-curso`,

--- a/libs/shared-data/src/lib/api/configuracao/schema.ts
+++ b/libs/shared-data/src/lib/api/configuracao/schema.ts
@@ -2379,6 +2379,7 @@ export interface paths {
         readonly get: {
             readonly parameters: {
                 readonly query?: {
+                    readonly cursoId?: string;
                     /** @description Cursor opaco AES-GCM emitido pelo servidor no header Link da página anterior. Ausente na primeira página. Cliente trata como string opaca — não decodificar (ADR-0026, ADR-0031). */
                     readonly cursor?: string;
                     /** @description Tamanho máximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026). */


### PR DESCRIPTION
## Contexto

Na entrega das telas de Curso e Oferta de Curso (#389, PR #426), a coluna "N ofertas vivas" foi omitida porque o backend não permitia obter as ofertas de um curso sem varrer todo o acervo. O bloqueio foi resolvido em **uniplus-api#755** (mergeado), que adicionou o filtro `?cursoId` a `GET /api/configuracao/ofertas-curso`.

Esta PR consome esse filtro para dar visibilidade sob demanda às ofertas vivas de um curso.

## O que muda

- **Ação "Ofertas" por linha** na lista de Curso → abre um `ui-drawer` que lista as ofertas do curso, buscadas via `?cursoId`, com **paginação por cursor bidirecional** (ADR-0026) reanexando o filtro a cada página.
- **Remoção bloqueada (409)** passa a abrir esse mesmo drawer com o **preview das ofertas** que impedem a exclusão.
- `OfertasCursoApi.listar` aceita `cursoId` opcional; baseline OpenAPI vendorizado + `schema.ts` gerado sincronizados com o param (api#755).

## Decisão de design — sem acoplar a UI ao vendor code

O fluxo de remoção **ramifica por status HTTP 409** (o único conflito possível no `DELETE` do curso é "referenciado por oferta viva"), **não** por uma string de `code` do erro. A mensagem exibida é a que a **própria API já devolve** no `ProblemDetails` (via `ProblemI18nService`, passthrough por padrão). O front não re-deriva texto de códigos nem se amarra ao identificador interno do erro.

O drawer zera lista/cursores ao abrir/trocar de curso, evitando exibir as ofertas do curso anterior sob o cabeçalho do novo enquanto o GET resolve.

## Critérios de aceite (#435)

- [x] A tela de Curso consulta as ofertas vivas de um curso via `?cursoId`, sem varrer o acervo.
- [x] A remoção mostra preview das ofertas referenciadoras (drawer no 409).
- [x] Paginação por cursor respeitada (reanexo do `cursoId`).
- [x] Cobertura de teste (componente + E2E).

## Validação local

- `nx build configuracao` — OK.
- `nx vite:test configuracao` — 180 ✅ · `nx vite:test shared-data` — 203 ✅.
- `nx lint configuracao,shared-data,configuracao-e2e` — limpo.
- `generate:api` sem drift (`codegen-drift-check` passa) após sincronizar o `cursoId` no baseline.
- E2E (`cursos.flow.spec.ts`) roda no CI (projeto `fluxo-chromium` depende de `auth-setup`/Keycloak).

## Codex AI

- P2 "Align the cursoId filter with the generated API contract" — **resolvido**: baseline OpenAPI vendorizado + `schema.ts` sincronizados com o param `cursoId`.

## Follow-up sugerido

- Centralizar os vendor codes de erro (ex.: `CURSO_CODIGO_JA_EXISTE_CODE`) na camada `shared-data` — discutido na review; fora do escopo desta story.

Closes #435
Refs #384