### PR TITLE
feat(configuracao): adiciona cadastro de precedência de fase

### DIFF
--- a/apps/configuracao-e2e/src/specs/precedencias-fase.flow.spec.ts
+++ b/apps/configuracao-e2e/src/specs/precedencias-fase.flow.spec.ts
@@ -1,0 +1,371 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test, type Page, type Route } from '@playwright/test';
+import { mockConfiguracaoRuntimeConfig } from '../support/runtime-config';
+
+/**
+ * E2E funcional do cadastro de Precedência de fase (issue #497). Convenção do
+ * repo: runtime-config e API mockados por `page.route`; autenticação real
+ * (Keycloak) via projeto `fluxo-chromium` (auth-setup + storageState).
+ */
+
+const CORS_HEADERS = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'GET, POST, PUT, DELETE, OPTIONS',
+  'access-control-allow-headers': 'authorization, content-type, accept, idempotency-key',
+};
+
+const ARESTA_ID = '01960000-0000-7000-0000-0000000000a1';
+
+const arestaSeed = {
+  id: ARESTA_ID,
+  antecessoraCodigo: 'INSCRICAO',
+  sucessoraCodigo: 'HOMOLOGACAO',
+  permiteSobreposicao: false,
+  criadoEm: '2026-07-15T12:00:00Z',
+};
+
+const fasesSeed = [
+  {
+    id: 'fase-inscricao',
+    codigo: 'INSCRICAO',
+    nome: 'Inscrição',
+    descricao: null,
+    donoTipico: 'CEPS',
+    agrupaEtapas: false,
+    permiteComplementacao: false,
+    baseLegal: null,
+    criadoEm: '2026-06-10T12:00:00Z',
+  },
+  {
+    id: 'fase-homologacao',
+    codigo: 'HOMOLOGACAO',
+    nome: 'Homologação',
+    descricao: null,
+    donoTipico: 'CEPS',
+    agrupaEtapas: false,
+    permiteComplementacao: true,
+    baseLegal: null,
+    criadoEm: '2026-06-10T12:00:00Z',
+  },
+];
+
+async function jsonRoute(route: Route, body: unknown, status = 200): Promise<void> {
+  if (route.request().method() === 'OPTIONS') {
+    await route.fulfill({ status: 204, headers: CORS_HEADERS });
+    return;
+  }
+  await route.fulfill({
+    status,
+    contentType: 'application/json',
+    headers: CORS_HEADERS,
+    body: JSON.stringify(body),
+  });
+}
+
+interface Capturado {
+  readonly posts: unknown[];
+  readonly postKeys: string[];
+  readonly puts: unknown[];
+  readonly deletedIds: string[];
+}
+
+function novoCapturado(): Capturado {
+  return { posts: [], postKeys: [], puts: [], deletedIds: [] };
+}
+
+async function mockApi(
+  page: Page,
+  capturado: Capturado,
+  lista: readonly unknown[],
+  opcoes: { readonly criarStatus?: number; readonly criarBody?: unknown } = {},
+): Promise<void> {
+  await page.route(/\/api\/configuracao\/admin\/precedencias-fase\/[^/?]+$/, async (route) => {
+    if (route.request().method() === 'DELETE') {
+      const partes = route.request().url().split('/');
+      capturado.deletedIds.push(partes[partes.length - 1] ?? '');
+      await route.fulfill({ status: 204, headers: CORS_HEADERS });
+      return;
+    }
+    if (route.request().method() === 'PUT') {
+      capturado.puts.push(route.request().postDataJSON());
+      await route.fulfill({ status: 204, headers: CORS_HEADERS });
+      return;
+    }
+    await route.fulfill({ status: 204, headers: CORS_HEADERS });
+  });
+  await page.route(/\/api\/configuracao\/admin\/precedencias-fase(\?.*)?$/, async (route) => {
+    if (route.request().method() === 'POST') {
+      capturado.posts.push(route.request().postDataJSON());
+      capturado.postKeys.push(route.request().headers()['idempotency-key'] ?? '');
+      const status = opcoes.criarStatus ?? 201;
+      await route.fulfill({
+        status,
+        contentType: status >= 400 ? 'application/problem+json' : 'application/json',
+        headers: CORS_HEADERS,
+        body: JSON.stringify(opcoes.criarBody ?? 'nova-aresta-id'),
+      });
+      return;
+    }
+    await route.fulfill({ status: 204, headers: CORS_HEADERS });
+  });
+  await page.route(/\/api\/configuracao\/precedencias-fase(\?.*)?$/, (route) =>
+    jsonRoute(route, lista),
+  );
+  // A página também lê o cadastro de Fase canônica para rotular as opções.
+  await page.route(/\/api\/configuracao\/fases-canonicas(\?.*)?$/, (route) =>
+    jsonRoute(route, fasesSeed),
+  );
+}
+
+async function abrirPagina(page: Page): Promise<void> {
+  await page.goto('/precedencias-fase');
+  await expect(page.getByRole('heading', { name: 'Precedência de Fase', level: 1 })).toBeVisible();
+}
+
+test.describe('Precedência de fase — CRUD (#497)', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockConfiguracaoRuntimeConfig(page);
+  });
+
+  test('CA-01: lista as arestas vivas com antecessora e sucessora', async ({ page }) => {
+    await mockApi(page, novoCapturado(), [arestaSeed]);
+    await abrirPagina(page);
+
+    // Escopado à tabela: os códigos também aparecem como <option> nos selects
+    // do drawer, presentes no DOM desde a carga (modo inicia em 'criar').
+    const linha = page.locator('tr[data-aresta="INSCRICAO>HOMOLOGACAO"]');
+    await expect(linha).toBeVisible();
+    await expect(linha.getByText('INSCRICAO', { exact: true })).toBeVisible();
+    await expect(linha.getByText('HOMOLOGACAO', { exact: true })).toBeVisible();
+  });
+
+  test('CA-02: cria uma aresta com fases distintas', async ({ page }) => {
+    const capturado = novoCapturado();
+    await mockApi(page, capturado, []);
+    await abrirPagina(page);
+
+    await page.getByRole('button', { name: 'Nova aresta' }).first().click();
+    await page.locator('#cfg-precedencia-antecessora').selectOption('AVALIACAO');
+    await page.locator('#cfg-precedencia-sucessora').selectOption('CLASSIFICACAO');
+    await page.getByRole('button', { name: 'Criar aresta' }).click();
+
+    await expect.poll(() => capturado.posts.length).toBe(1);
+    // `toEqual` e não `toMatchObject`: o contrato de criação tem exatamente
+    // estes três campos, e a asserção precisa falhar se um controle novo
+    // vazar para o payload.
+    expect(capturado.posts[0]).toEqual({
+      antecessoraCodigo: 'AVALIACAO',
+      sucessoraCodigo: 'CLASSIFICACAO',
+      permiteSobreposicao: false,
+    });
+  });
+
+  test('abrir edição e depois criação não vaza id nem valores da aresta editada', async ({
+    page,
+  }) => {
+    const capturado = novoCapturado();
+    await mockApi(page, capturado, [arestaSeed]);
+    await abrirPagina(page);
+
+    await page.getByRole('button', { name: 'Editar' }).first().click();
+    await expect(page.locator('#cfg-precedencia-antecessora')).toHaveValue('INSCRICAO');
+    await page.getByRole('button', { name: 'Cancelar' }).click();
+
+    await page.getByRole('button', { name: 'Nova aresta' }).first().click();
+    await page.locator('#cfg-precedencia-antecessora').selectOption('AVALIACAO');
+    await page.locator('#cfg-precedencia-sucessora').selectOption('CLASSIFICACAO');
+    await page.getByRole('button', { name: 'Criar aresta' }).click();
+
+    await expect.poll(() => capturado.posts.length).toBe(1);
+    expect(capturado.posts[0]).toEqual({
+      antecessoraCodigo: 'AVALIACAO',
+      sucessoraCodigo: 'CLASSIFICACAO',
+      permiteSobreposicao: false,
+    });
+    expect(capturado.puts).toHaveLength(0);
+  });
+
+  test('CA-03: self-loop é barrado no client e não chega ao backend', async ({ page }) => {
+    const capturado = novoCapturado();
+    await mockApi(page, capturado, []);
+    await abrirPagina(page);
+
+    await page.getByRole('button', { name: 'Nova aresta' }).first().click();
+    await page.locator('#cfg-precedencia-antecessora').selectOption('AVALIACAO');
+    await page.locator('#cfg-precedencia-sucessora').selectOption('AVALIACAO');
+    await page.getByRole('button', { name: 'Criar aresta' }).click();
+
+    await expect(
+      page.getByText('A fase sucessora não pode ser igual à antecessora.'),
+    ).toBeVisible();
+    expect(capturado.posts).toHaveLength(0);
+    await expect(page.locator('#cfg-precedencia-fase-form')).toBeVisible();
+  });
+
+  test('CA-04: aresta duplicada (422) aparece no campo sucessora sem fechar o drawer', async ({
+    page,
+  }) => {
+    await mockApi(page, novoCapturado(), [], {
+      criarStatus: 422,
+      criarBody: {
+        type: 'https://uniplus.dev/erros/uniplus.configuracao.precedencia_fase.aresta_duplicada',
+        title: 'Já existe uma aresta de precedência viva com este par de fases',
+        status: 422,
+        code: 'uniplus.configuracao.precedencia_fase.aresta_duplicada',
+      },
+    });
+    await abrirPagina(page);
+
+    await page.getByRole('button', { name: 'Nova aresta' }).first().click();
+    await page.locator('#cfg-precedencia-antecessora').selectOption('INSCRICAO');
+    await page.locator('#cfg-precedencia-sucessora').selectOption('HOMOLOGACAO');
+    await page.getByRole('button', { name: 'Criar aresta' }).click();
+
+    const campoSucessora = page.locator('#cfg-precedencia-sucessora').locator('..');
+    await expect(
+      campoSucessora.getByText('Já existe uma aresta de precedência viva com este par de fases'),
+    ).toBeVisible();
+    await expect(page.locator('#cfg-precedencia-fase-form')).toBeVisible();
+  });
+
+  test('CA-05: aresta que fecharia um ciclo (422) vira banner geral do drawer', async ({ page }) => {
+    await mockApi(page, novoCapturado(), [], {
+      criarStatus: 422,
+      criarBody: {
+        type: 'https://uniplus.dev/erros/uniplus.configuracao.precedencia_fase.ciclo_detectado',
+        title: 'A aresta fecharia um ciclo no grafo de precedências',
+        status: 422,
+        code: 'uniplus.configuracao.precedencia_fase.ciclo_detectado',
+      },
+    });
+    await abrirPagina(page);
+
+    await page.getByRole('button', { name: 'Nova aresta' }).first().click();
+    await page.locator('#cfg-precedencia-antecessora').selectOption('RESULTADO_FINAL');
+    await page.locator('#cfg-precedencia-sucessora').selectOption('INSCRICAO');
+    await page.getByRole('button', { name: 'Criar aresta' }).click();
+
+    await expect(page.getByText('Não foi possível salvar')).toBeVisible();
+    await expect(
+      page.getByText('A aresta fecharia um ciclo no grafo de precedências'),
+    ).toBeVisible();
+    await expect(page.locator('#cfg-precedencia-fase-form')).toBeVisible();
+  });
+
+  test('CA-06: na edição o par é somente leitura e o PUT leva só a sobreposição', async ({
+    page,
+  }) => {
+    const capturado = novoCapturado();
+    await mockApi(page, capturado, [arestaSeed]);
+    await abrirPagina(page);
+
+    await page.getByRole('button', { name: 'Editar' }).first().click();
+    const antecessora = page.locator('#cfg-precedencia-antecessora');
+    const sucessora = page.locator('#cfg-precedencia-sucessora');
+    await expect(antecessora).toHaveAttribute('readonly', '');
+    await expect(antecessora).toHaveValue('INSCRICAO');
+    await expect(sucessora).toHaveAttribute('readonly', '');
+    await expect(sucessora).toHaveValue('HOMOLOGACAO');
+
+    await page.locator('#cfg-precedencia-sobreposicao').selectOption({ label: 'Sim' });
+    await page.getByRole('button', { name: 'Salvar aresta' }).click();
+
+    await expect.poll(() => capturado.puts.length).toBe(1);
+    expect(capturado.puts[0]).toEqual({ id: ARESTA_ID, permiteSobreposicao: true });
+  });
+
+  test('CA-07: remove uma aresta após confirmação no modal', async ({ page }) => {
+    const capturado = novoCapturado();
+    await mockApi(page, capturado, [arestaSeed]);
+    await abrirPagina(page);
+
+    await page.getByRole('button', { name: 'Remover' }).first().click();
+    const dialog = page.locator('dialog.uni-dialog');
+    await dialog.getByRole('button', { name: 'Remover' }).click();
+
+    await expect.poll(() => capturado.deletedIds.length).toBe(1);
+    expect(capturado.deletedIds[0]).toBe(ARESTA_ID);
+  });
+
+  test('corrigir o formulário após 422 reenvia com Idempotency-Key nova', async ({ page }) => {
+    const capturado = novoCapturado();
+    await mockApi(page, capturado, [], {
+      criarStatus: 422,
+      criarBody: {
+        type: 'https://uniplus.dev/erros/uniplus.configuracao.precedencia_fase.aresta_duplicada',
+        title: 'Já existe uma aresta de precedência viva com este par de fases',
+        status: 422,
+        code: 'uniplus.configuracao.precedencia_fase.aresta_duplicada',
+      },
+    });
+    await abrirPagina(page);
+
+    await page.getByRole('button', { name: 'Nova aresta' }).first().click();
+    await page.locator('#cfg-precedencia-antecessora').selectOption('INSCRICAO');
+    await page.locator('#cfg-precedencia-sucessora').selectOption('HOMOLOGACAO');
+    await page.getByRole('button', { name: 'Criar aresta' }).click();
+    await expect.poll(() => capturado.posts.length).toBe(1);
+
+    // Correção e reenvio: o backend guarda a resposta 422 associada à chave, e
+    // reusá-la devolveria `body_mismatch` em vez de processar o novo comando.
+    await page.locator('#cfg-precedencia-sucessora').selectOption('AVALIACAO');
+    await page.getByRole('button', { name: 'Criar aresta' }).click();
+
+    await expect.poll(() => capturado.posts.length).toBe(2);
+    expect(capturado.postKeys[0]).toBeTruthy();
+    expect(capturado.postKeys[1]).not.toBe(capturado.postKeys[0]);
+  });
+});
+
+// Bloco `axe`: acessibilidade WCAG 2.1 AA (sem violações serious/critical).
+test.describe('Precedência de fase — acessibilidade axe-core (#497)', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockConfiguracaoRuntimeConfig(page);
+  });
+
+  async function violacoesGraves(page: Page): Promise<unknown[]> {
+    const resultado = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21aa'])
+      .analyze();
+    return resultado.violations.filter((v) => v.impact === 'serious' || v.impact === 'critical');
+  }
+
+  test('lista não tem violações serious/critical', async ({ page }) => {
+    await mockApi(page, novoCapturado(), [arestaSeed]);
+    await abrirPagina(page);
+    const graves = await violacoesGraves(page);
+    expect(graves, JSON.stringify(graves, null, 2)).toEqual([]);
+  });
+
+  test('drawer de criação aberto não tem violações serious/critical', async ({ page }) => {
+    await mockApi(page, novoCapturado(), [arestaSeed]);
+    await abrirPagina(page);
+    await page.getByRole('button', { name: 'Nova aresta' }).first().click();
+    await expect(page.locator('#cfg-precedencia-fase-form')).toBeVisible();
+    const graves = await violacoesGraves(page);
+    expect(graves, JSON.stringify(graves, null, 2)).toEqual([]);
+  });
+
+  test('drawer com erro de campo não tem violações serious/critical', async ({ page }) => {
+    await mockApi(page, novoCapturado(), []);
+    await abrirPagina(page);
+    await page.getByRole('button', { name: 'Nova aresta' }).first().click();
+    await page.locator('#cfg-precedencia-antecessora').selectOption('AVALIACAO');
+    await page.locator('#cfg-precedencia-sucessora').selectOption('AVALIACAO');
+    await page.getByRole('button', { name: 'Criar aresta' }).click();
+    await expect(
+      page.getByText('A fase sucessora não pode ser igual à antecessora.'),
+    ).toBeVisible();
+    const graves = await violacoesGraves(page);
+    expect(graves, JSON.stringify(graves, null, 2)).toEqual([]);
+  });
+
+  test('modal de remoção aberto não tem violações serious/critical', async ({ page }) => {
+    await mockApi(page, novoCapturado(), [arestaSeed]);
+    await abrirPagina(page);
+    await page.getByRole('button', { name: 'Remover' }).first().click();
+    await expect(page.locator('dialog.uni-dialog')).toBeVisible();
+    const graves = await violacoesGraves(page);
+    expect(graves, JSON.stringify(graves, null, 2)).toEqual([]);
+  });
+});

