### PR TITLE
refactor(shared-data): Regenera contratos shared-data removendo rotas api/_smoke/*

### DIFF
--- a/libs/shared-data/openapi/configuracao.openapi.json
+++ b/libs/shared-data/openapi/configuracao.openapi.json
@@ -89,79 +89,6 @@
         }
       }
     },
-    "/api/_smoke/storage/upload": {
-      "post": {
-        "tags": [
-          "_smoke"
-        ],
-        "summary": "Smoke E2E \u2014 Storage upload",
-        "description": "Faz upload de um arquivo no bucket configurado para validar conectividade \u002B credentials do MinIO. Restrito a usu\u00E1rios com role admin.",
-        "operationId": "smokeStorageUpload",
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "required": [
-                  "file"
-                ],
-                "type": "object",
-                "properties": {
-                  "file": {
-                    "$ref": "#/components/schemas/IFormFile"
-                  }
-                }
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
-    },
-    "/api/_smoke/cache/{key}": {
-      "get": {
-        "tags": [
-          "_smoke"
-        ],
-        "summary": "Smoke E2E \u2014 Cache probe",
-        "description": "Faz SET/GET de uma chave tempor\u00E1ria no Redis com TTL 5min para validar conectividade. Restrito a usu\u00E1rios com role admin.",
-        "operationId": "smokeCacheProbe",
-        "parameters": [
-          {
-            "name": "key",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
-    },
-    "/api/_smoke/messaging/publish": {
-      "post": {
-        "tags": [
-          "_smoke"
-        ],
-        "summary": "Smoke E2E \u2014 Messaging publish",
-        "description": "Publica um SmokePingMessage via Wolverine outbox para validar persist\u00EAncia \u002B transport (PG queue ou Kafka). O handler em Infrastructure.Core registra log do round-trip. Restrito a usu\u00E1rios com role admin.",
-        "operationId": "smokeMessagingPublish",
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
-    },
     "/api/configuracao/campi": {
       "get": {
         "tags": [
@@ -7893,10 +7820,6 @@
           }
         }
       },
-      "IFormFile": {
-        "type": "string",
-        "format": "binary"
-      },
       "LocalOfertaDto": {
         "required": [
           "id",
@@ -8633,9 +8556,6 @@
     },
     {
       "name": "Profile"
-    },
-    {
-      "name": "_smoke"
     },
     {
       "name": "Campi"

--- a/libs/shared-data/openapi/ingresso.openapi.json
+++ b/libs/shared-data/openapi/ingresso.openapi.json
@@ -88,79 +88,6 @@
           }
         }
       }
-    },
-    "/api/_smoke/storage/upload": {
-      "post": {
-        "tags": [
-          "_smoke"
-        ],
-        "summary": "Smoke E2E \u2014 Storage upload",
-        "description": "Faz upload de um arquivo no bucket configurado para validar conectividade \u002B credentials do MinIO. Restrito a usu\u00E1rios com role admin.",
-        "operationId": "smokeStorageUpload",
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "required": [
-                  "file"
-                ],
-                "type": "object",
-                "properties": {
-                  "file": {
-                    "$ref": "#/components/schemas/IFormFile"
-                  }
-                }
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
-    },
-    "/api/_smoke/cache/{key}": {
-      "get": {
-        "tags": [
-          "_smoke"
-        ],
-        "summary": "Smoke E2E \u2014 Cache probe",
-        "description": "Faz SET/GET de uma chave tempor\u00E1ria no Redis com TTL 5min para validar conectividade. Restrito a usu\u00E1rios com role admin.",
-        "operationId": "smokeCacheProbe",
-        "parameters": [
-          {
-            "name": "key",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
-    },
-    "/api/_smoke/messaging/publish": {
-      "post": {
-        "tags": [
-          "_smoke"
-        ],
-        "summary": "Smoke E2E \u2014 Messaging publish",
-        "description": "Publica um SmokePingMessage via Wolverine outbox para validar persist\u00EAncia \u002B transport (PG queue ou Kafka). O handler em Infrastructure.Core registra log do round-trip. Restrito a usu\u00E1rios com role admin.",
-        "operationId": "smokeMessagingPublish",
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
     }
   },
   "components": {
@@ -204,10 +131,6 @@
             "format": "date-time"
           }
         }
-      },
-      "IFormFile": {
-        "type": "string",
-        "format": "binary"
       },
       "ProblemDetails": {
         "type": "object",
@@ -311,9 +234,6 @@
     },
     {
       "name": "Profile"
-    },
-    {
-      "name": "_smoke"
     }
   ]
 }

--- a/libs/shared-data/openapi/organizacao.openapi.json
+++ b/libs/shared-data/openapi/organizacao.openapi.json
@@ -89,79 +89,6 @@
         }
       }
     },
-    "/api/_smoke/storage/upload": {
-      "post": {
-        "tags": [
-          "_smoke"
-        ],
-        "summary": "Smoke E2E \u2014 Storage upload",
-        "description": "Faz upload de um arquivo no bucket configurado para validar conectividade \u002B credentials do MinIO. Restrito a usu\u00E1rios com role admin.",
-        "operationId": "smokeStorageUpload",
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "required": [
-                  "file"
-                ],
-                "type": "object",
-                "properties": {
-                  "file": {
-                    "$ref": "#/components/schemas/IFormFile"
-                  }
-                }
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
-    },
-    "/api/_smoke/cache/{key}": {
-      "get": {
-        "tags": [
-          "_smoke"
-        ],
-        "summary": "Smoke E2E \u2014 Cache probe",
-        "description": "Faz SET/GET de uma chave tempor\u00E1ria no Redis com TTL 5min para validar conectividade. Restrito a usu\u00E1rios com role admin.",
-        "operationId": "smokeCacheProbe",
-        "parameters": [
-          {
-            "name": "key",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
-    },
-    "/api/_smoke/messaging/publish": {
-      "post": {
-        "tags": [
-          "_smoke"
-        ],
-        "summary": "Smoke E2E \u2014 Messaging publish",
-        "description": "Publica um SmokePingMessage via Wolverine outbox para validar persist\u00EAncia \u002B transport (PG queue ou Kafka). O handler em Infrastructure.Core registra log do round-trip. Restrito a usu\u00E1rios com role admin.",
-        "operationId": "smokeMessagingPublish",
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
-    },
     "/api/organizacao/instituicao": {
       "get": {
         "tags": [
@@ -1674,10 +1601,6 @@
           }
         }
       },
-      "IFormFile": {
-        "type": "string",
-        "format": "binary"
-      },
       "InstituicaoDto": {
         "required": [
           "id",
@@ -2014,9 +1937,6 @@
     },
     {
       "name": "Profile"
-    },
-    {
-      "name": "_smoke"
     },
     {
       "name": "Instituicao"

--- a/libs/shared-data/openapi/selecao.openapi.json
+++ b/libs/shared-data/openapi/selecao.openapi.json
@@ -89,79 +89,6 @@
         }
       }
     },
-    "/api/_smoke/storage/upload": {
-      "post": {
-        "tags": [
-          "_smoke"
-        ],
-        "summary": "Smoke E2E \u2014 Storage upload",
-        "description": "Faz upload de um arquivo no bucket configurado para validar conectividade \u002B credentials do MinIO. Restrito a usu\u00E1rios com role admin.",
-        "operationId": "smokeStorageUpload",
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "required": [
-                  "file"
-                ],
-                "type": "object",
-                "properties": {
-                  "file": {
-                    "$ref": "#/components/schemas/IFormFile"
-                  }
-                }
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
-    },
-    "/api/_smoke/cache/{key}": {
-      "get": {
-        "tags": [
-          "_smoke"
-        ],
-        "summary": "Smoke E2E \u2014 Cache probe",
-        "description": "Faz SET/GET de uma chave tempor\u00E1ria no Redis com TTL 5min para validar conectividade. Restrito a usu\u00E1rios com role admin.",
-        "operationId": "smokeCacheProbe",
-        "parameters": [
-          {
-            "name": "key",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
-    },
-    "/api/_smoke/messaging/publish": {
-      "post": {
-        "tags": [
-          "_smoke"
-        ],
-        "summary": "Smoke E2E \u2014 Messaging publish",
-        "description": "Publica um SmokePingMessage via Wolverine outbox para validar persist\u00EAncia \u002B transport (PG queue ou Kafka). O handler em Infrastructure.Core registra log do round-trip. Restrito a usu\u00E1rios com role admin.",
-        "operationId": "smokeMessagingPublish",
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        }
-      }
-    },
     "/api/selecao/obrigatoriedades-legais": {
       "get": {
         "tags": [
@@ -831,10 +758,6 @@
           }
         }
       },
-      "IFormFile": {
-        "type": "string",
-        "format": "binary"
-      },
       "JsonElement": {},
       "ObrigatoriedadeLegalDto": {
         "required": [
@@ -1198,9 +1121,6 @@
     },
     {
       "name": "Profile"
-    },
-    {
-      "name": "_smoke"
     },
     {
       "name": "ObrigatoriedadeLegal"

--- a/libs/shared-data/src/lib/api/configuracao/schema.ts
+++ b/libs/shared-data/src/lib/api/configuracao/schema.ts
@@ -44,66 +44,6 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
-    readonly "/api/_smoke/storage/upload": {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path?: never;
-            readonly cookie?: never;
-        };
-        readonly get?: never;
-        readonly put?: never;
-        /**
-         * Smoke E2E — Storage upload
-         * @description Faz upload de um arquivo no bucket configurado para validar conectividade + credentials do MinIO. Restrito a usuários com role admin.
-         */
-        readonly post: operations["smokeStorageUpload"];
-        readonly delete?: never;
-        readonly options?: never;
-        readonly head?: never;
-        readonly patch?: never;
-        readonly trace?: never;
-    };
-    readonly "/api/_smoke/cache/{key}": {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path?: never;
-            readonly cookie?: never;
-        };
-        /**
-         * Smoke E2E — Cache probe
-         * @description Faz SET/GET de uma chave temporária no Redis com TTL 5min para validar conectividade. Restrito a usuários com role admin.
-         */
-        readonly get: operations["smokeCacheProbe"];
-        readonly put?: never;
-        readonly post?: never;
-        readonly delete?: never;
-        readonly options?: never;
-        readonly head?: never;
-        readonly patch?: never;
-        readonly trace?: never;
-    };
-    readonly "/api/_smoke/messaging/publish": {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path?: never;
-            readonly cookie?: never;
-        };
-        readonly get?: never;
-        readonly put?: never;
-        /**
-         * Smoke E2E — Messaging publish
-         * @description Publica um SmokePingMessage via Wolverine outbox para validar persistência + transport (PG queue ou Kafka). O handler em Infrastructure.Core registra log do round-trip. Restrito a usuários com role admin.
-         */
-        readonly post: operations["smokeMessagingPublish"];
-        readonly delete?: never;
-        readonly options?: never;
-        readonly head?: never;
-        readonly patch?: never;
-        readonly trace?: never;
-    };
     readonly "/api/configuracao/campi": {
         readonly parameters: {
             readonly query?: never;
@@ -5342,8 +5282,6 @@ export interface components {
                 readonly [key: string]: string;
             };
         };
-        /** Format: binary */
-        readonly IFormFile: string;
         readonly LocalOfertaDto: {
             /** Format: uuid */
             readonly id: string;
@@ -5588,68 +5526,6 @@ export interface operations {
                 content: {
                     readonly "application/problem+json": components["schemas"]["ProblemDetails"];
                 };
-            };
-        };
-    };
-    readonly smokeStorageUpload: {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path?: never;
-            readonly cookie?: never;
-        };
-        readonly requestBody: {
-            readonly content: {
-                readonly "multipart/form-data": {
-                    readonly file: components["schemas"]["IFormFile"];
-                };
-            };
-        };
-        readonly responses: {
-            /** @description OK */
-            readonly 200: {
-                headers: {
-                    readonly [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    readonly smokeCacheProbe: {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path: {
-                readonly key: string;
-            };
-            readonly cookie?: never;
-        };
-        readonly requestBody?: never;
-        readonly responses: {
-            /** @description OK */
-            readonly 200: {
-                headers: {
-                    readonly [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    readonly smokeMessagingPublish: {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path?: never;
-            readonly cookie?: never;
-        };
-        readonly requestBody?: never;
-        readonly responses: {
-            /** @description OK */
-            readonly 200: {
-                headers: {
-                    readonly [name: string]: unknown;
-                };
-                content?: never;
             };
         };
     };

--- a/libs/shared-data/src/lib/api/ingresso/schema.ts
+++ b/libs/shared-data/src/lib/api/ingresso/schema.ts
@@ -44,66 +44,6 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
-    readonly "/api/_smoke/storage/upload": {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path?: never;
-            readonly cookie?: never;
-        };
-        readonly get?: never;
-        readonly put?: never;
-        /**
-         * Smoke E2E — Storage upload
-         * @description Faz upload de um arquivo no bucket configurado para validar conectividade + credentials do MinIO. Restrito a usuários com role admin.
-         */
-        readonly post: operations["smokeStorageUpload"];
-        readonly delete?: never;
-        readonly options?: never;
-        readonly head?: never;
-        readonly patch?: never;
-        readonly trace?: never;
-    };
-    readonly "/api/_smoke/cache/{key}": {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path?: never;
-            readonly cookie?: never;
-        };
-        /**
-         * Smoke E2E — Cache probe
-         * @description Faz SET/GET de uma chave temporária no Redis com TTL 5min para validar conectividade. Restrito a usuários com role admin.
-         */
-        readonly get: operations["smokeCacheProbe"];
-        readonly put?: never;
-        readonly post?: never;
-        readonly delete?: never;
-        readonly options?: never;
-        readonly head?: never;
-        readonly patch?: never;
-        readonly trace?: never;
-    };
-    readonly "/api/_smoke/messaging/publish": {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path?: never;
-            readonly cookie?: never;
-        };
-        readonly get?: never;
-        readonly put?: never;
-        /**
-         * Smoke E2E — Messaging publish
-         * @description Publica um SmokePingMessage via Wolverine outbox para validar persistência + transport (PG queue ou Kafka). O handler em Infrastructure.Core registra log do round-trip. Restrito a usuários com role admin.
-         */
-        readonly post: operations["smokeMessagingPublish"];
-        readonly delete?: never;
-        readonly options?: never;
-        readonly head?: never;
-        readonly patch?: never;
-        readonly trace?: never;
-    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -116,8 +56,6 @@ export interface components {
             /** Format: date-time */
             readonly timestamp: string;
         };
-        /** Format: binary */
-        readonly IFormFile: string;
         readonly ProblemDetails: {
             readonly type?: null | string;
             readonly title?: null | string;
@@ -201,68 +139,6 @@ export interface operations {
                 content: {
                     readonly "application/problem+json": components["schemas"]["ProblemDetails"];
                 };
-            };
-        };
-    };
-    readonly smokeStorageUpload: {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path?: never;
-            readonly cookie?: never;
-        };
-        readonly requestBody: {
-            readonly content: {
-                readonly "multipart/form-data": {
-                    readonly file: components["schemas"]["IFormFile"];
-                };
-            };
-        };
-        readonly responses: {
-            /** @description OK */
-            readonly 200: {
-                headers: {
-                    readonly [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    readonly smokeCacheProbe: {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path: {
-                readonly key: string;
-            };
-            readonly cookie?: never;
-        };
-        readonly requestBody?: never;
-        readonly responses: {
-            /** @description OK */
-            readonly 200: {
-                headers: {
-                    readonly [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    readonly smokeMessagingPublish: {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path?: never;
-            readonly cookie?: never;
-        };
-        readonly requestBody?: never;
-        readonly responses: {
-            /** @description OK */
-            readonly 200: {
-                headers: {
-                    readonly [name: string]: unknown;
-                };
-                content?: never;
             };
         };
     };

--- a/libs/shared-data/src/lib/api/organizacao/schema.ts
+++ b/libs/shared-data/src/lib/api/organizacao/schema.ts
@@ -44,66 +44,6 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
-    readonly "/api/_smoke/storage/upload": {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path?: never;
-            readonly cookie?: never;
-        };
-        readonly get?: never;
-        readonly put?: never;
-        /**
-         * Smoke E2E — Storage upload
-         * @description Faz upload de um arquivo no bucket configurado para validar conectividade + credentials do MinIO. Restrito a usuários com role admin.
-         */
-        readonly post: operations["smokeStorageUpload"];
-        readonly delete?: never;
-        readonly options?: never;
-        readonly head?: never;
-        readonly patch?: never;
-        readonly trace?: never;
-    };
-    readonly "/api/_smoke/cache/{key}": {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path?: never;
-            readonly cookie?: never;
-        };
-        /**
-         * Smoke E2E — Cache probe
-         * @description Faz SET/GET de uma chave temporária no Redis com TTL 5min para validar conectividade. Restrito a usuários com role admin.
-         */
-        readonly get: operations["smokeCacheProbe"];
-        readonly put?: never;
-        readonly post?: never;
-        readonly delete?: never;
-        readonly options?: never;
-        readonly head?: never;
-        readonly patch?: never;
-        readonly trace?: never;
-    };
-    readonly "/api/_smoke/messaging/publish": {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path?: never;
-            readonly cookie?: never;
-        };
-        readonly get?: never;
-        readonly put?: never;
-        /**
-         * Smoke E2E — Messaging publish
-         * @description Publica um SmokePingMessage via Wolverine outbox para validar persistência + transport (PG queue ou Kafka). O handler em Infrastructure.Core registra log do round-trip. Restrito a usuários com role admin.
-         */
-        readonly post: operations["smokeMessagingPublish"];
-        readonly delete?: never;
-        readonly options?: never;
-        readonly head?: never;
-        readonly patch?: never;
-        readonly trace?: never;
-    };
     readonly "/api/organizacao/instituicao": {
         readonly parameters: {
             readonly query?: never;
@@ -941,8 +881,6 @@ export interface components {
             readonly nivelResolucao: null | string;
             readonly origem: null | string;
         };
-        /** Format: binary */
-        readonly IFormFile: string;
         readonly InstituicaoDto: {
             /** Format: uuid */
             readonly id: string;
@@ -1077,68 +1015,6 @@ export interface operations {
                 content: {
                     readonly "application/problem+json": components["schemas"]["ProblemDetails"];
                 };
-            };
-        };
-    };
-    readonly smokeStorageUpload: {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path?: never;
-            readonly cookie?: never;
-        };
-        readonly requestBody: {
-            readonly content: {
-                readonly "multipart/form-data": {
-                    readonly file: components["schemas"]["IFormFile"];
-                };
-            };
-        };
-        readonly responses: {
-            /** @description OK */
-            readonly 200: {
-                headers: {
-                    readonly [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    readonly smokeCacheProbe: {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path: {
-                readonly key: string;
-            };
-            readonly cookie?: never;
-        };
-        readonly requestBody?: never;
-        readonly responses: {
-            /** @description OK */
-            readonly 200: {
-                headers: {
-                    readonly [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    readonly smokeMessagingPublish: {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path?: never;
-            readonly cookie?: never;
-        };
-        readonly requestBody?: never;
-        readonly responses: {
-            /** @description OK */
-            readonly 200: {
-                headers: {
-                    readonly [name: string]: unknown;
-                };
-                content?: never;
             };
         };
     };

--- a/libs/shared-data/src/lib/api/selecao/schema.ts
+++ b/libs/shared-data/src/lib/api/selecao/schema.ts
@@ -44,66 +44,6 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
-    readonly "/api/_smoke/storage/upload": {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path?: never;
-            readonly cookie?: never;
-        };
-        readonly get?: never;
-        readonly put?: never;
-        /**
-         * Smoke E2E — Storage upload
-         * @description Faz upload de um arquivo no bucket configurado para validar conectividade + credentials do MinIO. Restrito a usuários com role admin.
-         */
-        readonly post: operations["smokeStorageUpload"];
-        readonly delete?: never;
-        readonly options?: never;
-        readonly head?: never;
-        readonly patch?: never;
-        readonly trace?: never;
-    };
-    readonly "/api/_smoke/cache/{key}": {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path?: never;
-            readonly cookie?: never;
-        };
-        /**
-         * Smoke E2E — Cache probe
-         * @description Faz SET/GET de uma chave temporária no Redis com TTL 5min para validar conectividade. Restrito a usuários com role admin.
-         */
-        readonly get: operations["smokeCacheProbe"];
-        readonly put?: never;
-        readonly post?: never;
-        readonly delete?: never;
-        readonly options?: never;
-        readonly head?: never;
-        readonly patch?: never;
-        readonly trace?: never;
-    };
-    readonly "/api/_smoke/messaging/publish": {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path?: never;
-            readonly cookie?: never;
-        };
-        readonly get?: never;
-        readonly put?: never;
-        /**
-         * Smoke E2E — Messaging publish
-         * @description Publica um SmokePingMessage via Wolverine outbox para validar persistência + transport (PG queue ou Kafka). O handler em Infrastructure.Core registra log do round-trip. Restrito a usuários com role admin.
-         */
-        readonly post: operations["smokeMessagingPublish"];
-        readonly delete?: never;
-        readonly options?: never;
-        readonly head?: never;
-        readonly patch?: never;
-        readonly trace?: never;
-    };
     readonly "/api/selecao/obrigatoriedades-legais": {
         readonly parameters: {
             readonly query?: never;
@@ -527,8 +467,6 @@ export interface components {
             readonly atoNormativoUrl: null | string;
             readonly portariaInternaCodigo: null | string;
         };
-        /** Format: binary */
-        readonly IFormFile: string;
         readonly JsonElement: unknown;
         readonly ObrigatoriedadeLegalDto: {
             /** Format: uuid */
@@ -675,68 +613,6 @@ export interface operations {
                 content: {
                     readonly "application/problem+json": components["schemas"]["ProblemDetails"];
                 };
-            };
-        };
-    };
-    readonly smokeStorageUpload: {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path?: never;
-            readonly cookie?: never;
-        };
-        readonly requestBody: {
-            readonly content: {
-                readonly "multipart/form-data": {
-                    readonly file: components["schemas"]["IFormFile"];
-                };
-            };
-        };
-        readonly responses: {
-            /** @description OK */
-            readonly 200: {
-                headers: {
-                    readonly [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    readonly smokeCacheProbe: {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path: {
-                readonly key: string;
-            };
-            readonly cookie?: never;
-        };
-        readonly requestBody?: never;
-        readonly responses: {
-            /** @description OK */
-            readonly 200: {
-                headers: {
-                    readonly [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    readonly smokeMessagingPublish: {
-        readonly parameters: {
-            readonly query?: never;
-            readonly header?: never;
-            readonly path?: never;
-            readonly cookie?: never;
-        };
-        readonly requestBody?: never;
-        readonly responses: {
-            /** @description OK */
-            readonly 200: {
-                headers: {
-                    readonly [name: string]: unknown;
-                };
-                content?: never;
             };
         };
     };


### PR DESCRIPTION
## Resumo

<!-- 1-3 bullet points descrevendo o que este PR faz -->

Esse PR remove artefatos defasados de smoke test gerados pelo `uniplus-api#976` (Closes uniplus-api#829) em `lib/shared-data/` provenientes da aplicação `uniplus-api` (`/api/_smoke/storage/upload`, `/api/_smoke/cache/{key}`, `/api/_smoke/messaging/publish`).

> Obs.: O contrato `geo` está fora de escopo da issue #474. Portanto, permaneceu intocado nesse PR.

Closes #474

## Mudanças

<!-- Lista detalhada das mudanças por categoria -->

### Novos arquivos
<!-- - `path/to/file` — descrição -->

N/D.

### Modificados
<!-- - `path/to/file` — o que mudou -->

`libs/shared-data/openapi/*` - Remove endpoints `/api/_smoke`, schema `IFormFile` e tag `_smoke`

- `libs/shared-data/openapi/configuracao.openapi.json`;
- `libs/shared-data/openapi/ingresso.openapi.json`; 
- `libs/shared-data/openapi/organizacao.openapi.json`;
- `libs/shared-data/openapi/selecao.openapi.json`;

`src/lib/api/` - Remove ocorrências de `/api/_smoke`, `IFormFile` e tag `_smoke` do `schema.ts`

- `src/lib/api/configuracao/schema.ts`;
- `src/lib/api/ingresso/schema.ts`;
- `src/lib/api/organizacao/schema.ts`;
- `src/lib/api/selecao/schema.ts`;

## Testes

- [X] Testes unitários passando

## Checklist

- [X] Build sem erros e sem warnings
- [X] Nenhuma ocorrência de /api/_smoke nos baselines e schema.ts de configuracao, ingresso, organizacao e selecao.
- [X] Schema IFormFile e tag _smoke removidos onde só existiam por causa das rotas de smoke.
- [X] `geo` intocado.
- [X] Build e checagem de tipos verdes.