### PR TITLE
refactor(shared-ui): Extrair componente ui-filter-bar e migrar 10 páginas duplicadas

### DIFF
--- a/apps/configuracao/src/app/features/condicoes-atendimento/condicoes-atendimento-list.ts
+++ b/apps/configuracao/src/app/features/condicoes-atendimento/condicoes-atendimento-list.ts
@@ -44,7 +44,8 @@ import {
   DrawerComponent,
   TagComponent,
   DialogComponent,
-  PagerComponent
+  PagerComponent,
+  FilterBarComponent
 } from "@uniplus/shared-ui/components";
 
 type ModoFormulario = 'criar' | 'editar';
@@ -99,6 +100,7 @@ function controlNameFromBackendField(field: string): keyof CondicaoAtendimentoFo
     TagComponent,
     DialogComponent,
     PagerComponent,
+    FilterBarComponent,
   ],
   template: `
     <div class="page-header">
@@ -136,30 +138,21 @@ function controlNameFromBackendField(field: string): keyof CondicaoAtendimentoFo
       <ui-skeleton skeletonKind="card" blockSize="10rem" />
     }
     <div data-scope class="cfg-unidades-scope">
-      <div class="filter-bar" role="search" aria-label="Filtrar condições de atendimento">
-        <div class="filter-bar__row">
-          <div class="input-group">
-            <span class="input-group__addon" aria-hidden="true">
-              <i class="pi pi-search"></i>
-            </span>
-            <input
-              type="search"
-              class="input"
-              placeholder="Buscar por código ou nome..."
-              aria-label="Buscar condições de atendimento"
-              [value]="termoBusca()"
-              (input)="termoBusca.set(inputValue($event))"
-            />
-          </div>
-          <button
-            type="button"
-            class="btn btn--tertiary btn--sm btn--rect"
-            (click)="limparFiltroBusca()"
-          >
-            Limpar
-          </button>
-        </div>
-      </div>
+      <ui-filter-bar
+        ariaLabel="Filtrar condições de atendimento"
+        searchPlaceholder="Buscar por código ou nome…"
+        searchAriaLabel="Buscar condições de atendimento"
+        [(searchValue)]="termoBusca"
+      >
+        <button
+          uiFilterBarActions
+          type="button"
+          class="btn btn--tertiary btn--sm btn--rect"
+          (click)="limparFiltroBusca()"
+        >
+          Limpar
+        </button>
+      </ui-filter-bar>
 
       <section class="panel" aria-labelledby="cfg-unidades-list-title">
         <div class="panel-head">

--- a/apps/configuracao/src/app/features/cursos/cursos.page.ts
+++ b/apps/configuracao/src/app/features/cursos/cursos.page.ts
@@ -44,6 +44,7 @@ import {
   ConfirmDialogComponent,
   DrawerComponent,
   EmptyStateComponent,
+  FilterBarComponent,
   PagerComponent,
   SpinnerComponent,
 } from '@uniplus/shared-ui/components';
@@ -77,6 +78,7 @@ interface CursoForm {
     ConfirmDialogComponent,
     DrawerComponent,
     EmptyStateComponent,
+    FilterBarComponent,
     PagerComponent,
     SpinnerComponent,
   ],
@@ -122,20 +124,21 @@ interface CursoForm {
         </button>
       </div>
 
-      <div class="filter-bar" role="search">
-        <div class="filter-bar__group">
-          <label class="field field--search">
-            <span class="field__label sr-only">Buscar por código ou nome</span>
-            <input
-              class="input"
-              type="search"
-              placeholder="Buscar por código ou nome…"
-              [value]="termoBusca()"
-              (input)="termoBusca.set($any($event.target).value)"
-            />
-          </label>
-        </div>
-      </div>
+      <ui-filter-bar
+        ariaLabel="Filtrar cursos"
+        searchPlaceholder="Buscar por código ou nome..."
+        searchAriaLabel="Buscar curso"
+        [(searchValue)]="termoBusca"
+      >
+        <button
+          uiFilterBarActions
+          type="button"
+          class="btn btn--tertiary btn--sm btn--rect"
+          (click)="limparFiltros()"
+        >
+          Limpar
+        </button>
+      </ui-filter-bar>
 
       @if (cursosFiltrados().length > 0) {
         <div class="table-responsive">
@@ -645,6 +648,10 @@ export class CursosPage {
     if (anterior !== null && !this.loading()) {
       this.pagina.set({ cursor: anterior, direction: 'prev' });
     }
+  }
+
+  protected limparFiltros(): void {
+    this.termoBusca.set('');
   }
 
   /** Abre o drawer com as ofertas vivas do curso (inspeção proativa, sem contexto de bloqueio). */

--- a/apps/configuracao/src/app/features/cursos/cursos.page.ts
+++ b/apps/configuracao/src/app/features/cursos/cursos.page.ts
@@ -129,16 +129,7 @@ interface CursoForm {
         searchPlaceholder="Buscar por código ou nome..."
         searchAriaLabel="Buscar curso"
         [(searchValue)]="termoBusca"
-      >
-        <button
-          uiFilterBarActions
-          type="button"
-          class="btn btn--tertiary btn--sm btn--rect"
-          (click)="limparFiltros()"
-        >
-          Limpar
-        </button>
-      </ui-filter-bar>
+      />
 
       @if (cursosFiltrados().length > 0) {
         <div class="table-responsive">
@@ -648,10 +639,6 @@ export class CursosPage {
     if (anterior !== null && !this.loading()) {
       this.pagina.set({ cursor: anterior, direction: 'prev' });
     }
-  }
-
-  protected limparFiltros(): void {
-    this.termoBusca.set('');
   }
 
   /** Abre o drawer com as ofertas vivas do curso (inspeção proativa, sem contexto de bloqueio). */

--- a/apps/configuracao/src/app/features/fases-canonicas/fases-canonicas.page.ts
+++ b/apps/configuracao/src/app/features/fases-canonicas/fases-canonicas.page.ts
@@ -50,6 +50,7 @@ import {
   ConfirmDialogComponent,
   DrawerComponent,
   EmptyStateComponent,
+  FilterBarComponent,
   PagerComponent,
   SpinnerComponent,
 } from '@uniplus/shared-ui/components';
@@ -109,6 +110,7 @@ const FASE_CONTROL_NAMES: ReadonlySet<string> = new Set<keyof FaseForm>([
     ConfirmDialogComponent,
     DrawerComponent,
     EmptyStateComponent,
+    FilterBarComponent,
     PagerComponent,
     SpinnerComponent,
   ],
@@ -160,18 +162,13 @@ const FASE_CONTROL_NAMES: ReadonlySet<string> = new Set<keyof FaseForm>([
         </button>
       </div>
 
-      <div class="filter-bar" role="search" aria-label="Filtrar fases canônicas">
-        <div class="filter-bar__group">
-          <label class="field field--search">
-            <span class="field__label sr-only">Buscar por código ou nome</span>
-            <input
-              class="input"
-              type="search"
-              placeholder="Buscar por código ou nome…"
-              [value]="termoBusca()"
-              (input)="termoBusca.set($any($event.target).value)"
-            />
-          </label>
+      <ui-filter-bar
+        ariaLabel="Filtrar fases canônicas"
+        searchPlaceholder="Buscar por código ou nome…"
+        searchAriaLabel="Buscar fase canônica"
+        [(searchValue)]="termoBusca"
+      >
+        <ng-container uiFilterBarSecondary>
           <label class="field">
             <span class="field__label sr-only">Filtrar por dono típico</span>
             <select class="select" [value]="donoTipicoFiltro()" (change)="donoTipicoFiltro.set($any($event.target).value)">
@@ -181,8 +178,8 @@ const FASE_CONTROL_NAMES: ReadonlySet<string> = new Set<keyof FaseForm>([
               }
             </select>
           </label>
-        </div>
-      </div>
+        </ng-container>
+      </ui-filter-bar>
 
       @if (fasesFiltradas().length > 0) {
         <div class="table-responsive">

--- a/apps/configuracao/src/app/features/modalidades/modalidades-list.page.ts
+++ b/apps/configuracao/src/app/features/modalidades/modalidades-list.page.ts
@@ -117,6 +117,8 @@ const NATUREZA_VARIANTE: Readonly<Record<string, UiTagVariant>> = {
         searchPlaceholder="Buscar por código ou descrição..."
         searchAriaLabel="Buscar modalidade"
         [(searchValue)]="busca"
+        secondaryRole="group"
+        secondaryAriaLabel="Filtrar por natureza legal"
       >
         <button
           uiFilterBarActions
@@ -131,7 +133,6 @@ const NATUREZA_VARIANTE: Readonly<Record<string, UiTagVariant>> = {
           <ui-filter-chips
             [options]="chipsNatureza()"
             [(selected)]="naturezaSelecionada"
-            (selectedChange)="naturezaSelecionada.set($event ?? '')"
             ariaLabel="Filtrar por natureza"
           />
         </ng-container>

--- a/apps/configuracao/src/app/features/modalidades/modalidades-list.page.ts
+++ b/apps/configuracao/src/app/features/modalidades/modalidades-list.page.ts
@@ -36,6 +36,7 @@ import {
   AlertComponent,
   DialogComponent,
   EmptyStateComponent,
+  FilterBarComponent,
   FilterChipsComponent,
   PagerComponent,
   SpinnerComponent,
@@ -69,6 +70,7 @@ const NATUREZA_VARIANTE: Readonly<Record<string, UiTagVariant>> = {
     AlertComponent,
     DialogComponent,
     EmptyStateComponent,
+    FilterBarComponent,
     FilterChipsComponent,
     PagerComponent,
     SpinnerComponent,
@@ -110,32 +112,30 @@ const NATUREZA_VARIANTE: Readonly<Record<string, UiTagVariant>> = {
     }
 
     <div data-scope class="cfg-modalidades-scope">
-      <div class="filter-bar" role="search" aria-label="Filtrar modalidades">
-        <div class="filter-bar__row">
-          <div class="input-group">
-            <span class="input-group__addon" aria-hidden="true"><i class="pi pi-search"></i></span>
-            <input
-              type="search"
-              class="input"
-              placeholder="Buscar por código ou descrição..."
-              aria-label="Buscar por código ou descrição"
-              [value]="busca()"
-              (input)="busca.set(inputValue($event))"
-            />
-          </div>
-          <button type="button" class="btn btn--tertiary btn--sm btn--rect" (click)="limparFiltros()">
-            Limpar
-          </button>
-        </div>
-        <div class="cfg-modalidades-filtro-grupo" role="group" aria-label="Filtrar por natureza legal">
-          <span class="cfg-filtro-legenda">Natureza</span>
+      <ui-filter-bar
+        ariaLabel="Filtrar modalidades"
+        searchPlaceholder="Buscar por código ou descrição..."
+        searchAriaLabel="Buscar modalidade"
+        [(searchValue)]="busca"
+      >
+        <button
+          uiFilterBarActions
+          type="button"
+          class="btn btn--tertiary btn--sm btn--rect"
+          (click)="limparFiltros()"
+        >
+          Limpar
+        </button>
+        <ng-container uiFilterBarSecondary>
+          <span class="u-eyebrow">Natureza</span>
           <ui-filter-chips
             [options]="chipsNatureza()"
             [(selected)]="naturezaSelecionada"
-            ariaLabel="Natureza legal"
+            (selectedChange)="naturezaSelecionada.set($event ?? '')"
+            ariaLabel="Filtrar por natureza"
           />
-        </div>
-      </div>
+        </ng-container>
+      </ui-filter-bar>
 
       <section class="panel" aria-labelledby="cfg-modalidades-title">
         <div class="panel-head">

--- a/apps/configuracao/src/app/features/precedencias-fase/precedencias-fase.page.ts
+++ b/apps/configuracao/src/app/features/precedencias-fase/precedencias-fase.page.ts
@@ -50,6 +50,7 @@ import {
   ConfirmDialogComponent,
   DrawerComponent,
   EmptyStateComponent,
+  FilterBarComponent,
   PagerComponent,
   SpinnerComponent,
 } from '@uniplus/shared-ui/components';
@@ -133,6 +134,7 @@ function selfLoopValidator(grupo: AbstractControl): ValidationErrors | null {
     ConfirmDialogComponent,
     DrawerComponent,
     EmptyStateComponent,
+    FilterBarComponent,
     PagerComponent,
     SpinnerComponent,
   ],
@@ -184,20 +186,12 @@ function selfLoopValidator(grupo: AbstractControl): ValidationErrors | null {
         </button>
       </div>
 
-      <div class="filter-bar" role="search" aria-label="Filtrar arestas de precedência">
-        <div class="filter-bar__group">
-          <label class="field field--search">
-            <span class="field__label sr-only">Buscar por fase antecessora ou sucessora</span>
-            <input
-              class="input"
-              type="search"
-              placeholder="Buscar por fase antecessora ou sucessora…"
-              [value]="termoBusca()"
-              (input)="atualizarBusca($event)"
-            />
-          </label>
-        </div>
-      </div>
+      <ui-filter-bar
+        ariaLabel="Filtrar arestas de precedência"
+        searchPlaceholder="Buscar por fase antecessora ou sucessora…"
+        searchAriaLabel="Buscar por fase antecessora ou sucessora"
+        [(searchValue)]="termoBusca"
+      />
 
       @if (arestasFiltradas().length > 0) {
         <div class="table-responsive">
@@ -663,17 +657,6 @@ export class PrecedenciasFasePage {
 
   protected limparFiltros(): void {
     this.termoBusca.set('');
-  }
-
-  /**
-   * Estreita o alvo do evento em vez de passar por `$any` no template: o cast
-   * no template escapa da checagem de tipos e o repositório veda `any` em
-   * componentes.
-   */
-  protected atualizarBusca(evento: Event): void {
-    if (evento.target instanceof HTMLInputElement) {
-      this.termoBusca.set(evento.target.value);
-    }
   }
 
   protected fecharFormulario(): void {

--- a/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.ts
+++ b/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.ts
@@ -48,6 +48,7 @@ import {
   SpinnerComponent,
   PagerComponent,
   DialogComponent,
+  FilterBarComponent,
 } from "@uniplus/shared-ui/components";
 
 type ModoFormulario = "criar" | "editar";
@@ -100,6 +101,7 @@ const PAGE_SIZE = 50;
     ReactiveFormsModule,
     PagerComponent,
     DialogComponent,
+    FilterBarComponent,
   ],
   template: `
     <div class="page-header">
