### PR TITLE
docs: atualiza onboarding local e instruções de agentes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md — uniplus-web
+
+## Ambiente e comandos
+
+- Use `rtk` como prefixo de todo comando de shell.
+- Use Node.js 22 (`nvm use`) e `npm ci`; não altere o lockfile sem necessidade.
+- Execute comandos Nx a partir da raiz do workspace. Para uma mudança focada,
+  prefira `npx nx lint <projeto>`, `npx nx vite:test <projeto>` e
+  `npx nx build <projeto>` em vez de gates globais.
+- Para alterações somente em Markdown, valide os arquivos modificados com
+  `npx prettier --check <arquivos>` e `git diff --check`.
+
+## Arquitetura
+
+- Apps Angular: `selecao`, `ingresso`, `portal` e `configuracao`; as portas de
+  desenvolvimento são, respectivamente, 4200–4203.
+- Use os aliases `@uniplus/shared-*`; não faça deep imports em `libs/*/src`.
+- Componentes são standalone, `OnPush`, usam signals e não devem usar `any`.
+- Preserve a separação entre UI reutilizável (`shared-ui`) e regras de domínio.
+- O Uni+ DS é CSS-only: use tokens semânticos e wrappers `ui-*`; não introduza
+  uma paleta Tailwind paralela nem temas PrimeNG globais.
+
+## Runtime e autenticação
+
+- `provideRuntimeConfig()` deve aparecer antes de `provideAuth()` em todo
+  `app.config.ts`.
+- O fluxo OIDC, o interceptor e o refresh token pertencem a `shared-auth`.
+  Não implemente refresh por app nem persista JWT em `localStorage` ou
+  `sessionStorage`.
+- Para backend local, o repositório irmão `uniplus-api` sobe infra, APIs e
+  Traefik; execute somente os serviços documentados em
+  `docs/guia-testar-frontend-com-backend-local.md`, mantendo os containers
+  `*-web` desligados durante `nx serve`.
+
+## Qualidade e segurança
+
+- Mantenha textos visíveis ao usuário em pt-BR, formulários reativos tipados e
+  rotas de feature em lazy loading.
+- Valide acessibilidade (teclado, foco, 320 px, zoom 200% e contraste) em
+  alterações de interface.
+- Não exponha CPF nem tokens em logs; mascare dados pessoais.
+- Não altere arquivos fora do escopo da tarefa e preserve mudanças preexistentes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,8 @@
 
 ## Visao geral
 
-Frontend do Uni+ (S2U) (UniPlus) da Unifesspa. Monorepo Nx com 3 aplicacoes Angular e 3 bibliotecas compartilhadas.
+Frontend do Uni+ (S2U) da Unifesspa. Monorepo Nx com 4 aplicacoes Angular e
+bibliotecas compartilhadas.
 
 ## Stack e versões
 
@@ -11,7 +12,7 @@ Frontend do Uni+ (S2U) (UniPlus) da Unifesspa. Monorepo Nx com 3 aplicacoes Angu
 - **Uni+ DS** CSS-only (tokens semanticos, temas e anatomia HTML)
 - **PrimeNG** 21.x (uso legado/complexo encapsulado quando necessário)
 - **Tailwind CSS** 4.x (estilização utility-first com @theme)
-- **OIDC** (autenticação; adapter atual via keycloak-angular)
+- **OIDC Keycloak** (autenticação via `keycloak-js` e `keycloak-angular`)
 - **Playwright** (testes E2E)
 - **Vitest** (testes unitários via @analogjs/vitest-angular)
 - **TypeScript** 5.9.x (strict mode)
@@ -26,11 +27,16 @@ apps/
   ingresso-e2e/   → Testes E2E do ingresso
   portal/         → Portal público do candidato (inscrição, acompanhamento, documentos, recursos)
   portal-e2e/     → Testes E2E do portal
+  configuracao/   → Cadastros base e organização institucional
+  configuracao-e2e/ → Testes E2E da configuracao
 
 libs/
   shared-ui/      → Componentes reutilizáveis (cpf-input, data-table, file-upload, status-badge, etc.)
