### PR TITLE
refactor(organizacao): remove o campo de origem do cadastro de Unidade

### DIFF
--- a/apps/configuracao-e2e/src/specs/instituicao.visual.spec.ts
+++ b/apps/configuracao-e2e/src/specs/instituicao.visual.spec.ts
@@ -20,7 +20,6 @@ const REITORIAS = [
     unidadeAcademica: false,
     vigenciaInicio: '2026-01-01',
     vigenciaFim: null,
-    origem: 'CriadoNoUniPlus',
     criadoEm: '2026-06-10T12:00:00Z',
   },
 ] as const;

--- a/apps/configuracao-e2e/src/specs/unidades.visual.spec.ts
+++ b/apps/configuracao-e2e/src/specs/unidades.visual.spec.ts
@@ -17,7 +17,6 @@ const UNIDADES = [
     unidadeAcademica: false,
     vigenciaInicio: '2026-01-01',
     vigenciaFim: null,
-    origem: 'CriadoNoUniPlus',
     criadoEm: '2026-06-10T12:00:00Z',
   },
   {
@@ -32,7 +31,6 @@ const UNIDADES = [
     unidadeAcademica: false,
     vigenciaInicio: '2026-01-01',
     vigenciaFim: null,
-    origem: 'CriadoNoUniPlus',
     criadoEm: '2026-06-10T12:01:00Z',
   },
   {
@@ -47,7 +45,6 @@ const UNIDADES = [
     unidadeAcademica: false,
     vigenciaInicio: '2026-01-01',
     vigenciaFim: null,
-    origem: 'CriadoNoUniPlus',
     criadoEm: '2026-06-10T12:02:00Z',
   },
   {
@@ -62,7 +59,6 @@ const UNIDADES = [
     unidadeAcademica: false,
     vigenciaInicio: '2026-01-01',
     vigenciaFim: null,
-    origem: 'CriadoNoUniPlus',
     criadoEm: '2026-06-10T12:03:00Z',
   },
 ] as const;
@@ -136,7 +132,7 @@ test.describe('Unidade — cobertura visual DS', () => {
     await expect(drawer.getByRole('heading', { name: 'Nova unidade' })).toBeVisible();
     await expect(drawer.getByText('Identificadores')).toBeVisible();
     await expect(drawer.getByText('Classificação e hierarquia')).toBeVisible();
-    await expect(drawer.getByText('Vigência e origem')).toBeVisible();
+    await expect(drawer.getByText('Vigência', { exact: true })).toBeVisible();
 
     const footer = drawer.locator('.cfg-form-footer');
     await expect(footer.getByRole('button', { name: 'Cancelar' })).toBeVisible();

--- a/apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
@@ -8,12 +8,7 @@ import { ApplicationRef } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import { apiResultInterceptor, buildVendorMimeAccept } from '@uniplus/shared-core/http';
-import {
-  ORGANIZACAO_BASE_PATH,
-  OrigemUnidade,
-  TipoUnidade,
-  UnidadeDto,
-} from '@uniplus/shared-data/organizacao';
+import { ORGANIZACAO_BASE_PATH, TipoUnidade, UnidadeDto } from '@uniplus/shared-data/organizacao';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { UnidadesPage } from './unidades.page';
 
@@ -37,7 +32,6 @@ const unidadesSeed: readonly UnidadeDto[] = [
     unidadeAcademica: false,
     vigenciaInicio: '2026-01-01',
     vigenciaFim: null,
-    origem: 'CriadoNoUniPlus',
     criadoEm: '2026-06-10T12:00:00Z',
   },
   {
@@ -52,7 +46,6 @@ const unidadesSeed: readonly UnidadeDto[] = [
     unidadeAcademica: true,
     vigenciaInicio: '2026-01-01',
     vigenciaFim: null,
-    origem: 'CriadoNoUniPlus',
     criadoEm: '2026-06-10T12:01:00Z',
   },
 ];
@@ -270,7 +263,6 @@ describe('UnidadesPage', () => {
       unidadeAcademica: true,
       vigenciaInicio: '2026-02-01',
       vigenciaFim: '',
-      origem: OrigemUnidade.criadoNoUniPlus,
       motivoMudancaIdentificador: '',
     });
     const key = component['idempotencyKeyAtual']();
@@ -285,7 +277,6 @@ describe('UnidadesPage', () => {
       alias: null,
       unidadeSuperiorId: INSTITUTO_ID,
       tipo: TipoUnidade.faculdade,
-      origem: OrigemUnidade.criadoNoUniPlus,
     });
     post.flush('01960000-0000-7000-0000-000000000099', { status: 201, statusText: 'Created' });
     expect(component['formOpen']()).toBe(false);
@@ -310,7 +301,6 @@ describe('UnidadesPage', () => {
       unidadeAcademica: true,
       vigenciaInicio: '2026-06-10',
       vigenciaFim: '2026-06-02',
-      origem: OrigemUnidade.criadoNoUniPlus,
       motivoMudancaIdentificador: '',
     });
 
@@ -398,7 +388,6 @@ describe('UnidadesPage', () => {
       unidadeAcademica: true,
       vigenciaInicio: '2026-06-10',
       vigenciaFim: '2026-06-10',
-      origem: OrigemUnidade.criadoNoUniPlus,
       motivoMudancaIdentificador: '',
     });
 
@@ -442,7 +431,6 @@ describe('UnidadesPage', () => {
       unidadeAcademica: true,
       vigenciaInicio: '2026-06-10',
       vigenciaFim: '2026-06-10',
-      origem: OrigemUnidade.criadoNoUniPlus,
       motivoMudancaIdentificador: '',
     });
 
@@ -474,14 +462,10 @@ describe('UnidadesPage', () => {
 
   it('atualiza unidade sem enviar vigenciaInicio no command de update', async () => {
     await flushInicial();
-    component['abrirEdicao']({ ...unidadesSeed[1], origem: 'ImportadoSIORG' });
+    component['abrirEdicao'](unidadesSeed[1]);
     await flushOpcoesSuperior();
     component['form'].controls.nome.setValue('Instituto Renomeado');
     const key = component['idempotencyKeyAtual']();
-
-    expect(component['form'].controls.origem.disabled).toBe(true);
-    expect(component['form'].controls.origem.value).toBe(OrigemUnidade.importadoSiorg);
-    expect(component['origemEmEdicaoLabel']()).toBe('Importado SIORG');
 
     component['salvar']();
 
@@ -489,7 +473,6 @@ describe('UnidadesPage', () => {
     expect(put.request.method).toBe('PUT');
     expect(put.request.headers.get('Idempotency-Key')).toBe(key);
     expect(put.request.body).not.toHaveProperty('vigenciaInicio');
-    expect(put.request.body).not.toHaveProperty('origem');
     expect(put.request.body).toMatchObject({
       id: INSTITUTO_ID,
       nome: 'Instituto Renomeado',
@@ -542,24 +525,6 @@ describe('UnidadesPage', () => {
     component['form'].controls.tipo.setValue(TipoUnidade.faculdade);
     expect(component['tipoNaoReconhecido']()).toBe(false);
     expect(component['form'].controls.tipo.valid).toBe(true);
-  });
-
-  it('preserva origem desconhecida ao editar e reabilita o campo ao criar', async () => {
-    await flushInicial();
-
-    component['abrirEdicao']({ ...unidadesSeed[1], origem: 'OrigemExterna' });
-    await flushOpcoesSuperior();
-
-    expect(component['form'].controls.origem.disabled).toBe(true);
-    expect(component['form'].controls.origem.value).toBe('');
-    expect(component['origemEmEdicaoLabel']()).toBe('OrigemExterna');
-
-    component['abrirCadastro']();
-    await flushOpcoesSuperior();
-
-    expect(component['form'].controls.origem.enabled).toBe(true);
-    expect(component['form'].controls.origem.value).toBe(OrigemUnidade.criadoNoUniPlus);
-    expect(component['origemEmEdicaoLabel']()).toBe('');
   });
 
   it('remove unidade sem Idempotency-Key porque o endpoint DELETE não exige o header', async () => {

--- a/apps/configuracao/src/app/features/unidades/unidades.page.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.ts
@@ -34,9 +34,7 @@ import {
   AtualizarUnidadeCommand,
   CriarUnidadeCommand,
   ORGANIZACAO_BASE_PATH,
-  ORIGENS_UNIDADE,
   TIPOS_UNIDADE,
-  OrigemUnidade,
   TipoUnidade,
   UnidadeDto,
   UnidadesApi,
@@ -96,7 +94,6 @@ interface UnidadeForm {
   unidadeAcademica: FormControl<boolean>;
   vigenciaInicio: FormControl<string>;
   vigenciaFim: FormControl<string>;
-  origem: FormControl<string>;
   motivoMudancaIdentificador: FormControl<string>;
 }
 
@@ -114,7 +111,6 @@ const BACKEND_FIELD_TO_CONTROL = {
   MotivoMudancaIdentificador: 'motivoMudancaIdentificador',
   MotivoMudançaIdentificador: 'motivoMudancaIdentificador',
   Nome: 'nome',
-  Origem: 'origem',
   Sigla: 'sigla',
   Slug: 'slug',
   Tipo: 'tipo',
@@ -414,8 +410,6 @@ const BACKEND_FIELD_TO_CONTROL = {
           <dd>{{ unidadeSuperiorLabel(unidade.unidadeSuperiorId) }}</dd>
           <dt>Unidade acadêmica</dt>
           <dd>{{ unidade.unidadeAcademica ? 'Sim' : 'Não' }}</dd>
-          <dt>Origem</dt>
-          <dd>{{ unidade.origem }}</dd>
           <dt>Vigência</dt>
           <dd>{{ vigenciaLabel(unidade) }}</dd>
         </dl>
@@ -607,7 +601,7 @@ const BACKEND_FIELD_TO_CONTROL = {
         </section>
 
         <section aria-labelledby="cfg-form-vigencia">
-          <h3 id="cfg-form-vigencia" class="form-section__title">Vigência e origem</h3>
+          <h3 id="cfg-form-vigencia" class="form-section__title">Vigência</h3>
           <div class="form-grid">
             <label class="field" [class.is-error]="erroDoCampo('vigenciaInicio')">
               <span class="field__label is-required">Início de vigência</span>
@@ -635,21 +629,6 @@ const BACKEND_FIELD_TO_CONTROL = {
                 <span class="field__error">{{ erroDoCampo('vigenciaFim') }}</span>
               }
             </label>
-            @if (modo() === 'criar') {
-              <label class="field field--full">
-                <span class="field__label is-required">Origem do registro</span>
-                <select class="select" formControlName="origem">
-                  @for (origem of origemOptions; track origem.value) {
-                    <option [value]="origem.value">{{ origem.label }}</option>
-                  }
-                </select>
-              </label>
-            } @else {
-              <div class="field field--full">
-                <span class="field__label">Origem do registro</span>
-                <span class="field__readonly">{{ origemEmEdicaoLabel() }}</span>
-              </div>
-            }
             @if (modo() === 'editar') {
               <label class="field field--full">
                 <span class="field__label">Motivo da mudança de identificador</span>
@@ -706,7 +685,6 @@ export class UnidadesPage {
   protected readonly unidadeParaRemover = signal<UnidadeDto | null>(null);
   protected readonly modo = signal<ModoFormulario>('criar');
   protected readonly unidadeEmEdicaoId = signal<string | null>(null);
-  protected readonly origemEmEdicao = signal<string | null>(null);
   protected readonly idempotencyKeyAtual = signal(idempotencyKey.create());
 
   // Termo de busca aplicado — debounced (uma request por rajada, não por tecla).
@@ -920,10 +898,6 @@ export class UnidadesPage {
     value: tipo.value,
     label: tipo.label,
   }));
-  protected readonly origemOptions = ORIGENS_UNIDADE.map((origem) => ({
-    value: origem.value,
-    label: origem.label,
-  }));
 
   /**
    * Chips de tipo a partir do roster fechado `TIPOS_UNIDADE` (11 tipos).
@@ -947,9 +921,6 @@ export class UnidadesPage {
   protected readonly arvore = computed(() => montarArvore(this.unidades()));
   protected readonly formHeading = computed(() =>
     this.modo() === 'criar' ? 'Nova unidade' : 'Editar unidade',
-  );
-  protected readonly origemEmEdicaoLabel = computed(() =>
-    origemDisplayLabel(this.origemEmEdicao()),
   );
   protected readonly confirmMessage = computed(() => {
     const unidade = this.unidadeParaRemover();
@@ -984,10 +955,6 @@ export class UnidadesPage {
       validators: [Validators.required],
     }),
     vigenciaFim: new FormControl('', { nonNullable: true }),
-    origem: new FormControl(OrigemUnidade.criadoNoUniPlus, {
-      nonNullable: true,
-      validators: [Validators.required],
-    }),
     motivoMudancaIdentificador: new FormControl('', { nonNullable: true }),
   });
 
@@ -1100,8 +1067,6 @@ export class UnidadesPage {
   protected abrirCadastro(): void {
     this.modo.set('criar');
     this.unidadeEmEdicaoId.set(null);
-    this.origemEmEdicao.set(null);
-    this.form.controls.origem.enable({ emitEvent: false });
     this.form.reset({
       nome: '',
       alias: '',
@@ -1113,7 +1078,6 @@ export class UnidadesPage {
       unidadeAcademica: false,
       vigenciaInicio: dataAtualIso(),
       vigenciaFim: '',
-      origem: OrigemUnidade.criadoNoUniPlus,
       motivoMudancaIdentificador: '',
     });
     this.formError.set(null);
@@ -1125,8 +1089,6 @@ export class UnidadesPage {
   protected abrirEdicao(unidade: UnidadeDto): void {
     this.modo.set('editar');
     this.unidadeEmEdicaoId.set(unidade.id);
-    this.origemEmEdicao.set(unidade.origem);
-    this.form.controls.origem.disable({ emitEvent: false });
     this.form.reset({
       nome: unidade.nome,
       alias: unidade.alias ?? '',
@@ -1138,7 +1100,6 @@ export class UnidadesPage {
       unidadeAcademica: unidade.unidadeAcademica,
       vigenciaInicio: unidade.vigenciaInicio,
       vigenciaFim: unidade.vigenciaFim ?? '',
-      origem: origemValueFromLabel(unidade.origem),
       motivoMudancaIdentificador: '',
     });
     this.formError.set(null);
@@ -1332,7 +1293,6 @@ export class UnidadesPage {
       unidadeAcademica: raw.unidadeAcademica,
       vigenciaInicio: raw.vigenciaInicio,
       vigenciaFim: nullIfBlank(raw.vigenciaFim),
-      origem: raw.origem as OrigemUnidade,
     };
   }
 
@@ -1405,7 +1365,6 @@ function isUnidadeControlName(value: string): value is keyof UnidadeForm {
     'codigo',
     'motivoMudancaIdentificador',
     'nome',
-    'origem',
     'sigla',
     'slug',
     'tipo',
@@ -1441,24 +1400,6 @@ function tipoValueFromLabel(label: string): string {
   // Sem casamento: devolve vazio (controle inválido) em vez de assumir "Outro" —
   // editar+salvar não deve reclassificar a unidade silenciosamente.
   return option === undefined ? '' : option.value;
-}
-
-function origemValueFromLabel(label: string): string {
-  const option = ORIGENS_UNIDADE.find(
-    (origem) => normalizarEnumLabel(origem.label) === normalizarEnumLabel(label),
-  );
-  return option === undefined ? '' : option.value;
-}
-
-function origemDisplayLabel(label: string | null): string {
-  if (label === null || label.trim().length === 0) {
-    return '';
-  }
-
-  const option = ORIGENS_UNIDADE.find(
-    (origem) => normalizarEnumLabel(origem.label) === normalizarEnumLabel(label),
-  );
-  return option?.label ?? label;
 }
 
 function normalizarEnumLabel(value: string): string {

--- a/libs/shared-data/openapi/organizacao.openapi.json
+++ b/libs/shared-data/openapi/organizacao.openapi.json
@@ -323,6 +323,9 @@
                 }
               }
             }
+          },
+          "413": {
+            "description": "Corpo acima do limite dos endpoints idempotentes (uniplus.idempotency.body_muito_grande). O limite \u00E9 do filtro, n\u00E3o do servidor."
           }
         },
         "x-uniplus-idempotent": true
@@ -429,6 +432,12 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Requisi\u00E7\u00E3o concorrente com a mesma Idempotency-Key ainda em processamento (uniplus.idempotency.processing_conflict). Repetir depois \u2014 a opera\u00E7\u00E3o anterior ainda n\u00E3o concluiu."
+          },
+          "413": {
+            "description": "Corpo acima do limite dos endpoints idempotentes (uniplus.idempotency.body_muito_grande). O limite \u00E9 do filtro, n\u00E3o do servidor."
           }
         },
         "x-uniplus-idempotent": true
@@ -805,6 +814,9 @@
                 }
               }
             }
+          },
+          "413": {
+            "description": "Corpo acima do limite dos endpoints idempotentes (uniplus.idempotency.body_muito_grande). O limite \u00E9 do filtro, n\u00E3o do servidor."
           }
         },
         "x-uniplus-idempotent": true
@@ -921,6 +933,9 @@
                 }
               }
             }
+          },
+          "413": {
+            "description": "Corpo acima do limite dos endpoints idempotentes (uniplus.idempotency.body_muito_grande). O limite \u00E9 do filtro, n\u00E3o do servidor."
           }
         },
         "x-uniplus-idempotent": true
@@ -1431,8 +1446,7 @@
           "tipo",
           "unidadeAcademica",
           "vigenciaInicio",
-          "vigenciaFim",
-          "origem"
+          "vigenciaFim"
         ],
         "type": "object",
         "properties": {
@@ -1477,9 +1491,6 @@
               "string"
             ],
             "format": "date"
-          },
-          "origem": {
-            "$ref": "#/components/schemas/OrigemUnidade"
           }
         }
       },
@@ -1806,15 +1817,6 @@
           }
         }
       },
-      "OrigemUnidade": {
-        "enum": [
-          "nenhum",
-          "legadoCoc",
-          "criadoNoUniPlus",
-          "importadoSiorg"
-        ],
-        "type": "string"
-      },
       "ProblemDetails": {
         "type": "object",
         "properties": {
@@ -1883,7 +1885,6 @@
           "unidadeAcademica",
           "vigenciaInicio",
           "vigenciaFim",
-          "origem",
           "criadoEm"
         ],
         "type": "object",
@@ -1933,9 +1934,6 @@
               "string"
             ],
             "format": "date"
-          },
-          "origem": {
-            "type": "string"
           },
           "criadoEm": {
             "type": "string",

--- a/libs/shared-data/src/lib/api/organizacao/index.ts
+++ b/libs/shared-data/src/lib/api/organizacao/index.ts
@@ -10,14 +10,11 @@ export {
   type InstituicaoDto,
 } from './instituicao.api';
 export {
-  ORIGENS_UNIDADE,
-  OrigemUnidade,
   TIPOS_UNIDADE,
   TipoUnidade,
   UnidadesApi,
   type AtualizarUnidadeCommand,
   type CriarUnidadeCommand,
   type UnidadeDto,
-  type UnidadeOrigemOption,
   type UnidadeTipoOption,
 } from './unidades.api';

--- a/libs/shared-data/src/lib/api/organizacao/schema.ts
+++ b/libs/shared-data/src/lib/api/organizacao/schema.ts
@@ -233,6 +233,13 @@ export interface paths {
                         readonly "application/problem+json": components["schemas"]["ProblemDetails"];
                     };
                 };
+                /** @description Corpo acima do limite dos endpoints idempotentes (uniplus.idempotency.body_muito_grande). O limite é do filtro, não do servidor. */
+                readonly 413: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content?: never;
+                };
                 /** @description Unprocessable Entity */
                 readonly 422: {
                     headers: {
@@ -320,6 +327,20 @@ export interface paths {
                     content: {
                         readonly "application/problem+json": components["schemas"]["ProblemDetails"];
                     };
+                };
+                /** @description Requisição concorrente com a mesma Idempotency-Key ainda em processamento (uniplus.idempotency.processing_conflict). Repetir depois — a operação anterior ainda não concluiu. */
+                readonly 409: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Corpo acima do limite dos endpoints idempotentes (uniplus.idempotency.body_muito_grande). O limite é do filtro, não do servidor. */
+                readonly 413: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content?: never;
                 };
                 /** @description Unprocessable Entity */
                 readonly 422: {
@@ -602,6 +623,13 @@ export interface paths {
                         readonly "application/problem+json": components["schemas"]["ProblemDetails"];
                     };
                 };
+                /** @description Corpo acima do limite dos endpoints idempotentes (uniplus.idempotency.body_muito_grande). O limite é do filtro, não do servidor. */
+                readonly 413: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content?: never;
+                };
                 /** @description Unprocessable Entity */
                 readonly 422: {
                     headers: {
@@ -698,6 +726,13 @@ export interface paths {
                     content: {
                         readonly "application/problem+json": components["schemas"]["ProblemDetails"];
                     };
+                };
+                /** @description Corpo acima do limite dos endpoints idempotentes (uniplus.idempotency.body_muito_grande). O limite é do filtro, não do servidor. */
+                readonly 413: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content?: never;
                 };
                 /** @description Unprocessable Entity */
                 readonly 422: {
@@ -873,7 +908,6 @@ export interface components {
             readonly vigenciaInicio: string;
             /** Format: date */
             readonly vigenciaFim: null | string;
-            readonly origem: components["schemas"]["OrigemUnidade"];
         };
         readonly EnderecoGeoDto: {
             readonly cep: string;
@@ -936,8 +970,6 @@ export interface components {
                 readonly [key: string]: string;
             };
         };
-        /** @enum {string} */
-        readonly OrigemUnidade: OrigemUnidade;
         readonly ProblemDetails: {
             readonly type?: null | string;
             readonly title?: null | string;
@@ -964,7 +996,6 @@ export interface components {
             readonly vigenciaInicio: string;
             /** Format: date */
             readonly vigenciaFim: null | string;
-            readonly origem: string;
             /** Format: date-time */
             readonly criadoEm: string;
             readonly _links?: null | {
@@ -1115,12 +1146,6 @@ export interface operations {
 export enum PathsApiOrganizacaoUnidadesGetParametersQueryDirection {
     next = "next",
     prev = "prev"
-}
-export enum OrigemUnidade {
-    nenhum = "nenhum",
-    legadoCoc = "legadoCoc",
-    criadoNoUniPlus = "criadoNoUniPlus",
-    importadoSiorg = "importadoSiorg"
 }
 export enum TipoUnidade {
     nenhum = "nenhum",

--- a/libs/shared-data/src/lib/api/organizacao/unidades.api.spec.ts
+++ b/libs/shared-data/src/lib/api/organizacao/unidades.api.spec.ts
@@ -13,7 +13,6 @@ import {
 import {
   AtualizarUnidadeCommand,
   CriarUnidadeCommand,
-  OrigemUnidade,
   TIPOS_UNIDADE,
   TipoUnidade,
   UnidadeDto,
@@ -36,7 +35,6 @@ const unidadeSeed: UnidadeDto = {
   unidadeAcademica: true,
   vigenciaInicio: '2026-01-01',
   vigenciaFim: null,
-  origem: 'CriadoNoUniPlus',
   criadoEm: '2026-06-10T12:00:00Z',
 };
 
@@ -51,7 +49,6 @@ const criarCommand: CriarUnidadeCommand = {
   unidadeAcademica: true,
   vigenciaInicio: '2026-01-01',
   vigenciaFim: null,
-  origem: OrigemUnidade.criadoNoUniPlus,
 };
 
 const atualizarCommand: AtualizarUnidadeCommand = {

--- a/libs/shared-data/src/lib/api/organizacao/unidades.api.ts
+++ b/libs/shared-data/src/lib/api/organizacao/unidades.api.ts
@@ -2,22 +2,17 @@ import { HttpClient, HttpContext, HttpHeaders } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { ApiResult, withVendorMime } from '@uniplus/shared-core/http';
-import { OrigemUnidade, TipoUnidade } from './schema';
+import { TipoUnidade } from './schema';
 import { ORGANIZACAO_BASE_PATH } from './tokens';
 import type { components } from './schema';
 
 export type UnidadeDto = components['schemas']['UnidadeDto'];
 export type CriarUnidadeCommand = components['schemas']['CriarUnidadeCommand'];
 export type AtualizarUnidadeCommand = components['schemas']['AtualizarUnidadeCommand'];
-export { OrigemUnidade, TipoUnidade };
+export { TipoUnidade };
 
 export interface UnidadeTipoOption {
   readonly value: TipoUnidade;
-  readonly label: string;
-}
-
-export interface UnidadeOrigemOption {
-  readonly value: OrigemUnidade;
   readonly label: string;
 }
 
@@ -33,12 +28,6 @@ export const TIPOS_UNIDADE: readonly UnidadeTipoOption[] = [
   { value: TipoUnidade.divisao, label: 'Divisão' },
   { value: TipoUnidade.nucleo, label: 'Núcleo' },
   { value: TipoUnidade.outro, label: 'Outro' },
-] as const;
-
-export const ORIGENS_UNIDADE: readonly UnidadeOrigemOption[] = [
-  { value: OrigemUnidade.legadoCoc, label: 'Legado COC' },
-  { value: OrigemUnidade.criadoNoUniPlus, label: 'Criado no Uni+' },
-  { value: OrigemUnidade.importadoSiorg, label: 'Importado SIORG' },
 ] as const;
 
 @Injectable({ providedIn: 'root' })

--- a/libs/shared-data/src/lib/index.ts
+++ b/libs/shared-data/src/lib/index.ts
@@ -14,15 +14,12 @@ export { CONFIGURACAO_BASE_PATH } from './api/configuracao/tokens';
 export { ORGANIZACAO_BASE_PATH } from './api/organizacao/tokens';
 export { GEO_BASE_PATH } from './api/geo/tokens';
 export {
-  ORIGENS_UNIDADE,
-  OrigemUnidade,
   TIPOS_UNIDADE,
   TipoUnidade,
   UnidadesApi,
   type AtualizarUnidadeCommand,
   type CriarUnidadeCommand,
   type UnidadeDto,
-  type UnidadeOrigemOption,
   type UnidadeTipoOption,
 } from './api/organizacao/unidades.api';
 


### PR DESCRIPTION
## Resumo

Remove o campo de origem do cadastro de Unidade — espelho, no frontend, da remoção de `OrigemUnidade` no backend (`unifesspa-edu-br/uniplus-api#1001`, mergeada via `unifesspa-edu-br/uniplus-api#1002`). Procedência de registro é metadado de carga, não atributo de negócio da Unidade; "Importado SIORG" documentava uma integração que nunca existiu neste contexto.

## O que muda

- Ressincroniza `libs/shared-data/openapi/organizacao.openapi.json` a partir do contrato atual do backend (`origin/main` do `uniplus-api`) e regenera `schema.ts` via `npm run generate:api`: remove o enum `OrigemUnidade` e o campo `origem` de `UnidadeDto`/`CriarUnidadeCommand`. O mesmo baseline já trazia (não relacionado a esta issue) descrições de resposta `409`/`413` de idempotência que ainda não tinham sido sincronizadas — vieram junto por serem parte do mesmo arquivo.
- Remove `ORIGENS_UNIDADE`/`UnidadeOrigemOption` e o reexport de `OrigemUnidade` de `unidades.api.ts` e dos barrels (`organizacao/index.ts`, `shared-data/index.ts`).
- Remove o campo "Origem do registro" do formulário de Unidade (criar e editar), a linha correspondente no drawer de detalhe, o controle `origem` do `FormGroup`/`UnidadeForm` e as funções órfãs `origemValueFromLabel`/`origemDisplayLabel`.
- Ajusta os specs: remove `origem` dos seeds/comandos de teste e remove o teste que cobria origem desconhecida ao editar (perdeu sentido sem o campo).

## Sequenciamento

A issue original propunha 3 passos (tolerar ausência → merge do backend → remoção completa) para evitar uma janela insegura entre os dois merges. Como o PR do backend (`uniplus-api#1002`) já está mergeado em `main` e não há usuários reais em HML — alternativa citada no próprio comentário da issue —, este PR já aplica a remoção completa em um único passo, sem introduzir uma tolerância transitória que seria removida no mesmo PR.

## Critérios de aceite (issue)

- [x] Cadastrar unidade: não há mais campo de origem para preencher; o cadastro conclui normalmente.
- [x] Contrato regenerado: `OrigemUnidade` não existe mais em `schema.ts` e nada no workspace o referencia (confirmado por `grep` no repositório inteiro).

## Testes

- `npx nx run-many --target=typecheck --projects=shared-data,configuracao` ✅
- `npx nx run-many --target=lint --projects=shared-data,configuracao` ✅
- `npx nx run-many --target=vite:test --projects=shared-data,configuracao` ✅ (225 + 241 testes)
- `npx nx build configuracao` ✅ (aviso de orçamento de bundle é pré-existente, não introduzido por este PR)

Closes `#487`