### PR TITLE
Remove resíduos das paginas atendimento especializado

### DIFF
--- a/apps/configuracao/src/app/features/condicoes-atendimento/condicoes-atendimento-list.spec.ts
+++ b/apps/configuracao/src/app/features/condicoes-atendimento/condicoes-atendimento-list.spec.ts
@@ -65,6 +65,14 @@ describe('CondicoesAtendimentoListPage', () => {
     ) as HTMLButtonElement;
   }
 
+  function getInativarButtonEl(): HTMLButtonElement {
+    return fixture.nativeElement.querySelector('td[class="table-responsive__actions"] > button:last-child') as HTMLButtonElement;
+  }
+
+  function getEditarButtonEl(): HTMLButtonElement {
+    return fixture.nativeElement.querySelector('td[class="table-responsive__actions"] > button:first-child') as HTMLButtonElement;
+  }
+
   // Pós-mutação, `recarregar()` só dá reload no resource da lista principal —
     // os lookups de Curso/Local de oferta já estão em cache e não recarregam.
     async function flushRecarregarLista(items: readonly CondicaoAtendimentoDto[]): Promise<void> {
@@ -281,5 +289,27 @@ describe('CondicoesAtendimentoListPage', () => {
     expect(put.request.body.descricao).toBe(NOVA_DESCRICAO_PCD);
     put.flush(null, { status: 204, statusText: 'No Content' });
     await flushRecarregarLista([condicao_atendimento]);
+  });
+
+  it('desabilita o botão de inativação quando está carregando a lista', async () => {
+      component['condicoes'].set([condicao_atendimento_seed]);
+      const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/condicoes-atendimento`);
+      req.flush([condicao_atendimento_seed]);
+      expect(component['loading']()).toBe(true);
+      fixture.detectChanges();
+      const inativarButtonEl = getInativarButtonEl();
+      expect(inativarButtonEl).toBeTruthy();
+      expect(inativarButtonEl.disabled).toBe(true);
+    });
+
+  it('desabilita o botão de edição quando está carregando a lista', async () => {
+    component['condicoes'].set([condicao_atendimento_seed]);
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/condicoes-atendimento`);
+    req.flush([condicao_atendimento_seed]);
+    expect(component['loading']()).toBe(true);
+    fixture.detectChanges();
+    const editarButtonEl = getEditarButtonEl();
+    expect(editarButtonEl).toBeTruthy();
+    expect(editarButtonEl.disabled).toBe(true);
   });
 });