-  shared-auth/    → Autenticação OIDC (auth.service, guards, interceptor, providers)
-  shared-data/    → DTOs, API clients, utilitários (cpf.util, date.util, api-error-handler)
+  shared-auth/    → Autenticação OIDC (serviço, guards, interceptor e providers)
+  shared-core/    → HTTP, interceptors, DOM e notificações transversais
+  shared-data/    → Runtime config, DTOs e clientes API gerados por OpenAPI
+  shared-e2e/     → Fixtures, setup e utilitários compartilhados de Playwright
+  shared-utils/   → Utilitários sem dependência de domínio
 
 docs/referencias/
   poc-primeng/    → Código histórico da POC (read-only, fora do workspace Nx) — ADR-0022
@@ -67,19 +73,22 @@ uniplus-ds CSS-only
 
 ### Arquivos de referência
 
-| Arquivo | O que contém |
-|---------|-------------|
-| `libs/shared-ui/src/styles/tokens.css` | Tokens semanticos do Uni+ DS |
-| `libs/shared-ui/src/styles/base.css` | Reset, tipografia, foco, skip link e utilitarios base |
-| `libs/shared-ui/src/styles/components.css` | Classes canonicas de componentes CSS-only |
-| `apps/<app>/src/styles.css` | Imports da foundation + `@source` + `@theme inline` |
-| `docs/referencias/poc-primeng/` | POC historica read-only; nao governa novas implementacoes |
+| Arquivo                                    | O que contém                                              |
+| ------------------------------------------ | --------------------------------------------------------- |
+| `libs/shared-ui/src/styles/tokens.css`     | Tokens semanticos do Uni+ DS                              |
+| `libs/shared-ui/src/styles/base.css`       | Reset, tipografia, foco, skip link e utilitarios base     |
+| `libs/shared-ui/src/styles/components.css` | Classes canonicas de componentes CSS-only                 |
+| `apps/<app>/src/styles.css`                | Imports da foundation + `@source` + `@theme inline`       |
+| `docs/referencias/poc-primeng/`            | POC historica read-only; nao governa novas implementacoes |
 
 ## Path aliases
 
 - `@uniplus/shared-ui` → `libs/shared-ui/src/index.ts`
 - `@uniplus/shared-auth` → `libs/shared-auth/src/index.ts`
+- `@uniplus/shared-core` → `libs/shared-core/src/index.ts`
 - `@uniplus/shared-data` → `libs/shared-data/src/index.ts`
+- `@uniplus/shared-utils` → `libs/shared-utils/src/index.ts`
+- `@uniplus/shared-e2e` → `libs/shared-e2e/src/index.ts`
 
 ## Padroes de componentes
 
@@ -90,6 +99,15 @@ uniplus-ds CSS-only
 - **Lazy loading** para todas as feature routes
 - Reactive Forms com tipagem forte
 - Strings user-facing em pt-BR
+
+## Runtime config e autenticacao
+
+- Cada app carrega `assets/runtime-config.json` por `provideRuntimeConfig()`.
+  Em `app.config.ts`, esse provider deve vir **antes** de `provideAuth()`.
+- `shared-auth` concentra a integração OIDC, o interceptor e a renovação de
+  token. Não duplicar refresh em apps ou componentes.
+- Tokens JWT permanecem em memória: nunca usar `localStorage` ou
+  `sessionStorage` para persistência de credenciais.
 
 ## Comandos uteis
 
@@ -113,7 +131,7 @@ npx nx lint selecao
 npx nx run-many --target=lint --all
 
 # Testes E2E
-npx nx e2e selecao-e2e
+npx nx e2e <app>-e2e
 
 # Grafo de dependencias
 npx nx graph
