### PR TITLE
fix(configuracao): concatena tipo ao logradouro resolvido pelo CEP

### DIFF
--- a/apps/configuracao-e2e/src/specs/endereco.flow.spec.ts
+++ b/apps/configuracao-e2e/src/specs/endereco.flow.spec.ts
@@ -18,7 +18,7 @@ const CORS_HEADERS = {
 
 const CEP_LOGRADOURO = {
   cep: '68507590',
-  tipo: 'logradouro',
+  tipo: 'Rua',
   logradouro: 'Folha 31, Quadra 7',
   complemento: null,
   bairro: 'Nova Marabá',
@@ -85,7 +85,7 @@ test.describe('Endereço estruturado — fluxos do formulário (#412)', () => {
     await page.locator('#campus-endereco-cep').fill('68507590');
     await page.getByRole('button', { name: 'Buscar CEP' }).click();
 
-    await expect(page.locator('#campus-endereco-logradouro')).toHaveValue('Folha 31, Quadra 7');
+    await expect(page.locator('#campus-endereco-logradouro')).toHaveValue('Rua Folha 31, Quadra 7');
     await expect(page.locator('#campus-endereco-logradouro')).toHaveAttribute('readonly', '');
     await expect(page.locator('#campus-endereco-numero')).not.toHaveAttribute('readonly', '');
     await expect(page.getByText('Marabá — PA')).toBeVisible();

--- a/apps/configuracao/src/app/shared/endereco/endereco-form.spec.ts
+++ b/apps/configuracao/src/app/shared/endereco/endereco-form.spec.ts
@@ -30,7 +30,7 @@ class HostComponent {
 
 const cepLogradouro = {
   cep: '68507590',
-  tipo: 'logradouro',
+  tipo: 'Rua',
   logradouro: 'Folha 31, Quadra 7',
   complemento: null,
   bairro: 'Nova Marabá',
@@ -235,7 +235,7 @@ describe('EnderecoFormComponent', () => {
 
     expect(host.ctrl.value).toMatchObject({
       cep: '68507590',
-      logradouro: 'Folha 31, Quadra 7',
+      logradouro: 'Rua Folha 31, Quadra 7',
       bairro: 'Nova Marabá',
       cidade: { codigoIbge: '1504208', nome: 'Marabá', uf: 'PA' },
       nivelResolucao: 'logradouro',
@@ -265,9 +265,9 @@ describe('EnderecoFormComponent', () => {
     expect(cep.value).toBe('68507590');
     expect(() => botaoPorTexto(fixture, 'Trocar CEP')).toThrow();
     expect((fixture.nativeElement.querySelector('#t-logradouro') as HTMLInputElement).value).toBe(
-      'Folha 31, Quadra 7',
+      'Rua Folha 31, Quadra 7',
     );
-    expect(host.ctrl.value).toMatchObject({ logradouro: 'Folha 31, Quadra 7' });
+    expect(host.ctrl.value).toMatchObject({ logradouro: 'Rua Folha 31, Quadra 7' });
   });
 
   it('CA-01: corrige o CEP após "Trocar CEP" e re-ancora com o novo endereço resolvido — #438', () => {
@@ -320,7 +320,7 @@ describe('EnderecoFormComponent', () => {
 
     // A resolução anterior não é descartada por uma tentativa de correção que falhou.
     expect((fixture.nativeElement.querySelector('#t-logradouro') as HTMLInputElement)?.value).toBe(
-      'Folha 31, Quadra 7',
+      'Rua Folha 31, Quadra 7',
     );
     expect((fixture.nativeElement.querySelector('#t-cep-error') as HTMLElement).textContent).toContain(
       'CEP não encontrado',
@@ -333,7 +333,7 @@ describe('EnderecoFormComponent', () => {
     expect(host.ctrl.valid).toBe(true);
     expect(host.ctrl.value).toMatchObject({
       cep: '68507590',
-      logradouro: 'Folha 31, Quadra 7',
+      logradouro: 'Rua Folha 31, Quadra 7',
       nivelResolucao: 'logradouro',
     });
     expect(fixture.nativeElement.querySelector('#t-cep-error')).toBeNull();
@@ -423,7 +423,7 @@ describe('EnderecoFormComponent', () => {
 
     expect(host.ctrl.invalid).toBe(true);
     expect((fixture.nativeElement.querySelector('#t-logradouro') as HTMLInputElement)?.value).toBe(
-      'Folha 31, Quadra 7',
+      'Rua Folha 31, Quadra 7',
     );
 
     // Corrigir para o CEP original (sem nova busca) reaprova o formulário.
@@ -448,6 +448,51 @@ describe('EnderecoFormComponent', () => {
     expect(logradouro.readOnly).toBe(false);
     const bairro = fixture.nativeElement.querySelector('#t-bairro') as HTMLInputElement;
     expect(bairro.readOnly).toBe(true);
+  });
+
+  it('CA-01: concatena tipo e logradouro do Geo ao aplicar CEP resolvido — #439', () => {
+    setInput(fixture, 't-cep', '71720022');
+    botaoPorTexto(fixture, 'Buscar CEP').click();
+    controller.expectOne(`${BASE}/api/cep/71720022`).flush({
+      ...cepLogradouro,
+      cep: '71720022',
+      tipo: 'Terceira',
+      logradouro: 'Avenida Bloco 1740',
+    });
+    fixture.detectChanges();
+
+    expect(host.ctrl.value).toMatchObject({ logradouro: 'Terceira Avenida Bloco 1740' });
+    expect((fixture.nativeElement.querySelector('#t-logradouro') as HTMLInputElement).value).toBe(
+      'Terceira Avenida Bloco 1740',
+    );
+  });
+
+  it('CA-01: reproduz o segundo caso relatado na issue (Rua "8") — #439', () => {
+    setInput(fixture, 't-cep', '68508714');
+    botaoPorTexto(fixture, 'Buscar CEP').click();
+    controller.expectOne(`${BASE}/api/cep/68508714`).flush({
+      ...cepLogradouro,
+      cep: '68508714',
+      tipo: 'Rua',
+      logradouro: '8',
+    });
+    fixture.detectChanges();
+
+    expect(host.ctrl.value).toMatchObject({ logradouro: 'Rua 8' });
+  });
+
+  it('CA-01: tipo nulo mantém apenas o logradouro, sem prefixo — #439', () => {
+    setInput(fixture, 't-cep', '68500123');
+    botaoPorTexto(fixture, 'Buscar CEP').click();
+    controller.expectOne(`${BASE}/api/cep/68500123`).flush({
+      ...cepLogradouro,
+      cep: '68500123',
+      tipo: null,
+      logradouro: 'Travessa Sem Tipo',
+    });
+    fixture.detectChanges();
+
+    expect(host.ctrl.value).toMatchObject({ logradouro: 'Travessa Sem Tipo' });
   });
 
   it('CA-06: CEP inexistente (404) exibe erro inline e não exibe campos de endereço', () => {
@@ -577,7 +622,7 @@ describe('EnderecoFormComponent', () => {
     controller.expectOne(`${BASE}/api/cep/68507590`).flush(cepLogradouro);
     fixture.detectChanges();
     expect((fixture.nativeElement.querySelector('#t-logradouro') as HTMLInputElement).value).toBe(
-      'Folha 31, Quadra 7',
+      'Rua Folha 31, Quadra 7',
     );
 
     botaoPorTexto(fixture, 'preencher sem CEP').click();

--- a/apps/configuracao/src/app/shared/endereco/endereco-form.ts
+++ b/apps/configuracao/src/app/shared/endereco/endereco-form.ts
@@ -580,7 +580,7 @@ export class EnderecoFormComponent implements ControlValueAccessor, Validator {
     this.form.patchValue(
       {
         cep: dto.cep,
-        logradouro: dto.logradouro ?? '',
+        logradouro: logradouroCompleto(dto.tipo, dto.logradouro),
         complemento: dto.complemento ?? '',
         bairro: dto.bairro ?? '',
         distrito: dto.distrito ?? '',
@@ -722,4 +722,17 @@ function vazioParaNulo(value: string): string | null {
 /** Coordenada do DTO (`string | number | null`) → texto do form control. */
 function textoDeCoordenada(valor: string | number | null | undefined): string {
   return valor === null || valor === undefined ? '' : String(valor);
+}
+
+/**
+ * Nome completo do logradouro para exibição — o Geo devolve `tipo` (ex.
+ * "Rua", "Avenida", "Terceira") separado de `logradouro` porque a API não
+ * expõe um campo agregado; a concatenação precisa ser feita no client para
+ * refletir o nome real do DNE (ex. "Terceira Avenida Bloco 1740"). #439.
+ */
+function logradouroCompleto(tipo: string | null, logradouro: string | null): string {
+  if (logradouro === null || logradouro.length === 0) {
+    return '';
+  }
+  return tipo !== null && tipo.length > 0 ? `${tipo} ${logradouro}` : logradouro;
 }


### PR DESCRIPTION
## Descrição

A API do Geo retorna `tipo` (ex. "Rua", "Avenida", "Terceira") separado de `logradouro` — sem expor um campo agregado (`nomeCompleto`). O formulário de endereço (`EnderecoFormComponent.aplicarCepResolvido()`) copiava apenas `dto.logradouro`, omitindo o `tipo` e exibindo um endereço incompleto em relação ao nome real do DNE.

### Antes / depois (exemplos da issue)

| CEP | `tipo` | `logradouro` | Exibido antes | Exibido agora |
|---|---|---|---|---|
| `71720022` | `Terceira` | `Avenida Bloco 1740` | Avenida Bloco 1740 | Terceira Avenida Bloco 1740 |
| `68508714` | `Rua` | `8` | 8 | Rua 8 |

## Mudança

Extraída a função pura `logradouroCompleto(tipo, logradouro)` em `endereco-form.ts`, usada em `aplicarCepResolvido()` no lugar de `dto.logradouro ?? ''`:

- `tipo` e `logradouro` presentes → concatena (`"${tipo} ${logradouro}"`).
- `tipo` nulo/vazio → mantém só `logradouro` (comportamento anterior preservado).
- `logradouro` nulo/vazio → `''` (campo permanece vazio, ex. resolução a nível de bairro).

## Testes

- Corrigido o mock `cepLogradouro` (`tipo: 'logradouro'` → `tipo: 'Rua'`) e as expectations dependentes, que antes não exercitavam esse campo.
- Adicionados 3 casos novos cobrindo os dois exemplos reais da issue e o caso de borda `tipo: null`.
- Suíte completa do app `configuracao`: 209/209 passando. Lint e build limpos.

Closes `#439`

## Rollback

Reverter o commit — mudança isolada em um único componente compartilhado, sem alteração de contrato/API.