--- a/apps/configuracao/src/app/app.routes.ts
+++ b/apps/configuracao/src/app/app.routes.ts
@@ -84,6 +84,14 @@ export const appRoutes: Routes = [
           ),
       },
       {
+        path: 'precedencias-fase',
+        data: { breadcrumb: 'Precedência de Fase' },
+        loadChildren: () =>
+          import('./features/precedencias-fase/precedencias-fase.routes').then(
+            (m) => m.PRECEDENCIAS_FASE_ROUTES,
+          ),
+      },
+      {
         path: 'tipos-banca',
         data: { breadcrumb: 'Tipo de Banca' },
         loadChildren: () =>

--- a/apps/configuracao/src/app/features/precedencias-fase/precedencias-fase.page.spec.ts
+++ b/apps/configuracao/src/app/features/precedencias-fase/precedencias-fase.page.spec.ts
@@ -1,0 +1,587 @@
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ApplicationRef } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { apiResultInterceptor } from '@uniplus/shared-core/http';
+import { NotificationService } from '@uniplus/shared-core/notifications';
+import {
+  CODIGOS_FASE_CANONICA,
+  CONFIGURACAO_BASE_PATH,
+  FaseCanonicaDto,
+  PrecedenciaFaseDto,
+} from '@uniplus/shared-data/configuracao';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { PrecedenciasFasePage } from './precedencias-fase.page';
+
+const BASE = 'http://localhost:5000';
+const ARESTA_ID = '01960000-0000-7000-0000-0000000000a1';
+
+const arestaSeed: PrecedenciaFaseDto = {
+  id: ARESTA_ID,
+  antecessoraCodigo: 'INSCRICAO',
+  sucessoraCodigo: 'HOMOLOGACAO',
+  permiteSobreposicao: false,
+  criadoEm: '2026-07-15T12:00:00Z',
+};
+
+function faseCanonica(codigo: string, nome: string): FaseCanonicaDto {
+  return {
+    id: `fase-${codigo}`,
+    codigo,
+    nome,
+    descricao: null,
+    donoTipico: 'CEPS',
+    agrupaEtapas: false,
+    permiteComplementacao: false,
+    baseLegal: null,
+    criadoEm: '2026-06-10T12:00:00Z',
+  };
+}
+
+function problem(code: string, title: string, status = 422): Record<string, unknown> {
+  return { type: `https://uniplus.dev/erros/${code}`, title, status, code };
+}
+
+const PROBLEM_HEADERS = { 'Content-Type': 'application/problem+json' };
+
+describe('PrecedenciasFasePage', () => {
+  let fixture: ComponentFixture<PrecedenciasFasePage>;
+  let component: PrecedenciasFasePage;
+  let controller: HttpTestingController;
+  let appRef: ApplicationRef;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [PrecedenciasFasePage],
+      providers: [
+        provideHttpClient(withInterceptors([apiResultInterceptor])),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        { provide: CONFIGURACAO_BASE_PATH, useValue: BASE },
+      ],
+    });
+    fixture = TestBed.createComponent(PrecedenciasFasePage);
+    component = fixture.componentInstance;
+    controller = TestBed.inject(HttpTestingController);
+    appRef = TestBed.inject(ApplicationRef);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => controller.verify());
+
+  const propagate = async (): Promise<void> => {
+    await Promise.resolve();
+    appRef.tick();
+  };
+
+  /** O GET do cadastro de fases só alimenta rótulos; roda uma vez por página. */
+  async function flushFases(itens: readonly FaseCanonicaDto[]): Promise<void> {
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/fases-canonicas`);
+    req.flush(itens);
+    await propagate();
+  }
+
+  async function falharFases(): Promise<void> {
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/fases-canonicas`);
+    req.flush(problem('uniplus.erro', 'Serviço indisponível', 503), {
+      status: 503,
+      statusText: 'Service Unavailable',
+      headers: PROBLEM_HEADERS,
+    });
+    await propagate();
+  }
+
+  async function flushLista(itens: readonly PrecedenciaFaseDto[]): Promise<void> {
+    const req = controller.expectOne(
+      (r) => r.url === `${BASE}/api/configuracao/precedencias-fase`,
+    );
+    expect(req.request.params.get('limit')).toBe('100');
+    req.flush(itens);
+    await propagate();
+  }
+
+  async function abrirCriacaoValida(): Promise<void> {
+    component['abrirCadastro']();
+    component['form'].setValue({
+      antecessoraCodigo: 'AVALIACAO',
+      sucessoraCodigo: 'CLASSIFICACAO',
+      permiteSobreposicao: false,
+    });
+  }
+
+  it('CA-01: lista as arestas vivas com antecessora, sucessora e sobreposição', async () => {
+    await flushFases([faseCanonica('INSCRICAO', 'Inscrição')]);
+    await flushLista([arestaSeed]);
+
+    expect(component['arestas']()).toHaveLength(1);
+    fixture.detectChanges();
+    const texto = fixture.nativeElement.textContent;
+    expect(texto).toContain('INSCRICAO');
+    expect(texto).toContain('HOMOLOGACAO');
+    expect(texto).toContain('Não');
+  });
+
+  it('CA-01: busca filtra por código e por nome da fase', async () => {
+    const outra: PrecedenciaFaseDto = {
+      ...arestaSeed,
+      id: 'b2',
+      antecessoraCodigo: 'AVALIACAO',
+      sucessoraCodigo: 'CLASSIFICACAO',
+    };
+    await flushFases([faseCanonica('AVALIACAO', 'Avaliação')]);
+    await flushLista([arestaSeed, outra]);
+
+    component['termoBusca'].set('CLASSIFICACAO');
+    expect(component['arestasFiltradas']()).toEqual([outra]);
+
+    // Casa pelo nome enriquecido, não só pelo código.
+    component['termoBusca'].set('Avaliação');
+    expect(component['arestasFiltradas']()).toEqual([outra]);
+
+    component['termoBusca'].set('INSCRICAO');
+    expect(component['arestasFiltradas']()).toEqual([arestaSeed]);
+  });
+
+  it('CA-03: self-loop é bloqueado no client e não chega a disparar POST', async () => {
+    await flushFases([]);
+    await flushLista([]);
+
+    component['abrirCadastro']();
+    component['form'].setValue({
+      antecessoraCodigo: 'AVALIACAO',
+      sucessoraCodigo: 'AVALIACAO',
+      permiteSobreposicao: false,
+    });
+
+    component['salvar']();
+
+    controller.expectNone(`${BASE}/api/configuracao/admin/precedencias-fase`);
+    expect(component['form'].hasError('selfLoop')).toBe(true);
+    expect(component['erroDoCampo']('sucessoraCodigo')).toBe(
+      'A fase sucessora não pode ser igual à antecessora.',
+    );
+    expect(component['formOpen']()).toBe(true);
+  });
+
+  it('CA-03: self-loop recusado pelo backend (422) aparece no campo sucessora', async () => {
+    await flushFases([]);
+    await flushLista([]);
+    await abrirCriacaoValida();
+
+    component['salvar']();
+    const post = controller.expectOne(`${BASE}/api/configuracao/admin/precedencias-fase`);
+    post.flush(
+      problem(
+        'uniplus.configuracao.precedencia_fase.self_loop',
+        'A fase antecessora não pode ser igual à fase sucessora',
+      ),
+      { status: 422, statusText: 'Unprocessable Entity', headers: PROBLEM_HEADERS },
+    );
+    await propagate();
+
+    expect(component['formOpen']()).toBe(true);
+    expect(component['erroDoCampo']('sucessoraCodigo')).toContain(
+      'não pode ser igual à fase sucessora',
+    );
+  });
+
+  it('CA-04: aresta duplicada (422) é mapeada no campo sucessora e o drawer continua aberto', async () => {
+    await flushFases([]);
+    await flushLista([]);
+    await abrirCriacaoValida();
+
+    component['salvar']();
+    const post = controller.expectOne(`${BASE}/api/configuracao/admin/precedencias-fase`);
+    post.flush(
+      problem(
+        'uniplus.configuracao.precedencia_fase.aresta_duplicada',
+        'Já existe uma aresta de precedência viva com este par de fases',
+      ),
+      { status: 422, statusText: 'Unprocessable Entity', headers: PROBLEM_HEADERS },
+    );
+    await propagate();
+
+    expect(component['formOpen']()).toBe(true);
+    expect(component['erroDoCampo']('sucessoraCodigo')).toContain('Já existe uma aresta');
+    expect(component['formError']()).toBeNull();
+  });
+
+  it('CA-05: ciclo detectado (422) vira banner geral, não erro de campo', async () => {
+    await flushFases([]);
+    await flushLista([]);
+    await abrirCriacaoValida();
+
+    component['salvar']();
+    const post = controller.expectOne(`${BASE}/api/configuracao/admin/precedencias-fase`);
+    post.flush(
+      problem(
+        'uniplus.configuracao.precedencia_fase.ciclo_detectado',
+        'A aresta fecharia um ciclo no grafo de precedências',
+      ),
+      { status: 422, statusText: 'Unprocessable Entity', headers: PROBLEM_HEADERS },
+    );
+    await propagate();
+
+    expect(component['formOpen']()).toBe(true);
+    expect(component['formError']()).toContain('fecharia um ciclo');
+    expect(component['erroDoCampo']('sucessoraCodigo')).toBeNull();
+    expect(component['erroDoCampo']('antecessoraCodigo')).toBeNull();
+  });
+
+  it('renova a Idempotency-Key após 422 para que a correção seja um comando novo', async () => {
+    await flushFases([]);
+    await flushLista([]);
+    await abrirCriacaoValida();
+
+    component['salvar']();
+    const primeiro = controller.expectOne(`${BASE}/api/configuracao/admin/precedencias-fase`);
+    const chaveInicial = primeiro.request.headers.get('Idempotency-Key');
+    expect(chaveInicial).toBeTruthy();
+    primeiro.flush(
+      problem(
+        'uniplus.configuracao.precedencia_fase.aresta_duplicada',
+        'Já existe uma aresta de precedência viva com este par de fases',
+      ),
+      { status: 422, statusText: 'Unprocessable Entity', headers: PROBLEM_HEADERS },
+    );
+    await propagate();
+
+    // O filtro de idempotência do backend guarda a resposta de qualquer status
+    // abaixo de 500: reenviar o corpo corrigido com a chave anterior devolveria
+    // `body_mismatch` em vez de processar o comando.
+    component['form'].controls.sucessoraCodigo.setValue('RESULTADO_PRELIMINAR');
+    component['salvar']();
+
+    const segundo = controller.expectOne(`${BASE}/api/configuracao/admin/precedencias-fase`);
+    expect(segundo.request.headers.get('Idempotency-Key')).not.toBe(chaveInicial);
+    segundo.flush('novo-id', { status: 201, statusText: 'Created' });
+    await propagate();
+
+    expect(component['formOpen']()).toBe(false);
+    await flushLista([]);
+  });
+
+  it('CA-06: na edição o par é somente leitura e o PUT leva apenas id e permiteSobreposicao', async () => {
+    await flushFases([]);
+    await flushLista([arestaSeed]);
+
+    component['abrirEdicao'](arestaSeed);
+    fixture.detectChanges();
+
+    const antecessora = fixture.nativeElement.querySelector(
+      '#cfg-precedencia-antecessora',
+    ) as HTMLInputElement;
+    const sucessora = fixture.nativeElement.querySelector(
+      '#cfg-precedencia-sucessora',
+    ) as HTMLInputElement;
+    // `readonly` não tem efeito em <select>, por isso a edição troca o controle
+    // por <input readonly>.
+    expect(antecessora.tagName).toBe('INPUT');
+    expect(antecessora.readOnly).toBe(true);
+    expect(sucessora.tagName).toBe('INPUT');
+    expect(sucessora.readOnly).toBe(true);
+
+    component['form'].controls.permiteSobreposicao.setValue(true);
+    component['salvar']();
+
+    const put = controller.expectOne(`${BASE}/api/configuracao/admin/precedencias-fase/${ARESTA_ID}`);
+    expect(put.request.method).toBe('PUT');
+    expect(put.request.body).toEqual({ id: ARESTA_ID, permiteSobreposicao: true });
+    expect(put.request.body).not.toHaveProperty('antecessoraCodigo');
+    expect(put.request.body).not.toHaveProperty('sucessoraCodigo');
+    put.flush(null, { status: 204, statusText: 'No Content' });
+    await propagate();
+    await flushLista([arestaSeed]);
+  });
+
+  it('CA-07: remove a aresta após confirmação', async () => {
+    await flushFases([]);
+    await flushLista([arestaSeed]);
+
+    component['pedirRemocao'](arestaSeed);
+    component['removerConfirmado']();
+
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/precedencias-fase/${ARESTA_ID}`);
+    expect(req.request.method).toBe('DELETE');
+    req.flush(null, { status: 204, statusText: 'No Content' });
+    await propagate();
+
+    expect(component['confirmOpen']()).toBe(false);
+    await flushLista([]);
+  });
+
+  it('edição de aresta já removida por outro administrador (404) fecha o drawer e recarrega', async () => {
+    await flushFases([]);
+    await flushLista([arestaSeed]);
+
+    component['abrirEdicao'](arestaSeed);
+    component['form'].controls.permiteSobreposicao.setValue(true);
+    component['salvar']();
+
+    const put = controller.expectOne(`${BASE}/api/configuracao/admin/precedencias-fase/${ARESTA_ID}`);
+    put.flush(
+      problem(
+        'uniplus.configuracao.precedencia_fase.nao_encontrada',
+        'Aresta de precedência não encontrada',
+        404,
+      ),
+      { status: 404, statusText: 'Not Found', headers: PROBLEM_HEADERS },
+    );
+    await propagate();
+
+    expect(component['formOpen']()).toBe(false);
+    await flushLista([]);
+  });
+
+  it('remoção de aresta já removida (404) fecha o modal e recarrega', async () => {
+    await flushFases([]);
+    await flushLista([arestaSeed]);
+
+    component['pedirRemocao'](arestaSeed);
+    component['removerConfirmado']();
+
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/precedencias-fase/${ARESTA_ID}`);
+    req.flush(
+      problem(
+        'uniplus.configuracao.precedencia_fase.nao_encontrada',
+        'Aresta de precedência não encontrada',
+        404,
+      ),
+      { status: 404, statusText: 'Not Found', headers: PROBLEM_HEADERS },
+    );
+    await propagate();
+
+    expect(component['confirmOpen']()).toBe(false);
+    await flushLista([]);
+  });
+
+  it('opções cobrem o roster canônico e marcam as fases ainda não cadastradas', async () => {
+    await flushFases([faseCanonica('INSCRICAO', 'Inscrição')]);
+    await flushLista([]);
+
+    const opcoes = component['opcoesDeFase']();
+    expect(opcoes).toHaveLength(CODIGOS_FASE_CANONICA.length);
+    expect(opcoes.find((o) => o.codigo === 'INSCRICAO')?.rotulo).toBe('INSCRICAO — Inscrição');
+    expect(opcoes.find((o) => o.codigo === 'MATRICULA')?.rotulo).toBe('MATRICULA — (não cadastrada)');
+  });
+
+  it('falha ao consultar o cadastro de fases degrada os rótulos sem se confundir com "não cadastrada"', async () => {
+    await falharFases();
+    await flushLista([arestaSeed]);
+
+    expect(component['falhaAoCarregarFases']()).toBe(true);
+    // Indisponibilidade do cadastro não pode ser apresentada como ausência dele.
+    const opcoes = component['opcoesDeFase']();
+    expect(opcoes.every((o) => !o.rotulo.includes('não cadastrada'))).toBe(true);
+    expect(opcoes.find((o) => o.codigo === 'INSCRICAO')?.rotulo).toBe('INSCRICAO');
+    // A lista principal segue utilizável.
+    expect(component['arestas']()).toHaveLength(1);
+    expect(component['errorMessage']()).toBeNull();
+  });
+
+  it('corrigir a antecessora limpa o erro de par vindo do backend e libera o reenvio', async () => {
+    await flushFases([]);
+    await flushLista([]);
+    await abrirCriacaoValida();
+
+    component['salvar']();
+    const primeiro = controller.expectOne(`${BASE}/api/configuracao/admin/precedencias-fase`);
+    primeiro.flush(
+      problem(
+        'uniplus.configuracao.precedencia_fase.aresta_duplicada',
+        'Já existe uma aresta de precedência viva com este par de fases',
+      ),
+      { status: 422, statusText: 'Unprocessable Entity', headers: PROBLEM_HEADERS },
+    );
+    await propagate();
+    expect(component['erroDoCampo']('sucessoraCodigo')).toContain('Já existe uma aresta');
+
+    // A correção acontece do outro lado do par: o erro é da dupla, então
+    // precisa sumir mesmo sem tocar na sucessora — senão o formulário fica
+    // travado com uma combinação que já mudou.
+    component['form'].controls.antecessoraCodigo.setValue('RECURSOS');
+    expect(component['erroDoCampo']('sucessoraCodigo')).toBeNull();
+    expect(component['form'].valid).toBe(true);
+
+    component['salvar']();
+    const segundo = controller.expectOne(`${BASE}/api/configuracao/admin/precedencias-fase`);
+    expect(segundo.request.body).toEqual({
+      antecessoraCodigo: 'RECURSOS',
+      sucessoraCodigo: 'CLASSIFICACAO',
+      permiteSobreposicao: false,
+    });
+    segundo.flush('novo-id', { status: 201, statusText: 'Created' });
+    await propagate();
+    await flushLista([]);
+  });
+
+  it('conflito de processamento (409) preserva a chave para o retry do mesmo comando', async () => {
+    await flushFases([]);
+    await flushLista([]);
+    await abrirCriacaoValida();
+
+    component['salvar']();
+    const primeiro = controller.expectOne(`${BASE}/api/configuracao/admin/precedencias-fase`);
+    const chaveInicial = primeiro.request.headers.get('Idempotency-Key');
+    primeiro.flush(
+      problem(
+        'uniplus.idempotency.processing_conflict',
+        'Request com a mesma Idempotency-Key ainda em processamento; tentar novamente em alguns segundos',
+        409,
+      ),
+      { status: 409, statusText: 'Conflict', headers: PROBLEM_HEADERS },
+    );
+    await propagate();
+
+    // A execução anterior ainda pode concluir: reenviar com chave nova viraria
+    // um segundo comando em vez de recuperar o resultado do primeiro.
+    component['salvar']();
+    const retry = controller.expectOne(`${BASE}/api/configuracao/admin/precedencias-fase`);
+    expect(retry.request.headers.get('Idempotency-Key')).toBe(chaveInicial);
+    retry.flush('novo-id', { status: 201, statusText: 'Created' });
+    await propagate();
+    await flushLista([]);
+  });
+
+  it('formulário fica congelado durante a gravação e é reabilitado ao fim', async () => {
+    await flushFases([]);
+    await flushLista([]);
+    await abrirCriacaoValida();
+
+    component['salvar']();
+    // Congelado impede que a dupla mude sob a request em voo.
+    expect(component['form'].disabled).toBe(true);
+
+    const post = controller.expectOne(`${BASE}/api/configuracao/admin/precedencias-fase`);
+    post.flush(
+      problem(
+        'uniplus.configuracao.precedencia_fase.aresta_duplicada',
+        'Já existe uma aresta de precedência viva com este par de fases',
+      ),
+      { status: 422, statusText: 'Unprocessable Entity', headers: PROBLEM_HEADERS },
+    );
+    await propagate();
+
+    expect(component['form'].disabled).toBe(false);
+    // O erro sobrevive à reabilitação — `enable()` revalida e apagaria um erro
+    // gravado antes dele.
+    expect(component['erroDoCampo']('sucessoraCodigo')).toContain('Já existe uma aresta');
+  });
+
+  it('remoção não é bloqueada por uma gravação de formulário em curso', async () => {
+    await flushFases([]);
+    await flushLista([arestaSeed]);
+    await abrirCriacaoValida();
+
+    component['salvar']();
+    const post = controller.expectOne(`${BASE}/api/configuracao/admin/precedencias-fase`);
+
+    // Com o estado de gravação compartilhado, esta confirmação sumiria sem
+    // enviar nada — o diálogo fecha ao confirmar, independentemente do guard.
+    component['pedirRemocao'](arestaSeed);
+    component['removerConfirmado']();
+    const del = controller.expectOne(
+      `${BASE}/api/configuracao/admin/precedencias-fase/${ARESTA_ID}`,
+    );
+    expect(del.request.method).toBe('DELETE');
+    del.flush(null, { status: 204, statusText: 'No Content' });
+    await propagate();
+    await flushLista([]);
+
+    post.flush('novo-id', { status: 201, statusText: 'Created' });
+    await propagate();
+    await flushLista([]);
+  });
+
+  it('falha que chega com o drawer já fechado vira notificação em vez de sumir', async () => {
+    await flushFases([]);
+    await flushLista([]);
+    await abrirCriacaoValida();
+
+    component['salvar']();
+    const post = controller.expectOne(`${BASE}/api/configuracao/admin/precedencias-fase`);
+
+    // O botão Cancelar respeita `saving`, mas o X do cabeçalho e o Esc do
+    // <dialog> fecham o drawer mesmo assim. Com o formulário fora da tela, o
+    // erro de campo não seria visto por ninguém.
+    component['formOpen'].set(false);
+
+    post.flush(
+      problem(
+        'uniplus.configuracao.precedencia_fase.aresta_duplicada',
+        'Já existe uma aresta de precedência viva com este par de fases',
+      ),
+      { status: 422, statusText: 'Unprocessable Entity', headers: PROBLEM_HEADERS },
+    );
+    await propagate();
+
+    const erros = TestBed.inject(NotificationService)
+      .notifications()
+      .filter((n) => n.type === 'error');
+    expect(erros).toHaveLength(1);
+    expect(erros[0].title).toContain('Já existe uma aresta');
+    await flushLista([]);
+  });
+
+  it('busca lê o valor do input sem passar por cast no template', async () => {
+    await flushFases([]);
+    await flushLista([arestaSeed]);
+    fixture.detectChanges();
+
+    const input = fixture.nativeElement.querySelector(
+      'input[type="search"]',
+    ) as HTMLInputElement;
+    input.value = 'HOMOLOGACAO';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    expect(component['termoBusca']()).toBe('HOMOLOGACAO');
+  });
+
+  it('sucesso de uma abertura anterior recarrega a lista sem fechar o formulário atual', async () => {
+    await flushFases([]);
+    await flushLista([]);
+    await abrirCriacaoValida();
+
+    component['salvar']();
+    const post = controller.expectOne(`${BASE}/api/configuracao/admin/precedencias-fase`);
+
+    component['abrirEdicao'](arestaSeed);
+    post.flush('novo-id', { status: 201, statusText: 'Created' });
+    await propagate();
+
+    // O servidor mudou, então a lista precisa ser recarregada de qualquer forma;
+    // o drawer aberto depois é que não pode ser fechado pela resposta antiga.
+    expect(component['formOpen']()).toBe(true);
+    expect(component['modo']()).toBe('editar');
+    await flushLista([arestaSeed]);
+  });
+
+  it('resposta tardia de uma abertura anterior não fecha o formulário aberto depois', async () => {
+    await flushFases([]);
+    await flushLista([]);
+    await abrirCriacaoValida();
+
+    component['salvar']();
+    const post = controller.expectOne(`${BASE}/api/configuracao/admin/precedencias-fase`);
+
+    // Enquanto a resposta não chega, o administrador abre outro formulário.
+    component['abrirEdicao'](arestaSeed);
+
+    post.flush(
+      problem(
+        'uniplus.configuracao.precedencia_fase.aresta_duplicada',
+        'Já existe uma aresta de precedência viva com este par de fases',
+      ),
+      { status: 422, statusText: 'Unprocessable Entity', headers: PROBLEM_HEADERS },
+    );
+    await propagate();
+
+    // O erro pertencia à abertura anterior: não contamina o formulário atual.
+    expect(component['formOpen']()).toBe(true);
+    expect(component['modo']()).toBe('editar');
+    expect(component['formError']()).toBeNull();
+    expect(component['erroDoCampo']('sucessoraCodigo')).toBeNull();
+  });
+});

