### PR TITLE
feat(routing): usa base-href relativo no build de portal/selecao/ingresso

### DIFF
--- a/apps/ingresso/project.json
+++ b/apps/ingresso/project.json
@@ -13,6 +13,7 @@
         "outputPath": "dist/apps/ingresso",
         "browser": "apps/ingresso/src/main.ts",
         "tsConfig": "apps/ingresso/tsconfig.app.json",
+        "baseHref": "./",
         "assets": [
           {
             "glob": "**/*",

--- a/apps/portal/project.json
+++ b/apps/portal/project.json
@@ -13,6 +13,7 @@
         "outputPath": "dist/apps/portal",
         "browser": "apps/portal/src/main.ts",
         "tsConfig": "apps/portal/tsconfig.app.json",
+        "baseHref": "./",
         "assets": [
           {
             "glob": "**/*",

--- a/apps/selecao/project.json
+++ b/apps/selecao/project.json
@@ -13,6 +13,7 @@
         "outputPath": "dist/apps/selecao",
         "browser": "apps/selecao/src/main.ts",
         "tsConfig": "apps/selecao/tsconfig.app.json",
+        "baseHref": "./",
         "assets": [
           {
             "glob": "**/*",


### PR DESCRIPTION
## Contexto

Os 3 SPAs Angular (`portal`, `selecao`, `ingresso`) hoje assumem raiz do domínio no build — sem nenhum mecanismo de subpath. Precisam ser servidos sob `uniplus-hml.unifesspa.edu.br/portal`, `/selecao`, `/ingresso` (Feature #444, roteamento path-based do ambiente HML) **sem quebrar** o deploy atual em `standalone-compact` (raiz do domínio) — a mesma imagem Docker de cada app serve os dois cenários (invariante "imagem única por app", documentado em `docker/nginx.conf`).

## Decisão: base-href relativo, não fixo

`--base-href`/`--deploy-url` do Angular são valores de **build-time**, embutidos literalmente na tag `<base href>` do `index.html` compilado. Um valor absoluto fixo (ex. `/portal/`) quebraria `standalone-compact` (que serve na raiz); build-time substitution por ambiente violaria o invariante de imagem única.

Solução: `baseHref: "./"` (relativo) em vez de um valor fixo. **Validado empiricamente antes de implementar** (não assumido pela doc): o navegador resolve `<base href="./">` para uma URL **absoluta** em `document.baseURI` — testado via Playwright servindo o build em `/portal/`, resultou em `document.baseURI = "http://host/portal/"`. Esse é exatamente o valor que o `PathLocationStrategy` do Angular lê internamente (`getBaseHrefFromDOM()`), então o comportamento é idêntico a um `base href="/portal/"` fixo, sem precisar hardcode nenhum path.

## O que muda

`baseHref: "./"` adicionado ao build de `portal`, `selecao` e `ingresso` (`project.json`, opção compartilhada por todas as configurations). Sem mudança de código — assets (scripts, styles, favicon) já saem com paths relativos no `index.html` gerado, confirmado nos 3 builds.

## Requisito colateral (fora do escopo desta PR)

A URL do subpath precisa **sempre terminar em barra** (`/portal/`, não `/portal`) para o navegador resolver o base href relativo corretamente — vira responsabilidade da configuração nginx/Traefik (story de nginx, próxima da Feature #444).

## Validação

- Build dos 3 apps em `production` — `<base href="./"/>` confirmado nos 3 `index.html` gerados, assets relativos
- Teste real com Playwright: servido em `/portal/` (subpath simulado com servidor Node dedicado), `document.baseURI` resolveu corretamente para a URL absoluta esperada; chunks JS carregaram do path correto
- `lint` limpo nos 3 apps
- Service Worker e SSR/prerendering não estão habilitados neste workspace hoje (sem `ngsw-config.json`, sem `server`/`ssr` no `project.json`) — não há caso a considerar para esta mudança
- Não rodei a suíte E2E completa (exige backend/Keycloak local, ver `docs/guia-testar-frontend-com-backend-local.md`) — nenhum spec existente referencia `base href` diretamente (`grep` limpo)

## Critérios de aceite (issue #445)

- [x] `--base-href` configurável adicionado ao build de `portal`, `selecao`, `ingresso`

Closes #445
Refs #444