--- a/apps/configuracao/src/app/features/condicoes-atendimento/condicoes-atendimento-list.spec.ts
+++ b/apps/configuracao/src/app/features/condicoes-atendimento/condicoes-atendimento-list.spec.ts
@@ -66,11 +66,15 @@ describe('CondicoesAtendimentoListPage', () => {
   }
 
   function getInativarButtonEl(): HTMLButtonElement {
-    return fixture.nativeElement.querySelector('td[class="table-responsive__actions"] > button:last-child') as HTMLButtonElement;
+    return fixture.nativeElement.querySelector(
+      'td.table-responsive__actions > button:last-child',
+    ) as HTMLButtonElement;
   }
 
   function getEditarButtonEl(): HTMLButtonElement {
-    return fixture.nativeElement.querySelector('td[class="table-responsive__actions"] > button:first-child') as HTMLButtonElement;
+    return fixture.nativeElement.querySelector(
+      'td.table-responsive__actions > button:first-child',
+    ) as HTMLButtonElement;
   }
 
   // Pós-mutação, `recarregar()` só dá reload no resource da lista principal —
@@ -195,10 +199,7 @@ describe('CondicoesAtendimentoListPage', () => {
 
     fixture.detectChanges();
 
-    const inativarButtonEl = fixture.nativeElement.querySelector(
-      'td[class="table-responsive__actions"] > button:last-child',
-    ) as HTMLButtonElement;
-    expect(inativarButtonEl.disabled).toBe(true);
+    expect(getInativarButtonEl().disabled).toBe(true);
   });
 
   it('simula cenário que a primeira requisição falha e tenta novamente com sucesso', async () => {
@@ -291,25 +292,29 @@ describe('CondicoesAtendimentoListPage', () => {
     await flushRecarregarLista([condicao_atendimento]);
   });
 
-  it('desabilita o botão de inativação quando está carregando a lista', async () => {
-      component['condicoes'].set([condicao_atendimento_seed]);
-      const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/condicoes-atendimento`);
-      req.flush([condicao_atendimento_seed]);
-      expect(component['loading']()).toBe(true);
-      fixture.detectChanges();
-      const inativarButtonEl = getInativarButtonEl();
-      expect(inativarButtonEl).toBeTruthy();
-      expect(inativarButtonEl.disabled).toBe(true);
-    });
+  it('desabilita as ações da linha (Editar e Inativar) durante a recarga da lista', async () => {
+    // Condição não-PCD: o "Inativar" do PCD é desabilitado por regra própria, à parte do loading.
+    const condicaoAtiva = { ...condicao_atendimento_seed, codigo: 'MOBIL', nome: 'Mobilidade' };
 
-  it('desabilita o botão de edição quando está carregando a lista', async () => {
-    component['condicoes'].set([condicao_atendimento_seed]);
-    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/condicoes-atendimento`);
-    req.flush([condicao_atendimento_seed]);
-    expect(component['loading']()).toBe(true);
+    // Estado estável: lista carregada, nada em voo — os botões da linha estão habilitados.
+    await flushLista([condicaoAtiva]);
     fixture.detectChanges();
-    const editarButtonEl = getEditarButtonEl();
-    expect(editarButtonEl).toBeTruthy();
-    expect(editarButtonEl.disabled).toBe(true);
+    expect(component['loading']()).toBe(false);
+    expect(getEditarButtonEl().disabled).toBe(false);
+    expect(getInativarButtonEl().disabled).toBe(false);
+
+    // Recarga real: reload() deixa loading()=true com o GET em voo, preservando a linha.
+    component['tentarNovamente']();
+    await propagate();
+    fixture.detectChanges();
+    expect(component['loading']()).toBe(true);
+    expect(getEditarButtonEl().disabled).toBe(true);
+    expect(getInativarButtonEl().disabled).toBe(true);
+
+    // Encerra o GET pendente para o controller.verify() do afterEach.
+    controller
+      .expectOne((r) => r.url === `${BASE}/api/configuracao/condicoes-atendimento`)
+      .flush([condicaoAtiva]);
+    await propagate();
   });
 });

--- a/apps/configuracao/src/app/features/condicoes-atendimento/condicoes-atendimento-list.ts
+++ b/apps/configuracao/src/app/features/condicoes-atendimento/condicoes-atendimento-list.ts
@@ -60,7 +60,7 @@ type PaginaProps = {
   readonly direction: PaginationDirection
 } | undefined;
 
-/** Tamanho de página ao esgotar o cursor (ADR-0015/0026) — ver `carregar()`. */
+/** Tamanho de página ao esgotar o cursor (ADR-0015/0026). */
 const PAGE_SIZE = 50;
 
 /** Vendor code do DomainError `CondicaoAtendimento.CodigoJaExiste` (uniplus-api, 409 Conflict). */
@@ -227,7 +227,6 @@ function controlNameFromBackendField(field: string): keyof CondicaoAtendimentoFo
                           type="button"
                           class="btn btn--tertiary btn--sm btn--rect"
                           [disabled]="loading() || submitting() || condicao.codigo === 'PCD'"
-                          [aria-disabled]="loading() || submitting() || condicao.codigo === 'PCD'"
                           [title]="condicao.codigo === 'PCD' ? 'A condição PCD não pode ser inativada.' : ''"
                           (click)="abrirInativarCondicao(condicao)"
                         >
