### PR TITLE
Corrige carga lista retry nas páginas de atendimento especializado

### DIFF
--- a/apps/configuracao/src/app/features/condicoes-atendimento/condicoes-atendimento-list.spec.ts
+++ b/apps/configuracao/src/app/features/condicoes-atendimento/condicoes-atendimento-list.spec.ts
@@ -193,6 +193,21 @@ describe('CondicoesAtendimentoListPage', () => {
     expect(inativarButtonEl.disabled).toBe(true);
   });
 
+  it('simula cenário que a primeira requisição falha e tenta novamente com sucesso', async () => {
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/condicoes-atendimento`);
+    req.flush(null, { status: 500, statusText: 'Error' });
+    await propagate();
+    const tentarNovamenteButtonEl = fixture.nativeElement.querySelector(
+      '.cfg-campi__retry > button',
+    ) as HTMLButtonElement;
+    expect(tentarNovamenteButtonEl).toBeTruthy();
+
+    tentarNovamenteButtonEl.dispatchEvent(new Event('click'));
+    fixture.detectChanges();
+    await flushRecarregarLista([condicao_atendimento_seed,]);
+    expect(component['condicoes']()).toHaveLength(1);
+  });
+
   it('exibe tag com valor "Protegido" quando o código é "PCD"', async () => {
     await flushLista([condicao_atendimento_seed]);
     fixture.detectChanges();

--- a/apps/configuracao/src/app/features/condicoes-atendimento/condicoes-atendimento-list.ts
+++ b/apps/configuracao/src/app/features/condicoes-atendimento/condicoes-atendimento-list.ts
@@ -444,6 +444,8 @@ export class CondicoesAtendimentoListPage implements OnInit {
       return [...envelope.data];
     },
   });
+  // Busca client-side sobre a página carregada: o backend (api#588) só pagina
+  // por cursor, sem filtro de texto/código/nome no contrato.
   protected readonly condicoesFiltradas = computed(() => {
     const termo = this.termoBusca().trim().toLocaleLowerCase('pt-BR');
     if (termo.length === 0) {
@@ -455,8 +457,6 @@ export class CondicoesAtendimentoListPage implements OnInit {
         condicao.nome.toLocaleLowerCase('pt-BR').includes(termo),
     );
   });
-  readonly registros = signal<CondicaoAtendimentoDto[]>([]);
-  readonly isLoading = signal(false);
   protected readonly errorMessage = computed<string | null>(() => {
     const problem = this.lista.problem();
     if (problem) {
@@ -476,12 +476,6 @@ export class CondicoesAtendimentoListPage implements OnInit {
   protected readonly formHeading = computed(() =>
     this.modo() === 'criar' ? 'Nova condição de atendimento' : 'Editar condição de atendimento',
   );
-  protected readonly inativarMensagem = computed(() => {
-    return 'Você está prestes a inativar a condição ' +
-    this.condicaoParaInativar()?.codigo +
-    ' A inativação impede novos editais de utilizá-lo, mas não altera ofertas já congeladas — '+
-    'a cópia por valor de cada processo permanece íntegra.'
-  });
   readonly condicaoEmEdicaoId = signal<string | null>(null);
   protected readonly termoBusca = signal('');
   protected readonly form: FormGroup<CondicaoAtendimentoForm> =
@@ -553,8 +547,7 @@ export class CondicoesAtendimentoListPage implements OnInit {
   }
 
   tentarNovamente(): void {
-    if (!this.isLoading()) {
-      this.carregar();
+    if (!this.loading()) {
       this.lista.reload();
     }
   }
@@ -729,39 +722,6 @@ export class CondicoesAtendimentoListPage implements OnInit {
     if (control.errors['pattern'])
       return 'Formato inválido. Use letras maiúsculas, números e sublinhado, iniciando por letra (ex.: DISLEXIA, TDAH).';
     return 'Valor inválido.';
-  }
-
-  private carregar(): void {
-    if (this.isLoading()) {
-      return;
-    }
-    this.isLoading.set(true);
-
-    let acumulado: CondicaoAtendimentoDto[] = [];
-    let falhou: ProblemDetails | null = null;
-
-    this.api
-      .listar({ limit: PAGE_SIZE })
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (result) => {
-          if (!result.ok) {
-            falhou ??= result.problem;
-            return;
-          }
-          acumulado = [...acumulado, ...result.data];
-        },
-        complete: () => {
-          this.isLoading.set(false);
-          if (falhou !== null) {
-            if (falhou.status >= 500) {
-              this.notifications.errorFromProblem(falhou);
-            }
-            return;
-          }
-          this.registros.set(acumulado);
-        },
-      });
   }
 
   protected inativarConfirmado(): void {

--- a/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.spec.ts
+++ b/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.spec.ts
@@ -95,6 +95,23 @@ describe('RecursosAcessibilidadeListPage', () => {
     expect(fixture.nativeElement.textContent).not.toContain('Nenhum recurso de acessibilidade carregado');
   });
 
+  it('simula cenário que a primeira requisição falha e tenta novamente com sucesso', async () => {
+    const req = controller.expectOne(
+      (r) => r.url === `${BASE}/api/configuracao/recursos-acessibilidade`,
+    );
+    req.flush(null, { status: 500, statusText: 'Error' });
+    await propagate();
+    const tentarNovamenteButtonEl = fixture.nativeElement.querySelector(
+      '.cfg-campi__retry > button',
+    ) as HTMLButtonElement;
+    expect(tentarNovamenteButtonEl).toBeTruthy();
+
+    tentarNovamenteButtonEl.dispatchEvent(new Event('click'));
+    fixture.detectChanges();
+    await flushRecarregarLista([recurso_acessibilidade_seed]);
+    expect(component['recursos']()).toHaveLength(1);
+  });
+
   it('renderiza a lista de recursos de acessibilidade', async () => {
     await flushLista([recurso_acessibilidade_seed]);
     expect(component['recursos']()).toHaveLength(1);

--- a/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.ts
+++ b/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.ts
@@ -406,6 +406,8 @@ export class RecursosAcessibilidadeListPage {
         return [...envelope.data];
       },
     });
+  // Busca client-side sobre a página carregada: o backend (api#588) só pagina
+  // por cursor, sem filtro de texto/código/nome no contrato.
   protected readonly recursosFiltrados = computed(() => {
     const termo = this.termoBusca().trim().toLocaleLowerCase('pt-BR');
     if (termo.length === 0) {
@@ -415,8 +417,6 @@ export class RecursosAcessibilidadeListPage {
       (recurso) => recurso.nome.toLocaleLowerCase('pt-BR').includes(termo),
     );
   });
-  readonly registros = signal<RecursoAcessibilidadeDto[]>([]);
-  protected readonly busca = signal('');
   protected readonly errorMessage = computed<string | null>(() => {
     const problem = this.lista.problem();
     if (problem) {
@@ -424,7 +424,6 @@ export class RecursosAcessibilidadeListPage {
     }
     return this.lista.error() ? 'Erro inesperado ao carregar condições de atendimento.' : null;
   });
-  readonly isLoading = signal(false);
   readonly modo = signal<ModoFormulario>('criar');
   protected readonly formOpen = signal(false);
   protected readonly saving = signal(false);
@@ -471,45 +470,8 @@ export class RecursosAcessibilidadeListPage {
     .set('direction', pagina.direction);
   }
 
-  carregar(): void {
-    if (this.isLoading()) {
-      return;
-    }
-    this.isLoading.set(true);
-
-    let acumulado: RecursoAcessibilidadeDto[] = [];
-    let falhou: ProblemDetails | null = null;
-
-    this.api
-      .listar({ limit: PAGE_SIZE })
-      .pipe(
-        takeUntilDestroyed(this.destroyRef),
-      )
-      .subscribe({
-        next: (result) => {
-          if (!result.ok) {
-            falhou ??= result.problem;
-            return;
-          }
-          acumulado = [...acumulado, ...result.data];
-        },
-        complete: () => {
-          this.isLoading.set(false);
-          if (falhou !== null) {
-            if (falhou.status >= 500) {
-              this.notifications.errorFromProblem(falhou);
-            }
-            return;
-          }
-          this.registros.set(acumulado);
-        },
-      });
-
-  }
-
   tentarNovamente(): void {
-    if (!this.isLoading()) {
-      this.carregar();
+    if (!this.loading()) {
       this.lista.reload();
     }
   }

--- a/apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.spec.ts
+++ b/apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.spec.ts
@@ -132,6 +132,21 @@ describe('TiposDeficienciaListPage', () => {
       await flushLista([tipoDeficienciaSeed]);
   });
 
+  it('simula cenário que a primeira requisição falha e tenta novamente com sucesso', async () => {
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/tipos-deficiencia`)
+    req.flush(null, { status: 500, statusText: 'Error' });
+    await propagate();
+    const tentarNovamenteButtonEl = fixture.nativeElement.querySelector(
+      '.cfg-campi__retry > button',
+    ) as HTMLButtonElement;
+    expect(tentarNovamenteButtonEl).toBeTruthy();
+
+    tentarNovamenteButtonEl.dispatchEvent(new Event('click'));
+    fixture.detectChanges();
+    await flushRecarregarLista([tipoDeficienciaSeed]);
+    expect(component['tiposDeficiencia']()).toHaveLength(1);
+  });
+
   it('bloqueia botão de salvar quando os campos obrigatórios estão vazios', async () => {
     await flushLista([]);
     component['abrirDrawerCriacao']();

--- a/apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.ts
+++ b/apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.ts
@@ -130,7 +130,7 @@ const PAGE_SIZE = 50;
       </ui-alert>
     }
 
-    @if (loading() && registros().length === 0) {
+    @if (loading() && tiposDeficiencia().length === 0) {
       <ui-skeleton skeletonKind="card" blockSize="10rem" />
       <ui-skeleton skeletonKind="card" blockSize="10rem" />
     }
@@ -410,6 +410,8 @@ export class TiposDeficienciaListPage {
       return [...envelope.data];
     },
   });
