### PR TITLE
feat(shared-ui): cria componente bullet

### DIFF
--- a/libs/shared-ui/components/src/index.ts
+++ b/libs/shared-ui/components/src/index.ts
@@ -47,4 +47,4 @@ export { TagComponent, type UiTagVariant } from '../../src/lib/components/tag/ta
 export { TextInputComponent } from '../../src/lib/components/text-input/text-input';
 export { TextareaComponent } from '../../src/lib/components/textarea/textarea';
 export { VlibrasLoaderComponent } from '../../src/lib/components/vlibras-loader/vlibras-loader';
-export { BulletComponent } from '../../src/lib/components/bullet/bullet';
+export { BulletComponent, type UiBulletVariant } from '../../src/lib/components/bullet/bullet';

--- a/libs/shared-ui/components/src/index.ts
+++ b/libs/shared-ui/components/src/index.ts
@@ -47,3 +47,4 @@ export { TagComponent, type UiTagVariant } from '../../src/lib/components/tag/ta
 export { TextInputComponent } from '../../src/lib/components/text-input/text-input';
 export { TextareaComponent } from '../../src/lib/components/textarea/textarea';
 export { VlibrasLoaderComponent } from '../../src/lib/components/vlibras-loader/vlibras-loader';
+export { BulletComponent } from '../../src/lib/components/bullet/bullet';

--- a/libs/shared-ui/src/lib/components/bullet/bullet.ts
+++ b/libs/shared-ui/src/lib/components/bullet/bullet.ts
@@ -1,0 +1,23 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+
+export type UiBulletVariant = 'primary' | 'neutral' | 'success' | 'warning' | 'danger';
+
+@Component({
+  selector: 'ui-bullet',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <span
+      class="bullet"
+      [class.bullet--primary]="variant() === 'primary'"
+      [class.bullet--success]="variant() === 'success'"
+      [class.bullet--warning]="variant() === 'warning'"
+      [class.bullet--danger]="variant() === 'danger'"
+      [class.bullet--neutral]="variant() === 'neutral'"
+    >
+    </span>
+  `,
+})
+export class BulletComponent {
+  readonly variant = input<UiBulletVariant>('primary');
+}

--- a/libs/shared-ui/src/lib/index.ts
+++ b/libs/shared-ui/src/lib/index.ts
@@ -30,6 +30,7 @@ export { TagComponent, type UiTagVariant } from './components/tag/tag';
 export { TextInputComponent } from './components/text-input/text-input';
 export { TextareaComponent } from './components/textarea/textarea';
 export { VlibrasLoaderComponent } from './components/vlibras-loader/vlibras-loader';
+export { BulletComponent, type UiBulletVariant } from './components/bullet/bullet';
 
 // Pipes
 export { CpfPipe } from './pipes/cpf.pipe';

--- a/libs/shared-ui/src/styles/components.css
+++ b/libs/shared-ui/src/styles/components.css
@@ -285,6 +285,25 @@
 [data-theme="contrast"] .tag--solid { color: var(--text-on-primary); }
 
 /* ============================================================================
+ * BULLET
+ * variant: primary, success, warning, danger, neutral
+ * ========================================================================== */
+.bullet {
+  display: block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-top: 6px;
+  flex-shrink: 0;
+}
+
+.bullet--primary { background: var(--color-primary); }
+.bullet--success { background: var(--color-success-600); }
+.bullet--warning { background: var(--color-warning-600); }
+.bullet--neutral { background: var(--color-neutral-100); }
+.bullet--danger { background: var(--color-danger-500); }
+
+/* ============================================================================
  * CARD
  * ========================================================================== */
 .card {

--- a/libs/shared-ui/src/styles/components.css
+++ b/libs/shared-ui/src/styles/components.css
@@ -300,7 +300,7 @@
 .bullet--primary { background: var(--color-primary); }
 .bullet--success { background: var(--color-success-600); }
 .bullet--warning { background: var(--color-warning-600); }
-.bullet--neutral { background: var(--color-neutral-100); }
+.bullet--neutral { background: var(--text-muted); }
 .bullet--danger { background: var(--color-danger-500); }
 
 /* ============================================================================


### PR DESCRIPTION
## Resumo

Cria componente bullet na lib shared-ui para ser compartilhado com todos os apps da aplicação.

Closes #492

## Mudanças

### Novos arquivos
+ libs/shared-ui/src/lib/components/bullet/bullet.ts

### Modificados
+ libs/shared-ui/src/styles/components.css
+ libs/shared-ui/components/index.ts
+ libs/shared-ui/src/lib/index.ts

## Checklist

- [x] Cria componente com seletor `ui-bullet` no padrão de nomenclatura de seletor.
- [x] Aceita o input `variant` que tenha os possíveis valores: `primary`, `warning`, `danger`, `success`, `neutral` ', sendo o valor padrão `primary`.
- [x] Copiar as classes css que estão no projeto `uniplus-ds`  e adicionar no arquivo `components.css ` que está no diretório `libs/shared-ui/src/styles` mantendo sempre consistente com os comentários e padrões de css existentes.
- [x] Adiciona lógica de alteração da classe css quando o atributo `variant` mudar.