@@ -472,7 +471,7 @@ export class CondicoesAtendimentoListPage implements OnInit {
   readonly confirmOpen = signal(false);
   protected readonly modo = signal<ModoFormulario>('criar');
   protected readonly idempotencyKeyAtual = signal(idempotencyKey.create());
-  readonly temFiltro = computed(() => this.termoBusca().trim().length > 0);
+  protected readonly temFiltro = computed(() => this.termoBusca().trim().length > 0);
   protected readonly formHeading = computed(() =>
     this.modo() === 'criar' ? 'Nova condição de atendimento' : 'Editar condição de atendimento',
   );

--- a/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.spec.ts
+++ b/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.spec.ts
@@ -64,11 +64,15 @@ describe('RecursosAcessibilidadeListPage', () => {
   }
 
   function getInativarButtonEl(): HTMLButtonElement {
-    return fixture.nativeElement.querySelector('td[class="table-responsive__actions"] > button:last-child') as HTMLButtonElement;
+    return fixture.nativeElement.querySelector(
+      'td.table-responsive__actions > button:last-child',
+    ) as HTMLButtonElement;
   }
 
   function getEditarButtonEl(): HTMLButtonElement {
-    return fixture.nativeElement.querySelector('td[class="table-responsive__actions"] > button:first-child') as HTMLButtonElement;
+    return fixture.nativeElement.querySelector(
+      'td.table-responsive__actions > button:first-child',
+    ) as HTMLButtonElement;
   }
 
   // Pós-mutação, `recarregar()` só dá reload no resource da lista principal —
@@ -237,25 +241,26 @@ describe('RecursosAcessibilidadeListPage', () => {
     await flushRecarregarLista([recurso_acessibilidade]);
   });
 
-  it('desabilita o botão de inativação quando está carregando a lista', async () => {
-    component['recursos'].set([recurso_acessibilidade_seed]);
-    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/recursos-acessibilidade`);
-    req.flush([recurso_acessibilidade_seed]);
-    expect(component['loading']()).toBe(true);
+  it('desabilita as ações da linha (Editar e Inativar) durante a recarga da lista', async () => {
+    // Estado estável: lista carregada, nada em voo — os botões da linha estão habilitados.
+    await flushLista([recurso_acessibilidade_seed]);
     fixture.detectChanges();
-    const inativarButtonEl = getInativarButtonEl();
-    expect(inativarButtonEl).toBeTruthy();
-    expect(inativarButtonEl.disabled).toBe(true);
-  });
+    expect(component['loading']()).toBe(false);
+    expect(getEditarButtonEl().disabled).toBe(false);
+    expect(getInativarButtonEl().disabled).toBe(false);
 
-  it('desabilita o botão de edição quando está carregando a lista', async () => {
-    component['recursos'].set([recurso_acessibilidade_seed]);
-    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/recursos-acessibilidade`);
-    req.flush([recurso_acessibilidade_seed]);
-    expect(component['loading']()).toBe(true);
+    // Recarga real: reload() deixa loading()=true com o GET em voo, preservando a linha.
+    component['tentarNovamente']();
+    await propagate();
     fixture.detectChanges();
-    const editarButtonEl = getEditarButtonEl();
-    expect(editarButtonEl).toBeTruthy();
-    expect(editarButtonEl.disabled).toBe(true);
+    expect(component['loading']()).toBe(true);
+    expect(getEditarButtonEl().disabled).toBe(true);
+    expect(getInativarButtonEl().disabled).toBe(true);
+
+    // Encerra o GET pendente para o controller.verify() do afterEach.
+    controller
+      .expectOne((r) => r.url === `${BASE}/api/configuracao/recursos-acessibilidade`)
+      .flush([recurso_acessibilidade_seed]);
+    await propagate();
   });
 });