--- a/apps/configuracao/src/app/features/precedencias-fase/precedencias-fase.page.ts
+++ b/apps/configuracao/src/app/features/precedencias-fase/precedencias-fase.page.ts
@@ -1,0 +1,1057 @@
+import { HttpParams } from '@angular/common/http';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  effect,
+  inject,
+  linkedSignal,
+  signal,
+  untracked,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  AbstractControl,
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  ValidationErrors,
+  Validators,
+} from '@angular/forms';
+import { finalize, merge } from 'rxjs';
+import {
+  ApiResult,
+  Cursor,
+  PaginationDirection,
+  ProblemDetails,
+  ProblemI18nService,
+  ProblemValidationError,
+  cursorToString,
+  extractNextCursor,
+  extractPrevCursor,
+  idempotencyKey,
+  useApiResource,
+  withIdempotencyKey,
+  withVendorMime,
+} from '@uniplus/shared-core/http';
+import { NotificationService } from '@uniplus/shared-core/notifications';
+import {
+  CODIGOS_FASE_CANONICA,
+  CONFIGURACAO_BASE_PATH,
+  FasesCanonicasApi,
+  PrecedenciaFaseDto,
+  PrecedenciasFaseApi,
+  type AtualizarPrecedenciaFaseCommand,
+  type CriarPrecedenciaFaseCommand,
+} from '@uniplus/shared-data/configuracao';
+import {
+  AlertComponent,
+  ConfirmDialogComponent,
+  DrawerComponent,
+  EmptyStateComponent,
+  PagerComponent,
+  SpinnerComponent,
+} from '@uniplus/shared-ui/components';
+
+/**
+ * Janela da listagem. Um DAG sobre as quatorze fases canônicas comporta no
+ * máximo 91 arestas (14 × 13 ÷ 2), então o universo inteiro cabe em uma página
+ * — a busca client-side abaixo é, na prática, global. O pager continua ligado
+ * porque a navegação por cursor é contrato do endpoint (ADR-0026).
+ */
+const PAGE_SIZE = 100;
+
+/** Vendor codes dos DomainErrors de PrecedenciaFase (uniplus-api, todos 422). */
+const ERRO_SELF_LOOP = 'uniplus.configuracao.precedencia_fase.self_loop';
+const ERRO_ARESTA_DUPLICADA = 'uniplus.configuracao.precedencia_fase.aresta_duplicada';
+const ERRO_CICLO_DETECTADO = 'uniplus.configuracao.precedencia_fase.ciclo_detectado';
+const ERRO_ANTECESSORA_FORA_CANONICO =
+  'uniplus.configuracao.precedencia_fase.antecessora_fora_do_conjunto_canonico';
+const ERRO_SUCESSORA_FORA_CANONICO =
+  'uniplus.configuracao.precedencia_fase.sucessora_fora_do_conjunto_canonico';
+const ERRO_NAO_ENCONTRADA = 'uniplus.configuracao.precedencia_fase.nao_encontrada';
+
+/**
+ * 409 emitido quando a chave ainda está reservada por uma execução em curso —
+ * o backend pede retry com a **mesma** chave, porque o comando anterior pode
+ * ter persistido antes de a resposta falhar. Renová-la aqui transformaria o
+ * retry seguro em um comando novo.
+ */
+const ERRO_IDEMPOTENCIA_EM_PROCESSAMENTO = 'uniplus.idempotency.processing_conflict';
+
+type ModoFormulario = 'criar' | 'editar';
+
+interface PrecedenciaForm {
+  antecessoraCodigo: FormControl<string>;
+  sucessoraCodigo: FormControl<string>;
+  permiteSobreposicao: FormControl<boolean>;
+}
+
+const PRECEDENCIA_CONTROL_NAMES: ReadonlySet<string> = new Set<keyof PrecedenciaForm>([
+  'antecessoraCodigo',
+  'sucessoraCodigo',
+  'permiteSobreposicao',
+]);
+
+/**
+ * Vendor code → controle que recebe a mensagem inline. Só entram aqui os erros
+ * de um código isolado; os que dependem do par têm tratamento próprio (ver
+ * `CODIGOS_ERRO_DO_PAR`) e `ciclo_detectado` fica de fora dos dois porque a
+ * aresta que fecha um ciclo é inválida pelo grafo inteiro, não por um campo —
+ * vira banner do formulário.
+ */
+const CODIGO_ERRO_PARA_CONTROLE: ReadonlyMap<string, keyof PrecedenciaForm> = new Map([
+  [ERRO_SUCESSORA_FORA_CANONICO, 'sucessoraCodigo'],
+  [ERRO_ANTECESSORA_FORA_CANONICO, 'antecessoraCodigo'],
+]);
+
+/**
+ * Erros que qualificam o par, não um campo. Ficam fora de `setErrors` do
+ * controle: preso à sucessora, o erro sobreviveria à correção feita na
+ * antecessora — o Angular não revalida erros manuais de um irmão — e deixaria
+ * o formulário travado com uma dupla que já mudou.
+ */
+const CODIGOS_ERRO_DO_PAR: ReadonlySet<string> = new Set([ERRO_SELF_LOOP, ERRO_ARESTA_DUPLICADA]);
+
+/** Antecessora igual à sucessora — o backend recusa com 422; barramos antes. */
+function selfLoopValidator(grupo: AbstractControl): ValidationErrors | null {
+  const antecessora = grupo.get('antecessoraCodigo')?.value;
+  const sucessora = grupo.get('sucessoraCodigo')?.value;
+  if (!antecessora || !sucessora) {
+    return null;
+  }
+  return antecessora === sucessora ? { selfLoop: true } : null;
+}
+
+@Component({
+  selector: 'cfg-precedencias-fase-page',
+  standalone: true,
+  imports: [
+    ReactiveFormsModule,
+    AlertComponent,
+    ConfirmDialogComponent,
+    DrawerComponent,
+    EmptyStateComponent,
+    PagerComponent,
+    SpinnerComponent,
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="page-header">
+      <div class="page-header__content">
+        <h1 class="page-header__title">Precedência de Fase</h1>
+        <p class="page-header__desc">
+          Grafo de dependência entre as fases canônicas do cronograma — cada aresta diz que uma
+          fase antecede outra · UNI-REQ-0064.
+        </p>
+      </div>
+    </div>
+
+    <ui-alert variant="info" heading="Dependência condicional" [dynamic]="false">
+      Uma aresta só vale onde as duas fases coexistem no cronograma de um processo seletivo — a
+      ausência de uma delas não é violação. O par de fases é a chave da aresta e não muda: para
+      corrigi-lo, remova a aresta e crie outra.
+    </ui-alert>
+
+    @if (errorMessage()) {
+      <ui-alert variant="danger" heading="Não foi possível carregar as precedências">
+        {{ errorMessage() }}
+        <div class="cfg-precedencias-fase__retry">
+          <button
+            type="button"
+            class="btn btn--secondary btn--sm"
+            [disabled]="loading()"
+            (click)="tentarNovamente()"
+          >
+            Tentar novamente
+          </button>
+        </div>
+      </ui-alert>
+    }
+
+    <section class="panel" aria-labelledby="cfg-precedencias-fase-list-title">
+      <div class="panel-head">
+        <div class="panel-head__title">
+          <h2 id="cfg-precedencias-fase-list-title">Arestas de precedência</h2>
+          @if (loading()) {
+            <span class="cfg-precedencias-fase__loading"><ui-spinner size="sm" /> Carregando</span>
+          }
+        </div>
+        <button type="button" class="btn btn--primary" (click)="abrirCadastro()">
+          <i class="pi pi-plus btn__icon" aria-hidden="true"></i>
+          Nova aresta
+        </button>
+      </div>
+
+      <div class="filter-bar" role="search" aria-label="Filtrar arestas de precedência">
+        <div class="filter-bar__group">
+          <label class="field field--search">
+            <span class="field__label sr-only">Buscar por fase antecessora ou sucessora</span>
+            <input
+              class="input"
+              type="search"
+              placeholder="Buscar por fase antecessora ou sucessora…"
+              [value]="termoBusca()"
+              (input)="atualizarBusca($event)"
+            />
+          </label>
+        </div>
+      </div>
+
+      @if (arestasFiltradas().length > 0) {
+        <div class="table-responsive">
+          <table>
+            <thead>
+              <tr>
+                <th scope="col">Fase antecessora</th>
+                <th scope="col">Fase sucessora</th>
+                <th scope="col">Permite sobreposição</th>
+                <th scope="col"><span class="sr-only">Ações</span></th>
+              </tr>
+            </thead>
+            <tbody>
+              @for (aresta of arestasFiltradas(); track aresta.id) {
+                <tr [attr.data-aresta]="aresta.antecessoraCodigo + '>' + aresta.sucessoraCodigo">
+                  <td data-label="Fase antecessora">
+                    <code>{{ aresta.antecessoraCodigo }}</code>
+                    <span class="cfg-precedencias-fase__nome">{{
+                      nomeDaFase(aresta.antecessoraCodigo)
+                    }}</span>
+                  </td>
+                  <td data-label="Fase sucessora">
+                    <code>{{ aresta.sucessoraCodigo }}</code>
+                    <span class="cfg-precedencias-fase__nome">{{
+                      nomeDaFase(aresta.sucessoraCodigo)
+                    }}</span>
+                  </td>
+                  <td data-label="Permite sobreposição">
+                    @if (aresta.permiteSobreposicao) {
+                      <span class="tag tag--success">Sim</span>
+                    } @else {
+                      <span class="tag">Não</span>
+                    }
+                  </td>
+                  <td class="table-responsive__actions" data-label="Ações">
+                    <button
+                      type="button"
+                      class="btn btn--tertiary btn--sm btn--rect"
+                      [disabled]="loading()"
+                      (click)="abrirEdicao(aresta)"
+                    >
+                      Editar
+                    </button>
+                    <button
+                      type="button"
+                      class="btn btn--tertiary btn--sm btn--rect"
+                      [disabled]="loading() || removendo()"
+                      (click)="pedirRemocao(aresta)"
+                    >
+                      Remover
+                    </button>
+                  </td>
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+      } @else if (!loading() && !errorMessage()) {
+        @if (temFiltro()) {
+          <ui-empty-state
+            heading="Nenhuma aresta encontrada"
+            description="Ajuste a busca para ver resultados."
+          >
+            <button type="button" class="btn btn--secondary" (click)="limparFiltros()">
+              Limpar busca
+            </button>
+          </ui-empty-state>
+        } @else {
+          <ui-empty-state
+            heading="Nenhuma aresta de precedência cadastrada"
+            description="Cadastre a primeira aresta para descrever a ordem entre as fases do cronograma."
+          >
+            <button type="button" class="btn btn--primary" (click)="abrirCadastro()">
+              Nova aresta
+            </button>
+          </ui-empty-state>
+        }
+      }
+
+      @if (prevCursor() !== null || nextCursor() !== null) {
+        <ui-pager
+          statusText="Navegação por páginas"
+          navigationLabel="Paginação de arestas de precedência"
+          [hasPrevious]="prevCursor() !== null"
+          [hasNext]="nextCursor() !== null"
+          [isDisabled]="loading()"
+          (previous)="paginaAnterior()"
+          (next)="proximaPagina()"
+        />
+      }
+    </section>
+
+    <ui-drawer
+      class="cfg-form-drawer"
+      [(visible)]="formOpen"
+      [heading]="formHeading()"
+      ariaLabel="Formulário de aresta de precedência"
+      position="right"
+    >
+      @if (formError()) {
+        <ui-alert variant="danger" heading="Não foi possível salvar">{{ formError() }}</ui-alert>
+      }
+
+      @if (falhaAoCarregarFases()) {
+        <ui-alert variant="warning" heading="Nomes das fases indisponíveis">
+          Não foi possível consultar o cadastro de Fase Canônica agora, então as opções aparecem
+          só com o código. O cadastro da aresta continua disponível.
+        </ui-alert>
+      }
+
+      <form
+        [formGroup]="form"
+        id="cfg-precedencia-fase-form"
+        (ngSubmit)="salvar()"
+        novalidate
+        class="cfg-form"
+      >
+        <section aria-labelledby="cfg-precedencia-par">
+          <h3 id="cfg-precedencia-par" class="form-section__title">Par de fases</h3>
+          <div class="form-grid form-grid--1col">
+            @if (modo() === 'criar') {
+              <label class="field" [class.is-error]="erroDoCampo('antecessoraCodigo')">
+                <span class="field__label is-required">Fase antecessora</span>
+                <select
+                  id="cfg-precedencia-antecessora"
+                  class="select"
+                  formControlName="antecessoraCodigo"
+                  aria-describedby="cfg-precedencia-antecessora-hint"
+                  [attr.aria-invalid]="erroDoCampo('antecessoraCodigo') ? 'true' : null"
+                >
+                  <option value="" disabled>Selecione a fase antecessora</option>
+                  @for (opcao of opcoesDeFase(); track opcao.codigo) {
+                    <option [value]="opcao.codigo">{{ opcao.rotulo }}</option>
+                  }
+                </select>
+                <span id="cfg-precedencia-antecessora-hint" class="field__hint">
+                  Fase que precede. Imutável após a criação.
+                </span>
+                @if (erroDoCampo('antecessoraCodigo')) {
+                  <span class="field__error" role="alert">{{
+                    erroDoCampo('antecessoraCodigo')
+                  }}</span>
+                }
+              </label>
+            } @else {
+              <label class="field">
+                <span class="field__label is-required">Fase antecessora</span>
+                <input
+                  id="cfg-precedencia-antecessora"
+                  class="input"
+                  type="text"
+                  formControlName="antecessoraCodigo"
+                  readonly
+                  aria-describedby="cfg-precedencia-antecessora-hint"
+                />
+                <span id="cfg-precedencia-antecessora-hint" class="field__hint">
+                  O par de fases é a chave da aresta e não muda.
+                </span>
+              </label>
+            }
+
+            @if (modo() === 'criar') {
+              <label class="field" [class.is-error]="erroDoCampo('sucessoraCodigo')">
+                <span class="field__label is-required">Fase sucessora</span>
+                <select
+                  id="cfg-precedencia-sucessora"
+                  class="select"
+                  formControlName="sucessoraCodigo"
+                  aria-describedby="cfg-precedencia-sucessora-hint"
+                  [attr.aria-invalid]="erroDoCampo('sucessoraCodigo') ? 'true' : null"
+                >
+                  <option value="" disabled>Selecione a fase sucessora</option>
+                  @for (opcao of opcoesDeFase(); track opcao.codigo) {
+                    <option [value]="opcao.codigo">{{ opcao.rotulo }}</option>
+                  }
+                </select>
+                <span id="cfg-precedencia-sucessora-hint" class="field__hint">
+                  Fase que sucede. Não pode ser igual à antecessora.
+                </span>
+                @if (erroDoCampo('sucessoraCodigo')) {
+                  <span class="field__error" role="alert">{{
+                    erroDoCampo('sucessoraCodigo')
+                  }}</span>
+                }
+              </label>
+            } @else {
+              <label class="field">
+                <span class="field__label is-required">Fase sucessora</span>
+                <input
+                  id="cfg-precedencia-sucessora"
+                  class="input"
+                  type="text"
+                  formControlName="sucessoraCodigo"
+                  readonly
+                  aria-describedby="cfg-precedencia-sucessora-hint"
+                />
+                <span id="cfg-precedencia-sucessora-hint" class="field__hint">
+                  O par de fases é a chave da aresta e não muda.
+                </span>
+              </label>
+            }
+          </div>
+        </section>
+
+        <fieldset class="form-section">
+          <legend class="form-section__title">Sobreposição</legend>
+          <label class="field">
+            <span class="field__label">Permite sobreposição</span>
+            <select
+              id="cfg-precedencia-sobreposicao"
+              class="select"
+              formControlName="permiteSobreposicao"
+              aria-describedby="cfg-precedencia-sobreposicao-hint"
+            >
+              <option [ngValue]="true">Sim</option>
+              <option [ngValue]="false">Não</option>
+            </select>
+            <span id="cfg-precedencia-sobreposicao-hint" class="field__hint">
+              Define se as duas fases podem coexistir no tempo. O padrão é não sobrepor.
+            </span>
+          </label>
+        </fieldset>
+      </form>
+
+      <div class="cfg-form-footer">
+        <button
+          type="button"
+          class="btn btn--tertiary btn--rect"
+          [disabled]="saving()"
+          (click)="fecharFormulario()"
+        >
+          Cancelar
+        </button>
+        <button
+          type="submit"
+          form="cfg-precedencia-fase-form"
+          class="btn btn--primary"
+          [disabled]="saving()"
+        >
+          @if (saving()) {
+            <ui-spinner size="sm" />
+          }
+          {{ saving() ? 'Salvando...' : modo() === 'criar' ? 'Criar aresta' : 'Salvar aresta' }}
+        </button>
+      </div>
+    </ui-drawer>
+
+    <ui-confirm-dialog
+      [(visible)]="confirmOpen"
+      heading="Remover aresta de precedência"
+      [message]="confirmMessage()"
+      confirmLabel="Remover"
+      confirmVariant="danger"
+      (confirmed)="removerConfirmado()"
+    />
+  `,
+})
+export class PrecedenciasFasePage {
+  private readonly api = inject(PrecedenciasFaseApi);
+  private readonly fasesApi = inject(FasesCanonicasApi);
+  private readonly problemI18n = inject(ProblemI18nService);
+  private readonly notifications = inject(NotificationService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly basePath = inject(CONFIGURACAO_BASE_PATH);
+
+  protected readonly saving = signal(false);
+  /** Remoção tem estado próprio: não é bloqueada por uma gravação de formulário. */
+  protected readonly removendo = signal(false);
+  protected readonly formOpen = signal(false);
+  protected readonly confirmOpen = signal(false);
+  protected readonly formError = signal<string | null>(null);
+  /** Mensagem de erro que qualifica o par, exibida no campo Fase sucessora. */
+  protected readonly erroDoPar = signal<string | null>(null);
+  protected readonly modo = signal<ModoFormulario>('criar');
+  protected readonly arestaEmEdicaoId = signal<string | null>(null);
+  protected readonly arestaParaRemover = signal<PrecedenciaFaseDto | null>(null);
+  protected readonly idempotencyKeyAtual = signal(idempotencyKey.create());
+  protected readonly termoBusca = signal('');
+
+  /**
+   * Nomes das fases canônicas cadastradas, por código. Só enriquece a
+   * apresentação: o domínio fechado das opções é o roster canônico, que o
+   * backend valida contra `FaseCanonicaCatalogo` — não contra este cadastro.
+   */
+  private readonly nomesDasFases = signal<ReadonlyMap<string, string>>(new Map());
+  protected readonly falhaAoCarregarFases = signal(false);
+
+  /**
+   * Identifica a abertura de formulário que originou uma mutação. A resposta
+   * chega depois e só pode mexer na UI se o contexto ainda for o mesmo — sem
+   * isso, salvar A, fechar e abrir B faria a resposta de A fechar o drawer de B.
+   */
+  private readonly contextoDaAbertura = signal(0);
+
+  private readonly pagina = signal<
+    { readonly cursor: Cursor; readonly direction: PaginationDirection } | undefined
+  >(undefined);
+
+  private readonly lista = useApiResource<readonly PrecedenciaFaseDto[]>(() => ({
+    url: `${this.basePath}/api/configuracao/precedencias-fase`,
+    params: this.montarParams(),
+    context: withVendorMime('precedencia-fase', 1),
+  }));
+
+  protected readonly loading = this.lista.isLoading;
+
+  private readonly cursores = linkedSignal<
+    ApiResult<readonly PrecedenciaFaseDto[]> | undefined,
+    { readonly prev: Cursor | null; readonly next: Cursor | null }
+  >({
+    source: () => this.lista.value(),
+    computation: (envelope, previous) => {
+      const atual = previous?.value ?? { prev: null, next: null };
+      if (envelope === undefined) {
+        return atual;
+      }
+      const primeiraPagina = untracked(() => this.pagina() === undefined);
+      if (!envelope.ok) {
+        return primeiraPagina ? { prev: null, next: null } : atual;
+      }
+      const link = untracked(() => this.lista.headers()?.get('Link') ?? null);
+      return { prev: extractPrevCursor(link), next: extractNextCursor(link) };
+    },
+  });
+
+  protected readonly prevCursor = computed(() => this.cursores().prev);
+  protected readonly nextCursor = computed(() => this.cursores().next);
+
+  protected readonly arestas = linkedSignal<
+    ApiResult<readonly PrecedenciaFaseDto[]> | undefined,
+    readonly PrecedenciaFaseDto[]
+  >({
+    source: () => this.lista.value(),
+    computation: (envelope, previous) => {
+      const atual = previous?.value ?? [];
+      if (envelope === undefined) {
+        return atual;
+      }
+      const primeiraPagina = untracked(() => this.pagina() === undefined);
+      if (!envelope.ok) {
+        return primeiraPagina ? [] : atual;
+      }
+      return [...envelope.data];
+    },
+  });
+
+  // Busca client-side: o endpoint só aceita cursor/limit/direction, sem filtro
+  // de texto. Como a janela (PAGE_SIZE) cobre o máximo de arestas possível no
+  // grafo, o filtro alcança todo o cadastro.
+  protected readonly arestasFiltradas = computed(() => {
+    const termo = this.termoBusca().trim().toLocaleLowerCase('pt-BR');
+    if (termo.length === 0) {
+      return this.arestas();
+    }
+    return this.arestas().filter((aresta) => {
+      const nomes = this.nomesDasFases();
+      const alvos = [
+        aresta.antecessoraCodigo,
+        aresta.sucessoraCodigo,
+        nomes.get(aresta.antecessoraCodigo) ?? '',
+        nomes.get(aresta.sucessoraCodigo) ?? '',
+      ];
+      return alvos.some((alvo) => alvo.toLocaleLowerCase('pt-BR').includes(termo));
+    });
+  });
+
+  protected readonly temFiltro = computed(() => this.termoBusca().trim().length > 0);
+
+  /**
+   * Opções dos selects: o roster canônico completo, porque é contra ele que o
+   * backend valida. Fases ainda não cadastradas continuam selecionáveis e são
+   * marcadas como tal — restringir ao cadastro faria a tela recusar arestas que
+   * a API aceita, e o próprio seed do backend já cria arestas antes de as fases
+   * existirem no cadastro.
+   */
+  protected readonly opcoesDeFase = computed(() => {
+    const nomes = this.nomesDasFases();
+    return CODIGOS_FASE_CANONICA.map((codigo) => {
+      const nome = nomes.get(codigo);
+      if (nome !== undefined) {
+        return { codigo, rotulo: `${codigo} — ${nome}` };
+      }
+      return {
+        codigo,
+        rotulo: this.falhaAoCarregarFases() ? codigo : `${codigo} — (não cadastrada)`,
+      };
+    });
+  });
+
+  protected readonly errorMessage = computed<string | null>(() => {
+    const problem = this.lista.problem();
+    if (problem) {
+      return this.problemI18n.resolve(problem).title;
+    }
+    return this.lista.error() ? 'Erro inesperado ao carregar as precedências de fase.' : null;
+  });
+
+  protected readonly formHeading = computed(() =>
+    this.modo() === 'criar' ? 'Nova aresta de precedência' : 'Editar aresta',
+  );
+
+  protected readonly confirmMessage = computed(() => {
+    const aresta = this.arestaParaRemover();
+    return aresta
+      ? `Deseja remover a aresta de ${aresta.antecessoraCodigo} para ${aresta.sucessoraCodigo}? Cronogramas já publicados não são afetados — a ordem vigente neles foi congelada por snapshot no momento da publicação.`
+      : 'Deseja remover esta aresta de precedência?';
+  });
+
+  protected readonly form: FormGroup<PrecedenciaForm> = new FormGroup<PrecedenciaForm>(
+    {
+      antecessoraCodigo: new FormControl('', {
+        nonNullable: true,
+        validators: [Validators.required],
+      }),
+      sucessoraCodigo: new FormControl('', {
+        nonNullable: true,
+        validators: [Validators.required],
+      }),
+      permiteSobreposicao: new FormControl(false, { nonNullable: true }),
+    },
+    { validators: selfLoopValidator },
+  );
+
+  constructor() {
+    effect(() => {
+      const problem = this.lista.problem();
+      if (problem && problem.status >= 500) {
+        const titulo = this.problemI18n.resolve(problem).title;
+        untracked(() => this.notifications.errorFromProblem(problem, { title: titulo }));
+      }
+    });
+
+    // O erro do par deixa de valer assim que qualquer um dos dois lados muda.
+    merge(
+      this.form.controls.antecessoraCodigo.valueChanges,
+      this.form.controls.sucessoraCodigo.valueChanges,
+    )
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.erroDoPar.set(null));
+
+    this.carregarNomesDasFases();
+  }
+
+  protected proximaPagina(): void {
+    const proximo = this.nextCursor();
+    if (proximo !== null && !this.loading()) {
+      this.pagina.set({ cursor: proximo, direction: 'next' });
+    }
+  }
+
+  protected paginaAnterior(): void {
+    const anterior = this.prevCursor();
+    if (anterior !== null && !this.loading()) {
+      this.pagina.set({ cursor: anterior, direction: 'prev' });
+    }
+  }
+
+  protected tentarNovamente(): void {
+    if (!this.loading()) {
+      this.lista.reload();
+    }
+  }
+
+  protected limparFiltros(): void {
+    this.termoBusca.set('');
+  }
+
+  /**
+   * Estreita o alvo do evento em vez de passar por `$any` no template: o cast
+   * no template escapa da checagem de tipos e o repositório veda `any` em
+   * componentes.
+   */
+  protected atualizarBusca(evento: Event): void {
+    if (evento.target instanceof HTMLInputElement) {
+      this.termoBusca.set(evento.target.value);
+    }
+  }
+
+  protected fecharFormulario(): void {
+    if (!this.saving()) {
+      this.formOpen.set(false);
+    }
+  }
+
+  protected abrirCadastro(): void {
+    this.modo.set('criar');
+    this.arestaEmEdicaoId.set(null);
+    this.form.reset({ antecessoraCodigo: '', sucessoraCodigo: '', permiteSobreposicao: false });
+    this.formError.set(null);
+    this.erroDoPar.set(null);
+    this.idempotencyKeyAtual.set(idempotencyKey.create());
+    this.contextoDaAbertura.update((contexto) => contexto + 1);
+    this.formOpen.set(true);
+  }
+
+  protected abrirEdicao(aresta: PrecedenciaFaseDto): void {
+    this.modo.set('editar');
+    this.arestaEmEdicaoId.set(aresta.id);
+    this.form.reset({
+      antecessoraCodigo: aresta.antecessoraCodigo,
+      sucessoraCodigo: aresta.sucessoraCodigo,
+      permiteSobreposicao: aresta.permiteSobreposicao,
+    });
+    this.formError.set(null);
+    this.erroDoPar.set(null);
+    this.idempotencyKeyAtual.set(idempotencyKey.create());
+    this.contextoDaAbertura.update((contexto) => contexto + 1);
+    this.formOpen.set(true);
+  }
+
+  protected pedirRemocao(aresta: PrecedenciaFaseDto): void {
+    this.arestaParaRemover.set(aresta);
+    this.confirmOpen.set(true);
+  }
+
+  protected removerConfirmado(): void {
+    const aresta = this.arestaParaRemover();
+    if (aresta === null || this.removendo()) {
+      return;
+    }
+    this.removendo.set(true);
+    this.api
+      .remover(aresta.id)
+      .pipe(
+        finalize(() => this.removendo.set(false)),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe((result) => {
+        if (result.ok) {
+          this.notifications.success(
+            'Aresta removida',
+            `${aresta.antecessoraCodigo} → ${aresta.sucessoraCodigo}`,
+          );
+          this.confirmOpen.set(false);
+          this.arestaParaRemover.set(null);
+          this.recarregar();
+          return;
+        }
+        // Removida por outro administrador entre a leitura e a confirmação: a
+        // linha já não existe, então fechar o modal e recarregar deixa a tela
+        // coerente em vez de insistir num alvo inexistente.
+        if (result.problem.code === ERRO_NAO_ENCONTRADA || result.problem.status === 404) {
+          this.confirmOpen.set(false);
+          this.arestaParaRemover.set(null);
+          this.recarregar();
+        }
+        this.notifications.errorFromProblem(result.problem, {
+          title: this.problemI18n.resolve(result.problem).title,
+        });
+      });
+  }
+
+  protected salvar(): void {
+    if (this.saving()) {
+      return;
+    }
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      this.focarPrimeiroCampoInvalido();
+      return;
+    }
+    this.formError.set(null);
+    this.erroDoPar.set(null);
+
+    const contexto = this.contextoDaAbertura();
+    const criando = this.modo() === 'criar';
+    // O payload é montado antes de congelar, e o congelamento impede que o
+    // formulário mude sob a request — sem isso, a resposta de uma dupla
+    // chegaria sobre outra dupla já digitada na tela.
+    const command = criando ? this.criarCommand() : this.atualizarCommand();
+    this.iniciarGravacao();
+
+    if (criando) {
+      this.api
+        .criar(command as CriarPrecedenciaFaseCommand, withIdempotencyKey(this.idempotencyKeyAtual()))
+        .pipe(
+          finalize(() => this.encerrarGravacao()),
+          takeUntilDestroyed(this.destroyRef),
+        )
+        .subscribe((result) => this.handleSalvarResult(result, contexto));
+      return;
+    }
+
+    this.api
+      .atualizar(
+        this.arestaEmEdicaoId() ?? '',
+        command as AtualizarPrecedenciaFaseCommand,
+        withIdempotencyKey(this.idempotencyKeyAtual()),
+      )
+      .pipe(
+        finalize(() => this.encerrarGravacao()),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe((result) => this.handleSalvarResult(result, contexto));
+  }
+
+  private iniciarGravacao(): void {
+    this.saving.set(true);
+    this.form.disable({ emitEvent: false });
+  }
+
+  /**
+   * Idempotente de propósito: é chamado no início do tratamento da resposta,
+   * para que os erros do backend sejam aplicados sobre um formulário já
+   * reabilitado, e de novo pelo `finalize` como rede de segurança. Sem a
+   * guarda, o segundo `enable()` revalidaria o formulário e apagaria os erros
+   * que o primeiro caminho acabou de gravar.
+   */
+  private encerrarGravacao(): void {
+    if (this.form.disabled) {
+      this.form.enable({ emitEvent: false });
+    }
+    this.saving.set(false);
+  }
+
+  protected erroDoCampo(nome: keyof PrecedenciaForm): string | null {
+    // Erros do par são exibidos na sucessora, que é o campo escolhido por
+    // último. O do backend nasce de um envio explícito, então não depende de o
+    // campo ter sido tocado.
+    if (nome === 'sucessoraCodigo') {
+      const erroPar = this.erroDoPar();
+      if (erroPar !== null) {
+        return erroPar;
+      }
+    }
+    const control = this.form.controls[nome];
+    const shouldShowError = control.touched || control.dirty;
+    if (!shouldShowError) {
+      return null;
+    }
+    if (nome === 'sucessoraCodigo' && this.form.hasError('selfLoop')) {
+      return 'A fase sucessora não pode ser igual à antecessora.';
+    }
+    if (control.errors === null) {
+      return null;
+    }
+    if (control.errors['backend']) {
+      const backend = control.errors['backend'] as { code: string; message: string };
+      return backend.message;
+    }
+    if (control.errors['required']) return 'Campo obrigatório.';
+    return 'Valor inválido.';
+  }
+
+  protected nomeDaFase(codigo: string): string {
+    return this.nomesDasFases().get(codigo) ?? '';
+  }
+
+  /**
+   * Uma leitura por vida da página: o cadastro de fases canônicas só alimenta
+   * rótulos, então não acompanha os reloads da lista de precedências. A falha
+   * é sinalizada à parte para não se confundir com o erro da lista principal.
+   */
+  private carregarNomesDasFases(): void {
+    this.fasesApi
+      .listar({ limit: 100 })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((result) => {
+        // O interceptor converte 4xx/5xx em `ApiResult` de falha, sem erro de
+        // stream — a degradação depende de checar `ok`, não de `catchError`.
+        if (!result.ok) {
+          this.falhaAoCarregarFases.set(true);
+          return;
+        }
+        this.falhaAoCarregarFases.set(false);
+        this.nomesDasFases.set(new Map(result.data.map((fase) => [fase.codigo, fase.nome])));
+      });
+  }
+
+  private montarParams(): HttpParams {
+    const pagina = this.pagina();
+    if (pagina === undefined) {
+      return new HttpParams().set('limit', String(PAGE_SIZE));
+    }
+    return new HttpParams()
+      .set('cursor', cursorToString(pagina.cursor))
+      .set('direction', pagina.direction);
+  }
+
+  private recarregar(): void {
+    if (this.pagina() === undefined) {
+      this.lista.reload();
+    } else {
+      this.pagina.set(undefined);
+    }
+  }
+
+  private handleSalvarResult(result: ApiResult<string | void>, contexto: number): void {
+    // Reabilita antes de qualquer `setErrors`: `enable()` revalida e apagaria
+    // os erros do backend se viesse depois.
+    this.encerrarGravacao();
+    if (result.ok) {
+      // Efeitos de UI só valem para a abertura que originou a request.
+      if (contexto === this.contextoDaAbertura()) {
+        this.notifications.success(this.modo() === 'criar' ? 'Aresta criada' : 'Aresta atualizada');
+        this.formOpen.set(false);
+        this.idempotencyKeyAtual.set(idempotencyKey.create());
+      }
+      this.recarregar();
+      return;
+    }
+    if (contexto === this.contextoDaAbertura()) {
+      this.aplicarFalha(result.problem);
+    }
+  }
+
+  private aplicarFalha(problem: ProblemDetails): void {
+    // Falha corrigível renova a chave: o filtro de idempotência guarda a
+    // resposta de qualquer status abaixo de 500, então reenviar o formulário
+    // corrigido com a chave anterior devolveria `body_mismatch` em vez de
+    // processar o novo comando. A exceção é o conflito de processamento, em
+    // que a execução anterior ainda pode concluir e o retry precisa continuar
+    // sendo o mesmo comando.
+    if (
+      problem.code !== ERRO_IDEMPOTENCIA_EM_PROCESSAMENTO &&
+      (problem.status === 422 || problem.status === 409)
+    ) {
+      this.renovarIdempotencyKey();
+    }
+
+    // O drawer pode ter sido fechado durante a gravação — o botão Cancelar
+    // respeita `saving`, mas o X do cabeçalho e o Esc do `<dialog>` não. Com o
+    // formulário fora da tela, erro de campo e banner não seriam vistos por
+    // ninguém, então a falha vira notificação.
+    if (!this.formOpen()) {
+      this.notifications.errorFromProblem(problem, {
+        title: this.problemI18n.resolve(problem).title,
+      });
+      this.recarregar();
+      return;
+    }
+
+    // A aresta sumiu entre abrir o formulário e salvar.
+    if (problem.code === ERRO_NAO_ENCONTRADA || problem.status === 404) {
+      this.formOpen.set(false);
+      this.notifications.errorFromProblem(problem, {
+        title: this.problemI18n.resolve(problem).title,
+      });
+      this.recarregar();
+      return;
+    }
+
+    // DomainError não traz `errors[]` (só o pipeline de validação traz), então
+    // os erros de grafo são reconhecidos pelo `code`.
+    if (CODIGOS_ERRO_DO_PAR.has(problem.code)) {
+      this.erroDoPar.set(this.problemI18n.resolve(problem).title);
+      this.form.controls.sucessoraCodigo.markAsTouched();
+      this.focarCampo('sucessoraCodigo');
+      return;
+    }
+
+    const controle = CODIGO_ERRO_PARA_CONTROLE.get(problem.code);
+    if (controle !== undefined) {
+      this.form.controls[controle].setErrors({
+        backend: { code: problem.code, message: this.problemI18n.resolve(problem).title },
+      });
+      this.form.controls[controle].markAsTouched();
+      this.focarCampo(controle);
+      return;
+    }
+
+    // O ciclo não pertence a um campo: é o grafo inteiro que recusa a aresta.
+    if (problem.code === ERRO_CICLO_DETECTADO) {
+      this.formError.set(this.problemI18n.resolve(problem).title);
+      return;
+    }
+
+    if (problem.status === 422 && problem.errors && problem.errors.length > 0) {
+      this.aplicarErrosDeValidacao(problem.errors);
+      return;
+    }
+
+    this.formError.set(this.problemI18n.resolve(problem).title);
+    if (problem.status >= 500) {
+      this.notifications.errorFromProblem(problem);
+    }
+  }
+
+  private renovarIdempotencyKey(): void {
+    this.idempotencyKeyAtual.set(idempotencyKey.create());
+  }
+
+  private aplicarErrosDeValidacao(errors: ReadonlyArray<ProblemValidationError>): void {
+    let aplicouAlgum = false;
+    let primeiro: keyof PrecedenciaForm | null = null;
+    for (const erro of errors) {
+      const controlName = controlNameFromBackendField(erro.field);
+      if (controlName === null) continue;
+      const control = this.form.controls[controlName];
+      control.setErrors({ backend: { code: erro.code, message: erro.message } });
+      control.markAsTouched();
+      aplicouAlgum = true;
+      primeiro ??= controlName;
+    }
+
+    if (aplicouAlgum) {
+      this.formError.set(null);
+      if (primeiro !== null) {
+        this.focarCampo(primeiro);
+      }
+      return;
+    }
+    this.formError.set('Não foi possível mapear os erros de validação. Revise os campos.');
+  }
+
+  private focarPrimeiroCampoInvalido(): void {
+    if (this.form.controls.antecessoraCodigo.invalid) {
+      this.focarCampo('antecessoraCodigo');
+      return;
+    }
+    this.focarCampo('sucessoraCodigo');
+  }
+
+  private focarCampo(nome: keyof PrecedenciaForm): void {
+    if (typeof document === 'undefined') {
+      return;
+    }
+    const id =
+      nome === 'antecessoraCodigo'
+        ? 'cfg-precedencia-antecessora'
+        : nome === 'sucessoraCodigo'
+          ? 'cfg-precedencia-sucessora'
+          : 'cfg-precedencia-sobreposicao';
+    queueMicrotask(() => document.getElementById(id)?.focus());
+  }
+
+  private criarCommand(): CriarPrecedenciaFaseCommand {
+    // Projeção explícita: nunca repassar `getRawValue()` nem espalhar o objeto
+    // do formulário, para que um campo novo no form não vaze para o payload.
+    const raw = this.form.getRawValue();
+    return {
+      antecessoraCodigo: raw.antecessoraCodigo,
+      sucessoraCodigo: raw.sucessoraCodigo,
+      permiteSobreposicao: raw.permiteSobreposicao,
+    };
+  }
+
+  private atualizarCommand(): AtualizarPrecedenciaFaseCommand {
+    // O par de fases é imutável: o comando de atualização só transporta o
+    // sinalizador de sobreposição, mesmo que o formulário ainda os exiba.
+    const raw = this.form.getRawValue();
+    return {
+      id: this.arestaEmEdicaoId() ?? '',
+      permiteSobreposicao: raw.permiteSobreposicao,
+    };
+  }
+}
+
+function controlNameFromBackendField(field: string): keyof PrecedenciaForm | null {
+  const normalized =
+    field
+      .split('.')
+      .at(-1)
+      ?.replace(/\[\d+\]$/u, '') ?? field;
+  const camelCase = normalized.charAt(0).toLocaleLowerCase('pt-BR') + normalized.slice(1);
+  return PRECEDENCIA_CONTROL_NAMES.has(camelCase) ? (camelCase as keyof PrecedenciaForm) : null;
+}

--- a/apps/configuracao/src/app/features/precedencias-fase/precedencias-fase.routes.ts
+++ b/apps/configuracao/src/app/features/precedencias-fase/precedencias-fase.routes.ts
@@ -1,0 +1,8 @@
+import { Routes } from '@angular/router';
+
+export const PRECEDENCIAS_FASE_ROUTES: Routes = [
+  {
+    path: '',
+    loadComponent: () => import('./precedencias-fase.page').then((m) => m.PrecedenciasFasePage),
+  },
+];

--- a/apps/configuracao/src/app/layout/layout.ts
+++ b/apps/configuracao/src/app/layout/layout.ts
@@ -264,6 +264,12 @@ export class LayoutComponent {
           exact: true,
         },
         {
+          label: 'Precedência de Fase',
+          icon: 'pi-sort-alt',
+          routerLink: '/precedencias-fase',
+          exact: true,
+        },
+        {
           label: 'Reserva Demográfica',
           icon: 'pi-chart-bar',
           routerLink: '/reserva-demografica',

--- a/libs/shared-data/src/lib/api/configuracao/index.ts
+++ b/libs/shared-data/src/lib/api/configuracao/index.ts
@@ -66,6 +66,13 @@ export {
   type OrigemDataFase,
 } from './fases-canonicas.api';
 export {
+  PrecedenciasFaseApi,
+  type AtualizarPrecedenciaFaseCommand,
+  type CriarPrecedenciaFaseCommand,
+  type PrecedenciaFaseDto,
+  type PrecedenciasFaseQuery,
+} from './precedencias-fase.api';
+export {
   TiposBancaApi,
   CODIGOS_TIPO_BANCA,
   type AtualizarTipoBancaCommand,

--- a/libs/shared-data/src/lib/api/configuracao/precedencias-fase.api.spec.ts
+++ b/libs/shared-data/src/lib/api/configuracao/precedencias-fase.api.spec.ts
@@ -1,0 +1,123 @@
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  ApiResult,
+  apiResultInterceptor,
+  buildVendorMimeAccept,
+  isApiOk,
+  withIdempotencyKey,
+} from '@uniplus/shared-core/http';
+import {
+  CriarPrecedenciaFaseCommand,
+  PrecedenciaFaseDto,
+  PrecedenciasFaseApi,
+} from './precedencias-fase.api';
+import { CONFIGURACAO_BASE_PATH } from './tokens';
+
+const BASE = 'http://localhost:5000';
+const ID = '01960000-0000-7000-0000-0000000000a1';
+
+const arestaSeed: PrecedenciaFaseDto = {
+  id: ID,
+  antecessoraCodigo: 'INSCRICAO',
+  sucessoraCodigo: 'HOMOLOGACAO',
+  permiteSobreposicao: false,
+  criadoEm: '2026-07-15T12:00:00Z',
+};
+
+const criarCommand: CriarPrecedenciaFaseCommand = {
+  antecessoraCodigo: 'AVALIACAO',
+  sucessoraCodigo: 'CLASSIFICACAO',
+  permiteSobreposicao: false,
+};
+
+describe('PrecedenciasFaseApi', () => {
+  let api: PrecedenciasFaseApi;
+  let controller: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([apiResultInterceptor])),
+        provideHttpClientTesting(),
+        { provide: CONFIGURACAO_BASE_PATH, useValue: BASE },
+      ],
+    });
+    api = TestBed.inject(PrecedenciasFaseApi);
+    controller = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => controller.verify());
+
+  it('listar() faz GET /api/configuracao/precedencias-fase com limit e Accept versionado', async () => {
+    const promise = firstValueFrom(api.listar({ limit: 100 }));
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/precedencias-fase`);
+    expect(req.request.params.get('limit')).toBe('100');
+    expect(req.request.headers.get('Accept')).toBe(buildVendorMimeAccept('precedencia-fase', 1));
+    req.flush([arestaSeed]);
+    const result = (await promise) as ApiResult<readonly PrecedenciaFaseDto[]>;
+    expect(isApiOk(result)).toBe(true);
+  });
+
+  it('listar() com cursor envia cursor + direction e omite limit', async () => {
+    const promise = firstValueFrom(api.listar({ cursor: 'abc', direction: 'prev' }));
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/precedencias-fase`);
+    expect(req.request.params.get('cursor')).toBe('abc');
+    expect(req.request.params.get('direction')).toBe('prev');
+    expect(req.request.params.has('limit')).toBe(false);
+    req.flush([arestaSeed]);
+    await promise;
+  });
+
+  it('obter() faz GET /api/configuracao/precedencias-fase/{id} com Accept versionado', async () => {
+    const promise = firstValueFrom(api.obter(ID));
+    const req = controller.expectOne(`${BASE}/api/configuracao/precedencias-fase/${ID}`);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.headers.get('Accept')).toBe(buildVendorMimeAccept('precedencia-fase', 1));
+    req.flush(arestaSeed);
+    const result = (await promise) as ApiResult<PrecedenciaFaseDto>;
+    expect(isApiOk(result)).toBe(true);
+  });
+
+  it('criar() faz POST /api/configuracao/admin/precedencias-fase com Idempotency-Key e Accept JSON', async () => {
+    const promise = firstValueFrom(api.criar(criarCommand, withIdempotencyKey('k')));
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/precedencias-fase`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.headers.get('Idempotency-Key')).toBe('k');
+    expect(req.request.headers.get('Accept')).toBe('application/json');
+    expect(req.request.body).toEqual(criarCommand);
+    req.flush(ID, { status: 201, statusText: 'Created' });
+    const result = (await promise) as ApiResult<string>;
+    expect(isApiOk(result)).toBe(true);
+  });
+
+  it('atualizar() faz PUT /api/configuracao/admin/precedencias-fase/{id} só com o sinalizador de sobreposição', async () => {
+    const promise = firstValueFrom(
+      api.atualizar(ID, { id: ID, permiteSobreposicao: true }, withIdempotencyKey('k')),
+    );
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/precedencias-fase/${ID}`);
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.headers.get('Idempotency-Key')).toBe('k');
+    expect(req.request.body).toEqual({ id: ID, permiteSobreposicao: true });
+    expect(req.request.body).not.toHaveProperty('antecessoraCodigo');
+    expect(req.request.body).not.toHaveProperty('sucessoraCodigo');
+    req.flush(null, { status: 204, statusText: 'No Content' });
+    const result = (await promise) as ApiResult<void>;
+    expect(isApiOk(result)).toBe(true);
+  });
+
+  it('remover() faz DELETE /api/configuracao/admin/precedencias-fase/{id} sem Idempotency-Key', async () => {
+    const promise = firstValueFrom(api.remover(ID));
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/precedencias-fase/${ID}`);
+    expect(req.request.method).toBe('DELETE');
+    // O contrato não marca o DELETE como `RequiresIdempotencyKey`; enviar o
+    // header seria divergência com a API.
+    expect(req.request.headers.has('Idempotency-Key')).toBe(false);
+    req.flush(null, { status: 204, statusText: 'No Content' });
+    const result = (await promise) as ApiResult<void>;
+    expect(isApiOk(result)).toBe(true);
+  });
+});