@@ -129,10 +147,19 @@ npx nx affected --target=vite:test
 ### Testar um app contra o backend real (local)
 
 Para exercitar um app contra as APIs do `uniplus-api` (login Keycloak + dados
-reais), o backend precisa validar o realm `unifesspa` — suba o `uniplus-api` com
-o override `frontend-test`, senão **toda mutação responde 401 + loop de re-login**
-(o GET de lista é `[AllowAnonymous]` e mascara). Passo a passo, credenciais e
-sintomas: [`docs/guia-testar-frontend-com-backend-local.md`](docs/guia-testar-frontend-com-backend-local.md).
+reais), suba a infraestrutura, as APIs e o Traefik pelo override atual, sem
+iniciar os serviços `*-web`; assim, as portas 4200–4203 ficam livres para o Nx.
+Os apps usam o gateway `http://localhost:5000` e o realm `unifesspa`.
+
+```bash
+# No repositório irmão uniplus-api
+docker compose -f docker/docker-compose.yml \
+  -f docker/docker-compose.override.yml \
+  up -d --build postgres redis kafka minio apicurio keycloak \
+    uniplus-api geo-api portal-api traefik
+```
+
+Passo a passo, credenciais e sintomas: [`docs/guia-testar-frontend-com-backend-local.md`](docs/guia-testar-frontend-com-backend-local.md).
 
 ## Localização do repositório
 

--- a/README.md
+++ b/README.md
@@ -4,33 +4,49 @@ Frontend do Uni+ (S2U) da Unifesspa, construido como monorepo Nx com Angular 21.
 
 ## Aplicações
 
-| App | Descrição | Porta |
-|-----|-----------|-------|
-| **selecao** | Gestão de processos seletivos (editais, inscrições, homologação, notas, classificação) | 4200 |
-| **ingresso** | Gestão de ingresso (chamadas, convocações, matrículas) | 4201 |
-| **portal** | Portal público do candidato (inscrição, acompanhamento, documentos, recursos) | 4202 |
+| App              | Descrição                                                                              | Porta | Client OIDC        |
+| ---------------- | -------------------------------------------------------------------------------------- | ----- | ------------------ |
+| **selecao**      | Gestão de processos seletivos (editais, inscrições, homologação, notas, classificação) | 4200  | `selecao-web`      |
+| **ingresso**     | Gestão de ingresso (chamadas, convocações, matrículas)                                 | 4201  | `ingresso-web`     |
+| **portal**       | Portal público do candidato (inscrição, acompanhamento, documentos, recursos)          | 4202  | `portal-web`       |
+| **configuracao** | Painel administrativo de cadastros base e organização institucional                    | 4203  | `configuracao-web` |
 
 ## Bibliotecas compartilhadas
 
-| Lib | Descricao |
-|-----|-----------|
-| **shared-ui** | Wrappers Angular reutilizaveis do Uni+ DS (CSS-only), shells, forms, dados e overlays |
-| **shared-auth** | Autenticacao OIDC (services, guards, interceptors) |
-| **shared-data** | DTOs, API clients OpenAPI, utilitarios |
+| Lib             | Descricao                                                                             |
+| --------------- | ------------------------------------------------------------------------------------- |
+| **shared-ui**   | Wrappers Angular reutilizaveis do Uni+ DS (CSS-only), shells, forms, dados e overlays |
+| **shared-auth** | Autenticacao OIDC (services, guards, interceptors)                                    |
+| **shared-data** | DTOs, API clients OpenAPI, utilitarios                                                |
 
 ## Pre-requisitos
 
 - Node.js 22.x LTS
 - npm 10.x+
-- Docker (para build de producao)
+- Docker Compose v2 (para rodar contra o backend local ou para build de produção)
 
