### PR TITLE
Corrige exibição do componente empty state

### DIFF
--- a/apps/configuracao/src/app/features/condicoes-atendimento/condicoes-atendimento-list.spec.ts
+++ b/apps/configuracao/src/app/features/condicoes-atendimento/condicoes-atendimento-list.spec.ts
@@ -85,6 +85,18 @@ describe('CondicoesAtendimentoListPage', () => {
     expect(fixture.nativeElement.textContent).toContain('Nenhuma condição de atendimento carregada');
   });
 
+  it('busca sem resultado mostra o empty-state de filtro, não o de lista vazia', async () => {
+    await flushLista([condicao_atendimento_seed]);
+
+    component['termoBusca'].set('condicao-inexistente');
+    fixture.detectChanges();
+
+    expect(component['condicoesFiltradas']()).toHaveLength(0);
+    expect(fixture.nativeElement.textContent).toContain('Nenhuma condição de atendimento encontrada');
+    expect(fixture.nativeElement.textContent).toContain('Ajuste a busca para ver resultados.');
+    expect(fixture.nativeElement.textContent).not.toContain('Nenhuma condição de atendimento carregada');
+  });
+
   it('renderiza a lista de condições de atendimento', async () => {
     await flushLista([condicao_atendimento_seed]);
     expect(component['condicoes']()).toHaveLength(1);

--- a/apps/configuracao/src/app/features/condicoes-atendimento/condicoes-atendimento-list.ts
+++ b/apps/configuracao/src/app/features/condicoes-atendimento/condicoes-atendimento-list.ts
@@ -55,11 +55,6 @@ interface CondicaoAtendimentoForm {
   descricao: FormControl<string>;
 }
 
-export interface CondicaoAtendimentoTipoOption {
-  readonly value: string;
-  readonly label: string;
-}
-
 type PaginaProps = {
   readonly cursor: Cursor;
   readonly direction: PaginationDirection
@@ -510,19 +505,6 @@ export class CondicoesAtendimentoListPage implements OnInit {
       }),
   });
   protected readonly formError = signal<string | null>(null);
