### PR TITLE
fix(configuracao): permite corrigir CEP resolvido sem perder dados

### DIFF
--- a/apps/configuracao/src/app/shared/endereco/endereco-form.spec.ts
+++ b/apps/configuracao/src/app/shared/endereco/endereco-form.spec.ts
@@ -344,6 +344,8 @@ describe('EnderecoFormComponent', () => {
     botaoPorTexto(fixture, 'Buscar CEP').click();
     controller.expectOne(`${BASE}/api/cep/68507590`).flush(cepLogradouro);
     fixture.detectChanges();
+    setInput(fixture, 't-numero', '123');
+    fixture.detectChanges();
 
     botaoPorTexto(fixture, 'Trocar CEP').click();
     fixture.detectChanges();
@@ -353,13 +355,27 @@ describe('EnderecoFormComponent', () => {
 
     // Nada fica visível mas fora do que seria submetido: os campos de detalhe
     // (derivados da resolução anterior) somem junto com o CEP, não continuam
-    // na tela para um valor que não seria mais enviado.
+    // na tela para um valor que não seria mais enviado. numero também é
+    // limpo — do contrário, vazaria para o próximo CEP resolvido (endereço
+    // potencialmente diferente).
     expect(fixture.nativeElement.querySelector('#t-logradouro')).toBeNull();
     expect(fixture.nativeElement.textContent).not.toContain('Marabá');
     expect(host.ctrl.valid).toBe(true);
     expect(host.ctrl.value).toBeNull();
     expect(enderecoParaCommand(host.ctrl.value).endereco).toBeNull();
     expect(enderecoParaCommand(host.ctrl.value).cidadeCodigoIbge).toBeNull();
+
+    // Resolver um novo CEP não ressuscita o número do endereço abandonado.
+    setInput(fixture, 't-cep', '68500000');
+    botaoPorTexto(fixture, 'Buscar CEP').click();
+    controller.expectOne(`${BASE}/api/cep/68500000`).flush({
+      ...cepLogradouro,
+      cep: '68500000',
+      bairro: 'Novo Bairro',
+      nivelResolucao: 'bairro',
+    });
+    fixture.detectChanges();
+    expect((fixture.nativeElement.querySelector('#t-numero') as HTMLInputElement).value).toBe('');
   });
 
   it('CA-01: nível bairro deixa logradouro editável e número sempre editável', () => {

--- a/apps/configuracao/src/app/shared/endereco/endereco-form.spec.ts
+++ b/apps/configuracao/src/app/shared/endereco/endereco-form.spec.ts
@@ -248,6 +248,59 @@ describe('EnderecoFormComponent', () => {
     expect(numero.readOnly).toBe(false);
   });
 
+  it('CA-01: "Trocar CEP" destrava o campo sem descartar o restante do endereço resolvido — #438', () => {
+    setInput(fixture, 't-cep', '68507590');
+    botaoPorTexto(fixture, 'Buscar CEP').click();
+    controller.expectOne(`${BASE}/api/cep/68507590`).flush(cepLogradouro);
+    fixture.detectChanges();
+
+    const cep = fixture.nativeElement.querySelector('#t-cep') as HTMLInputElement;
+    expect(cep.readOnly).toBe(true);
+    expect(() => botaoPorTexto(fixture, 'Buscar CEP')).toThrow();
+
+    botaoPorTexto(fixture, 'Trocar CEP').click();
+    fixture.detectChanges();
+
+    expect(cep.readOnly).toBe(false);
+    expect(cep.value).toBe('68507590');
+    expect(() => botaoPorTexto(fixture, 'Trocar CEP')).toThrow();
+    expect((fixture.nativeElement.querySelector('#t-logradouro') as HTMLInputElement).value).toBe(
+      'Folha 31, Quadra 7',
+    );
+    expect(host.ctrl.value).toMatchObject({ logradouro: 'Folha 31, Quadra 7' });
+  });
+
+  it('CA-01: corrige o CEP após "Trocar CEP" e re-ancora com o novo endereço resolvido — #438', () => {
+    setInput(fixture, 't-cep', '68507590');
+    botaoPorTexto(fixture, 'Buscar CEP').click();
+    controller.expectOne(`${BASE}/api/cep/68507590`).flush(cepLogradouro);
+    fixture.detectChanges();
+
+    botaoPorTexto(fixture, 'Trocar CEP').click();
+    fixture.detectChanges();
+
+    setInput(fixture, 't-cep', '68500000');
+    botaoPorTexto(fixture, 'Buscar CEP').click();
+    controller.expectOne(`${BASE}/api/cep/68500000`).flush({
+      ...cepLogradouro,
+      cep: '68500000',
+      logradouro: null,
+      bairro: 'Novo Bairro',
+      nivelResolucao: 'bairro',
+    });
+    fixture.detectChanges();
+
+    expect(host.ctrl.value).toMatchObject({
+      cep: '68500000',
+      bairro: 'Novo Bairro',
+      nivelResolucao: 'bairro',
+    });
+    const cep = fixture.nativeElement.querySelector('#t-cep') as HTMLInputElement;
+    expect(cep.readOnly).toBe(true);
+    expect(() => botaoPorTexto(fixture, 'Trocar CEP')).not.toThrow();
+    expect(() => botaoPorTexto(fixture, 'Buscar CEP')).toThrow();
+  });
+
   it('CA-01: nível bairro deixa logradouro editável e número sempre editável', () => {
     setInput(fixture, 't-cep', '68500000');
     botaoPorTexto(fixture, 'Buscar CEP').click();

--- a/apps/configuracao/src/app/shared/endereco/endereco-form.spec.ts
+++ b/apps/configuracao/src/app/shared/endereco/endereco-form.spec.ts
@@ -339,6 +339,29 @@ describe('EnderecoFormComponent', () => {
     expect(fixture.nativeElement.querySelector('#t-cep-error')).toBeNull();
   });
 
+  it('CA-01: esvaziar o CEP durante a correção descarta a resolução preservada — #438', () => {
+    setInput(fixture, 't-cep', '68507590');
+    botaoPorTexto(fixture, 'Buscar CEP').click();
+    controller.expectOne(`${BASE}/api/cep/68507590`).flush(cepLogradouro);
+    fixture.detectChanges();
+
+    botaoPorTexto(fixture, 'Trocar CEP').click();
+    fixture.detectChanges();
+
+    setInput(fixture, 't-cep', '');
+    fixture.detectChanges();
+
+    // Nada fica visível mas fora do que seria submetido: os campos de detalhe
+    // (derivados da resolução anterior) somem junto com o CEP, não continuam
+    // na tela para um valor que não seria mais enviado.
+    expect(fixture.nativeElement.querySelector('#t-logradouro')).toBeNull();
+    expect(fixture.nativeElement.textContent).not.toContain('Marabá');
+    expect(host.ctrl.valid).toBe(true);
+    expect(host.ctrl.value).toBeNull();
+    expect(enderecoParaCommand(host.ctrl.value).endereco).toBeNull();
+    expect(enderecoParaCommand(host.ctrl.value).cidadeCodigoIbge).toBeNull();
+  });
+
   it('CA-01: nível bairro deixa logradouro editável e número sempre editável', () => {
     setInput(fixture, 't-cep', '68500000');
     botaoPorTexto(fixture, 'Buscar CEP').click();

--- a/apps/configuracao/src/app/shared/endereco/endereco-form.spec.ts
+++ b/apps/configuracao/src/app/shared/endereco/endereco-form.spec.ts
@@ -378,6 +378,35 @@ describe('EnderecoFormComponent', () => {
     expect((fixture.nativeElement.querySelector('#t-numero') as HTMLInputElement).value).toBe('');
   });
 
+  it('CA-01: abandonar a correção (esvaziar CEP após falha) limpa o erro obsoleto — #438', () => {
+    setInput(fixture, 't-cep', '68507590');
+    botaoPorTexto(fixture, 'Buscar CEP').click();
+    controller.expectOne(`${BASE}/api/cep/68507590`).flush(cepLogradouro);
+    fixture.detectChanges();
+
+    botaoPorTexto(fixture, 'Trocar CEP').click();
+    fixture.detectChanges();
+
+    setInput(fixture, 't-cep', '00000000');
+    botaoPorTexto(fixture, 'Buscar CEP').click();
+    controller.expectOne(`${BASE}/api/cep/00000000`).flush(null, {
+      status: 404,
+      statusText: 'Not Found',
+    });
+    fixture.detectChanges();
+    expect((fixture.nativeElement.querySelector('#t-cep-error') as HTMLElement).textContent).toContain(
+      'CEP não encontrado',
+    );
+
+    // Desiste da correção esvaziando o campo por completo — endereço vazio é
+    // válido (opcional), então o erro da tentativa anterior não pode persistir.
+    setInput(fixture, 't-cep', '');
+    fixture.detectChanges();
+
+    expect(host.ctrl.valid).toBe(true);
+    expect(fixture.nativeElement.querySelector('#t-cep-error')).toBeNull();
+  });
+
   it('CA-01: nível bairro deixa logradouro editável e número sempre editável', () => {
     setInput(fixture, 't-cep', '68500000');
     botaoPorTexto(fixture, 'Buscar CEP').click();

--- a/apps/configuracao/src/app/shared/endereco/endereco-form.spec.ts
+++ b/apps/configuracao/src/app/shared/endereco/endereco-form.spec.ts
@@ -301,6 +301,40 @@ describe('EnderecoFormComponent', () => {
     expect(() => botaoPorTexto(fixture, 'Buscar CEP')).toThrow();
   });
 
+  it('CA-01: falha ao corrigir CEP preserva a última resolução válida em vez de descartá-la — #438', () => {
+    setInput(fixture, 't-cep', '68507590');
+    botaoPorTexto(fixture, 'Buscar CEP').click();
+    controller.expectOne(`${BASE}/api/cep/68507590`).flush(cepLogradouro);
+    fixture.detectChanges();
+
+    botaoPorTexto(fixture, 'Trocar CEP').click();
+    fixture.detectChanges();
+
+    setInput(fixture, 't-cep', '00000000');
+    botaoPorTexto(fixture, 'Buscar CEP').click();
+    controller.expectOne(`${BASE}/api/cep/00000000`).flush(null, {
+      status: 404,
+      statusText: 'Not Found',
+    });
+    fixture.detectChanges();
+
+    // A resolução anterior não é descartada por uma tentativa de correção que falhou.
+    expect((fixture.nativeElement.querySelector('#t-logradouro') as HTMLInputElement)?.value).toBe(
+      'Folha 31, Quadra 7',
+    );
+
+    // Voltar ao CEP original (sem nova busca) reaprova o formulário com nivelResolucao consistente.
+    setInput(fixture, 't-cep', '68507590');
+    fixture.detectChanges();
+
+    expect(host.ctrl.valid).toBe(true);
+    expect(host.ctrl.value).toMatchObject({
+      cep: '68507590',
+      logradouro: 'Folha 31, Quadra 7',
+      nivelResolucao: 'logradouro',
+    });
+  });
+
   it('CA-01: nível bairro deixa logradouro editável e número sempre editável', () => {
     setInput(fixture, 't-cep', '68500000');
     botaoPorTexto(fixture, 'Buscar CEP').click();

--- a/apps/configuracao/src/app/shared/endereco/endereco-form.spec.ts
+++ b/apps/configuracao/src/app/shared/endereco/endereco-form.spec.ts
@@ -407,6 +407,32 @@ describe('EnderecoFormComponent', () => {
     expect(fixture.nativeElement.querySelector('#t-cep-error')).toBeNull();
   });
 
+  it('CA-01: texto sem dígitos (ex.: "abc") durante a correção não descarta a resolução preservada — #438', () => {
+    setInput(fixture, 't-cep', '68507590');
+    botaoPorTexto(fixture, 'Buscar CEP').click();
+    controller.expectOne(`${BASE}/api/cep/68507590`).flush(cepLogradouro);
+    fixture.detectChanges();
+
+    botaoPorTexto(fixture, 'Trocar CEP').click();
+    fixture.detectChanges();
+
+    // "abc" não tem dígitos, mas o campo não está vazio — é formato pendente
+    // (CA-06), não abandono da correção. A resolução preservada continua ali.
+    setInput(fixture, 't-cep', 'abc');
+    fixture.detectChanges();
+
+    expect(host.ctrl.invalid).toBe(true);
+    expect((fixture.nativeElement.querySelector('#t-logradouro') as HTMLInputElement)?.value).toBe(
+      'Folha 31, Quadra 7',
+    );
+
+    // Corrigir para o CEP original (sem nova busca) reaprova o formulário.
+    setInput(fixture, 't-cep', '68507590');
+    fixture.detectChanges();
+    expect(host.ctrl.valid).toBe(true);
+    expect(host.ctrl.value).toMatchObject({ cep: '68507590', nivelResolucao: 'logradouro' });
+  });
+
   it('CA-01: nível bairro deixa logradouro editável e número sempre editável', () => {
     setInput(fixture, 't-cep', '68500000');
     botaoPorTexto(fixture, 'Buscar CEP').click();

--- a/apps/configuracao/src/app/shared/endereco/endereco-form.spec.ts
+++ b/apps/configuracao/src/app/shared/endereco/endereco-form.spec.ts
@@ -322,8 +322,11 @@ describe('EnderecoFormComponent', () => {
     expect((fixture.nativeElement.querySelector('#t-logradouro') as HTMLInputElement)?.value).toBe(
       'Folha 31, Quadra 7',
     );
+    expect((fixture.nativeElement.querySelector('#t-cep-error') as HTMLElement).textContent).toContain(
+      'CEP não encontrado',
+    );
 
-    // Voltar ao CEP original (sem nova busca) reaprova o formulário com nivelResolucao consistente.
+    // Voltar ao CEP original (sem nova busca) reaprova o formulário e limpa o erro obsoleto.
     setInput(fixture, 't-cep', '68507590');
     fixture.detectChanges();
 
@@ -333,6 +336,7 @@ describe('EnderecoFormComponent', () => {
       logradouro: 'Folha 31, Quadra 7',
       nivelResolucao: 'logradouro',
     });
+    expect(fixture.nativeElement.querySelector('#t-cep-error')).toBeNull();
   });
 
   it('CA-01: nível bairro deixa logradouro editável e número sempre editável', () => {

--- a/apps/configuracao/src/app/shared/endereco/endereco-form.ts
+++ b/apps/configuracao/src/app/shared/endereco/endereco-form.ts
@@ -651,6 +651,10 @@ export class EnderecoFormComponent implements ControlValueAccessor, Validator {
       this.cidade.set(null);
       this.origem.set(null);
       this.cepResolvido.set('');
+      // Descartar a resolução preservada torna o CEP vazio válido de novo
+      // (endereço é opcional); um erro de uma tentativa de correção anterior
+      // (404, formato) não pode continuar na tela contradizendo isso.
+      this.cepErro.set(null);
       // numero também é limpo aqui: embora seja "dado próprio" (nunca
       // ancorado pelo DNE), ele descreve um imóvel específico do endereço
       // abandonado — mantê-lo faria o número vazar para o próximo CEP

--- a/apps/configuracao/src/app/shared/endereco/endereco-form.ts
+++ b/apps/configuracao/src/app/shared/endereco/endereco-form.ts
@@ -647,9 +647,16 @@ export class EnderecoFormComponent implements ControlValueAccessor, Validator {
     const cepDigitos = raw.cep.replace(/\D/g, '');
     this.cepAtual.set(cepDigitos);
     this.cepTextoAtual.set(raw.cep.trim());
+    const cepCorrespondeAoResolvido = cepDigitos.length > 0 && cepDigitos === this.cepResolvido();
+    if (cepCorrespondeAoResolvido) {
+      // O usuário voltou ao CEP já resolvido (ex.: desistiu de uma correção que
+      // falhou) sem disparar nova busca — limpa um eventual erro de tentativa
+      // anterior, que do contrário ficaria preso na tela mesmo com o formulário
+      // válido outra vez. #438.
+      this.cepErro.set(null);
+    }
     this.onValidatorChange();
-    const cepResolvidoNoValor =
-      cepDigitos.length > 0 && cepDigitos === this.cepResolvido() ? vazioParaNulo(raw.cep) : null;
+    const cepResolvidoNoValor = cepCorrespondeAoResolvido ? vazioParaNulo(raw.cep) : null;
 
     const algumPreenchido =
       cidade !== null ||

--- a/apps/configuracao/src/app/shared/endereco/endereco-form.ts
+++ b/apps/configuracao/src/app/shared/endereco/endereco-form.ts
@@ -550,8 +550,15 @@ export class EnderecoFormComponent implements ControlValueAccessor, Validator {
           return;
         }
         if (result.status === 404) {
-          // CEP não encontrado: mantém os campos editáveis para entrada manual.
-          this.nivel.set(null);
+          // CEP não encontrado. Sem resolução anterior, mantém os campos
+          // editáveis para entrada manual. Em correção de um CEP já resolvido
+          // (editandoCep), preserva a última resolução válida em vez de
+          // descartá-la — do contrário, retornar ao CEP original sem uma nova
+          // busca reaprovaria o formulário com `nivelResolucao` nulo enquanto
+          // os campos de detalhe ainda carregam os dados da resolução antiga. #438.
+          if (this.cepResolvido().length === 0) {
+            this.nivel.set(null);
+          }
           this.cepErro.set('CEP não encontrado. Verifique ou preencha o endereço manualmente.');
           return;
         }

--- a/apps/configuracao/src/app/shared/endereco/endereco-form.ts
+++ b/apps/configuracao/src/app/shared/endereco/endereco-form.ts
@@ -641,12 +641,14 @@ export class EnderecoFormComponent implements ControlValueAccessor, Validator {
     let raw = this.form.getRawValue();
     const cepDigitos = raw.cep.replace(/\D/g, '');
 
-    if (cepDigitos.length === 0 && this.nivel() !== null) {
-      // Correção via "Trocar CEP" abandonada (campo esvaziado por completo)
-      // enquanto havia uma resolução preservada — descarta a resolução antiga
-      // e os campos derivados dela em vez de deixá-los visíveis mas fora do
-      // que é submetido (`enderecoParaCommand` só monta `endereco` com CEP de
-      // 8 dígitos; sem cidade, a cidade top-level também some). #438.
+    if (raw.cep.trim().length === 0 && this.nivel() !== null) {
+      // Correção via "Trocar CEP" abandonada (campo esvaziado por completo —
+      // texto bruto vazio, não só sem dígitos: um valor tipo "abc" não conta
+      // como abandono, e sim como formato pendente, ver cepPendente) enquanto
+      // havia uma resolução preservada — descarta a resolução antiga e os
+      // campos derivados dela em vez de deixá-los visíveis mas fora do que é
+      // submetido (`enderecoParaCommand` só monta `endereco` com CEP de 8
+      // dígitos; sem cidade, a cidade top-level também some). #438.
       this.nivel.set(null);
       this.cidade.set(null);
       this.origem.set(null);

--- a/apps/configuracao/src/app/shared/endereco/endereco-form.ts
+++ b/apps/configuracao/src/app/shared/endereco/endereco-form.ts
@@ -70,6 +70,10 @@ interface EnderecoFormControls {
  * - **Fallback manual / sem CEP** (CA-02): o usuário escolhe a cidade pelo
  *   seletor (`GET /api/cidades`) e digita o endereço manualmente.
  *
+ * Um CEP já resolvido pode ser corrigido via botão "Trocar CEP" — reabre só o
+ * campo CEP (`iniciarEdicaoCep`) sem descartar o restante do endereço já
+ * preenchido; uma nova resolução bem-sucedida re-ancora o campo. #438.
+ *
  * Erros de CEP (formato/404) são exibidos inline (CA-06); o erro de coerência
  * cidade↔CEP (422) do backend chega via `erroExterno` do parent. Acessibilidade
  * WCAG 2.1 AA / e-MAG (CA-05): `fieldset/legend`, labels associadas,
@@ -97,24 +101,35 @@ interface EnderecoFormControls {
               placeholder="00000-000"
               maxlength="9"
               [formControl]="form.controls.cep"
-              [readonly]="ehAncorado('cep') || resolvendoCep()"
-              [attr.aria-readonly]="ehAncorado('cep') || resolvendoCep() ? 'true' : null"
+              [readonly]="(ehAncorado('cep') && !editandoCep()) || resolvendoCep()"
+              [attr.aria-readonly]="(ehAncorado('cep') && !editandoCep()) || resolvendoCep() ? 'true' : null"
               [attr.aria-invalid]="cepErro() !== null ? 'true' : null"
               [attr.aria-describedby]="cepErro() !== null ? id('cep') + '-error' : null"
               (blur)="aoSairDoCep()"
             />
-            <button
-              type="button"
-              class="btn btn--secondary btn--rect"
-              [disabled]="disabled() || resolvendoCep() || ehAncorado('cep')"
-              [attr.aria-busy]="resolvendoCep() ? 'true' : null"
-              (click)="resolverCep()"
-            >
-              @if (resolvendoCep()) {
-                <ui-spinner size="sm" />
-              }
-              Buscar CEP
-            </button>
+            @if (ehAncorado('cep') && !editandoCep()) {
+              <button
+                type="button"
+                class="btn btn--secondary btn--rect"
+                [disabled]="disabled()"
+                (click)="iniciarEdicaoCep()"
+              >
+                Trocar CEP
+              </button>
+            } @else {
+              <button
+                type="button"
+                class="btn btn--secondary btn--rect"
+                [disabled]="disabled() || resolvendoCep()"
+                [attr.aria-busy]="resolvendoCep() ? 'true' : null"
+                (click)="resolverCep()"
+              >
+                @if (resolvendoCep()) {
+                  <ui-spinner size="sm" />
+                }
+                Buscar CEP
+              </button>
+            }
           </div>
           <span class="field__hint">
             Informe o CEP para preencher o endereço automaticamente, ou
@@ -290,6 +305,8 @@ export class EnderecoFormComponent implements ControlValueAccessor, Validator {
   protected readonly disabled = signal(false);
   protected readonly resolvendoCep = signal(false);
   protected readonly cepErro = signal<string | null>(null);
+  /** CEP ancorado reaberto para correção via "Trocar CEP" — ver `iniciarEdicaoCep`. */
+  protected readonly editandoCep = signal(false);
   protected readonly modoManual = signal(false);
   protected readonly cidade = signal<CidadeRef | null>(null);
   protected readonly buscaCidade = signal('');
@@ -411,6 +428,7 @@ export class EnderecoFormComponent implements ControlValueAccessor, Validator {
       this.origem.set(null);
       this.modoManual.set(false);
       this.cepErro.set(null);
+      this.editandoCep.set(false);
       this.cepResolvido.set('');
       this.cepAtual.set('');
       this.cepTextoAtual.set('');
@@ -441,6 +459,7 @@ export class EnderecoFormComponent implements ControlValueAccessor, Validator {
     // Endereço gravado manualmente reabre em modo manual (tudo editável).
     this.modoManual.set(value.origem === ORIGEM_MANUAL);
     this.cepErro.set(null);
+    this.editandoCep.set(false);
   }
 
   registerOnChange(fn: (value: EnderecoEstruturado | null) => void): void {
@@ -494,6 +513,16 @@ export class EnderecoFormComponent implements ControlValueAccessor, Validator {
     }
   }
 
+  /**
+   * Reabre o campo CEP para correção sem descartar o restante do endereço já
+   * resolvido — antes disso, a única forma de corrigir um CEP ancorado era o
+   * fluxo "sem CEP", que zera CEP e campos derivados como efeito colateral. #438.
+   */
+  protected iniciarEdicaoCep(): void {
+    this.editandoCep.set(true);
+    this.cepErro.set(null);
+  }
+
   protected resolverCep(): void {
     if (this.resolvendoCep() || this.disabled()) {
       return;
@@ -536,6 +565,7 @@ export class EnderecoFormComponent implements ControlValueAccessor, Validator {
 
   private aplicarCepResolvido(dto: CepResolvidoDto, digitos: string): void {
     this.modoManual.set(false);
+    this.editandoCep.set(false);
     this.cepResolvido.set(digitos);
     this.cidade.set({ codigoIbge: dto.codigoIbge, nome: dto.cidade, uf: dto.uf });
     this.nivel.set(normalizarNivel(dto.nivelResolucao));
@@ -560,6 +590,7 @@ export class EnderecoFormComponent implements ControlValueAccessor, Validator {
     const manual = !this.modoManual();
     this.modoManual.set(manual);
     this.cepErro.set(null);
+    this.editandoCep.set(false);
     if (manual) {
       // Entrada manual: libera todos os campos (nada ancorado) e marca a origem.
       this.nivel.set(null);

--- a/apps/configuracao/src/app/shared/endereco/endereco-form.ts
+++ b/apps/configuracao/src/app/shared/endereco/endereco-form.ts
@@ -638,13 +638,31 @@ export class EnderecoFormComponent implements ControlValueAccessor, Validator {
   }
 
   private emitir(): void {
-    const raw = this.form.getRawValue();
+    let raw = this.form.getRawValue();
+    const cepDigitos = raw.cep.replace(/\D/g, '');
+
+    if (cepDigitos.length === 0 && this.nivel() !== null) {
+      // Correção via "Trocar CEP" abandonada (campo esvaziado por completo)
+      // enquanto havia uma resolução preservada — descarta a resolução antiga
+      // e os campos derivados dela em vez de deixá-los visíveis mas fora do
+      // que é submetido (`enderecoParaCommand` só monta `endereco` com CEP de
+      // 8 dígitos; sem cidade, a cidade top-level também some). #438.
+      this.nivel.set(null);
+      this.cidade.set(null);
+      this.origem.set(null);
+      this.cepResolvido.set('');
+      this.form.patchValue(
+        { logradouro: '', complemento: '', bairro: '', distrito: '', latitude: '', longitude: '' },
+        { emitEvent: false },
+      );
+      raw = this.form.getRawValue();
+    }
+
     const cidade = this.cidade();
     // Só um CEP efetivamente resolvido pelo Geo entra no valor. Um CEP digitado
     // mas não resolvido (ex.: lookup 404, ou ainda sem "Buscar") NÃO deve virar
     // `endereco`: o mapeamento trataria os 8 dígitos como endereço válido e
     // submeteria um CEP que o usuário não conseguiu validar. #412.
-    const cepDigitos = raw.cep.replace(/\D/g, '');
     this.cepAtual.set(cepDigitos);
     this.cepTextoAtual.set(raw.cep.trim());
     const cepCorrespondeAoResolvido = cepDigitos.length > 0 && cepDigitos === this.cepResolvido();

--- a/apps/configuracao/src/app/shared/endereco/endereco-form.ts
+++ b/apps/configuracao/src/app/shared/endereco/endereco-form.ts
@@ -651,8 +651,12 @@ export class EnderecoFormComponent implements ControlValueAccessor, Validator {
       this.cidade.set(null);
       this.origem.set(null);
       this.cepResolvido.set('');
+      // numero também é limpo aqui: embora seja "dado próprio" (nunca
+      // ancorado pelo DNE), ele descreve um imóvel específico do endereço
+      // abandonado — mantê-lo faria o número vazar para o próximo CEP
+      // resolvido, que pode ser uma rua/cidade completamente diferente.
       this.form.patchValue(
-        { logradouro: '', complemento: '', bairro: '', distrito: '', latitude: '', longitude: '' },
+        { logradouro: '', numero: '', complemento: '', bairro: '', distrito: '', latitude: '', longitude: '' },
         { emitEvent: false },
       );
       raw = this.form.getRawValue();


### PR DESCRIPTION
## Contexto

Ao resolver um CEP com sucesso em `cfg-endereco-form`, o campo CEP fica
`readonly` (âncora) e o botão "Buscar CEP" fica desabilitado, sem nenhum
controle visível para corrigir um dígito errado. A única forma de correção
era fechar o formulário inteiro — perdendo Nome, Sigla, Código e-MEC etc. do
formulário pai — ou usar "preencher sem CEP" como workaround não-óbvio, que
zera CEP e todos os campos derivados como efeito colateral (não foi desenhado
para esse fluxo).

Reproduzido no formulário de Instituição; o componente `cfg-endereco-form` é
compartilhado com Campus e Local de Oferta.

## O que muda

- Novo botão **"Trocar CEP"**, visível apenas quando o CEP está ancorado
  (resolvido): reabre só o campo para edição (`iniciarEdicaoCep`), preservando
  o valor atual e o restante do endereço já resolvido (logradouro, bairro,
  cidade etc.) — nada é descartado.
- Uma nova resolução bem-sucedida (`aplicarCepResolvido`) re-ancora o campo
  automaticamente, voltando ao estado read-only com o endereço atualizado.
- Estado de edição é resetado em `writeValue` e `alternarModoManual` para
  evitar ficar obsoleto ao carregar um novo valor externo ou trocar de fluxo.

## Testes

- 2 testes novos em `endereco-form.spec.ts`: exibição do botão "Trocar CEP" e
  destravamento do campo sem perda de dados; correção completa (destrava →
  novo CEP → nova resolução → re-ancora).
- Suíte completa do app `configuracao`: 202/202 passando.
- `nx lint configuracao`: limpo.
- `nx build configuracao`: build de produção OK (warning de budget
  pré-existente, não relacionado a esta mudança).

## Verificação manual

Não foi possível exercitar o fluxo completo em navegador contra o backend
real — a rota exige `authGuard` (login Keycloak) e o app não sobe sem a
stack completa localmente. A verificação foi feita via testes Vitest que
simulam clique real nos botões e leem o atributo `readOnly` do DOM
renderizado pelo Angular (TestBed + HttpTestingController), cobrindo o
mesmo comportamento que seria observado no navegador.

## Escopo

- Não inclui botão "Cancelar" explícito — não pedido pela issue; clicar
  "Buscar CEP" com o mesmo CEP já re-resolve e re-trava o campo.
- Não inclui foco/seleção automática do campo ao destravar — nice-to-have
  não exigido pela issue.

Closes `#438`