--- a/libs/shared-data/src/lib/api/configuracao/precedencias-fase.api.ts
+++ b/libs/shared-data/src/lib/api/configuracao/precedencias-fase.api.ts
@@ -1,0 +1,101 @@
+import { HttpClient, HttpContext, HttpHeaders, HttpParams } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiResult, withVendorMime } from '@uniplus/shared-core/http';
+import type { components } from './schema';
+import { CONFIGURACAO_BASE_PATH } from './tokens';
+
+export type PrecedenciaFaseDto = components['schemas']['PrecedenciaFaseDto'];
+export type CriarPrecedenciaFaseCommand = components['schemas']['CriarPrecedenciaFaseCommand'];
+export type AtualizarPrecedenciaFaseCommand =
+  components['schemas']['AtualizarPrecedenciaFaseCommand'];
+
+/** Filtro de listagem de arestas de precedência (cursor pagination, ADR-0026). */
+export interface PrecedenciasFaseQuery {
+  readonly cursor?: string;
+  readonly direction?: 'next' | 'prev';
+  readonly limit?: number;
+}
+
+/**
+ * Cliente Angular standalone do recurso Precedência de fase (módulo
+ * Configuração). Cada registro é uma aresta do grafo de dependência entre as
+ * fases canônicas do cronograma (UNI-REQ-0064): a antecessora precede a
+ * sucessora, e `permiteSobreposicao` diz se as duas podem coexistir no tempo.
+ *
+ * O par (antecessora, sucessora) é a chave natural e é imutável — o
+ * `Atualizar*Command` só aceita `permiteSobreposicao`. Para trocar o par,
+ * remova a aresta e crie outra.
+ *
+ * API thin (ADR-0013): tipos do `schema.ts` gerado; resposta envelopada em
+ * `ApiResult<T>` (ADR-0011); versionamento por vendor MIME `precedencia-fase v1`
+ * (ADR-0016). Espelha `FasesCanonicasApi`.
+ */
+@Injectable({ providedIn: 'root' })
+export class PrecedenciasFaseApi {
+  private readonly http = inject(HttpClient);
+  private readonly basePath = inject(CONFIGURACAO_BASE_PATH);
+
+  /** GET `/api/configuracao/precedencias-fase` — lista paginada por cursor (ADR-0026). */
+  listar(query: PrecedenciasFaseQuery = {}): Observable<ApiResult<readonly PrecedenciaFaseDto[]>> {
+    let params = new HttpParams();
+    if (query.cursor !== undefined) {
+      params = params.set('cursor', query.cursor).set('direction', query.direction ?? 'next');
+    } else {
+      params = params.set('limit', String(query.limit ?? 100));
+    }
+    return this.http.get<ApiResult<readonly PrecedenciaFaseDto[]>>(
+      `${this.basePath}/api/configuracao/precedencias-fase`,
+      { params, context: withVendorMime('precedencia-fase', 1) },
+    );
+  }
+
+  /** GET `/api/configuracao/precedencias-fase/{id}` — detalhe de uma aresta. */
+  obter(id: string): Observable<ApiResult<PrecedenciaFaseDto>> {
+    return this.http.get<ApiResult<PrecedenciaFaseDto>>(
+      `${this.basePath}/api/configuracao/precedencias-fase/${encodeURIComponent(id)}`,
+      { context: withVendorMime('precedencia-fase', 1) },
+    );
+  }
+
+  /** POST `/api/configuracao/admin/precedencias-fase` — cria. Idempotency-Key obrigatório. */
+  criar(
+    command: CriarPrecedenciaFaseCommand,
+    context: HttpContext,
+  ): Observable<ApiResult<string>> {
+    return this.http.post<ApiResult<string>>(
+      `${this.basePath}/api/configuracao/admin/precedencias-fase`,
+      command,
+      { context, headers: new HttpHeaders({ Accept: 'application/json' }) },
+    );
+  }
+
+  /**
+   * PUT `/api/configuracao/admin/precedencias-fase/{id}` — atualiza só
+   * `permiteSobreposicao`; o par de fases é imutável. Idempotency-Key obrigatório.
+   */
+  atualizar(
+    id: string,
+    command: AtualizarPrecedenciaFaseCommand,
+    context: HttpContext,
+  ): Observable<ApiResult<void>> {
+    return this.http.put<ApiResult<void>>(
+      `${this.basePath}/api/configuracao/admin/precedencias-fase/${encodeURIComponent(id)}`,
+      command,
+      { context },
+    );
+  }
+
+  /**
+   * DELETE `/api/configuracao/admin/precedencias-fase/{id}` — remoção lógica.
+   *
+   * Sem `Idempotency-Key`: diferente de `criar`/`atualizar`, o contrato não
+   * marca o DELETE como `RequiresIdempotencyKey`, e um DELETE por id já é
+   * idempotente por natureza.
+   */
+  remover(id: string): Observable<ApiResult<void>> {
+    return this.http.delete<ApiResult<void>>(
+      `${this.basePath}/api/configuracao/admin/precedencias-fase/${encodeURIComponent(id)}`,
+    );
+  }
+}