--- a/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.spec.ts
+++ b/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.spec.ts
@@ -57,10 +57,18 @@ describe('RecursosAcessibilidadeListPage', () => {
     await propagate();
   }
 
-  function getSalvarOuEditarButtonEl() {
+  function getSalvarOuEditarButtonEl(): HTMLButtonElement {
     return fixture.nativeElement.querySelector(
       'button[form="cfg-unidade-form"]',
     ) as HTMLButtonElement;
+  }
+
+  function getInativarButtonEl(): HTMLButtonElement {
+    return fixture.nativeElement.querySelector('td[class="table-responsive__actions"] > button:last-child') as HTMLButtonElement;
+  }
+
+  function getEditarButtonEl(): HTMLButtonElement {
+    return fixture.nativeElement.querySelector('td[class="table-responsive__actions"] > button:first-child') as HTMLButtonElement;
   }
 
   // Pós-mutação, `recarregar()` só dá reload no resource da lista principal —
@@ -227,5 +235,27 @@ describe('RecursosAcessibilidadeListPage', () => {
     expect(put.request.body.nome).toBe(NOVO_NOME);
     put.flush(null, { status: 204, statusText: 'No Content' });
     await flushRecarregarLista([recurso_acessibilidade]);
+  });
+
+  it('desabilita o botão de inativação quando está carregando a lista', async () => {
+    component['recursos'].set([recurso_acessibilidade_seed]);
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/recursos-acessibilidade`);
+    req.flush([recurso_acessibilidade_seed]);
+    expect(component['loading']()).toBe(true);
+    fixture.detectChanges();
+    const inativarButtonEl = getInativarButtonEl();
+    expect(inativarButtonEl).toBeTruthy();
+    expect(inativarButtonEl.disabled).toBe(true);
+  });
+
+  it('desabilita o botão de edição quando está carregando a lista', async () => {
+    component['recursos'].set([recurso_acessibilidade_seed]);
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/recursos-acessibilidade`);
+    req.flush([recurso_acessibilidade_seed]);
+    expect(component['loading']()).toBe(true);
+    fixture.detectChanges();
+    const editarButtonEl = getEditarButtonEl();
+    expect(editarButtonEl).toBeTruthy();
+    expect(editarButtonEl.disabled).toBe(true);
   });
 });

--- a/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.ts
+++ b/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.ts
@@ -85,7 +85,7 @@ function controlNameFromBackendField(field: string): keyof RecursoAcessibilidade
   return RECURSO_ACESSIBILIDADE_CONTROL_NAMES.has(camelCase) ? (camelCase as keyof RecursoAcessibilidadeForm) : null;
 }
 
-/** Tamanho de página ao esgotar o cursor (ADR-0015/0026) */
+/** Tamanho de página ao esgotar o cursor (ADR-0015/0026). */
 const PAGE_SIZE = 50;
 
 @Component({
@@ -421,7 +421,7 @@ export class RecursosAcessibilidadeListPage {
     if (problem) {
       return this.problemI18n.resolve(problem).title;
     }
-    return this.lista.error() ? 'Erro inesperado ao carregar recursos de acessibilidade' : null;
+    return this.lista.error() ? 'Erro inesperado ao carregar recursos de acessibilidade.' : null;
   });
   readonly modo = signal<ModoFormulario>('criar');
   protected readonly formOpen = signal(false);

--- a/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.ts
+++ b/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.ts
@@ -85,7 +85,7 @@ function controlNameFromBackendField(field: string): keyof RecursoAcessibilidade
   return RECURSO_ACESSIBILIDADE_CONTROL_NAMES.has(camelCase) ? (camelCase as keyof RecursoAcessibilidadeForm) : null;
 }
 
-/** Tamanho de página ao esgotar o cursor (ADR-0015/0026) — ver `carregar()`. */
+/** Tamanho de página ao esgotar o cursor (ADR-0015/0026) */
 const PAGE_SIZE = 50;
 
 @Component({
@@ -211,7 +211,6 @@ const PAGE_SIZE = 50;
                           type="button"
                           class="btn btn--tertiary btn--sm btn--rect"
                           [disabled]="loading() || submitting()"
-                          [aria-disabled]="loading() || submitting()"
                           (click)="abrirInativarRecurso(recursoAcessibilidade)"
                         >
                           Inativar
@@ -422,7 +421,7 @@ export class RecursosAcessibilidadeListPage {
     if (problem) {
       return this.problemI18n.resolve(problem).title;
     }
-    return this.lista.error() ? 'Erro inesperado ao carregar condições de atendimento.' : null;
+    return this.lista.error() ? 'Erro inesperado ao carregar recursos de acessibilidade' : null;
   });
   readonly modo = signal<ModoFormulario>('criar');
   protected readonly formOpen = signal(false);
@@ -443,7 +442,7 @@ export class RecursosAcessibilidadeListPage {
     }),
   });
   protected readonly formError = signal<string | null>(null);