-## Inicio rapido
+## Início rápido com backend local
+
+O desenvolvimento diário usa dois repositórios irmãos: o `uniplus-api` sobe a
+infra, as APIs e o gateway por Docker; o `uniplus-web` roda a app escolhida com
+hot reload via Nx. O guia completo, incluindo login e testes, está em
+[`docs/tutorial-rodar-e-testar-a-aplicacao.md`](docs/tutorial-rodar-e-testar-a-aplicacao.md).
 
 ```bash
-# Instalar dependencias (requer Node 22.x — veja CONTRIBUTING.md para setup com nvm)
-nvm use && npm install
+# Em uniplus-api (uma vez por clone)
+cp docker/.env.example docker/.env
+cp docker/docker-compose.override.example.yml docker/docker-compose.override.yml
 
-# Servir a aplicacao selecao
+# Infra, APIs e gateway; não inicia os containers *-web, deixando 4200-4203 livres.
+docker compose -f docker/docker-compose.yml \
+  -f docker/docker-compose.override.yml \
+  up -d --build postgres redis kafka minio apicurio keycloak \
+    uniplus-api geo-api portal-api traefik
+
+# Em uniplus-web (requer Node 22.x — veja CONTRIBUTING.md para setup com nvm)
+nvm use && npm ci
+
+# Servir uma das aplicações com hot reload
 npx nx serve selecao
 
 # Abrir no navegador
@@ -44,6 +60,7 @@ open http://localhost:4200
 npx nx serve selecao
 npx nx serve ingresso
 npx nx serve portal
+npx nx serve configuracao
 
 # Build
 npx nx run-many --target=build --all

--- a/docs/guia-testar-frontend-com-backend-local.md
+++ b/docs/guia-testar-frontend-com-backend-local.md
@@ -4,38 +4,38 @@ Como rodar um app do `uniplus-web` (`selecao`, `configuracao`, `ingresso`,
 `portal`) contra as APIs reais do `uniplus-api` conteinerizadas — autenticando no
 Keycloak de desenvolvimento e persistindo dados de verdade.
 
-## 1. Suba o backend com o override `frontend-test`
+## 1. Suba infraestrutura, APIs e gateway
 
-No repositório `uniplus-api`, copie o template do override (gitignored) e suba a
-stack com os **três** arquivos compose:
+No repositório `uniplus-api`, copie os arquivos locais na primeira execução e
+suba apenas a infraestrutura, as APIs e o gateway. O
+`docker-compose.override.yml` já contém o realm `unifesspa` consumido pelos
+frontends e o Traefik em `:5000`.
 
 ```bash
-cd repositories/uniplus-api/docker
-cp docker-compose.override.example.yml docker-compose.override.yml   # 1ª vez
+cd repositories/uniplus-api
+cp docker/.env.example docker/.env                                    # 1ª vez
+cp docker/docker-compose.override.example.yml docker/docker-compose.override.yml   # 1ª vez
 
-docker compose -f docker-compose.yml \
-               -f docker-compose.override.yml \
-               -f docker-compose.frontend-test.yml up -d --build --wait
+docker compose -f docker/docker-compose.yml \
+               -f docker/docker-compose.override.yml \
+               up -d --build postgres redis kafka minio apicurio keycloak \
+                 uniplus-api geo-api portal-api traefik
 ```
 
 Isso sobe a infra (Postgres/Redis/Kafka/MinIO/Apicurio/Keycloak) + as **3 APIs**
 (`uniplus-api` na :5200 — o monólito com os 4 módulos internos; `geo-api` na :5400;
 `portal-api` na :5302) + um **gateway Traefik na :5000**.
 
-> **Por que o `frontend-test.yml`?** Ele faz duas coisas obrigatórias:
-> 1. **Realinha o `Auth__Authority`** das APIs ao realm **`unifesspa`** — o realm em
->    que os frontends autenticam (clients `*-web`). O override base usa
->    `unifesspa-dev-local`, e sem o realinhamento **toda mutação** (POST/PUT/DELETE)
->    responde **401** e o app entra em loop de re-login (o GET de lista é
->    `[AllowAnonymous]` e mascara o problema).
-> 2. **Sobe o gateway na :5000**, que separa o tráfego: `/api/{cidades,estados,cep,
->    logradouros}` → `geo-api`; todo o resto de `/api/` → monólito. É o `apiUrl`
->    único que os apps consomem (espelha o ingress de HML/PROD no uniplus-infra).
+> **Importante:** não execute o `up` sem a lista de serviços quando for usar
+> `nx serve`. O override completo também sobe os containers `selecao-web`,
+> `ingresso-web`, `portal-web` e `configuracao-web`, que ocupam as portas
+> 4200–4203 usadas pelo hot reload.
 
 ## 2. Sirva o app
 
 ```bash
 cd repositories/uniplus-web