### PR DESCRIPTION
Implementa a tela de administração do grafo de precedência entre as fases canônicas do
cronograma (UNI-REQ-0064), em `/configuracao/precedencias-fase`.

Closes #497
Refs #496

> **Empilhado sobre #503.** A base deste PR é `fix/501-sincroniza-contrato-openapi`, porque a
> tela consome os tipos de `precedencias-fase` que só existem depois daquela sincronização.
> Revisar e mergear o #503 primeiro; o diff aqui mostra apenas os três commits desta story.

## Commits

- **`62861a7`** — `PrecedenciasFaseApi`, no padrão de `FasesCanonicasApi`.
- **`ac02163`** — a tela: lista com busca e paginação por cursor, drawer de criação/edição,
  modal de remoção, rota e item de sidebar.
- **`34cfffc`** — 19 specs Vitest na página, 6 no client, E2E Playwright com axe-core em
  quatro estados.

## Decisões que fogem do texto da issue

**Origem das opções dos selects.** A issue manda popular a partir de
`fasesCanonicas.api.listar()`. O backend valida o código contra `FaseCanonicaCatalogo` — um
roster fixo no domínio — e não tem chave estrangeira para o cadastro vivo; o próprio seed cria
seis arestas antes de as fases existirem no cadastro. Restringir a lista faria a tela recusar
arestas que a API aceita. As opções vêm do roster canônico, o cadastro enriquece o nome
(`AVALIACAO — Avaliação`), fases ausentes aparecem marcadas como não cadastradas, e a
indisponibilidade da consulta é sinalizada à parte para não ser lida como ausência.