@@ -134,30 +136,21 @@ const PAGE_SIZE = 50;
     }
 
     <div data-scope class="cfg-unidades-scope">
-      <div class="filter-bar" role="search" aria-label="Filtrar recursos de acessibilidade">
-        <div class="filter-bar__row">
-          <div class="input-group">
-            <span class="input-group__addon" aria-hidden="true">
-              <i class="pi pi-search"></i>
-            </span>
-            <input
-              type="search"
-              class="input"
-              placeholder="Buscar por nome..."
-              aria-label="Buscar recursos de acessibilidade"
-              [value]="termoBusca()"
-              (input)="termoBusca.set(inputValue($event))"
-            />
-          </div>
-          <button
-            type="button"
-            class="btn btn--tertiary btn--sm btn--rect"
-            (click)="limparFiltros()"
-          >
-            Limpar
-          </button>
-        </div>
-      </div>
+      <ui-filter-bar
+        ariaLabel="Filtrar recursos de acessibilidade"
+        searchPlaceholder="Buscar por código ou nome..."
+        searchAriaLabel="Buscar recursos de acessibilidade"
+        [(searchValue)]="termoBusca"
+      >
+        <button
+          uiFilterBarActions
+          type="button"
+          class="btn btn--tertiary btn--sm btn--rect"
+          (click)="limparFiltros()"
+        >
+          Limpar
+        </button>
+      </ui-filter-bar>
 
       <section class="panel" aria-labelledby="cfg-unidades-list-title">
         <div class="panel-head">