-  // Busca client-side sobre a página carregada: o backend (api#588) só pagina
-  // por cursor, sem filtro de texto/código/nome no contrato.
-  protected readonly registrosFiltrados = computed(() => {
-    const termo = this.termoBusca().trim().toLocaleLowerCase('pt-BR');
-    if (termo.length === 0) {
-      return this.registros();
-    }
-    return this.registros().filter(
-      (registro) =>
-        registro.codigo.toLocaleLowerCase('pt-BR').includes(termo) ||
-        registro.nome.toLocaleLowerCase('pt-BR').includes(termo),
-    );
-  });
 
   constructor() {
     effect(() => {

--- a/apps/configuracao/src/app/features/condicoes-atendimento/condicoes-atendimento-list.ts
+++ b/apps/configuracao/src/app/features/condicoes-atendimento/condicoes-atendimento-list.ts
@@ -248,7 +248,7 @@ function controlNameFromBackendField(field: string): keyof CondicaoAtendimentoFo
           @if (temFiltro()) {
             <ui-empty-state
               heading="Nenhuma condição de atendimento encontrada"
-              description="Ajuste a busca ou o filtro de tipo para ver resultados."
+              description="Ajuste a busca para ver resultados."
             >
               <button type="button" class="btn btn--secondary" (click)="limparFiltros()">
                 Limpar filtros
@@ -477,7 +477,7 @@ export class CondicoesAtendimentoListPage implements OnInit {
   readonly confirmOpen = signal(false);
   protected readonly modo = signal<ModoFormulario>('criar');
   protected readonly idempotencyKeyAtual = signal(idempotencyKey.create());
-  readonly temFiltro = signal(false);
+  readonly temFiltro = computed(() => this.termoBusca().trim().length > 0);
   protected readonly formHeading = computed(() =>
     this.modo() === 'criar' ? 'Nova condição de atendimento' : 'Editar condição de atendimento',
   );

--- a/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.spec.ts
+++ b/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.spec.ts
@@ -83,6 +83,18 @@ describe('RecursosAcessibilidadeListPage', () => {
     expect(fixture.nativeElement.textContent).toContain('Nenhum recurso de acessibilidade carregado');
   });
 
+  it('busca sem resultado mostra o empty-state de filtro, não o de lista vazia', async () => {
+    await flushLista([recurso_acessibilidade_seed]);
+
+    component['termoBusca'].set('recurso-inexistente');
+    fixture.detectChanges();
+
+    expect(component['recursosFiltrados']()).toHaveLength(0);
+    expect(fixture.nativeElement.textContent).toContain('Nenhum recurso de acessibilidade encontrado');
+    expect(fixture.nativeElement.textContent).toContain('Ajuste a busca para ver resultados.');
+    expect(fixture.nativeElement.textContent).not.toContain('Nenhum recurso de acessibilidade carregado');
+  });
+
   it('renderiza a lista de recursos de acessibilidade', async () => {
     await flushLista([recurso_acessibilidade_seed]);
     expect(component['recursos']()).toHaveLength(1);

--- a/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.ts
+++ b/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.ts
@@ -445,7 +445,7 @@ export class RecursosAcessibilidadeListPage {
   });
   protected readonly formError = signal<string | null>(null);
   readonly condicaoEmEdicaoId = signal<string | null>(null);
-  readonly temFiltro = computed(() => this.termoBusca().trim().length > 0);
+  protected readonly temFiltro = computed(() => this.termoBusca().trim().length > 0);
 
   protected readonly formHeading = computed(() =>
     this.modo() === 'criar' ? 'Novo recurso de acessibilidade' : 'Editar recurso de acessibilidade',

--- a/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.ts
+++ b/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.ts
@@ -62,11 +62,6 @@ interface RecursoAcessibilidadeForm {
   descricao: FormControl<string>;
 }
 
-export interface CondicaoAtendimentoTipoOption {
-  readonly value: string;
-  readonly label: string;
-}
-
 /** Vendor code do DomainError `RecursoAcessibilidade.NomeJaExiste` (uniplus-api, 409 Conflict). */
 const RECURSO_ACESSIBILIDADE_NOME_JA_EXISTE_CODE = 'uniplus.configuracao.recurso_acessibilidade.nome_ja_existe';
 
@@ -215,8 +210,7 @@ const PAGE_SIZE = 50;
                         <button
                           type="button"
                           class="btn btn--tertiary btn--sm btn--rect"
-                          [disabled]="isLoading()"
-                          [disabled]="submitting()"
+                          [disabled]="isLoading() || submitting()"
                           (click)="abrirInativarRecurso(recursoAcessibilidade)"
                         >
                           Inativar
@@ -434,7 +428,6 @@ export class RecursosAcessibilidadeListPage {
   protected readonly formOpen = signal(false);
   protected readonly saving = signal(false);
   readonly drawerOpen = signal(false);
-  readonly editTarget = signal<unknown | null>(null);
   readonly submitting = signal(false);
   readonly recursoParaInativar = signal<RecursoAcessibilidadeDto | null>(null);
   readonly confirmOpen = signal(false);

--- a/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.ts
+++ b/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.ts
@@ -210,7 +210,8 @@ const PAGE_SIZE = 50;
                         <button
                           type="button"
                           class="btn btn--tertiary btn--sm btn--rect"
-                          [disabled]="isLoading() || submitting()"
+                          [disabled]="loading() || submitting()"
+                          [aria-disabled]="loading() || submitting()"
                           (click)="abrirInativarRecurso(recursoAcessibilidade)"
                         >
                           Inativar

--- a/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.ts
+++ b/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.ts
@@ -231,7 +231,7 @@ const PAGE_SIZE = 50;
           @if (temFiltro()) {
             <ui-empty-state
               heading="Nenhum recurso de acessibilidade encontrado"
-              description="Ajuste a busca ou o filtro de tipo para ver resultados."
+              description="Ajuste a busca para ver resultados."
             >
               <button type="button" class="btn btn--secondary" (click)="limparFiltros()">
                 Limpar filtros
@@ -451,7 +451,7 @@ export class RecursosAcessibilidadeListPage {
   });
   protected readonly formError = signal<string | null>(null);
   readonly condicaoEmEdicaoId = signal<string | null>(null);
-  readonly temFiltro = signal(false);
+  readonly temFiltro = computed(() => this.termoBusca().trim().length > 0);
 
   protected readonly formHeading = computed(() =>
     this.modo() === 'criar' ? 'Novo recurso de acessibilidade' : 'Editar recurso de acessibilidade',

--- a/apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.spec.ts
+++ b/apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.spec.ts
@@ -84,6 +84,18 @@ describe('TiposDeficienciaListPage', () => {
     expect(fixture.nativeElement.textContent).toContain('Nenhum tipo de deficiência carregado');
   });
 
+  it('busca sem resultado mostra o empty-state de filtro, não o de lista vazia', async () => {
+    await flushLista([tipoDeficienciaSeed]);
+
+    component['termoBusca'].set('tipo-deficiencia-inexistente');
+    fixture.detectChanges();
+
+    expect(component['tiposDeficienciaFiltrados']()).toHaveLength(0);
+    expect(fixture.nativeElement.textContent).toContain('Nenhum tipo de deficiência encontrado');
+    expect(fixture.nativeElement.textContent).toContain('Ajuste a busca para ver resultados.');
+    expect(fixture.nativeElement.textContent).not.toContain('Nenhum tipo de deficiência carregado');
+  });
+
   it('renderiza a lista de tipos de deficiência', async () => {
     await flushLista([tipoDeficienciaSeed]);
     expect(component['tiposDeficiencia']()).toHaveLength(1);

--- a/apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.ts
+++ b/apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.ts
@@ -227,7 +227,7 @@ const PAGE_SIZE = 50;
           @if (temFiltro()) {
             <ui-empty-state
               heading="Nenhum tipo de deficiência encontrado"
-              description="Ajuste a busca ou o filtro de tipo para ver resultados."
+              description="Ajuste a busca para ver resultados."
             >
               <button type="button" class="btn btn--secondary" (click)="limparFiltros()">
                 Limpar filtros
@@ -448,7 +448,7 @@ export class TiposDeficienciaListPage {
   });
   protected readonly formError = signal<string | null>(null);
   readonly tipoDeficienciaEmEdicaoId = signal<string | null>(null);
-  readonly temFiltro = signal(false);
+  readonly temFiltro = computed(() => this.termoBusca().trim().length > 0);
   readonly registros = signal<TipoDeficienciaDto[]>([]);
   protected readonly busca = signal('');
 

--- a/apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.ts
+++ b/apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.ts
@@ -449,7 +449,7 @@ export class TiposDeficienciaListPage {
   });
   protected readonly formError = signal<string | null>(null);
   readonly tipoDeficienciaEmEdicaoId = signal<string | null>(null);
-  readonly temFiltro = computed(() => this.termoBusca().trim().length > 0);
+  protected readonly temFiltro = computed(() => this.termoBusca().trim().length > 0);
   readonly registros = signal<TipoDeficienciaDto[]>([]);
   protected readonly busca = signal('');
 

--- a/apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.ts
+++ b/apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.ts
@@ -213,6 +213,7 @@ const PAGE_SIZE = 50;
                         type="button"
                         class="btn btn--tertiary btn--sm btn--rect"
                         [disabled]="loading() || submitting()"
+                        [aria-disabled]="loading() || submitting()"
                         (click)="abrirInativarTipoDeficiencia(tipoDeficiencia)"
                       >
                         Inativar


### PR DESCRIPTION
## Resumo
Corrige a exibição do componente de empty state quando não há itens vivos ou quando o filtro de busca não encontra dados.

## Justificativa para a mudança da implementação

A issue #465 apresentava um problema que a propriedade `temFiltro` não estava sendo utilizada, logo deveria ser removida. Contudo, essa propriedade havia sido inicializada de forma errônea na resolução de uma issue anterior e permaneceu assim.

Quando o filtro de busca por nome ou código está preenchido `temFiltro` deve assumir valor verdadeiro, do contrário assume valor falso.

Quando não há itens cadastrados e a busca está vazia o empty state mostra uma mensagem "Nenhuma condição de atendimento carregada" . Porém quando a busca por nome não consegue filtrar os itens a mensagem é a seguinte:  "Nenhuma condição de atendimento encontrada". 

Esse comportamento acontece em outras páginas do módulo de Configuração, logo deve ser mantido para fins de padronização.

Closes #465
Closes #467 
Closes #470
## Mudanças

### Modificados
apps/configuracao/src/app/features/condicoes-atendimento/condicoes-atendimento-list.ts
apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.ts
apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.ts

## Testes

- [x] Testes unitários passando

## Checklist

- [x] Exibe corretamente título e descrição do empty state quando não há itens cadastrados.
- [x] Exibe corretamente  título e descrição do empty state quando há itens cadastrados mas a busca client-side não encontra itens.
- [x] Remove declaração de variáveis e interfaces não utilizadas.