**Sem `Idempotency-Key` no DELETE.** A issue pede a chave nas três mutações; o contrato só
marca POST e PUT como `RequiresIdempotencyKey`. O teste fixa a ausência para que uma
divergência futura apareça como falha.

**Componentes.** A issue lista `ui-data-table`, `ui-form-field`, `ui-select` e `ui-tag`. A
story #393, apontada pela própria issue como fonte do padrão, usa as classes canônicas do
Uni+ DS (ADR-0023) e apenas os seis componentes `ui-*` existentes. Segui o código.

## Pontos de correção que valem revisão

- **Rotação da chave de idempotência.** Os três erros de grafo (self-loop, aresta duplicada,
  ciclo) são `422` de domínio, e erro de domínio não popula `errors[]` — só o pipeline de
  validação popula. O padrão de `fases-canonicas` renova a chave apenas quando há `errors[]`,
  então aqui o usuário ficaria preso em `body_mismatch` ao corrigir e reenviar. Renova-se em
  todo 422/409, **exceto** `processing_conflict`, que pede retry com a mesma chave porque a
  execução anterior ainda pode concluir.
- **Erro do par fora do controle.** `self_loop` e `aresta_duplicada` qualificam a dupla, não um
  campo. Em `setErrors` da sucessora, sobreviveriam a uma correção feita na antecessora — o
  Angular não revalida erro manual de um irmão — travando o formulário com uma combinação que
  já mudou. Ficam num sinal próprio, limpo quando qualquer lado muda.