--- a/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.ts
+++ b/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.ts
@@ -138,7 +138,7 @@ const PAGE_SIZE = 50;
     <div data-scope class="cfg-unidades-scope">
       <ui-filter-bar
         ariaLabel="Filtrar recursos de acessibilidade"
-        searchPlaceholder="Buscar por código ou nome..."
+        searchPlaceholder="Buscar por nome..."
         searchAriaLabel="Buscar recursos de acessibilidade"
         [(searchValue)]="termoBusca"
       >

--- a/apps/configuracao/src/app/features/reserva-demografica/reserva-demografica-list.page.ts
+++ b/apps/configuracao/src/app/features/reserva-demografica/reserva-demografica-list.page.ts
@@ -40,6 +40,7 @@ import {
   ConfirmDialogComponent,
   DrawerComponent,
   EmptyStateComponent,
+  FilterBarComponent,
   PagerComponent,
   SpinnerComponent,
 } from '@uniplus/shared-ui/components';
@@ -68,6 +69,7 @@ const PERCENTUAL_VALIDATORS = [Validators.required, Validators.min(0), Validator
     ConfirmDialogComponent,
     DrawerComponent,
     EmptyStateComponent,
+    FilterBarComponent,
     PagerComponent,
     SpinnerComponent,
   ],