+npm ci                            # primeira vez ou após alteração do lockfile
 npx nx serve selecao        # http://localhost:4200  (client selecao-web)
 npx nx serve ingresso       # http://localhost:4201  (client ingresso-web)
 npx nx serve portal         # http://localhost:4202  (client portal-web)
@@ -56,22 +56,22 @@ há reescrita de path** (o shim legado `/api/editais` foi removido).
 Usuários do realm `unifesspa` (senha inicial **temporária** — o Keycloak pede para
 trocar no primeiro login; basta repetir a mesma senha):
 
-| Usuário | Senha inicial | Papel |
-|---|---|---|
-| `admin` | `Changeme!123` | `plataforma-admin` (painel admin completo) |
-| `gestor` | `Changeme!123` | gestor |
-| `avaliador` | `Changeme!123` | avaliador |
-| `candidato` | `Changeme!123` | candidato (portal) |
+| Usuário     | Senha inicial  | Papel                                      |
+| ----------- | -------------- | ------------------------------------------ |
+| `admin`     | `Changeme!123` | `plataforma-admin` (painel admin completo) |
+| `gestor`    | `Changeme!123` | gestor                                     |
+| `avaliador` | `Changeme!123` | avaliador                                  |
+| `candidato` | `Changeme!123` | candidato (portal)                         |
 
 ## Sintomas comuns
 
-| Sintoma | Causa | Correção |
-|---|---|---|
-| Listas carregam, mas salvar dá erro e volta pro login | Realm desalinhado (API em `unifesspa-dev-local`) | Suba com o `frontend-test.yml` (passo 1) |
-| `404` em `/api/cidades` ou `/api/cep` | `geo-api` fora do ar ou gateway sem rota geo | Confirme `geo-api` healthy e o `frontend-test.yml` (gateway) no `up` |
-| `404` em `/api/{modulo}/...` | Gateway fora do ar (subiu sem o `frontend-test.yml`) | Inclua o `frontend-test.yml` no `up` |
-| `ERR_CONNECTION_REFUSED` em :420x | Dev server caiu | `npx nx serve <app>` |
-| Redireciona ao Keycloak no meio de uma ação longa | `accessTokenLifespan` curto (300s) | Ampliar para 1800s (opcional — ver CONTRIBUTING do `uniplus-api`) |
+| Sintoma                                               | Causa                                                              | Correção                                                               |
+| ----------------------------------------------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------- |
+| Listas carregam, mas salvar dá erro e volta pro login | APIs não foram iniciadas com o override atual do realm `unifesspa` | Refaça o passo 1 com os dois arquivos compose e a lista de serviços    |
+| `404` em `/api/cidades` ou `/api/cep`                 | `geo-api` ou Traefik fora do ar                                    | Confirme ambos os serviços healthy no Compose do passo 1               |
+| `404` em `/api/{modulo}/...`                          | Monólito, portal-api ou gateway fora do ar                         | Confirme `uniplus-api`, `portal-api` e `traefik` no Compose do passo 1 |
+| `ERR_CONNECTION_REFUSED` em :420x                     | Dev server caiu                                                    | `npx nx serve <app>`                                                   |
+| Redireciona ao Keycloak no meio de uma ação longa     | `accessTokenLifespan` curto (300s)                                 | Ampliar para 1800s (opcional — ver CONTRIBUTING do `uniplus-api`)      |
 
 ## E2E automatizado
 

--- a/docs/tutorial-rodar-e-testar-a-aplicacao.md
+++ b/docs/tutorial-rodar-e-testar-a-aplicacao.md
@@ -5,10 +5,10 @@ aplicação, **logar nela** e executar os testes (unitários e E2E).
 
 A plataforma tem dois repositórios que sobem juntos:
 
-| Repositório | Papel | O que você roda |
-|---|---|---|
+| Repositório   | Papel                                                        | O que você roda            |
+| ------------- | ------------------------------------------------------------ | -------------------------- |
 | `uniplus-api` | Backend .NET + infra (PostgreSQL, Keycloak, etc. via Docker) | `docker compose ... up -d` |