- **Formulário congelado durante a gravação**, e reabilitado antes de aplicar os erros do
  backend: `enable()` revalida e apagaria erros gravados antes dele.
- **Contexto da abertura** carregado pela resposta, para que uma resposta atrasada não feche um
  formulário aberto depois. O recarregamento da lista roda fora dessa guarda, porque o servidor
  mudou de qualquer forma.
- **Remoção com estado próprio**, separada da gravação do formulário: o diálogo de confirmação
  fecha ao confirmar, então um guard compartilhado faria a confirmação sumir sem enviar o
  DELETE.
- **Janela de 100 itens** na listagem: um grafo acíclico sobre quatorze fases comporta no
  máximo 91 arestas, então a busca client-side alcança todo o cadastro e não há página órfã
  após criar ou remover.

## Validação

Local, com Node 22.22.2: `lint`, `typecheck`, `build` e `vite:test` verdes nos 15 projetos, e
`codegen-api-check` sem drift. O E2E não roda localmente — o OIDC do Keycloak fixa o redirect
em `:4203` — e é validado no CI, que já fechou 8/8 verde numa revisão anterior desta branch.

O warning de budget do bundle inicial é preexistente: 512.46 kB antes desta branch, 513.59 kB
depois; o acréscimo é a entrada de rota e o item de menu, e a página é lazy chunk (21.10 kB).