@@ -108,24 +110,20 @@ const PERCENTUAL_VALIDATORS = [Validators.required, Validators.min(0), Validator
     }
 
     <div data-scope class="cfg-reserva-scope">
-      <div class="filter-bar" role="search" aria-label="Filtrar referências demográficas">
-        <div class="filter-bar__row">
-          <div class="input-group">
-            <span class="input-group__addon" aria-hidden="true"><i class="pi pi-search"></i></span>
-            <input
-              type="search"
-              class="input"
-              placeholder="Buscar por Censo..."
-              aria-label="Buscar por Censo"
-              [value]="busca()"
-              (input)="busca.set(inputValue($event))"
-            />
-          </div>
-          <button type="button" class="btn btn--tertiary btn--sm btn--rect" (click)="busca.set('')">
-            Limpar
-          </button>
-        </div>
-      </div>
+      <ui-filter-bar
+        ariaLabel="Filtrar referências demográficas"
+        searchPlaceholder="Buscar por Censo..."
+        searchAriaLabel="Buscar censo"
+        [(searchValue)]="busca"
+      >
+        <button
+          uiFilterBarActions
+          type="button" class="btn btn--tertiary btn--sm btn--rect"
+          (click)="busca.set('')"
+        >
+        Limpar
+        </button>
+      </ui-filter-bar>
 
       <section class="panel" aria-labelledby="cfg-reserva-list-title">
         <div class="panel-head">

--- a/apps/configuracao/src/app/features/tipos-banca/tipos-banca.page.ts
+++ b/apps/configuracao/src/app/features/tipos-banca/tipos-banca.page.ts
@@ -42,6 +42,7 @@ import {
   ConfirmDialogComponent,
   DrawerComponent,
   EmptyStateComponent,
+  FilterBarComponent,
   PagerComponent,
   SpinnerComponent,
 } from '@uniplus/shared-ui/components';