-| `uniplus-web` | Frontend Angular (Nx) | `npx nx serve <app>` |
+| `uniplus-web` | Frontend Angular (Nx)                                        | `npx nx serve <app>`       |
 
 > **Atalho:** se você já tem os repositórios e a infra de pé, use a referência
 > rápida em [`guia-testar-frontend-com-backend-local.md`](guia-testar-frontend-com-backend-local.md).
@@ -18,15 +18,15 @@ A plataforma tem dois repositórios que sobem juntos:
 
 ## Pré-requisitos
 
-| Ferramenta | Versão | Verificação |
-|---|---|---|
-| Docker | 24+ | `docker --version` |
-| Docker Compose | 2.20+ | `docker compose version` |
-| .NET SDK | 10.0 | `dotnet --version` |
-| Node.js | **22** (ver `.nvmrc`) | `node --version` |
-| Python 3 | 3.8+ (para os snippets do Keycloak Admin API) | `python3 --version` |
-| Git | 2.40+ | `git --version` |
-| GitHub CLI (opcional) | 2.50+ | `gh --version` |
+| Ferramenta            | Versão                                        | Verificação              |
+| --------------------- | --------------------------------------------- | ------------------------ |
+| Docker                | 24+                                           | `docker --version`       |
+| Docker Compose        | 2.20+                                         | `docker compose version` |
+| .NET SDK              | 10.0                                          | `dotnet --version`       |
+| Node.js               | **22** (ver `.nvmrc`)                         | `node --version`         |
+| Python 3              | 3.8+ (para os snippets do Keycloak Admin API) | `python3 --version`      |
+| Git                   | 2.40+                                         | `git --version`          |
+| GitHub CLI (opcional) | 2.50+                                         | `gh --version`           |
 
 > O frontend exige **Node 22** — se você usa `nvm`, rode `nvm use 22` dentro de
 > `uniplus-web` (há um `.nvmrc`). Node 24 (default de algumas máquinas) quebra o build.
@@ -48,32 +48,36 @@ git clone https://github.com/unifesspa-edu-br/uniplus-web.git
 ## Passo 2 — Subir o backend (APIs + infra + Keycloak)
 
 Num clone fresco, `docker/.env` e `docker/docker-compose.override.yml` **não
