### PR TITLE
fix(routing): corrige base href em deep links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,9 @@ jobs:
               - 'eslint.config.mjs'
               - 'vitest.workspace.ts'
               - 'playwright.config.ts'
+              - 'docker/**'
               - 'tools/e2e-docker/**'
+              - 'tools/test-nginx-base-href.sh'
               - '.github/workflows/ci.yml'
 
       - id: gate
@@ -144,6 +146,10 @@ jobs:
 
       - if: steps.gate.outputs.run == 'true'
         run: npm ci
+
+      - name: Validar base href sob subpath
+        if: steps.gate.outputs.run == 'true'
+        run: bash tools/test-nginx-base-href.sh
 
       - name: Extrair versão do Playwright
         id: pw-version

--- a/apps/ingresso/project.json
+++ b/apps/ingresso/project.json
@@ -13,7 +13,6 @@
         "outputPath": "dist/apps/ingresso",
         "browser": "apps/ingresso/src/main.ts",
         "tsConfig": "apps/ingresso/tsconfig.app.json",
-        "baseHref": "./",
         "assets": [
           {
             "glob": "**/*",

--- a/apps/portal/project.json
+++ b/apps/portal/project.json
@@ -13,7 +13,6 @@
         "outputPath": "dist/apps/portal",
         "browser": "apps/portal/src/main.ts",
         "tsConfig": "apps/portal/tsconfig.app.json",
-        "baseHref": "./",
         "assets": [
           {
             "glob": "**/*",

--- a/apps/selecao/project.json
+++ b/apps/selecao/project.json
@@ -13,7 +13,6 @@
         "outputPath": "dist/apps/selecao",
         "browser": "apps/selecao/src/main.ts",
         "tsConfig": "apps/selecao/tsconfig.app.json",
-        "baseHref": "./",
         "assets": [
           {
             "glob": "**/*",

--- a/docker/Dockerfile.configuracao
+++ b/docker/Dockerfile.configuracao
@@ -8,7 +8,11 @@ RUN npx nx build configuracao --configuration=production
 
 # Stage 2: Serve — base unprivileged (UID 101, listen :8080) — #4 hardening.
 FROM nginxinc/nginx-unprivileged:1.27-alpine
-COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+ENV APP_BASE_HREF=/
+ENV NGINX_ENVSUBST_FILTER=^APP_BASE_(HREF|PATH)$
+RUN rm /etc/nginx/conf.d/default.conf
+COPY --chown=nginx:nginx docker/nginx.conf.template /etc/nginx/templates/default.conf.template
+COPY --chmod=755 docker/prepare-base-href.envsh /docker-entrypoint.d/10-prepare-base-href.envsh
 COPY --from=build --chown=nginx:nginx /app/dist/apps/configuracao/browser /usr/share/nginx/html
 # Sobrescreve o runtime-config.json copiado do dist (que tem URLs DEV
 # de localhost) por placeholders inválidos. Garante que produção sem

--- a/docker/Dockerfile.ingresso
+++ b/docker/Dockerfile.ingresso
@@ -8,7 +8,11 @@ RUN npx nx build ingresso --configuration=production
 
 # Stage 2: Serve — base unprivileged (UID 101, listen :8080) — #4 hardening.
 FROM nginxinc/nginx-unprivileged:1.27-alpine
-COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+ENV APP_BASE_HREF=/
+ENV NGINX_ENVSUBST_FILTER=^APP_BASE_(HREF|PATH)$
+RUN rm /etc/nginx/conf.d/default.conf
+COPY --chown=nginx:nginx docker/nginx.conf.template /etc/nginx/templates/default.conf.template
+COPY --chmod=755 docker/prepare-base-href.envsh /docker-entrypoint.d/10-prepare-base-href.envsh
 COPY --from=build --chown=nginx:nginx /app/dist/apps/ingresso/browser /usr/share/nginx/html
 # Sobrescreve o runtime-config.json copiado do dist (que tem URLs DEV
 # de localhost) por placeholders inválidos. Garante que produção sem

--- a/docker/Dockerfile.portal
+++ b/docker/Dockerfile.portal
@@ -8,7 +8,11 @@ RUN npx nx build portal --configuration=production
 
 # Stage 2: Serve — base unprivileged (UID 101, listen :8080) — #4 hardening.
 FROM nginxinc/nginx-unprivileged:1.27-alpine
-COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+ENV APP_BASE_HREF=/
+ENV NGINX_ENVSUBST_FILTER=^APP_BASE_(HREF|PATH)$
+RUN rm /etc/nginx/conf.d/default.conf
+COPY --chown=nginx:nginx docker/nginx.conf.template /etc/nginx/templates/default.conf.template
+COPY --chmod=755 docker/prepare-base-href.envsh /docker-entrypoint.d/10-prepare-base-href.envsh
 COPY --from=build --chown=nginx:nginx /app/dist/apps/portal/browser /usr/share/nginx/html
 # Sobrescreve o runtime-config.json copiado do dist (que tem URLs DEV
 # de localhost) por placeholders inválidos. Garante que produção sem

--- a/docker/Dockerfile.selecao
+++ b/docker/Dockerfile.selecao
@@ -8,7 +8,11 @@ RUN npx nx build selecao --configuration=production
 
 # Stage 2: Serve — base unprivileged (UID 101, listen :8080) — #4 hardening.
 FROM nginxinc/nginx-unprivileged:1.27-alpine
-COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+ENV APP_BASE_HREF=/
+ENV NGINX_ENVSUBST_FILTER=^APP_BASE_(HREF|PATH)$
+RUN rm /etc/nginx/conf.d/default.conf
+COPY --chown=nginx:nginx docker/nginx.conf.template /etc/nginx/templates/default.conf.template
+COPY --chmod=755 docker/prepare-base-href.envsh /docker-entrypoint.d/10-prepare-base-href.envsh
 COPY --from=build --chown=nginx:nginx /app/dist/apps/selecao/browser /usr/share/nginx/html
 # Sobrescreve o runtime-config.json copiado do dist (que tem URLs DEV
 # de localhost) por placeholders inválidos. Garante que produção sem

--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -2,6 +2,11 @@
 # Imagem base é `nginxinc/nginx-unprivileged` (#4 hardening) — escuta em :8080
 # como UID 101, sem CAP_NET_BIND_SERVICE.
 #
+# APP_BASE_HREF é configurado no runtime do container. A imagem continua única
+# por app: `/` atende standalone-compact/lab; `/portal/`, `/selecao/` e
+# `/ingresso/` atendem o HML path-based sem rebuild. O Traefik não remove o
+# prefixo, por isso as locations abaixo o removem antes de buscar o arquivo.
+#
 # Headers de segurança e CSP cobrem o requisito da #4. Runtime config (#84)
 # vive em /assets/runtime-config.json, servido aqui mas montado por ConfigMap
 # em produção — `connect-src` precisa permitir URLs externas que o ConfigMap
@@ -14,8 +19,25 @@ server {
     index index.html;
 
     server_tokens off;
+    # O redirect para a barra final precisa manter host e porta originais do
+    # cliente (especialmente atrás do Traefik), não expor localhost:8080.
+    absolute_redirect off;
 
-    # Healthcheck estático (smoke pós-build via docker run + curl).
+    # A tag <base> é compilada como raiz e substituída pelo mount point em
+    # runtime. Diferentemente de `./`, um caminho absoluto permanece correto
+    # após hard reload em uma rota com múltiplos segmentos.
+    sub_filter_once on;
+    sub_filter '<base href="/">' '<base href="${APP_BASE_HREF}">';
+
+    # Mantém a URL canônica com barra final. `APP_BASE_PATH` é derivado pelo
+    # entrypoint a partir de APP_BASE_HREF e fica em um path inócuo na raiz.
+    location = ${APP_BASE_PATH} {
+        return 308 ${APP_BASE_HREF};
+    }
+
+    # Healthcheck estático (smoke pós-build via docker run + curl). O probe
+    # do Kubernetes chega diretamente ao Pod, portanto fica deliberadamente
+    # na raiz mesmo quando a app é exposta por subpath no Traefik.
     location = /health.json {
         access_log off;
         default_type application/json;
@@ -26,7 +48,8 @@ server {
     # Runtime config (ADR-0020 + #84) — sobrescrito por ConfigMap em produção.
     # `no-store` garante que o navegador sempre busca a versão atual ao carregar
     # a app, mesmo após bump de ConfigMap sem rolling restart.
-    location = /assets/runtime-config.json {
+    location = ${APP_BASE_HREF}assets/runtime-config.json {
+        rewrite ^${APP_BASE_HREF}(.*)$ /$1 break;
         add_header Cache-Control "no-store" always;
         try_files $uri =404;
     }
@@ -37,7 +60,8 @@ server {
     # Esta location explicita a CSP relaxada SOMENTE para esse arquivo —
     # nginx requer redeclarar TODOS os add_header desejados quando algum é
     # definido na location (regra de override do `add_header`).
-    location = /assets/silent-check-sso.html {
+    location = ${APP_BASE_HREF}assets/silent-check-sso.html {
+        rewrite ^${APP_BASE_HREF}(.*)$ /$1 break;
         add_header Cache-Control "no-store" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header X-Frame-Options "SAMEORIGIN" always;
@@ -56,13 +80,22 @@ server {
         try_files $uri =404;
     }
 
-    location / {
-        try_files $uri $uri/ /index.html;
-    }
-
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|unityweb)$ {
+    # Arquivos versionados precisam ser servidos pelo mount point, mas existem
+    # fisicamente na raiz do artefato. A reescrita é interna: a URL visível e
+    # o base href continuam com o prefixo configurado.
+    location ~* ^${APP_BASE_HREF}.*\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|unityweb)$ {
+        rewrite ^${APP_BASE_HREF}(.*)$ /$1 break;
+        try_files $uri =404;
         expires 1y;
         add_header Cache-Control "public, immutable";
+    }
+
+    # Toda rota da SPA, inclusive deep links, perde o prefixo apenas para o
+    # lookup local. Sem isso `/selecao/foo/bar` procuraria um arquivo físico em
+    # `/usr/share/nginx/html/selecao/foo/bar`.
+    location ${APP_BASE_HREF} {
+        rewrite ^${APP_BASE_HREF}(.*)$ /$1 break;
+        try_files $uri $uri/ /index.html;
     }
 
     # Headers de segurança (#4). HSTS aplicado pelo gateway TLS em produção

--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -32,7 +32,9 @@ server {
     # Mantém a URL canônica com barra final. `APP_BASE_PATH` é derivado pelo
     # entrypoint a partir de APP_BASE_HREF e fica em um path inócuo na raiz.
     location = ${APP_BASE_PATH} {
-        return 308 ${APP_BASE_HREF};
+        # `$is_args$args` evita perder parâmetros de deep links, inclusive
+        # callbacks OIDC que chegam sem a barra final.
+        return 308 ${APP_BASE_HREF}$is_args$args;
     }
 
     # Healthcheck estático (smoke pós-build via docker run + curl). O probe

--- a/docker/prepare-base-href.envsh
+++ b/docker/prepare-base-href.envsh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -eu
+
+# O valor é interpolado no template Nginx antes do processo iniciar. Aceitar
+# somente raiz ou segmentos URL seguros evita configuração malformada e garante
+# que toda base não-raiz comece e termine com barra.
+if ! printf '%s' "${APP_BASE_HREF:-}" | grep -Eq '^/([A-Za-z0-9_-]+/)*$'; then
+  echo "APP_BASE_HREF inválido: use / ou /segmento/subsegmento/." >&2
+  exit 1
+fi
+
+# A location exata só é necessária para subpaths. Nginx não aceita uma
+# location vazia; na raiz usamos um path reservado que nunca é publicado.
+if [ "$APP_BASE_HREF" = / ]; then
+  export APP_BASE_PATH=/__uniplus-root-base-href__
+else
+  export APP_BASE_PATH="${APP_BASE_HREF%/}"
+fi

--- a/docs/adrs/0028-base-href-parametrizado-em-runtime.md
+++ b/docs/adrs/0028-base-href-parametrizado-em-runtime.md
@@ -1,0 +1,75 @@
+---
+status: "accepted"
+date: "2026-07-15"
+decision-makers:
+  - "Tech Lead"
+consulted:
+  - "DevOps"
+informed:
+  - "Apps portal, selecao, ingresso e configuracao"
+---
+
+# ADR-0028: `base href` parametrizado em runtime pelo container Nginx
+
+## Contexto e enunciado do problema
+
+A Feature #444 prepara as SPAs Angular para operar tanto na raiz do host quanto sob paths como `/portal/`, `/selecao/` e `/ingresso/`, sem `StripPrefix` no Traefik. A story #445 adotou `baseHref: "./"` no build para preservar a imagem única por app da ADR-0020. Essa solução só foi validada na raiz do subpath: em um hard reload para uma rota com dois ou mais segmentos, a resolução padrão de URL trata o último segmento como arquivo. Assim, em `/selecao/inscricoes/123`, `./` passa a apontar para `/selecao/inscricoes/`, e não para `/selecao/`.
+
+O defeito foi reproduzido pela suíte de `configuracao` durante a story #446 e está registrado em #462. O fallback de SPA sozinho não o elimina: ele devolve o `index.html`, mas a URL profunda do documento continua sendo a base usada pelo navegador para resolver assets e chunks.
+
+Além do HTML, o Nginx recebe do Traefik o path completo — não há `StripPrefix`. Portanto, uma requisição como `/selecao/assets/main.js` precisa ser mapeada internamente para o arquivo físico `/assets/main.js`, preservando o prefixo na URL pública.
+
+## Drivers da decisão
+
+- Corrigir hard reload e deep links de qualquer profundidade sob subpath.
+- Preservar a imagem única por app entre standalone-compact, lab e HML, conforme ADR-0020 e ADR-0021.
+- Não embutir o prefixo de um ambiente no bundle Angular.
+- Manter `runtime-config.json`, silent SSO, assets versionados e healthcheck coerentes sob raiz e subpath.
+- Tornar a regressão reproduzível localmente sem backend, OIDC ou cluster.
+
+## Opções consideradas
+
+- **A. Manter `baseHref: "./"` no build e ampliar somente o fallback de SPA** — mantém o bundle único, mas não muda a regra de resolução relativa do navegador após hard reload; não corrige #462.
+- **B. Gerar uma imagem por ambiente com `baseHref` absoluto** — funciona tecnicamente, mas viola o invariante de imagem única e exige rebuild para promover o mesmo release entre ambientes.
+- **C. Configurar um `base href` absoluto em runtime no Nginx** — o bundle permanece com `<base href="/">`; o container injeta a base de montagem e remove o prefixo apenas para servir os arquivos locais.
+
+## Resultado da decisão
+
+**Escolhida:** "C. Configurar um `base href` absoluto em runtime no Nginx", porque corrige a semântica de URL em rotas profundas sem tornar a imagem dependente do ambiente.
+
+Os builds de `portal`, `selecao` e `ingresso` deixam de definir `baseHref: "./"`, voltando a emitir `<base href="/">`. O template Nginx recebe `APP_BASE_HREF`, cujo valor válido é `/` ou um caminho absoluto terminado em barra, como `/selecao/`. O valor padrão da imagem é `/`; assim, standalone-compact e lab não exigem configuração adicional.
+
+Na inicialização, o entrypoint oficial `envsubst` gera a configuração Nginx com esse valor. O Nginx substitui a tag `<base href="/">` da resposta HTML, redireciona o subpath sem barra final para a forma canônica e remove internamente o prefixo ao procurar `index.html`, `assets/runtime-config.json`, silent SSO e assets versionados. A URL exibida pelo navegador não é reescrita. Logo, um documento carregado em `/selecao/inscricoes/123` recebe a base absoluta `/selecao/`, e os chunks são buscados em `/selecao/assets/...`.
+
+O chart `uniplus-infra` continua responsável por fornecer o valor efetivo: quando `pathPrefix` é vazio, `APP_BASE_HREF=/`; quando for `/portal`, deve injetar `APP_BASE_HREF=/portal/`. Essa alteração é parte da story `uniplus-infra#448`; este repositório não codifica paths de ambiente.
+
+## Consequências
+
+### Positivas
+
+- Deep links com dois ou mais segmentos funcionam porque a base é absoluta e independente da URL atual.
+- A mesma imagem pode ser promovida entre raiz e subpath sem rebuild.
+- Traefik continua sem `StripPrefix`; o mapeamento para o filesystem é encapsulado no container que conhece seu mount point.
+- A validação local cobre raiz e os quatro apps sob subpath, incluindo uma rota aninhada e o carregamento de assets e runtime config.
+
+### Negativas
+
+- O container passa a depender dos scripts de template da imagem oficial Nginx; a versão é pinada e o teste de regressão executa a mesma imagem.
+- A ativação em HML exige a alteração coordenada no chart do `uniplus-infra`; publicar somente esta mudança ainda mantém o valor padrão `/`.
+
+### Neutras
+
+- `APP_BASE_HREF` não contém URLs de API, segredos nem parâmetros OIDC; esses continuam no `runtime-config.json` montado por ConfigMap.
+- `configuracao` recebe a mesma capacidade e cobertura de regressão, embora os paths públicos planejados da Feature #444 sejam portal, seleção e ingresso.
+
+## Confirmação
+
+`bash tools/test-nginx-base-href.sh` inicia a imagem `nginxinc/nginx-unprivileged:1.27-alpine` com o template real, para cada base `/`, `/portal/`, `/selecao/`, `/ingresso/` e `/configuracao/`. Para cada cenário, o teste faz hard reload em `rota/aninhada`, verifica o `<base href>` absoluto retornado, confirma o redirecionamento da forma sem barra e busca assets e `runtime-config.json` através do mesmo prefixo.
+
+## Mais informações
+
+- Issue #462 — defeito de `baseHref: "./"` em navegação direta para rota profunda.
+- Feature #444 e story #445 — subpath Angular; a decisão original foi implementada pelo PR #460.
+- PR #461 — resolução de runtime config, silent SSO e VLibras com `document.baseURI`; identificou #462.
+- Story `uniplus-infra#448` — parametrização do Nginx/chart por subpath.
+- ADR-0020 e ADR-0021 — invariante de imagem única e configuração de runtime.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -56,6 +56,7 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0025](0025-autoria-css-scss-no-angular.md) | Autoria CSS/SCSS nos componentes Angular | accepted | 2026-05-31 |
 | [0026](0026-navegacao-lista-prev-next-cursor-bidirecional.md) | Navegação de lista por prev/next sobre cursor bidirecional | accepted | 2026-06-16 |
 | [0027](0027-modelagem-papeis-dominio-frontend.md) | Modelagem de papéis de domínio no frontend — `UserRole` como contrato de display | accepted | 2026-06-24 |
+| [0028](0028-base-href-parametrizado-em-runtime.md) | `base href` parametrizado em runtime pelo container Nginx | accepted | 2026-07-15 |
 
 ## Como adicionar um novo ADR
 

--- a/tools/test-nginx-base-href.sh
+++ b/tools/test-nginx-base-href.sh
@@ -74,6 +74,14 @@ run_case() {
   fi
   grep -Fq "<base href=\"$base_href\">" <<<"$html"
   if [[ "$base_href" != / ]]; then
+    # A canonicalização sem a barra final não pode descartar parâmetros de
+    # callback/deep link (por exemplo, code e state enviados pelo OIDC).
+    if ! curl --silent --show-error --dump-header - --output /dev/null \
+      "http://127.0.0.1:$host_port${base_href%/}?code=authorization-code&state=opaque-state" \
+      | grep -Fq "Location: ${base_href}?code=authorization-code&state=opaque-state"; then
+      docker logs "$container" >&2 || true
+      exit 1
+    fi
     if ! curl --fail --silent --show-error --location "http://127.0.0.1:$host_port${base_href%/}" \
       | grep -Fq "<base href=\"$base_href\">"; then
       docker logs "$container" >&2 || true

--- a/tools/test-nginx-base-href.sh
+++ b/tools/test-nginx-base-href.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+# Regressão de #462: executa o template Nginx na mesma imagem de produção e
+# verifica hard reload de rota aninhada, base absoluto e assets sob o subpath.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+IMAGE="nginxinc/nginx-unprivileged:1.27-alpine"
+TEMPLATE="$REPO_ROOT/docker/nginx.conf.template"
+PREPARE_BASE_HREF="$REPO_ROOT/docker/prepare-base-href.envsh"
+FIXTURE_DIR="$(mktemp -d)"
+CONTAINERS=()
+
+# nginxinc/nginx-unprivileged executa como UID 101 e precisa atravessar o
+# diretório temporário montado no container.
+chmod 755 "$FIXTURE_DIR"
+
+cleanup() {
+  for container in "${CONTAINERS[@]}"; do
+    docker rm -f "$container" >/dev/null 2>&1 || true
+  done
+  rm -rf "$FIXTURE_DIR"
+}
+trap cleanup EXIT
+
+for command in curl docker grep mktemp; do
+  command -v "$command" >/dev/null || {
+    echo "ERRO: comando obrigatório ausente: $command" >&2
+    exit 1
+  }
+done
+
+mkdir -p "$FIXTURE_DIR/assets"
+printf '%s\n' '<!doctype html><html><head><base href="/"></head><body>Uni+</body></html>' \
+  > "$FIXTURE_DIR/index.html"
+printf '%s\n' 'console.log("asset-ok");' > "$FIXTURE_DIR/assets/main.js"
+printf '%s\n' '{"apiUrl":"https://api.invalid"}' > "$FIXTURE_DIR/assets/runtime-config.json"
+printf '%s\n' '<!doctype html><title>silent</title>' > "$FIXTURE_DIR/assets/silent-check-sso.html"
+
+run_case() {
+  local name="$1"
+  local base_href="$2"
+  local container="uniplus-web-base-href-${name}-$$"
+  local host_port
+  local html
+
+  CONTAINERS+=("$container")
+  docker run -d --rm --name "$container" -P \
+    -e "APP_BASE_HREF=$base_href" \
+    -e 'NGINX_ENVSUBST_FILTER=^APP_BASE_(HREF|PATH)$' \
+    -v "$TEMPLATE:/etc/nginx/templates/default.conf.template:ro" \
+    -v "$PREPARE_BASE_HREF:/docker-entrypoint.d/10-prepare-base-href.envsh:ro" \
+    -v "$FIXTURE_DIR:/usr/share/nginx/html:ro" \
+    "$IMAGE" >/dev/null
+
+  for _ in {1..20}; do
+    host_port="$(docker port "$container" 8080/tcp 2>/dev/null | head -1 | sed 's/.*://')"
+    if [[ -n "$host_port" ]] && curl --fail --silent "http://127.0.0.1:$host_port/health.json" >/dev/null; then
+      break
+    fi
+    sleep 0.25
+  done
+
+  [[ -n "${host_port:-}" ]] || {
+    echo "ERRO: Nginx não publicou a porta para $name" >&2
+    docker logs "$container" >&2 || true
+    exit 1
+  }
+
+  if ! html="$(curl --fail --silent --show-error "http://127.0.0.1:$host_port${base_href}rota/aninhada")"; then
+    docker logs "$container" >&2 || true
+    exit 1
+  fi
+  grep -Fq "<base href=\"$base_href\">" <<<"$html"
+  if [[ "$base_href" != / ]]; then
+    if ! curl --fail --silent --show-error --location "http://127.0.0.1:$host_port${base_href%/}" \
+      | grep -Fq "<base href=\"$base_href\">"; then
+      docker logs "$container" >&2 || true
+      exit 1
+    fi
+  fi
+  curl --fail --silent --show-error "http://127.0.0.1:$host_port${base_href}assets/main.js" \
+    | grep -Fq 'asset-ok'
+  curl --fail --silent --show-error "http://127.0.0.1:$host_port${base_href}assets/runtime-config.json" \
+    | grep -Fq 'apiUrl'
+  docker exec "$container" nginx -t >/dev/null
+
+  echo "ok   $name ($base_href)"
+}
+
+# Raiz preserva standalone-compact/lab. Os quatro apps exercitam uma rota com
+# dois segmentos sob subpath, exatamente o cenário que falhava com `./`.
+run_case root /
+run_case portal /portal/
+run_case selecao /selecao/
+run_case ingresso /ingresso/
+run_case configuracao /configuracao/
+
+for dockerfile in "$REPO_ROOT"/docker/Dockerfile.{portal,selecao,ingresso,configuracao}; do
+  grep -Fq 'ENV APP_BASE_HREF=/' "$dockerfile"
+  grep -Fq 'docker/nginx.conf.template' "$dockerfile"
+  grep -Fq 'docker/prepare-base-href.envsh' "$dockerfile"
+done
+
+echo '5 cenários de base href validados.'


### PR DESCRIPTION
## O que muda

- remove o `baseHref: "./"` dos builds de portal, seleção e ingresso;
- parametriza o `base href` no runtime do container com `APP_BASE_HREF`;
- remove internamente o prefixo encaminhado pelo Traefik, sem `StripPrefix`, para servir SPA, assets, runtime config e silent SSO;
- normaliza `/portal` para `/portal/` sem expor `localhost:8080`;
- registra a ADR-0028 e adiciona teste de regressão no CI.

## Causa raiz

`base href="./"` é resolvido contra a URL do documento. Em um hard reload para uma rota profunda, como `/selecao/inscricoes/123`, ele passa a apontar para `/selecao/inscricoes/` e quebra o carregamento de assets e chunks.

## Validação

- `bash tools/test-nginx-base-href.sh` — raiz, portal, seleção, ingresso e configuração; hard reload em rota aninhada, assets, runtime config e barra final.
- ADR lint e Markdown lint.
- lint, testes (212), builds e typechecks de portal, seleção, ingresso e configuração.

## Dependência de ativação

O chart em `uniplus-infra#448` deve injetar `APP_BASE_HREF=/portal/`, `/selecao/` ou `/ingresso/` conforme `pathPrefix`. Sem esse ajuste coordenado, as imagens mantêm corretamente o comportamento padrão de raiz.

Closes #462