-  readonly condicaoEmEdicaoId = signal<string | null>(null);
+  readonly recursosAcessibilidadeEmEdicaoId = signal<string | null>(null);
   protected readonly temFiltro = computed(() => this.termoBusca().trim().length > 0);
 
   protected readonly formHeading = computed(() =>
@@ -505,7 +504,7 @@ export class RecursosAcessibilidadeListPage {
   }
 
   protected abrirEdicao(recurso: RecursoAcessibilidadeDto): void {this.modo.set('editar');
-    this.condicaoEmEdicaoId.set(recurso.id);
+    this.recursosAcessibilidadeEmEdicaoId.set(recurso.id);
     this.form.reset({
       nome: recurso.nome,
       descricao: recurso.descricao ?? ''
@@ -565,7 +564,7 @@ export class RecursosAcessibilidadeListPage {
 
     this.api
       .atualizar(
-        this.condicaoEmEdicaoId() ?? '',
+        this.recursosAcessibilidadeEmEdicaoId() ?? '',
         this.atualizarCommand(),
         withIdempotencyKey(this.idempotencyKeyAtual()),
       )
@@ -582,7 +581,7 @@ export class RecursosAcessibilidadeListPage {
   }
 
   private atualizarCommand(): AtualizarRecursoAcessibilidadeCommand {
-    return { id: this.condicaoEmEdicaoId() ?? '', ...this.criarCommand() };
+    return { id: this.recursosAcessibilidadeEmEdicaoId() ?? '', ...this.criarCommand() };
   }
 
   private renovarIdempotencyKey(): void {

--- a/apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.spec.ts
+++ b/apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.spec.ts
@@ -74,6 +74,14 @@ describe('TiposDeficienciaListPage', () => {
     ) as HTMLButtonElement;
   }
 
+  function getInativarButtonEl(): HTMLButtonElement {
+    return fixture.nativeElement.querySelector('td[class="table-responsive__actions"] > button:last-child') as HTMLButtonElement;
+  }
+
+  function getEditarButtonEl(): HTMLButtonElement {
+    return fixture.nativeElement.querySelector('td[class="table-responsive__actions"] > button:first-child') as HTMLButtonElement;
+  }
+
   it('drawer mostra empty-state quando tipos de deficiência não tem ofertas vivas', async () => {
     await flushLista([]);
 
@@ -226,4 +234,25 @@ describe('TiposDeficienciaListPage', () => {
       put.flush(null, { status: 204, statusText: 'No Content' });
       await flushRecarregarLista([tipo_deficiencia]);
     });
+  it('desabilita o botão de inativação quando está carregando a lista', async () => {
+        component['tiposDeficiencia'].set([tipoDeficienciaSeed]);
+        const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/tipos-deficiencia`)
+        req.flush([tipoDeficienciaSeed]);
+        expect(component['loading']()).toBe(true);
+        fixture.detectChanges();
+        const inativarButtonEl = getInativarButtonEl();
+        expect(inativarButtonEl).toBeTruthy();
+        expect(inativarButtonEl.disabled).toBe(true);
+      });
+
+  it('desabilita o botão de edição quando está carregando a lista', async () => {
+    component['tiposDeficiencia'].set([tipoDeficienciaSeed]);
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/tipos-deficiencia`)
+    req.flush([tipoDeficienciaSeed]);
+    expect(component['loading']()).toBe(true);
+    fixture.detectChanges();
+    const editarButtonEl = getEditarButtonEl();
+    expect(editarButtonEl).toBeTruthy();
+    expect(editarButtonEl.disabled).toBe(true);
+  });
 });

--- a/apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.spec.ts
+++ b/apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.spec.ts
@@ -6,7 +6,6 @@ import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { provideRouter } from '@angular/router';
 import {
   CONFIGURACAO_BASE_PATH,
-  RecursoAcessibilidadeDto,
   TipoDeficienciaDto,
 } from '@uniplus/shared-data/configuracao';
 import { apiResultInterceptor } from '@uniplus/shared-core/http';
@@ -14,7 +13,7 @@ import { TiposDeficienciaListPage } from './tipos-deficiencia-list.page';
 
 const BASE = 'http://localhost:5000';
 const TIPO_DEFICIENCIA_ID = '019f41cf-69fd-759a-ac6d-09acabc1b027';
-const tipoDeficienciaSeed: RecursoAcessibilidadeDto = {
+const tipoDeficienciaSeed: TipoDeficienciaDto = {
   'id': TIPO_DEFICIENCIA_ID,
   nome: 'Visual',
   descricao: 'Inclui baixa visão e cegueira',
@@ -51,7 +50,7 @@ describe('TiposDeficienciaListPage', () => {
     appRef.tick();
   };
 
-  async function flushLista(items: readonly RecursoAcessibilidadeDto[]): Promise<void> {
+  async function flushLista(items: readonly TipoDeficienciaDto[]): Promise<void> {
     const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/tipos-deficiencia`);
     expect(req.request.params.get('limit')).toBe('50');
     req.flush(items);
@@ -60,7 +59,7 @@ describe('TiposDeficienciaListPage', () => {
 
   // Pós-mutação, `recarregar()` só dá reload no resource da lista principal —
   // os lookups de Tipos de Deficiência já estão em cache e não recarregam.
-  async function flushRecarregarLista(items: readonly RecursoAcessibilidadeDto[]): Promise<void> {
+  async function flushRecarregarLista(items: readonly TipoDeficienciaDto[]): Promise<void> {
     await propagate();
     controller
       .expectOne((r) => r.url === `${BASE}/api/configuracao/tipos-deficiencia`)
@@ -75,11 +74,15 @@ describe('TiposDeficienciaListPage', () => {
   }
 
   function getInativarButtonEl(): HTMLButtonElement {
-    return fixture.nativeElement.querySelector('td[class="table-responsive__actions"] > button:last-child') as HTMLButtonElement;
+    return fixture.nativeElement.querySelector(
+      'td.table-responsive__actions > button:last-child',
+    ) as HTMLButtonElement;
   }
 
   function getEditarButtonEl(): HTMLButtonElement {
-    return fixture.nativeElement.querySelector('td[class="table-responsive__actions"] > button:first-child') as HTMLButtonElement;
+    return fixture.nativeElement.querySelector(
+      'td.table-responsive__actions > button:first-child',
+    ) as HTMLButtonElement;
   }
 
   it('drawer mostra empty-state quando tipos de deficiência não tem ofertas vivas', async () => {
@@ -234,25 +237,26 @@ describe('TiposDeficienciaListPage', () => {
       put.flush(null, { status: 204, statusText: 'No Content' });
       await flushRecarregarLista([tipo_deficiencia]);
     });
-  it('desabilita o botão de inativação quando está carregando a lista', async () => {
-        component['tiposDeficiencia'].set([tipoDeficienciaSeed]);
-        const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/tipos-deficiencia`)
-        req.flush([tipoDeficienciaSeed]);
-        expect(component['loading']()).toBe(true);
-        fixture.detectChanges();
-        const inativarButtonEl = getInativarButtonEl();
-        expect(inativarButtonEl).toBeTruthy();
-        expect(inativarButtonEl.disabled).toBe(true);
-      });
-
-  it('desabilita o botão de edição quando está carregando a lista', async () => {
-    component['tiposDeficiencia'].set([tipoDeficienciaSeed]);
-    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/tipos-deficiencia`)
-    req.flush([tipoDeficienciaSeed]);
-    expect(component['loading']()).toBe(true);
+  it('desabilita as ações da linha (Editar e Inativar) durante a recarga da lista', async () => {
+    // Estado estável: lista carregada, nada em voo — os botões da linha estão habilitados.
+    await flushLista([tipoDeficienciaSeed]);
     fixture.detectChanges();
-    const editarButtonEl = getEditarButtonEl();
-    expect(editarButtonEl).toBeTruthy();
-    expect(editarButtonEl.disabled).toBe(true);
+    expect(component['loading']()).toBe(false);
+    expect(getEditarButtonEl().disabled).toBe(false);
+    expect(getInativarButtonEl().disabled).toBe(false);
+
+    // Recarga real: reload() deixa loading()=true com o GET em voo, preservando a linha.
+    component['tentarNovamente']();
+    await propagate();
+    fixture.detectChanges();
+    expect(component['loading']()).toBe(true);
+    expect(getEditarButtonEl().disabled).toBe(true);
+    expect(getInativarButtonEl().disabled).toBe(true);
+
+    // Encerra o GET pendente para o controller.verify() do afterEach.
+    controller
+      .expectOne((r) => r.url === `${BASE}/api/configuracao/tipos-deficiencia`)
+      .flush([tipoDeficienciaSeed]);
+    await propagate();
   });
 });

--- a/apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.ts
+++ b/apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.ts
@@ -81,7 +81,7 @@ function controlNameFromBackendField(field: string): keyof TipoDeficienciaForm |
   return TIPO_DEFICIENCIA_CONTROL_NAMES.has(camelCase) ? (camelCase as keyof TipoDeficienciaForm) : null;
 }
 
-/** Tamanho de página ao esgotar o cursor (ADR-0015/0026). **/
+/** Tamanho de página ao esgotar o cursor (ADR-0015/0026). */
 const PAGE_SIZE = 50;
 
 @Component({

--- a/apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.ts
+++ b/apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.ts
@@ -81,7 +81,7 @@ function controlNameFromBackendField(field: string): keyof TipoDeficienciaForm |
   return TIPO_DEFICIENCIA_CONTROL_NAMES.has(camelCase) ? (camelCase as keyof TipoDeficienciaForm) : null;
 }
 
-/** Tamanho de página ao esgotar o cursor (ADR-0015/0026) — ver `carregar()`. */
+/** Tamanho de página ao esgotar o cursor (ADR-0015/0026). **/
 const PAGE_SIZE = 50;
 
 @Component({
@@ -213,7 +213,6 @@ const PAGE_SIZE = 50;
                         type="button"
                         class="btn btn--tertiary btn--sm btn--rect"
                         [disabled]="loading() || submitting()"
-                        [aria-disabled]="loading() || submitting()"
                         (click)="abrirInativarTipoDeficiencia(tipoDeficiencia)"
                       >
                         Inativar
@@ -429,7 +428,7 @@ export class TiposDeficienciaListPage {
     if (problem) {
       return this.problemI18n.resolve(problem).title;
     }
-    return this.lista.error() ? 'Erro inesperado ao carregar condições de atendimento.' : null;
+    return this.lista.error() ? 'Erro inesperado ao carregar tipos de deficiência.' : null;
   });
   readonly modo = signal<ModoFormulario>('criar');
   protected readonly formOpen = signal(false);
@@ -450,7 +449,7 @@ export class TiposDeficienciaListPage {
   });
   protected readonly formError = signal<string | null>(null);
   readonly tipoDeficienciaEmEdicaoId = signal<string | null>(null);
-  readonly temFiltro = computed(() => this.termoBusca().trim().length > 0);
+  protected readonly temFiltro = computed(() => this.termoBusca().trim().length > 0);
 
   constructor() {
     effect(() => {


### PR DESCRIPTION
## Resumo

Este PR resolve as issues  [#471](https://github.com/unifesspa-edu-br/uniplus-web/issues/471) e  [#473](https://github.com/unifesspa-edu-br/uniplus-web/issues/473) para resolver todos os problemas em um único PR.

+ Remove referência inexistente de método no comentário (Issue [#473](https://github.com/unifesspa-edu-br/uniplus-web/issues/473)).
+ Adiciona testes de checagem de desabilitação de botão de inativação  quando a lista está carregando.

Closes #471 
Closes #473

## Mudanças
### Modificados

+ apps/configuracao/src/app/features/condicoes-atendimento/condicoes-atendimento-list.ts
+ apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.ts
+ apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.ts

+ apps/configuracao/src/app/features/condicoes-atendimento/condicoes-atendimento-list.spec.ts
+ apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.spec.ts
+ apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.spec.ts

## Testes

- [x] Testes unitários passando
## Checklist

- [x] A referência a carregar() no JSDoc de PAGE_SIZE é removida ou reapontada para o caminho de carga atual (lista) nas três telas.
- [x] Visibilidade de temFiltro uniforme nas três telas.
- [x] Estado desabilitado dos botões de ação expresso de uma única forma, igual nos dois botões da linha.
- [x] Cada tela exibindo mensagem de erro que a nomeia corretamente.
- [x] Nomenclatura de signals coerente com a entidade da tela.
- [x] Estado desabilitado do "Inativar" durante recarga coberto por teste.
- [x]  Renomear condicaoEmEdicaoId para recursoEmEdicaoId em Recursos de Acessibilidade.