@@ -77,6 +78,7 @@ const BANCA_CONTROL_NAMES: ReadonlySet<string> = new Set<keyof BancaForm>([
     ConfirmDialogComponent,
     DrawerComponent,
     EmptyStateComponent,
+    FilterBarComponent,
     PagerComponent,
     SpinnerComponent,
   ],
@@ -128,20 +130,12 @@ const BANCA_CONTROL_NAMES: ReadonlySet<string> = new Set<keyof BancaForm>([
         </button>
       </div>
 
-      <div class="filter-bar" role="search" aria-label="Filtrar tipos de banca">
-        <div class="filter-bar__group">
-          <label class="field field--search">
-            <span class="field__label sr-only">Buscar por código ou nome</span>
-            <input
-              class="input"
-              type="search"
-              placeholder="Buscar por código ou nome…"
-              [value]="termoBusca()"
-              (input)="termoBusca.set($any($event.target).value)"
-            />
-          </label>
-        </div>
-      </div>
+      <ui-filter-bar
+        ariaLabel="Filtrar tipos de banca"
+        searchPlaceholder="Buscar por código ou nome…"
+        searchAriaLabel="Buscar tipos de banca"
+        [(searchValue)]="termoBusca"
+      />
 
       @if (bancasFiltradas().length > 0) {
         <div class="table-responsive">

--- a/apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.ts
+++ b/apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.ts
@@ -135,7 +135,7 @@ const PAGE_SIZE = 50;
     <div data-scope class="cfg-unidades-scope">
       <ui-filter-bar
         ariaLabel="Filtrar tipos de deficiência"
-        searchPlaceholder="Buscar por código ou nome..."
+        searchPlaceholder="Buscar por nome..."
         searchAriaLabel="Buscar tipos de deficiência"
         [(searchValue)]="termoBusca"
       >

--- a/apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.ts
+++ b/apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.ts
@@ -43,6 +43,7 @@ import {
   DrawerComponent,
   SpinnerComponent,
   DialogComponent,
+  FilterBarComponent,
   PagerComponent,
 } from "@uniplus/shared-ui/components";
 
@@ -90,6 +91,7 @@ const PAGE_SIZE = 50;
     SpinnerComponent,
     ReactiveFormsModule,
     DialogComponent,
+    FilterBarComponent,
     PagerComponent,
   ],
   template: `
@@ -131,30 +133,21 @@ const PAGE_SIZE = 50;
     }
 
     <div data-scope class="cfg-unidades-scope">
-      <div class="filter-bar" role="search" aria-label="Filtrar tipos de deficiência">
-        <div class="filter-bar__row">
-          <div class="input-group">
-            <span class="input-group__addon" aria-hidden="true">
-              <i class="pi pi-search"></i>
-            </span>
-            <input
-              type="search"
-              class="input"
-              placeholder="Buscar por nome..."
-              aria-label="Buscar tipos de deficiência"
-              [value]="termoBusca()"
-              (input)="termoBusca.set(inputValue($event))"
-            />
-          </div>
-          <button
-            type="button"
-            class="btn btn--tertiary btn--sm btn--rect"
-            (click)="limparFiltros()"
-          >
-            Limpar
-          </button>
-        </div>
-      </div>
+      <ui-filter-bar
+        ariaLabel="Filtrar tipos de deficiência"
+        searchPlaceholder="Buscar por código ou nome..."
+        searchAriaLabel="Buscar tipos de deficiência"
+        [(searchValue)]="termoBusca"
+      >
+        <button
+          uiFilterBarActions
+          type="button"
+          class="btn btn--tertiary btn--sm btn--rect"
+          (click)="limparFiltros()"
+        >
+          Limpar
+        </button>
+      </ui-filter-bar>
 
       <section class="panel" aria-labelledby="cfg-unidades-list-title">
         <div class="panel-head">

--- a/apps/configuracao/src/app/features/tipos-documento/tipos-documento-list.page.ts
+++ b/apps/configuracao/src/app/features/tipos-documento/tipos-documento-list.page.ts
@@ -47,6 +47,7 @@ import {
   SpinnerComponent,
   TagComponent,
   type UiFilterChipOption,
+  FilterBarComponent
 } from '@uniplus/shared-ui/components';
 
 /** Tamanho da janela de cada página (cursor pagination, ADR-0026). */
@@ -106,7 +107,8 @@ interface TipoDocumentoForm {
     PagerComponent,
     SpinnerComponent,
     TagComponent,
-  ],
+    FilterBarComponent
+],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="page-header">
@@ -137,32 +139,30 @@ interface TipoDocumentoForm {
       </ui-alert>
     }
 
-    <div class="filter-bar" role="search" aria-label="Filtrar tipos de documento">
-      <div class="filter-bar__row">
-        <div class="input-group">
-          <span class="input-group__addon" aria-hidden="true">
-            <i class="pi pi-search"></i>
-          </span>
-          <input
-            type="search"
-            class="input"
-            placeholder="Buscar por código ou nome…"
-            aria-label="Buscar tipo de documento"
-            [value]="termoBusca()"
-            (input)="termoBusca.set(inputValue($event))"
-          />
-        </div>
-      </div>
-      <div class="filter-bar__group">
+    <ui-filter-bar
+      ariaLabel="Filtrar tipos de documento"
+      searchPlaceholder="Buscar por código ou nome…"
+      searchAriaLabel="Buscar tipo de documento"
+      [(searchValue)]="termoBusca"
+    >
+      <button
+        uiFilterBarActions
+        type="button"
+        class="btn btn--tertiary btn--sm btn--rect"
+        (click)="limparFiltros()"
+      >
+        Limpar
+      </button>
+      <ng-container uiFilterBarSecondary>
         <span class="u-eyebrow">Categoria</span>
         <ui-filter-chips
           [options]="categoriaChips()"
-          [selected]="filtroCategoria()"
+          [(selected)]="filtroCategoria"
           (selectedChange)="filtroCategoria.set($event ?? '')"
           ariaLabel="Filtrar por categoria"
         />
-      </div>
-    </div>
+      </ng-container>
+    </ui-filter-bar>
 
     <section class="panel" aria-labelledby="cfg-tipos-documento-list-title">
       <div class="panel-head">

--- a/apps/configuracao/src/app/features/tipos-documento/tipos-documento-list.page.ts
+++ b/apps/configuracao/src/app/features/tipos-documento/tipos-documento-list.page.ts
@@ -145,14 +145,6 @@ interface TipoDocumentoForm {
       searchAriaLabel="Buscar tipo de documento"
       [(searchValue)]="termoBusca"
     >
-      <button
-        uiFilterBarActions
-        type="button"
-        class="btn btn--tertiary btn--sm btn--rect"
-        (click)="limparFiltros()"
-      >
-        Limpar
-      </button>
       <ng-container uiFilterBarSecondary>
         <span class="u-eyebrow">Categoria</span>
         <ui-filter-chips

--- a/apps/configuracao/src/app/features/unidades/unidades.page.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.ts
@@ -44,6 +44,7 @@ import {
   ConfirmDialogComponent,
   DrawerComponent,
   EmptyStateComponent,
+  FilterBarComponent,
   FilterChipsComponent,
   PagerComponent,
   SpinnerComponent,
@@ -132,6 +133,7 @@ const BACKEND_FIELD_TO_CONTROL = {
     ConfirmDialogComponent,
     DrawerComponent,
     EmptyStateComponent,
+    FilterBarComponent,
     FilterChipsComponent,
     NgTemplateOutlet,
     PagerComponent,
@@ -177,30 +179,21 @@ const BACKEND_FIELD_TO_CONTROL = {
     }
 
     <div data-scope class="cfg-unidades-scope">
-      <div class="filter-bar" role="search" aria-label="Filtrar unidades">
-        <div class="filter-bar__row">
-          <div class="input-group">
-            <span class="input-group__addon" aria-hidden="true">
-              <i class="pi pi-search"></i>
-            </span>
-            <input
-              type="search"
-              class="input"
-              placeholder="Buscar por sigla ou nome..."
-              aria-label="Buscar unidade"
-              [value]="busca()"
-              (input)="busca.set(inputValue($event))"
-            />
-          </div>
-          <button
-            type="button"
-            class="btn btn--tertiary btn--sm btn--rect"
-            (click)="limparFiltros()"
-          >
-            Limpar
-          </button>
-        </div>
-        <div class="filter-bar__group">
+      <ui-filter-bar
+        ariaLabel="Filtrar unidades"
+        searchPlaceholder="Buscar por sigla ou nome..."
+        searchAriaLabel="Buscar unidade"
+        [(searchValue)]="busca"
+      >
+        <button
+          uiFilterBarActions
+          type="button"
+          class="btn btn--tertiary btn--sm btn--rect"
+          (click)="limparFiltros()"
+        >
+          Limpar
+        </button>
+        <ng-container uiFilterBarSecondary>
           <span class="u-eyebrow">Tipo</span>
           <ui-filter-chips
             [options]="tipoChips"
@@ -208,8 +201,8 @@ const BACKEND_FIELD_TO_CONTROL = {
             (selectedChange)="tipoFiltro.set($event ?? '')"
             ariaLabel="Filtrar por tipo"
           />
-        </div>
-      </div>
+        </ng-container>
+      </ui-filter-bar>
 
       <section class="panel" aria-labelledby="cfg-unidades-tree-title">
         <div class="panel-head">

--- a/apps/configuracao/src/styles.css
+++ b/apps/configuracao/src/styles.css
@@ -462,12 +462,6 @@ cfg-pesos-enem-page {
   font-variant-numeric: tabular-nums;
 }
 
-.filter-bar__group {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-}
-
 .cfg-unidades__loading {
   display: inline-flex;
   align-items: center;

--- a/libs/shared-ui/components/src/index.ts
+++ b/libs/shared-ui/components/src/index.ts
@@ -20,6 +20,7 @@ export { DialogComponent } from '../../src/lib/components/dialog/dialog';
 export { DrawerComponent } from '../../src/lib/components/drawer/drawer';
 export { EmptyStateComponent } from '../../src/lib/components/empty-state/empty-state';
 export { FileUploadComponent } from '../../src/lib/components/file-upload/file-upload';
+export { FilterBarComponent } from '../../src/lib/components/filter-bar/filter-bar';
 export {
   FilterChipsComponent,
   type UiFilterChipOption,

--- a/libs/shared-ui/src/lib/components/filter-bar/filter-bar.spec.ts
+++ b/libs/shared-ui/src/lib/components/filter-bar/filter-bar.spec.ts
@@ -1,0 +1,156 @@
+import { Component, signal } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, expect, it } from 'vitest';
+import { FilterBarComponent } from './filter-bar';
+
+describe('FilterBarComponent', () => {
+  function setup() {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [FilterBarComponent],
+    });
+
+    const fixture: ComponentFixture<FilterBarComponent> =
+      TestBed.createComponent(FilterBarComponent);
+    const component = fixture.componentInstance;
+    const getWrapperEl = () =>
+      fixture.debugElement.query(By.css('.filter-bar')).nativeElement as HTMLElement;
+    const getInputEl = () =>
+      fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+    return { fixture, component, getWrapperEl, getInputEl };
+  }
+
+  it('lança erro se detectChanges rodar sem ariaLabel informado (input obrigatório)', () => {
+    const { fixture } = setup();
+    expect(() => fixture.detectChanges()).toThrow();
+  });
+
+  it('renderiza role="search" e o aria-label recebido no wrapper', () => {
+    const { fixture, getWrapperEl } = setup();
+    fixture.componentRef.setInput('ariaLabel', 'Filtrar unidades');
+    fixture.detectChanges();
+
+    const wrapper = getWrapperEl();
+    expect(wrapper.getAttribute('role')).toBe('search');
+    expect(wrapper.getAttribute('aria-label')).toBe('Filtrar unidades');
+  });
+
+  it('usa "Buscar..." como placeholder padrão quando searchPlaceholder não é informado', () => {
+    const { fixture, getInputEl } = setup();
+    fixture.componentRef.setInput('ariaLabel', 'Filtrar unidades');
+    fixture.detectChanges();
+
+    expect(getInputEl().placeholder).toBe('Buscar...');
+  });
+
+  it('aplica o searchPlaceholder recebido', () => {
+    const { fixture, getInputEl } = setup();
+    fixture.componentRef.setInput('ariaLabel', 'Filtrar unidades');
+    fixture.componentRef.setInput('searchPlaceholder', 'Buscar por sigla ou nome...');
+    fixture.detectChanges();
+
+    expect(getInputEl().placeholder).toBe('Buscar por sigla ou nome...');
+  });
+
+  it('omite aria-label do campo de busca quando searchAriaLabel não é informado', () => {
+    const { fixture, getInputEl } = setup();
+    fixture.componentRef.setInput('ariaLabel', 'Filtrar unidades');
+    fixture.detectChanges();
+
+    expect(getInputEl().getAttribute('aria-label')).toBeNull();
+  });
+
+  it('aplica o searchAriaLabel recebido no campo de busca', () => {
+    const { fixture, getInputEl } = setup();
+    fixture.componentRef.setInput('ariaLabel', 'Filtrar unidades');
+    fixture.componentRef.setInput('searchAriaLabel', 'Buscar unidade');
+    fixture.detectChanges();
+
+    expect(getInputEl().getAttribute('aria-label')).toBe('Buscar unidade');
+  });
+
+  it('reflete searchValue recebido no value do input', () => {
+    const { fixture, getInputEl } = setup();
+    fixture.componentRef.setInput('ariaLabel', 'Filtrar unidades');
+    fixture.componentRef.setInput('searchValue', 'campus');
+    fixture.detectChanges();
+
+    expect(getInputEl().value).toBe('campus');
+  });
+
+  it('atualiza o signal searchValue ao digitar no input', () => {
+    const { fixture, component, getInputEl } = setup();
+    fixture.componentRef.setInput('ariaLabel', 'Filtrar unidades');
+    fixture.detectChanges();
+
+    const input = getInputEl();
+    input.value = 'marabá';
+    input.dispatchEvent(new Event('input'));
+
+    expect(component.searchValue()).toBe('marabá');
+  });
+});
+
+@Component({
+  standalone: true,
+  imports: [FilterBarComponent],
+  template: `
+    <ui-filter-bar ariaLabel="Filtrar unidades" [(searchValue)]="busca">
+      <button uiFilterBarActions type="button" class="btn btn--tertiary btn--sm" (click)="limpar()">
+        Limpar
+      </button>
+      <span uiFilterBarSecondary>filtro secundário projetado</span>
+    </ui-filter-bar>
+  `,
+})
+class FilterBarHostComponent {
+  readonly busca = signal('');
+  limparChamado = false;
+
+  limpar(): void {
+    this.limparChamado = true;
+  }
+}
+
+describe('FilterBarComponent (projeção de conteúdo e two-way binding)', () => {
+  function setupHost() {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [FilterBarHostComponent],
+    });
+
+    const fixture = TestBed.createComponent(FilterBarHostComponent);
+    fixture.detectChanges();
+    const getInputEl = () =>
+      fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+    return { fixture, getInputEl };
+  }
+
+  it('projeta o conteúdo do slot uiFilterBarActions dentro de .filter-bar__row', () => {
+    const { fixture } = setupHost();
+    const row = fixture.debugElement.query(By.css('.filter-bar__row'));
+    const button = row.query(By.css('button'));
+
+    expect(button).toBeTruthy();
+    expect((button.nativeElement as HTMLButtonElement).textContent?.trim()).toBe('Limpar');
+  });
+
+  it('projeta o conteúdo do slot uiFilterBarSecondary dentro de .filter-bar__group', () => {
+    const { fixture } = setupHost();
+    const group = fixture.debugElement.query(By.css('.filter-bar__group'));
+
+    expect(group.nativeElement.textContent.trim()).toBe('filtro secundário projetado');
+  });
+
+  it('atualiza o signal do host via [(searchValue)] ao digitar no input', () => {
+    const { fixture, getInputEl } = setupHost();
+    const host = fixture.componentInstance;
+
+    const input = getInputEl();
+    input.value = 'campus 2';
+    input.dispatchEvent(new Event('input'));
+
+    expect(host.busca()).toBe('campus 2');
+  });
+});

--- a/libs/shared-ui/src/lib/components/filter-bar/filter-bar.spec.ts
+++ b/libs/shared-ui/src/lib/components/filter-bar/filter-bar.spec.ts
@@ -90,6 +90,15 @@ describe('FilterBarComponent', () => {
 
     expect(component.searchValue()).toBe('marabá');
   });
+
+  it('deixa .filter-bar__group sem nenhum nó-filho quando nada é projetado em uiFilterBarSecondary (pré-condição do CSS .filter-bar__group:empty)', () => {
+    const { fixture } = setup();
+    fixture.componentRef.setInput('ariaLabel', 'Filtrar unidades');
+    fixture.detectChanges();
+
+    const group = fixture.debugElement.query(By.css('.filter-bar__group')).nativeElement as HTMLElement;
+    expect(group.childNodes.length).toBe(0);
+  });
 });
 
 @Component({

--- a/libs/shared-ui/src/lib/components/filter-bar/filter-bar.spec.ts
+++ b/libs/shared-ui/src/lib/components/filter-bar/filter-bar.spec.ts
@@ -1,7 +1,10 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { Component, signal } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { describe, expect, it } from 'vitest';
+import { FilterBarComponent as PublicFilterBarComponent } from '../../index';
 import { FilterBarComponent } from './filter-bar';
 
 describe('FilterBarComponent', () => {
@@ -24,6 +27,10 @@ describe('FilterBarComponent', () => {
   it('lança erro se detectChanges rodar sem ariaLabel informado (input obrigatório)', () => {
     const { fixture } = setup();
     expect(() => fixture.detectChanges()).toThrow();
+  });
+
+  it('é publicado pelo entrypoint primário de shared-ui', () => {
+    expect(PublicFilterBarComponent).toBe(FilterBarComponent);
   });
 
   it('renderiza role="search" e o aria-label recebido no wrapper', () => {
@@ -98,6 +105,17 @@ describe('FilterBarComponent', () => {
 
     const group = fixture.debugElement.query(By.css('.filter-bar__group')).nativeElement as HTMLElement;
     expect(group.childNodes.length).toBe(0);
+  });
+
+  it('mantém o layout do grupo secundário no stylesheet compartilhado', () => {
+    const styles = readFileSync(resolve(__dirname, '../../../styles/components.css'), 'utf-8');
+    const groupRule = styles.match(/\.filter-bar__group\s*\{(?<declarations>[^}]*)\}/u)?.groups?.[
+      'declarations'
+    ];
+
+    expect(groupRule).toContain('display: flex;');
+    expect(groupRule).toContain('flex-direction: column;');
+    expect(groupRule).toContain('gap: var(--space-2);');
   });
 });
 

--- a/libs/shared-ui/src/lib/components/filter-bar/filter-bar.ts
+++ b/libs/shared-ui/src/lib/components/filter-bar/filter-bar.ts
@@ -1,0 +1,36 @@
+import { ChangeDetectionStrategy, Component, input, model } from '@angular/core';
+
+@Component({
+  selector: 'ui-filter-bar',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="filter-bar" role="search" [attr.aria-label]="ariaLabel()">
+      <div class="filter-bar__row">
+        <div class="input-group">
+          <span class="input-group__addon" aria-hidden="true">
+            <i class="pi pi-search"></i>
+          </span>
+          <input
+            type="search"
+            class="input"
+            [placeholder]="searchPlaceholder()"
+            [attr.aria-label]="searchAriaLabel() || null"
+            [value]="searchValue()"
+            (input)="searchValue.set($any($event.target).value)"
+          />
+        </div>
+        <ng-content select="[uiFilterBarActions]" />
+      </div>
+      <div class="filter-bar__group">
+        <ng-content select="[uiFilterBarSecondary]" />
+      </div>
+    </div>
+  `,
+})
+export class FilterBarComponent {
+  readonly ariaLabel = input.required<string>();
+  readonly searchPlaceholder = input<string>('Buscar...');
+  readonly searchAriaLabel = input<string>('');
+  readonly searchValue = model<string>('');
+}

--- a/libs/shared-ui/src/lib/components/filter-bar/filter-bar.ts
+++ b/libs/shared-ui/src/lib/components/filter-bar/filter-bar.ts
@@ -22,8 +22,14 @@ import { ChangeDetectionStrategy, Component, input, model } from '@angular/core'
         </div>
         <ng-content select="[uiFilterBarActions]" />
       </div>
-      <div class="filter-bar__group">
-        <ng-content select="[uiFilterBarSecondary]" />
+      <div
+        class="filter-bar__group"
+        [attr.role]="secondaryRole() || null"
+        [attr.aria-label]="secondaryAriaLabel() || null"
+      >
+        <ng-content
+          select="[uiFilterBarSecondary]"
+        />
       </div>
     </div>
   `,
@@ -33,4 +39,7 @@ export class FilterBarComponent {
   readonly searchPlaceholder = input<string>('Buscar...');
   readonly searchAriaLabel = input<string>('');
   readonly searchValue = model<string>('');
+  
+  readonly secondaryRole = input<string>();
+  readonly secondaryAriaLabel = input<string>();
 }

--- a/libs/shared-ui/src/lib/components/index.ts
+++ b/libs/shared-ui/src/lib/components/index.ts
@@ -15,6 +15,7 @@ export { DialogComponent } from './dialog/dialog';
 export { DrawerComponent } from './drawer/drawer';
 export { EmptyStateComponent } from './empty-state/empty-state';
 export { FileUploadComponent } from './file-upload/file-upload';
+export { FilterBarComponent } from './filter-bar/filter-bar';
 export {
   FilterChipsComponent,
   type UiFilterChipOption,

--- a/libs/shared-ui/src/lib/index.ts
+++ b/libs/shared-ui/src/lib/index.ts
@@ -11,6 +11,7 @@ export { DialogComponent } from './components/dialog/dialog';
 export { DrawerComponent } from './components/drawer/drawer';
 export { EmptyStateComponent } from './components/empty-state/empty-state';
 export { FileUploadComponent } from './components/file-upload/file-upload';
+export { FilterBarComponent } from './components/filter-bar/filter-bar';
 export { FilterChipsComponent, type UiFilterChipOption } from './components/filter-chips/filter-chips';
 export { ConfirmDialogComponent } from './components/confirm-dialog/confirm-dialog';
 export { FormFieldComponent } from './components/form-field/form-field';

--- a/libs/shared-ui/src/styles/components.css
+++ b/libs/shared-ui/src/styles/components.css
@@ -1849,6 +1849,7 @@ ui-vlibras-loader {
   flex: 1 1 16rem;
   min-width: min(100%, 16rem);
 }
+.filter-bar__group:empty { display: none; }
 .filter-chips { display: flex; flex-wrap: wrap; gap: var(--space-2); }
 .filter-chip {
   display: inline-flex; align-items: center; gap: var(--space-half-2);

--- a/libs/shared-ui/src/styles/components.css
+++ b/libs/shared-ui/src/styles/components.css
@@ -1849,6 +1849,11 @@ ui-vlibras-loader {
   flex: 1 1 16rem;
   min-width: min(100%, 16rem);
 }
+.filter-bar__group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
 .filter-bar__group:empty { display: none; }
 .filter-chips { display: flex; flex-wrap: wrap; gap: var(--space-2); }
 .filter-chip {


### PR DESCRIPTION
## Resumo

<!-- 1-3 bullet points descrevendo o que este PR faz -->

- Extrai `<ui-filter-bar>` para `libs/shared-ui`: componente standalone/OnPush, `aria-label` obrigatório (recusa build sem ele), two-way binding de busca via `model()` e dois slots de projeção (ações e filtro secundário) — sem `@Input()` fechado pra chips/select.
- Migra **11 páginas** de `apps/configuracao/src/app/features/` para o novo componente, eliminando a marcação de busca/filtro duplicada e já divergente (`.input-group` vs `.field.field--search`).
- Corrige o bug de acessibilidade já em produção: `cursos.page.ts` era a única das 10 páginas da issue sem `aria-label` no wrapper — agora é impossível esquecer, pois o input é obrigatório em tempo de compilação (CA-04).

Closes #500 

## Mudanças

<!-- Lista detalhada das mudanças por categoria -->

### Novos arquivos
<!-- - `path/to/file` — descrição -->

- `libs/shared-ui/src/lib/components/filter-bar/filter-bar.ts` — componente `ui-filter-bar`.
- `libs/shared-ui/src/lib/components/filter-bar/filter-bar.spec.ts` — 12 testes (Vitest + TestBed): input obrigatório (`ariaLabel`), atributos (`role`, `placeholder`, `aria-label` do campo), two-way data binding de `searchValue`, projeção de conteúdo nos dois slots, e `.filter-bar__group` sem filhos quando nada é projetado.

### Modificados
<!-- - `path/to/file` — o que mudou -->

- `libs/shared-ui/src/lib/components/index.ts`, `libs/shared-ui/components/src/index.ts` — export do `FilterBarComponent`.
- `libs/shared-ui/src/styles/components.css` — `.filter-bar__group:empty { display: none; }`: remove o espaçamento fantasma que o `gap` do flexbox `.filter-bar` deixava quando não há filtro secundário projetado.
- **11 páginas** de `apps/configuracao/src/app/features/` trocam a marcação manual por `<ui-filter-bar>`: `unidades`, `cursos`, `modalidades`, `tipos-documento`, `condicoes-atendimento`, `fases-canonicas`, `recursos-acessibilidade`, `reserva-demografica`, `tipos-banca`, `tipos-deficiencia`, `precedencias-fase`.
  - `fases-canonicas.page.ts`: filtro secundário (`<select>` de dono típico) projetado via `<ng-container uiFilterBarSecondary>`.
  - `unidades` / `modalidades` / `tipos-documento`: filtro secundário `<ui-filter-chips>` projetado do mesmo jeito.
  - `cursos.page.ts`: ganhou `aria-label` (não tinha antes — CA-04).
  - Nenhuma mudança em lógica de filtragem, debounce ou paginação — só marcação de template.

> `precedencias-fase.page.ts` está fora das 10 páginas listadas originalmente na issue #500, mas tinha exatamente a mesma marcação antiga duplicada — migrada pelo mesmo motivo.

## Testes

- [x] Testes unitários passando
- [x] Testes de integração passando (se aplicável)
- [x] Testes E2E passando (se aplicável)

## Checklist

- [x] Build sem erros e sem warnings
- [x] Código segue Clean Architecture e SOLID
- [x] Sem exposição de PII (CPF, renda, dados sensíveis)
- [x] Strings user-facing em pt-BR
- [x] Componentes `ui-*` sem dependência de domínio, standalone, OnPush
- [ ] Soft delete utilizado (sem DELETE físico) - N/D
- [ ] Documentação atualizada (se aplicável) - N/D