+  // Busca client-side sobre a página carregada: o backend (api#588) só pagina
+  // por cursor, sem filtro de texto/código/nome no contrato.
   protected readonly tiposDeficienciaFiltrados = computed(() => {
     const termo = this.termoBusca().trim().toLocaleLowerCase('pt-BR');
     if (termo.length === 0) {
@@ -429,7 +431,6 @@ export class TiposDeficienciaListPage {
     }
     return this.lista.error() ? 'Erro inesperado ao carregar condições de atendimento.' : null;
   });
-  readonly isLoading = signal(false);
   readonly modo = signal<ModoFormulario>('criar');
   protected readonly formOpen = signal(false);
   protected readonly saving = signal(false);
@@ -449,9 +450,7 @@ export class TiposDeficienciaListPage {
   });
   protected readonly formError = signal<string | null>(null);
   readonly tipoDeficienciaEmEdicaoId = signal<string | null>(null);
-  protected readonly temFiltro = computed(() => this.termoBusca().trim().length > 0);
-  readonly registros = signal<TipoDeficienciaDto[]>([]);
-  protected readonly busca = signal('');
+  readonly temFiltro = computed(() => this.termoBusca().trim().length > 0);
 
   constructor() {
     effect(() => {
@@ -473,40 +472,8 @@ export class TiposDeficienciaListPage {
       .set('direction', pagina.direction);
   }
 
-  carregar(): void {
-    if (this.isLoading()) {
-      return;
-    }
-    this.isLoading.set(true);
-    let acumulado: TipoDeficienciaDto[] = [];
-    let falhou: ProblemDetails | null = null;
-    this.api
-      .listar({ limit: PAGE_SIZE })
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (result) => {
-          if (!result.ok) {
-            falhou ??= result.problem;
-            return;
-          }
-          acumulado = [...acumulado, ...result.data];
-        },
-        complete: () => {
-          this.isLoading.set(false);
-          if (falhou !== null) {
-            if (falhou.status >= 500) {
-              this.notifications.errorFromProblem(falhou);
-            }
-            return;
-          }
-          this.registros.set(acumulado);
-        },
-      });
-  }
-
   tentarNovamente(): void {
-    if (!this.isLoading()) {
-      this.carregar();
+    if (!this.loading()) {
       this.lista.reload();
     }
   }


### PR DESCRIPTION
## Resumo

+ Gate do skeleton consistente entre as três telas, baseado na fonte que alimenta a tabela.
+ faz um único caminho de carga por tela.
+ Remove variáveis não utilizadas.

Closes #469

## Mudanças
### Modificados
+ apps/configuracao/src/app/features/condicoes-atendimento/condicoes-atendimento-list.ts
+ apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.ts
+ apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.ts

+ apps/configuracao/src/app/features/condicoes-atendimento/condicoes-atendimento-list.spec.ts
+ apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.spec.ts
+ apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.spec.ts

## Testes

- [x] Testes unitários passando

## Checklist

- [x]  Remover `carregar()`, `registros` e `isLoading` nas três telas.
- [x]  O método `tentarNovamente()` passa a chamar apenas `lista.reload()`
- [x] Remover o signal órfão `busca` em Recursos de Acessibilidade e Tipos de Deficiência.
- [x] Realocar o comentário sobre a paginação por cursor (`api#588`) para junto do computed de filtro correspondente.
- [x] Teste cobrindo que `tentarNovamente()` dispara exatamente uma requisição.