-existem** (são gitignored) — copie-os dos `.example` primeiro. Depois suba a
-stack com os **três** arquivos compose; o terceiro (`frontend-test.yml`) é
-**obrigatório** para testar o frontend — ele realinha a autenticação de todas as
-APIs ao realm `unifesspa` (ver "Solução de problemas").
+existem** (são gitignored) — copie-os dos `.example` primeiro. Depois suba
+somente a infraestrutura, as APIs e o gateway. O override atual já configura as
+APIs para o realm `unifesspa` e inclui o Traefik que atende o `apiUrl` local.
 
 ```bash
 cd uniplus-api
 cp docker/.env.example docker/.env
 cp docker/docker-compose.override.example.yml docker/docker-compose.override.yml
 
-cd docker
-docker compose -f docker-compose.yml \
-               -f docker-compose.override.yml \
-               -f docker-compose.frontend-test.yml up -d
+docker compose -f docker/docker-compose.yml \
+               -f docker/docker-compose.override.yml \
+               up -d --build postgres redis kafka minio apicurio keycloak \
+                 uniplus-api geo-api portal-api traefik
 ```
 
 > Setup canônico do backend (mais detalhes): `uniplus-api/docs/setup-ambiente-local.md`.
 
 Isso sobe PostgreSQL, Redis, Kafka, MinIO, **Keycloak** (que importa o realm
-`unifesspa` automaticamente) e as APIs de módulo (`organizacao-api` em `:5263`,
-`selecao-api`, etc.).
+`unifesspa` automaticamente), as três APIs (`uniplus-api` em :5200, `geo-api`
+em :5400 e `portal-api` em :5302) e o gateway Traefik em :5000.
+
+> **Não suba o override completo** quando quiser hot reload. Ele também inicia
+> os containers `selecao-web`, `ingresso-web`, `portal-web` e
+> `configuracao-web`, que ocupam 4200–4203. O comando acima deixa essas portas
+> livres para o Nx.
 
 Aguarde tudo ficar **healthy**:
 
 ```bash
-docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.frontend-test.yml ps
+docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml ps
 ```
 
 > Se as APIs ficarem `unhealthy`, normalmente é o **Keycloak ainda subindo** (o
@@ -92,14 +96,16 @@ npm ci                # instala dependências (primeira vez)
 npx nx serve configuracao   # painel administrativo  -> http://localhost:4203
 ```
 
-Cada app lê o backend e o Keycloak do seu `runtime-config.json`. O
-`configuracao` fala **direto** com a `organizacao-api` (`:5263`) — é o caminho
-testado neste tutorial.
+Cada app lê o backend e o Keycloak do seu `runtime-config.json`. Todas usam o
+gateway `http://localhost:5000` e o issuer
+`http://localhost:8080/realms/unifesspa`.
 
-> `npx nx serve selecao` (`:4200`) funciona via gateway Traefik `:5000`. Os apps
-> `ingresso` (`:4201`) e `portal` (`:4202`) sobem, mas o Traefik de dev hoje só
-> roteia as rotas de Seleção (`/api/editais`, `/api/selecao/*`) — testá-los
-> contra o backend local ainda exige rotas adicionais no `traefik/dynamic.yml`.
+| App          | Comando                     | URL                   | Client OIDC        |
+| ------------ | --------------------------- | --------------------- | ------------------ |
+| Seleção      | `npx nx serve selecao`      | http://localhost:4200 | `selecao-web`      |
+| Ingresso     | `npx nx serve ingresso`     | http://localhost:4201 | `ingresso-web`     |
+| Portal       | `npx nx serve portal`       | http://localhost:4202 | `portal-web`       |
+| Configuração | `npx nx serve configuracao` | http://localhost:4203 | `configuracao-web` |
 
 ---
 
@@ -131,11 +137,11 @@ curl -s -X PUT "$KC/admin/realms/unifesspa/users/$ADMIN_ID/reset-password" \
 
 Credenciais de login:
 
-| Campo | Valor |
-|---|---|
-| Usuário | `admin` |
-| Senha | `E2eTest!123` (após o reset acima) |
-| Realm | `unifesspa` (já configurado no app) |
+| Campo   | Valor                               |
+| ------- | ----------------------------------- |
+| Usuário | `admin`                             |
+| Senha   | `E2eTest!123` (após o reset acima)  |
+| Realm   | `unifesspa` (já configurado no app) |
 
 > O admin do **Keycloak** (console em `:8080`) é `admin` / `admin` no realm
 > `master` — não confundir com o usuário `admin` da aplicação no realm `unifesspa`.
@@ -159,7 +165,7 @@ npx nx run-many --target=vite:test --all
 ### Frontend — E2E (Playwright)
 
 As specs visuais **mockam a API** via `page.route` — não exigem as APIs de pé,
-só o **Keycloak** (o *setup project* `auth-setup` reseta a senha do usuário de
+só o **Keycloak** (o _setup project_ `auth-setup` reseta a senha do usuário de
 teste e faz login real). Como o Keycloak já subiu no Passo 2, basta:
 
 ```bash
@@ -205,11 +211,11 @@ curl -s -X PUT http://localhost:8080/admin/realms/unifesspa \
 ## Comandos úteis
 
 ```bash
-# Servir aplicações (uniplus-web)
-npx nx serve selecao          # http://localhost:4200 (via gateway Traefik :5000)
+# Servir aplicações (uniplus-web; todas usam o gateway Traefik :5000)
+npx nx serve selecao          # http://localhost:4200
 npx nx serve ingresso         # http://localhost:4201
 npx nx serve portal           # http://localhost:4202
-npx nx serve configuracao     # http://localhost:4203 (direto na organizacao-api :5263)
+npx nx serve configuracao     # http://localhost:4203
 
 # Build
 npx nx build configuracao
@@ -237,7 +243,8 @@ npx nx affected --target=build
 npx nx affected --target=vite:test
 
 # Backend (uniplus-api) — a partir da raiz do repositório uniplus-api
-docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml -f docker/docker-compose.frontend-test.yml up -d   # subir stack p/ testar frontend
+docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml \
+  up -d --build postgres redis kafka minio apicurio keycloak uniplus-api geo-api portal-api traefik
 dotnet test UniPlus.slnx                          # todos os testes
 dotnet test --filter "Category!=Integration"      # só unitários (sem Docker)
 ```
@@ -246,15 +253,15 @@ dotnet test --filter "Category!=Integration"      # só unitários (sem Docker)
 
 ## Solução de problemas
 
-| Sintoma | Causa | Correção |
-|---|---|---|
-| Listas carregam, mas **salvar dá erro e volta pro login** | Realm desalinhado: as APIs validam `unifesspa-dev-local`, o app autentica em `unifesspa`. O GET de lista é anônimo e mascara; só a mutação dá **401** | Suba o backend **com** `docker-compose.frontend-test.yml` (Passo 2) |
-| `ERR_CONNECTION_REFUSED` em `:4203` | Dev server não está rodando | `npx nx serve configuracao` |
-| APIs `unhealthy` | Keycloak ainda subindo / parado | Aguardar; conferir `docker compose ps` do `docker-keycloak-1` |
-| Keycloak pede troca de senha no login | Senha semeada é temporária (`Changeme!123`) | Resetar para `E2eTest!123` (Passo 4) |
-| Build do frontend quebra | Node ≠ 22 | `nvm use 22` |
-| E2E falha em `auth-setup` (`KEYCLOAK_ADMIN_PASSWORD não definido`) | Variável ausente | Prefixar o comando com `KEYCLOAK_ADMIN_PASSWORD=admin` |
-| Redireciona ao Keycloak no meio de uma ação | `accessTokenLifespan` curto | Ampliar para 1800s (Passo 6) |
+| Sintoma                                                            | Causa                                                              | Correção                                                            |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------ | ------------------------------------------------------------------- |
+| Listas carregam, mas **salvar dá erro e volta pro login**          | APIs não foram iniciadas com o override atual do realm `unifesspa` | Refaça o Passo 2 com os dois arquivos compose e a lista de serviços |
+| `ERR_CONNECTION_REFUSED` em `:4203`                                | Dev server não está rodando                                        | `npx nx serve configuracao`                                         |
+| APIs `unhealthy`                                                   | Keycloak ainda subindo / parado                                    | Aguardar; conferir `docker compose ps` do `docker-keycloak-1`       |
+| Keycloak pede troca de senha no login                              | Senha semeada é temporária (`Changeme!123`)                        | Resetar para `E2eTest!123` (Passo 4)                                |
+| Build do frontend quebra                                           | Node ≠ 22                                                          | `nvm use 22`                                                        |
+| E2E falha em `auth-setup` (`KEYCLOAK_ADMIN_PASSWORD não definido`) | Variável ausente                                                   | Prefixar o comando com `KEYCLOAK_ADMIN_PASSWORD=admin`              |
+| Redireciona ao Keycloak no meio de uma ação                        | `accessTokenLifespan` curto                                        | Ampliar para 1800s (Passo 6)                                        |
 
 ---
 


### PR DESCRIPTION
## Resumo

Atualiza o onboarding local do frontend para refletir a topologia atual: infraestrutura, APIs e Traefik sobem no repositório `uniplus-api`; cada app Angular roda com hot reload via Nx.

Também alinha as instruções para colaboradores e agentes à estrutura atual do workspace.

## Alterações

- documenta os quatro apps, portas e clients OIDC;
- substitui o fluxo obsoleto baseado em `frontend-test.yml`;
- orienta o uso do gateway local `http://localhost:5000` e do realm `unifesspa`;
- adiciona `AGENTS.md` e atualiza `CLAUDE.md` com as invariantes de runtime e autenticação.

## Impacto

Quem inicia no projeto passa a ter um comando reproduzível para subir backend/infra e manter as portas 4200–4203 livres para `nx serve`.

## Validação

- `prettier --check` nos documentos alterados;
- `git diff --check`;
- `docker compose ... config --quiet` no `uniplus-api`;
- confirmação dos quatro clients OIDC e do alvo `configuracao-e2e`.

Closes #491