### PR TITLE
feat(selecao): consome tipos de processo configuráveis

### DIFF
--- a/apps/selecao-e2e/src/specs/processo-seletivo.ds-matrix.spec.ts
+++ b/apps/selecao-e2e/src/specs/processo-seletivo.ds-matrix.spec.ts
@@ -1,6 +1,23 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page, type Route } from '@playwright/test';
 
 type DsTheme = 'light' | 'dark' | 'contrast';
+
+const CORS_HEADERS = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'GET, OPTIONS',
+  'access-control-allow-headers': 'authorization, accept',
+};
+
+const TIPOS_PROCESSO = [
+  {
+    id: '01960000-0000-7000-0000-000000000515',
+    codigo: 'SISU',
+    nome: 'SISU',
+    descricao: 'Seleção unificada pelo ENEM.',
+    ativo: true,
+    criadoEm: '2026-08-11T00:00:00Z',
+  },
+] as const;
 
 /**
  * Matriz do Uni+ DS para o cadastro de processo seletivo: 320 px, 768 px e
@@ -10,9 +27,11 @@ type DsTheme = 'light' | 'dark' | 'contrast';
  */
 test.describe('Cadastro de processo seletivo — matriz DS @ds', () => {
   test.beforeEach(async ({ page }, testInfo) => {
+    await mockTiposProcesso(page);
     await instalarPreferencia(page, temaDoProject(testInfo.project.name));
     await page.goto('/processo-seletivo');
     await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+    await expect(page.getByRole('radio').first()).toBeVisible();
   });
 
   /**
@@ -174,4 +193,29 @@ async function instalarPreferencia(page: Page, theme: DsTheme): Promise<void> {
 function temaDoProject(projectName: string): DsTheme {
   const parte = projectName.split('-').at(-1);
   return parte === 'dark' || parte === 'contrast' ? parte : 'light';
+}
+
+/**
+ * O CI do frontend sobe Keycloak, mas não a API. O catálogo configurável é
+ * contrato do passo 1, portanto a matriz DS o materializa por rota para manter
+ * o fluxo determinístico e não voltar a depender de opções hardcoded.
+ */
+async function mockTiposProcesso(page: Page): Promise<void> {
+  await page.route(/\/api\/configuracao\/tipos-processo(\?.*)?$/, async (route: Route) => {
+    const request = route.request();
+    if (request.method() === 'OPTIONS') {
+      await route.fulfill({ status: 204, headers: CORS_HEADERS });
+      return;
+    }
+
+    expect(request.method()).toBe('GET');
+    expect(request.headers()['accept']).toBe('application/vnd.uniplus.tipo-processo.v1+json');
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/vnd.uniplus.tipo-processo.v1+json',
+      headers: CORS_HEADERS,
+      body: JSON.stringify(TIPOS_PROCESSO),
+    });
+  });
 }

--- a/apps/selecao/src/app/features/processo-seletivo/components/type-card/type-card.component.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/components/type-card/type-card.component.ts
@@ -10,7 +10,7 @@ import { TipoProcessoOption } from '../../steps/processo-seletivo.models';
       <input
         class="sr-only"
         type="radio"
-        name="tipo-edital"
+        name="tipo-processo"
         [value]="option().value"
         [checked]="selected()"
         (change)="selectChange.emit(option().value)"
@@ -39,7 +39,9 @@ import { TipoProcessoOption } from '../../steps/processo-seletivo.models';
           }
         </div>
       }
-      <span class="type-card__legal">{{ option().legal }}</span>
+      @if (option().legal; as legal) {
+        <span class="type-card__legal">{{ legal }}</span>
+      }
     </label>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/apps/selecao/src/app/features/processo-seletivo/processo-seletivo.page.spec.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/processo-seletivo.page.spec.ts
@@ -1,11 +1,20 @@
+import { HttpHeaders } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { apiOk } from '@uniplus/shared-core/http';
+import { TipoProcessoDto, TiposProcessoApi } from '@uniplus/shared-data/configuracao';
 import { ProcessoSeletivoPage } from './processo-seletivo.page';
 import { ProcessoSeletivoStore } from './steps/processo-seletivo.store';
+
+const tiposProcessoApiStub = {
+  listar: () => of(apiOk<readonly TipoProcessoDto[]>([], 200, new HttpHeaders())),
+};
 
 describe('ProcessoSeletivoPage — estrutura', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ProcessoSeletivoPage],
+      providers: [{ provide: TiposProcessoApi, useValue: tiposProcessoApiStub }],
     }).compileComponents();
   });
 
@@ -47,6 +56,7 @@ describe('ProcessoSeletivoPage — lista de etapas', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ProcessoSeletivoPage],
+      providers: [{ provide: TiposProcessoApi, useValue: tiposProcessoApiStub }],
     }).compileComponents();
   });
 
@@ -98,6 +108,7 @@ describe('ProcessoSeletivoPage — bloqueio de scroll', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ProcessoSeletivoPage],
+      providers: [{ provide: TiposProcessoApi, useValue: tiposProcessoApiStub }],
     }).compileComponents();
   });
 
@@ -126,6 +137,7 @@ describe('ProcessoSeletivoPage — publicação', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ProcessoSeletivoPage],
+      providers: [{ provide: TiposProcessoApi, useValue: tiposProcessoApiStub }],
     }).compileComponents();
   });
 

--- a/apps/selecao/src/app/features/processo-seletivo/steps/processo-seletivo.data.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/processo-seletivo.data.ts
@@ -5,7 +5,6 @@ import {
   CriterioDesempate,
   Curso,
   DocumentoGrupo,
-  TipoProcessoOption,
 } from './processo-seletivo.models';
 
 export const STEP_LABELS = [
@@ -38,73 +37,6 @@ export const REVIEW_NAMES = [
   'Locais de prova',
   'Atendimento especializado',
 ] as const;
-
-export const TIPO_PROCESSO_OPTIONS: TipoProcessoOption[] = [
-  {
-    value: 'sisu',
-    name: 'SiSU',
-    description:
-      'Sistema de Seleção Unificada — utiliza notas do ENEM para classificação. Notas obtidas via integração com INEP, sem prova local.',
-    tags: ['2 opções'],
-    legal: 'Portaria MEC 21/2012; Lei 12.711/2012 atualizada pela Lei 14.723/2023',
-  },
-  {
-    value: 'psiq',
-    name: 'PSIQ — Indígena e Quilombola',
-    description:
-      'Processo Seletivo Especial para candidatos indígenas e quilombolas, com vagas suplementares e prova presencial em 3 polos.',
-    tags: ['2 opções', 'Presencial', 'Suplementares'],
-    legal: 'Resolução Unifesspa 532/2021',
-  },
-  {
-    value: 'pse',
-    name: 'PSE — Educação do Campo',
-    description:
-      'Processo Seletivo Especial para Licenciatura em Educação do Campo. Exige declaração de pertencimento territorial e entrevista.',
-    tags: ['Presencial'],
-    legal: 'Resolução Unifesspa 805/2024',
-  },
-  {
-    value: 'psvr',
-    name: 'PSVR — Vestibular Remanescente',
-    description:
-      'Processo Seletivo para vagas remanescentes após SiSU. Utiliza prova presencial objetiva + redação.',
-    tags: ['Presencial'],
-    legal: 'Portaria MEC 18/2012; Resolução CONSEPE Unifesspa',
-  },
-  {
-    value: 'ps-convenios',
-    name: 'PS Convênios',
-    description:
-      'Processo Seletivo de cursos por convênio com municípios. Aplica bônus regional configurável (padrão 20% sobre AC).',
-    tags: ['Presencial'],
-    legal: 'PN MEC 2.027/2023; Resolução Unifesspa do convênio específico',
-  },
-  {
-    value: 'mobin',
-    name: 'Transferência Interna (MOBIN)',
-    description:
-      'Mobilidade interna entre cursos da Unifesspa. Análise de histórico e carta de intenção.',
-    tags: [],
-    legal: 'Resolução Unifesspa 414/2020',
-  },
-  {
-    value: 'mobex',
-    name: 'Transferência Externa (MOBEX)',
-    description:
-      'Mobilidade externa de outras IFES para a Unifesspa. Análise de histórico e carta de intenção.',
-    tags: [],
-    legal: 'Resolução Unifesspa 414/2020',
-  },
-  {
-    value: 'portador-diploma',
-    name: 'Portador de Diploma',
-    description:
-      'Ingresso para portadores de diploma de curso superior. Análise de histórico de graduação anterior.',
-    tags: [],
-    legal: 'Resolução Unifesspa 414/2020',
-  },
-];
 
 /**
  * Modalidades de concorrência do processo seletivo, no vocabulário canônico

--- a/apps/selecao/src/app/features/processo-seletivo/steps/processo-seletivo.models.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/processo-seletivo.models.ts
@@ -24,7 +24,7 @@ export interface TipoProcessoOption {
   name: string;
   description: string;
   tags: string[];
-  legal: string;
+  legal?: string;
 }
 
 export interface UploadItem {

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-01-tipo-processo/step-01-tipo-processo.component.html
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-01-tipo-processo/step-01-tipo-processo.component.html
@@ -3,39 +3,52 @@
   <h1 tabindex="-1">Passo 1: Tipo do processo</h1>
   <p>Escolha o tipo de processo seletivo.</p>
 </div>
-<div class="type-search">
-  <div class="input-group">
-    <span class="input-group__addon"
-      ><svg
-        aria-hidden="true"
-        fill="none"
-        height="16"
-        stroke="currentColor"
-        stroke-linecap="round"
-        stroke-width="2"
-        viewBox="0 0 24 24"
-        width="16"
-      >
-        <circle cx="11" cy="11" r="7" />
-        <path d="M21 21l-4.5-4.5" /></svg
-    ></span>
-    <input
-      class="input"
-      type="search"
-      aria-label="Buscar tipos de processo seletivo"
-      placeholder="Buscar por nome..."
-      [value]="query()"
-      (input)="query.set($any($event.target).value)"
-    />
+@if (loading()) {
+  <p role="status" aria-live="polite">Carregando tipos de processo...</p>
+} @else if (errorMessage(); as error) {
+  <div role="alert">
+    <p>{{ error }}</p>
+    <button class="button button--secondary" type="button" (click)="carregar()">
+      Tentar novamente
+    </button>
   </div>
-</div>
-<fieldset class="type-grid">
-  <legend class="sr-only">Tipo do processo seletivo</legend>
-  @for (option of filteredOptions(); track option.value) {
-    <sel-type-card
-      [option]="option"
-      [selected]="store.draft().tipoProcesso.selected === option.value"
-      (selectChange)="select($event)"
-    />
-  }
-</fieldset>
+} @else if (options().length === 0) {
+  <p role="status">Não há tipos de processo ativos disponíveis no momento.</p>
+} @else {
+  <div class="type-search">
+    <div class="input-group">
+      <span class="input-group__addon"
+        ><svg
+          aria-hidden="true"
+          fill="none"
+          height="16"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="16"
+        >
+          <circle cx="11" cy="11" r="7" />
+          <path d="M21 21l-4.5-4.5" /></svg
+      ></span>
+      <input
+        class="input"
+        type="search"
+        aria-label="Buscar tipos de processo seletivo"
+        placeholder="Buscar por nome..."
+        [value]="query()"
+        (input)="query.set($any($event.target).value)"
+      />
+    </div>
+  </div>
+  <fieldset class="type-grid">
+    <legend class="sr-only">Tipo do processo seletivo</legend>
+    @for (option of filteredOptions(); track option.value) {
+      <sel-type-card
+        [option]="option"
+        [selected]="store.draft().tipoProcesso.selected === option.value"
+        (selectChange)="select($event)"
+      />
+    }
+  </fieldset>
+}

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-01-tipo-processo/step-01-tipo-processo.component.html
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-01-tipo-processo/step-01-tipo-processo.component.html
@@ -8,9 +8,7 @@
 } @else if (errorMessage(); as error) {
   <div role="alert">
     <p>{{ error }}</p>
-    <button class="button button--secondary" type="button" (click)="carregar()">
-      Tentar novamente
-    </button>
+    <button class="btn btn--secondary" type="button" (click)="carregar()">Tentar novamente</button>
   </div>
 } @else if (options().length === 0) {
   <p role="status">Não há tipos de processo ativos disponíveis no momento.</p>

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-01-tipo-processo/step-01-tipo-processo.component.spec.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-01-tipo-processo/step-01-tipo-processo.component.spec.ts
@@ -3,7 +3,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Observable, Subject, of, throwError } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { ApiResult, apiFailure, apiOk } from '@uniplus/shared-core/http';
-import { TipoProcessoDto, TiposProcessoApi } from '@uniplus/shared-data/configuracao';
+import {
+  TipoProcessoDto,
+  TiposProcessoApi,
+  TiposProcessoQuery,
+} from '@uniplus/shared-data/configuracao';
 import { ProcessoSeletivoStore } from '../../processo-seletivo.store';
 import { Step01TipoProcessoComponent } from './step-01-tipo-processo.component';
 
@@ -32,7 +36,7 @@ const tiposSeed: readonly TipoProcessoDto[] = [
 
 describe('Step01TipoProcessoComponent', () => {
   let fixture: ComponentFixture<Step01TipoProcessoComponent>;
-  let listar: () => Observable<ApiResult<readonly TipoProcessoDto[]>>;
+  let listar: (query?: TiposProcessoQuery) => Observable<ApiResult<readonly TipoProcessoDto[]>>;
 
   beforeEach(async () => {
     listar = () => of(apiOk(tiposSeed, 200, headers));
@@ -40,7 +44,10 @@ describe('Step01TipoProcessoComponent', () => {
       imports: [Step01TipoProcessoComponent],
       providers: [
         ProcessoSeletivoStore,
-        { provide: TiposProcessoApi, useValue: { listar: () => listar() } },
+        {
+          provide: TiposProcessoApi,
+          useValue: { listar: (query?: TiposProcessoQuery) => listar(query) },
+        },
       ],
     }).compileComponents();
   });
@@ -67,6 +74,26 @@ describe('Step01TipoProcessoComponent', () => {
     fixture.detectChanges();
 
     expect(component.store.draft().tipoProcesso.selected).toBe(ID_SISU);
+  });
+
+  it('percorre todos os cursores next do catálogo antes de exibir os tipos', () => {
+    const consultas: Array<TiposProcessoQuery | undefined> = [];
+    const headersComProximaPagina = new HttpHeaders({
+      Link: '</api/configuracao/tipos-processo?cursor=proxima%2Bpagina&direction=next>; rel="next"',
+    });
+    listar = (query) => {
+      consultas.push(query);
+      return consultas.length === 1
+        ? of(apiOk([tiposSeed[0]], 200, headersComProximaPagina))
+        : of(apiOk([tiposSeed[1]], 200, headers));
+    };
+
+    montar();
+    const host = fixture.nativeElement as HTMLElement;
+
+    expect(consultas).toEqual([undefined, { cursor: 'proxima+pagina', direction: 'next' }]);
+    expect(host.textContent).toContain('SiSU');
+    expect(host.textContent).toContain('Medicina');
   });
 
   it('filtra pelo nome dos tipos retornados pela API', () => {

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-01-tipo-processo/step-01-tipo-processo.component.spec.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-01-tipo-processo/step-01-tipo-processo.component.spec.ts
@@ -1,0 +1,169 @@
+import { HttpHeaders } from '@angular/common/http';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Observable, Subject, of, throwError } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { ApiResult, apiFailure, apiOk } from '@uniplus/shared-core/http';
+import { TipoProcessoDto, TiposProcessoApi } from '@uniplus/shared-data/configuracao';
+import { ProcessoSeletivoStore } from '../../processo-seletivo.store';
+import { Step01TipoProcessoComponent } from './step-01-tipo-processo.component';
+
+const ID_SISU = '01960000-0000-7000-0000-000000000515';
+const ID_MEDICINA = '01960000-0000-7000-0000-000000000516';
+const headers = new HttpHeaders();
+
+const tiposSeed: readonly TipoProcessoDto[] = [
+  {
+    id: ID_SISU,
+    codigo: 'SISU',
+    nome: 'SiSU',
+    descricao: 'Sistema de Seleção Unificada.',
+    ativo: true,
+    criadoEm: '2026-08-11T12:00:00Z',
+  },
+  {
+    id: ID_MEDICINA,
+    codigo: 'MEDICINA',
+    nome: 'Medicina',
+    descricao: null,
+    ativo: true,
+    criadoEm: '2026-08-11T12:00:00Z',
+  },
+];
+
+describe('Step01TipoProcessoComponent', () => {
+  let fixture: ComponentFixture<Step01TipoProcessoComponent>;
+  let listar: () => Observable<ApiResult<readonly TipoProcessoDto[]>>;
+
+  beforeEach(async () => {
+    listar = () => of(apiOk(tiposSeed, 200, headers));
+    await TestBed.configureTestingModule({
+      imports: [Step01TipoProcessoComponent],
+      providers: [
+        ProcessoSeletivoStore,
+        { provide: TiposProcessoApi, useValue: { listar: () => listar() } },
+      ],
+    }).compileComponents();
+  });
+
+  afterEach(() => fixture?.destroy());
+
+  function montar(): Step01TipoProcessoComponent {
+    fixture = TestBed.createComponent(Step01TipoProcessoComponent);
+    fixture.detectChanges();
+    return fixture.componentInstance;
+  }
+
+  it('exibe os tipos retornados pela API e guarda o UUID selecionado', () => {
+    const component = montar();
+    const host = fixture.nativeElement as HTMLElement;
+
+    expect(host.textContent).toContain('SiSU');
+    expect(host.textContent).toContain('Medicina');
+
+    const radio = host.querySelector<HTMLInputElement>(`input[value="${ID_SISU}"]`);
+    if (radio === null) throw new Error('O card do tipo retornado pela API não foi renderizado.');
+    expect(radio.name).toBe('tipo-processo');
+    radio.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+
+    expect(component.store.draft().tipoProcesso.selected).toBe(ID_SISU);
+  });
+
+  it('filtra pelo nome dos tipos retornados pela API', () => {
+    montar();
+    const host = fixture.nativeElement as HTMLElement;
+    const search = host.querySelector<HTMLInputElement>('input[type="search"]');
+    if (search === null) throw new Error('Busca de tipos ausente.');
+
+    search.value = 'med';
+    search.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    expect(host.textContent).toContain('Medicina');
+    expect(host.textContent).not.toContain('SiSU');
+  });
+
+  it('expõe estado de carregamento enquanto a consulta está pendente', () => {
+    const response = new Subject<ApiResult<readonly TipoProcessoDto[]>>();
+    listar = () => response.asObservable();
+
+    montar();
+    const host = fixture.nativeElement as HTMLElement;
+    expect(host.querySelector('[role="status"]')?.textContent).toContain('Carregando');
+
+    response.next(apiOk(tiposSeed, 200, headers));
+    response.complete();
+    fixture.detectChanges();
+    expect(host.textContent).toContain('SiSU');
+  });
+
+  it('expõe estado vazio quando não há tipos ativos', () => {
+    listar = () => of(apiOk([], 200, headers));
+
+    montar();
+    const host = fixture.nativeElement as HTMLElement;
+    expect(host.querySelector('[role="status"]')?.textContent).toContain('Não há tipos');
+  });
+
+  it('permite nova tentativa depois de falha na consulta', () => {
+    let attempts = 0;
+    listar = () => {
+      attempts += 1;
+      return attempts === 1
+        ? throwError(() => new Error('indisponível'))
+        : of(apiOk(tiposSeed, 200, headers));
+    };
+
+    montar();
+    const host = fixture.nativeElement as HTMLElement;
+    expect(host.querySelector('[role="alert"]')?.textContent).toContain(
+      'Não foi possível carregar',
+    );
+
+    const retry = host.querySelector<HTMLButtonElement>('button');
+    if (retry === null) throw new Error('Ação de nova tentativa ausente.');
+    retry.click();
+    fixture.detectChanges();
+
+    expect(attempts).toBe(2);
+    expect(host.textContent).toContain('SiSU');
+    expect(host.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('permite nova tentativa depois de ApiFailure normalizado', () => {
+    let attempts = 0;
+    listar = () => {
+      attempts += 1;
+      return attempts === 1
+        ? of(
+            apiFailure(
+              {
+                type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.internal.unexpected',
+                title: 'Erro interno do servidor',
+                status: 500,
+                code: 'uniplus.internal.unexpected',
+                traceId: '01960000000070000000000000000515',
+              },
+              500,
+              headers,
+            ),
+          )
+        : of(apiOk(tiposSeed, 200, headers));
+    };
+
+    montar();
+    const host = fixture.nativeElement as HTMLElement;
+    expect(host.querySelector('[role="alert"]')?.textContent).toContain(
+      'Não foi possível carregar',
+    );
+
+    const retry = host.querySelector<HTMLButtonElement>('button');
+    if (retry === null) throw new Error('Ação de nova tentativa ausente.');
+    retry.click();
+    fixture.detectChanges();
+
+    expect(attempts).toBe(2);
+    expect(host.textContent).toContain('SiSU');
+    expect(host.querySelector('[role="alert"]')).toBeNull();
+  });
+});

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-01-tipo-processo/step-01-tipo-processo.component.spec.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-01-tipo-processo/step-01-tipo-processo.component.spec.ts
@@ -149,6 +149,7 @@ describe('Step01TipoProcessoComponent', () => {
 
     const retry = host.querySelector<HTMLButtonElement>('button');
     if (retry === null) throw new Error('Ação de nova tentativa ausente.');
+    expect(retry.className).toBe('btn btn--secondary');
     retry.click();
     fixture.detectChanges();
 

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-01-tipo-processo/step-01-tipo-processo.component.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-01-tipo-processo/step-01-tipo-processo.component.ts
@@ -7,7 +7,7 @@ import {
   signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { isApiOk } from '@uniplus/shared-core/http';
+import { extractNextCursor, isApiOk } from '@uniplus/shared-core/http';
 import { TipoProcessoDto, TiposProcessoApi } from '@uniplus/shared-data/configuracao';
 import { TypeCardComponent } from '../../../components/type-card/type-card.component';
 import { ProcessoSeletivoStore } from '../../processo-seletivo.store';
@@ -46,24 +46,34 @@ export class Step01TipoProcessoComponent {
     this.loading.set(true);
     this.errorMessage.set(null);
 
-    this.tiposProcessoApi
-      .listar()
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        next: (result) => {
-          this.loading.set(false);
-          if (isApiOk(result)) {
-            this.options.set(result.data.map((tipo) => this.toOption(tipo)));
-            return;
-          }
+    this.carregarPagina();
+  }
 
-          this.errorMessage.set('Não foi possível carregar os tipos de processo. Tente novamente.');
-        },
-        error: () => {
-          this.loading.set(false);
-          this.errorMessage.set('Não foi possível carregar os tipos de processo. Tente novamente.');
-        },
-      });
+  private carregarPagina(cursor?: string, acumulados: readonly TipoProcessoOption[] = []): void {
+    const consulta =
+      cursor === undefined
+        ? this.tiposProcessoApi.listar()
+        : this.tiposProcessoApi.listar({ cursor, direction: 'next' });
+
+    consulta.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (result) => {
+        if (!isApiOk(result)) {
+          this.exibirErro();
+          return;
+        }
+
+        const tipos = [...acumulados, ...result.data.map((tipo) => this.toOption(tipo))];
+        const proximoCursor = extractNextCursor(result.headers.get('Link'));
+        if (proximoCursor !== null) {
+          this.carregarPagina(proximoCursor, tipos);
+          return;
+        }
+
+        this.options.set(tipos);
+        this.loading.set(false);
+      },
+      error: () => this.exibirErro(),
+    });
   }
 
   select(value: string): void {
@@ -84,5 +94,10 @@ export class Step01TipoProcessoComponent {
       description: tipo.descricao ?? `Código: ${tipo.codigo}`,
       tags: [tipo.codigo],
     };
+  }
+
+  private exibirErro(): void {
+    this.loading.set(false);
+    this.errorMessage.set('Não foi possível carregar os tipos de processo. Tente novamente.');
   }
 }

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-01-tipo-processo/step-01-tipo-processo.component.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-01-tipo-processo/step-01-tipo-processo.component.ts
@@ -1,8 +1,17 @@
-import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { isApiOk } from '@uniplus/shared-core/http';
+import { TipoProcessoDto, TiposProcessoApi } from '@uniplus/shared-data/configuracao';
 import { TypeCardComponent } from '../../../components/type-card/type-card.component';
 import { ProcessoSeletivoStore } from '../../processo-seletivo.store';
 import { StepValidation, TipoProcessoOption } from '../../processo-seletivo.models';
-import { TIPO_PROCESSO_OPTIONS } from '../../processo-seletivo.data';
 
 @Component({
   selector: 'sel-step-01-tipo-processo',
@@ -13,15 +22,49 @@ import { TIPO_PROCESSO_OPTIONS } from '../../processo-seletivo.data';
 })
 export class Step01TipoProcessoComponent {
   readonly store = inject(ProcessoSeletivoStore);
-  /** Lista local até a API de tipos de processo seletivo ser integrada. */
-  readonly options: TipoProcessoOption[] = TIPO_PROCESSO_OPTIONS;
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly tiposProcessoApi = inject(TiposProcessoApi);
+
+  /** Tipos ativos retornados pelo catálogo de Configuração (ADR-0122). */
+  readonly options = signal<readonly TipoProcessoOption[]>([]);
+  readonly loading = signal(true);
+  readonly errorMessage = signal<string | null>(null);
   readonly query = signal('');
   readonly filteredOptions = computed(() => {
     const query = this.query().trim().toLocaleLowerCase('pt-BR');
+    const options = this.options();
     return query
-      ? this.options.filter((item) => item.name.toLocaleLowerCase('pt-BR').includes(query))
-      : this.options;
+      ? options.filter((item) => item.name.toLocaleLowerCase('pt-BR').includes(query))
+      : options;
   });
+
+  constructor() {
+    this.carregar();
+  }
+
+  carregar(): void {
+    this.loading.set(true);
+    this.errorMessage.set(null);
+
+    this.tiposProcessoApi
+      .listar()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (result) => {
+          this.loading.set(false);
+          if (isApiOk(result)) {
+            this.options.set(result.data.map((tipo) => this.toOption(tipo)));
+            return;
+          }
+
+          this.errorMessage.set('Não foi possível carregar os tipos de processo. Tente novamente.');
+        },
+        error: () => {
+          this.loading.set(false);
+          this.errorMessage.set('Não foi possível carregar os tipos de processo. Tente novamente.');
+        },
+      });
+  }
 
   select(value: string): void {
     this.store.patchObjectSection('tipoProcesso', { selected: value });
@@ -32,5 +75,14 @@ export class Step01TipoProcessoComponent {
     return this.store.draft().tipoProcesso.selected
       ? { valid: true }
       : { valid: false, message: 'Selecione um tipo de processo seletivo para continuar.' };
+  }
+
+  private toOption(tipo: TipoProcessoDto): TipoProcessoOption {
+    return {
+      value: tipo.id,
+      name: tipo.nome,
+      description: tipo.descricao ?? `Código: ${tipo.codigo}`,
+      tags: [tipo.codigo],
+    };
   }
 }

--- a/libs/shared-data/openapi/configuracao.openapi.json
+++ b/libs/shared-data/openapi/configuracao.openapi.json
@@ -8281,6 +8281,506 @@
           }
         }
       }
+    },
+    "/api/configuracao/tipos-processo": {
+      "get": {
+        "tags": [
+          "TiposProcesso"
+        ],
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Tamanho m\u00E1ximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026).",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Dire\u00E7\u00E3o de navega\u00E7\u00E3o keyset (ADR-0089): \u0027next\u0027 (default) avan\u00E7a, \u0027prev\u0027 retrocede. Normalmente o cliente apenas segue o cursor opaco do rel=\u0022prev\u0022/rel=\u0022next\u0022 do header Link \u2014 que j\u00E1 inclui o direction correto.",
+            "schema": {
+              "enum": [
+                "next",
+                "prev"
+              ],
+              "type": "string",
+              "default": "next"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Link": {
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022prev\u0022/rel=\u0022next\u0022 quando h\u00E1 p\u00E1gina anterior/pr\u00F3xima (ADR-0089). Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 e o \u0060direction\u0060 correspondente (ADR-0026).",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Quantidade de itens retornados na p\u00E1gina atual (sempre menor ou igual ao limit efetivo).",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TipoProcessoDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TipoProcessoDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TipoProcessoDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-paginated": true
+      }
+    },
+    "/api/configuracao/tipos-processo/{id}": {
+      "get": {
+        "tags": [
+          "TiposProcesso"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TipoProcessoDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TipoProcessoDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TipoProcessoDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/configuracao/admin/tipos-processo": {
+      "post": {
+        "tags": [
+          "TiposProcesso"
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarTipoProcessoCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarTipoProcessoCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarTipoProcessoCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Corpo acima do limite dos endpoints idempotentes (uniplus.idempotency.body_muito_grande). O limite \u00E9 do filtro, n\u00E3o do servidor.",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
+    "/api/configuracao/admin/tipos-processo/{id}": {
+      "put": {
+        "tags": [
+          "TiposProcesso"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarTipoProcessoCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarTipoProcessoCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/AtualizarTipoProcessoCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Corpo acima do limite dos endpoints idempotentes (uniplus.idempotency.body_muito_grande). O limite \u00E9 do filtro, n\u00E3o do servidor.",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      },
+      "delete": {
+        "tags": [
+          "TiposProcesso"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -8908,6 +9408,28 @@
             "format": "int32"
           },
           "tipoEquivalente": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "AtualizarTipoProcessoCommand": {
+        "required": [
+          "id",
+          "nome"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "descricao": {
             "type": [
               "null",
               "string"
@@ -9833,6 +10355,27 @@
             "format": "int32"
           },
           "tipoEquivalente": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "CriarTipoProcessoCommand": {
+        "required": [
+          "codigo",
+          "nome"
+        ],
+        "type": "object",
+        "properties": {
+          "codigo": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "descricao": {
             "type": [
               "null",
               "string"
@@ -11176,6 +11719,51 @@
         ],
         "type": "string"
       },
+      "TipoProcessoDto": {
+        "required": [
+          "id",
+          "codigo",
+          "nome",
+          "descricao",
+          "ativo",
+          "criadoEm"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "codigo": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "descricao": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "ativo": {
+            "type": "boolean"
+          },
+          "criadoEm": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "UnidadeOfertanteDto": {
         "required": [
           "origemId",
@@ -11315,6 +11903,9 @@
     },
     {
       "name": "TiposDocumento"
+    },
+    {
+      "name": "TiposProcesso"
     }
   ]
 }

--- a/libs/shared-data/openapi/selecao.openapi.json
+++ b/libs/shared-data/openapi/selecao.openapi.json
@@ -2270,6 +2270,167 @@
         "x-uniplus-idempotent": true
       }
     },
+    "/api/selecao/processos-seletivos/{id}/divulgacao": {
+      "put": {
+        "tags": [
+          "ProcessoSeletivo"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DefinirConfiguracaoDivulgacaoRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DefinirConfiguracaoDivulgacaoRequest"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/DefinirConfiguracaoDivulgacaoRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content",
+            "headers": {
+              "ETag": {
+                "description": "ETag forte da sess\u00E3o editorial de retifica\u00E7\u00E3o, no formato \u0022{idDaSessao}:{revisao}\u0022. Devolva-o no If-Match da pr\u00F3xima muta\u00E7\u00E3o. Toda muta\u00E7\u00E3o aceita INCREMENTA a revis\u00E3o e emite o tag novo aqui \u2014 o cliente encadeia sem um GET no meio. Ausente quando n\u00E3o h\u00E1 sess\u00E3o em curso (o processo em rascunho n\u00E3o tem precondi\u00E7\u00E3o a satisfazer).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "412": {
+            "description": "Precondition Failed",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "428": {
+            "description": "Precondition Required",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Requisi\u00E7\u00E3o concorrente com a mesma Idempotency-Key ainda em processamento (uniplus.idempotency.processing_conflict). Repetir depois \u2014 a opera\u00E7\u00E3o anterior ainda n\u00E3o concluiu.",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Corpo acima do limite dos endpoints idempotentes (uniplus.idempotency.body_muito_grande). O limite \u00E9 do filtro, n\u00E3o do servidor.",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Requisi\u00E7\u00E3o n\u00E3o autenticada \u2014 token ausente ou inv\u00E1lido (a rota exige autentica\u00E7\u00E3o). Tamb\u00E9m emitido quando o principal \u00E9 exigido e n\u00E3o est\u00E1 presente (uniplus.idempotency.principal_requerido).",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Autenticado, mas sem a autoriza\u00E7\u00E3o exigida pela rota (ex.: a role plataforma-admin).",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
     "/api/selecao/processos-seletivos/{id}/cascata-remanejamento": {
       "put": {
         "tags": [
@@ -5438,6 +5599,27 @@
           }
         }
       },
+      "ConfiguracaoDivulgacaoDto": {
+        "required": [
+          "camposPublicos",
+          "justificativa"
+        ],
+        "type": "object",
+        "properties": {
+          "camposPublicos": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "justificativa": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
       "ConformidadeLegalProcessoSeletivoDto": {
         "required": [
           "processoSeletivoId",
@@ -5549,7 +5731,7 @@
       "CriarProcessoSeletivoCommand": {
         "required": [
           "nome",
-          "tipo",
+          "tipoProcessoOrigemId",
           "origemCandidatos",
           "unidadeAdministradoraOrigemId"
         ],
@@ -5558,8 +5740,9 @@
           "nome": {
             "type": "string"
           },
-          "tipo": {
-            "$ref": "#/components/schemas/TipoProcesso"
+          "tipoProcessoOrigemId": {
+            "type": "string",
+            "format": "uuid"
           },
           "origemCandidatos": {
             "$ref": "#/components/schemas/OrigemCandidatos"
@@ -5891,6 +6074,30 @@
           },
           "baseadoEmEnem": {
             "type": "boolean"
+          }
+        }
+      },
+      "DefinirConfiguracaoDivulgacaoRequest": {
+        "required": [
+          "camposPublicos",
+          "justificativa"
+        ],
+        "type": "object",
+        "properties": {
+          "camposPublicos": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "justificativa": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -6522,6 +6729,61 @@
           }
         }
       },
+      "FatoFormularioRenderizavelDto": {
+        "required": [
+          "fatoCodigo",
+          "ordem",
+          "rotulo",
+          "tipoRenderizacao",
+          "obrigatorio",
+          "precondicao",
+          "valoresSelecionaveis"
+        ],
+        "type": "object",
+        "properties": {
+          "fatoCodigo": {
+            "type": "string"
+          },
+          "ordem": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "rotulo": {
+            "type": "string"
+          },
+          "tipoRenderizacao": {
+            "type": "string"
+          },
+          "obrigatorio": {
+            "type": "boolean"
+          },
+          "precondicao": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/CondicaoPrecondicaoDto"
+              }
+            }
+          },
+          "valoresSelecionaveis": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ValorSelecionavelDto"
+            }
+          }
+        }
+      },
       "FecharRetificacaoRequest": {
         "required": [
           "numero",
@@ -6578,7 +6840,7 @@
           "fatosColetados": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/FatoColetadoDto"
+              "$ref": "#/components/schemas/FatoFormularioRenderizavelDto"
             }
           }
         }
@@ -7451,7 +7713,7 @@
         "required": [
           "id",
           "nome",
-          "tipo",
+          "tipoProcesso",
           "status",
           "origemCandidatos",
           "unidadeAdministradora",
@@ -7470,6 +7732,7 @@
           "regrasDerivacao",
           "formularioTitulo",
           "formularioTermoAceiteTexto",
+          "configuracaoDivulgacao",
           "criadoEm"
         ],
         "type": "object",
@@ -7481,8 +7744,8 @@
           "nome": {
             "type": "string"
           },
-          "tipo": {
-            "type": "string"
+          "tipoProcesso": {
+            "$ref": "#/components/schemas/TipoProcessoSnapshotDto"
           },
           "status": {
             "type": "string"
@@ -7603,6 +7866,16 @@
               "string"
             ]
           },
+          "configuracaoDivulgacao": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ConfiguracaoDivulgacaoDto"
+              }
+            ]
+          },
           "criadoEm": {
             "type": "string",
             "format": "date-time"
@@ -7622,7 +7895,7 @@
         "required": [
           "id",
           "nome",
-          "tipo",
+          "tipoProcesso",
           "status",
           "criadoEm"
         ],
@@ -7635,8 +7908,8 @@
           "nome": {
             "type": "string"
           },
-          "tipo": {
-            "type": "string"
+          "tipoProcesso": {
+            "$ref": "#/components/schemas/TipoProcessoSnapshotDto"
           },
           "status": {
             "type": "string"
@@ -8250,19 +8523,25 @@
           }
         }
       },
-      "TipoProcesso": {
-        "enum": [
-          "nenhum",
-          "siSU",
-          "psiq",
-          "pseCampo",
-          "psvr",
-          "transferenciaInterna",
-          "transferenciaExterna",
-          "portadorDiploma",
-          "reopcao"
+      "TipoProcessoSnapshotDto": {
+        "required": [
+          "origemId",
+          "codigo",
+          "nome"
         ],
-        "type": "string"
+        "type": "object",
+        "properties": {
+          "origemId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "codigo": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          }
+        }
       },
       "UnidadeAdministradoraSnapshotDto": {
         "required": [
@@ -8378,6 +8657,33 @@
             "type": "string"
           },
           "quantidade": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          }
+        }
+      },
+      "ValorSelecionavelDto": {
+        "required": [
+          "codigo",
+          "descricao",
+          "ordem"
+        ],
+        "type": "object",
+        "properties": {
+          "codigo": {
+            "type": "string"
+          },
+          "descricao": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "ordem": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
             "type": [
               "integer",

--- a/libs/shared-data/selecao/src/index.ts
+++ b/libs/shared-data/selecao/src/index.ts
@@ -1,2 +1,2 @@
-export { SELECAO_BASE_PATH } from '../../src/lib/api/selecao/tokens';
+export * from '../../src/lib/api/selecao/index';
 export type { Cota, ModalidadeConcorrencia } from '../../src/lib/models/cota.model';

--- a/libs/shared-data/src/lib/api/configuracao/index.ts
+++ b/libs/shared-data/src/lib/api/configuracao/index.ts
@@ -82,6 +82,11 @@ export {
   type TiposBancaQuery,
 } from './tipos-banca.api';
 export {
+  TiposProcessoApi,
+  type TipoProcessoDto,
+  type TiposProcessoQuery,
+} from './tipos-processo.api';
+export {
   TiposDocumentoApi,
   CATEGORIAS_DOCUMENTO,
   type AtualizarTipoDocumentoCommand,

--- a/libs/shared-data/src/lib/api/configuracao/schema.ts
+++ b/libs/shared-data/src/lib/api/configuracao/schema.ts
@@ -6735,6 +6735,409 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/api/configuracao/tipos-processo": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get: {
+            readonly parameters: {
+                readonly query?: {
+                    /** @description Cursor opaco AES-GCM emitido pelo servidor no header Link da página anterior. Ausente na primeira página. Cliente trata como string opaca — não decodificar (ADR-0026, ADR-0031). */
+                    readonly cursor?: string;
+                    /** @description Tamanho máximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026). */
+                    readonly limit?: number;
+                    /** @description Direção de navegação keyset (ADR-0089): 'next' (default) avança, 'prev' retrocede. Normalmente o cliente apenas segue o cursor opaco do rel="prev"/rel="next" do header Link — que já inclui o direction correto. */
+                    readonly direction?: PathsApiConfiguracaoTiposProcessoGetParametersQueryDirection;
+                };
+                readonly header?: never;
+                readonly path?: never;
+                readonly cookie?: never;
+            };
+            readonly requestBody?: never;
+            readonly responses: {
+                /** @description OK */
+                readonly 200: {
+                    headers: {
+                        /** @description Links de navegação da paginação (RFC 5988/8288). rel="self" sempre presente; rel="prev"/rel="next" quando há página anterior/próxima (ADR-0089). Cada link carrega o cursor opaco no parâmetro `cursor` e o `direction` correspondente (ADR-0026). */
+                        readonly Link?: string;
+                        /** @description Quantidade de itens retornados na página atual (sempre menor ou igual ao limit efetivo). */
+                        readonly "X-Page-Size"?: number;
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "text/plain": readonly components["schemas"]["TipoProcessoDto"][];
+                        readonly "application/json": readonly components["schemas"]["TipoProcessoDto"][];
+                        readonly "text/json": readonly components["schemas"]["TipoProcessoDto"][];
+                    };
+                };
+                /** @description Bad Request */
+                readonly 400: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Not Acceptable */
+                readonly 406: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Gone */
+                readonly 410: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Unprocessable Entity */
+                readonly 422: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/api/configuracao/tipos-processo/{id}": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get: {
+            readonly parameters: {
+                readonly query?: never;
+                readonly header?: never;
+                readonly path: {
+                    readonly id: string;
+                };
+                readonly cookie?: never;
+            };
+            readonly requestBody?: never;
+            readonly responses: {
+                /** @description OK */
+                readonly 200: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "text/plain": components["schemas"]["TipoProcessoDto"];
+                        readonly "application/json": components["schemas"]["TipoProcessoDto"];
+                        readonly "text/json": components["schemas"]["TipoProcessoDto"];
+                    };
+                };
+                /** @description Not Found */
+                readonly 404: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Not Acceptable */
+                readonly 406: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        readonly put?: never;
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/api/configuracao/admin/tipos-processo": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put?: never;
+        readonly post: {
+            readonly parameters: {
+                readonly query?: never;
+                readonly header: {
+                    /** @description Chave opaca (1-255 ASCII printable, sem ',' ou ';') para retry seguro do comando. Replay com mesma key + mesmo body retorna response cacheada (ADR-0027). */
+                    readonly "Idempotency-Key": string;
+                };
+                readonly path?: never;
+                readonly cookie?: never;
+            };
+            readonly requestBody: {
+                readonly content: {
+                    readonly "application/json": components["schemas"]["CriarTipoProcessoCommand"];
+                    readonly "text/json": components["schemas"]["CriarTipoProcessoCommand"];
+                    readonly "application/*+json": components["schemas"]["CriarTipoProcessoCommand"];
+                };
+            };
+            readonly responses: {
+                /** @description Created */
+                readonly 201: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "text/plain": string;
+                        readonly "application/json": string;
+                        readonly "text/json": string;
+                    };
+                };
+                /** @description Bad Request */
+                readonly 400: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Unauthorized */
+                readonly 401: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Forbidden */
+                readonly 403: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Conflict */
+                readonly 409: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Corpo acima do limite dos endpoints idempotentes (uniplus.idempotency.body_muito_grande). O limite é do filtro, não do servidor. */
+                readonly 413: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Unprocessable Entity */
+                readonly 422: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/api/configuracao/admin/tipos-processo/{id}": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put: {
+            readonly parameters: {
+                readonly query?: never;
+                readonly header: {
+                    /** @description Chave opaca (1-255 ASCII printable, sem ',' ou ';') para retry seguro do comando. Replay com mesma key + mesmo body retorna response cacheada (ADR-0027). */
+                    readonly "Idempotency-Key": string;
+                };
+                readonly path: {
+                    readonly id: string;
+                };
+                readonly cookie?: never;
+            };
+            readonly requestBody: {
+                readonly content: {
+                    readonly "application/json": components["schemas"]["AtualizarTipoProcessoCommand"];
+                    readonly "text/json": components["schemas"]["AtualizarTipoProcessoCommand"];
+                    readonly "application/*+json": components["schemas"]["AtualizarTipoProcessoCommand"];
+                };
+            };
+            readonly responses: {
+                /** @description No Content */
+                readonly 204: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Bad Request */
+                readonly 400: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Unauthorized */
+                readonly 401: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Forbidden */
+                readonly 403: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Not Found */
+                readonly 404: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Conflict */
+                readonly 409: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Corpo acima do limite dos endpoints idempotentes (uniplus.idempotency.body_muito_grande). O limite é do filtro, não do servidor. */
+                readonly 413: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Unprocessable Entity */
+                readonly 422: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        readonly post?: never;
+        readonly delete: {
+            readonly parameters: {
+                readonly query?: never;
+                readonly header?: never;
+                readonly path: {
+                    readonly id: string;
+                };
+                readonly cookie?: never;
+            };
+            readonly requestBody?: never;
+            readonly responses: {
+                /** @description No Content */
+                readonly 204: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Unauthorized */
+                readonly 401: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Forbidden */
+                readonly 403: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Not Found */
+                readonly 404: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Unprocessable Entity */
+                readonly 422: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -6890,6 +7293,12 @@ export interface components {
             /** Format: int32 */
             readonly tamanhoMaximoMb?: null | number | string;
             readonly tipoEquivalente?: null | string;
+        };
+        readonly AtualizarTipoProcessoCommand: {
+            /** Format: uuid */
+            readonly id: string;
+            readonly nome: string;
+            readonly descricao?: null | string;
         };
         readonly AuthenticatedUserResponse: {
             readonly userId: null | string;
@@ -7108,6 +7517,11 @@ export interface components {
             /** Format: int32 */
             readonly tamanhoMaximoMb?: null | number | string;
             readonly tipoEquivalente?: null | string;
+        };
+        readonly CriarTipoProcessoCommand: {
+            readonly codigo: string;
+            readonly nome: string;
+            readonly descricao?: null | string;
         };
         readonly CursoDto: {
             /** Format: uuid */
@@ -7435,6 +7849,19 @@ export interface components {
         };
         /** @enum {string} */
         readonly TipoLocalOferta: TipoLocalOferta;
+        readonly TipoProcessoDto: {
+            /** Format: uuid */
+            readonly id: string;
+            readonly codigo: string;
+            readonly nome: string;
+            readonly descricao: null | string;
+            readonly ativo: boolean;
+            /** Format: date-time */
+            readonly criadoEm: string;
+            readonly _links?: null | {
+                readonly [key: string]: string;
+            };
+        };
         readonly UnidadeOfertanteDto: {
             /** Format: uuid */
             readonly origemId: string;
@@ -7582,6 +8009,10 @@ export enum PathsApiConfiguracaoTiposDeficienciaGetParametersQueryDirection {
     prev = "prev"
 }
 export enum PathsApiConfiguracaoTiposDocumentoGetParametersQueryDirection {
+    next = "next",
+    prev = "prev"
+}
+export enum PathsApiConfiguracaoTiposProcessoGetParametersQueryDirection {
     next = "next",
     prev = "prev"
 }

--- a/libs/shared-data/src/lib/api/configuracao/tipos-processo.api.spec.ts
+++ b/libs/shared-data/src/lib/api/configuracao/tipos-processo.api.spec.ts
@@ -1,0 +1,71 @@
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  ApiResult,
+  apiResultInterceptor,
+  buildVendorMimeAccept,
+  isApiOk,
+} from '@uniplus/shared-core/http';
+import { TipoProcessoDto, TiposProcessoApi } from './tipos-processo.api';
+import { CONFIGURACAO_BASE_PATH } from './tokens';
+
+const BASE = 'http://localhost:5000';
+const ID = '01960000-0000-7000-0000-000000000051';
+
+const tipoSeed: TipoProcessoDto = {
+  id: ID,
+  codigo: 'SISU',
+  nome: 'SiSU',
+  descricao: 'Sistema de Seleção Unificada.',
+  ativo: true,
+  criadoEm: '2026-08-11T12:00:00Z',
+};
+
+describe('TiposProcessoApi', () => {
+  let api: TiposProcessoApi;
+  let controller: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([apiResultInterceptor])),
+        provideHttpClientTesting(),
+        { provide: CONFIGURACAO_BASE_PATH, useValue: BASE },
+      ],
+    });
+    api = TestBed.inject(TiposProcessoApi);
+    controller = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => controller.verify());
+
+  it('listar() faz GET público com limit e Accept tipo-processo v1', async () => {
+    const promise = firstValueFrom(api.listar({ limit: 50 }));
+    const req = controller.expectOne(`${BASE}/api/configuracao/tipos-processo?limit=50`);
+
+    expect(req.request.method).toBe('GET');
+    expect(req.request.headers.get('Accept')).toBe(buildVendorMimeAccept('tipo-processo', 1));
+    req.flush([tipoSeed]);
+
+    const result = (await promise) as ApiResult<readonly TipoProcessoDto[]>;
+    expect(isApiOk(result)).toBe(true);
+    if (result.ok) expect(result.data).toEqual([tipoSeed]);
+  });
+
+  it('listar() repassa o cursor opaco sem decodificá-lo', async () => {
+    const cursor = 'aes-gcm:V2l0aCtwbHVzL3NpZ25zPT0=';
+    const promise = firstValueFrom(api.listar({ cursor, direction: 'prev' }));
+    const req = controller.expectOne(
+      (request) => request.url === `${BASE}/api/configuracao/tipos-processo`,
+    );
+
+    expect(req.request.params.get('cursor')).toBe(cursor);
+    expect(req.request.params.get('direction')).toBe('prev');
+    expect(req.request.params.has('limit')).toBe(false);
+    req.flush([tipoSeed]);
+    await promise;
+  });
+});

--- a/libs/shared-data/src/lib/api/configuracao/tipos-processo.api.ts
+++ b/libs/shared-data/src/lib/api/configuracao/tipos-processo.api.ts
@@ -1,0 +1,43 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiResult, withVendorMime } from '@uniplus/shared-core/http';
+import type { components } from './schema';
+import { CONFIGURACAO_BASE_PATH } from './tokens';
+
+export type TipoProcessoDto = components['schemas']['TipoProcessoDto'];
+
+/** Filtro da listagem pública paginada de tipos ativos (cursor opaco, ADR-0026). */
+export interface TiposProcessoQuery {
+  readonly cursor?: string;
+  readonly direction?: 'next' | 'prev';
+  readonly limit?: number;
+}
+
+/**
+ * Cliente de leitura pública dos tipos de Processo Seletivo configuráveis.
+ *
+ * A origem dos tipos é o módulo Configuração; consumidores de Seleção devem
+ * guardar o `id` retornado ao criar um Processo Seletivo, sem manter um
+ * vocabulário local dos tipos semeados (ADR-0122 da API).
+ */
+@Injectable({ providedIn: 'root' })
+export class TiposProcessoApi {
+  private readonly http = inject(HttpClient);
+  private readonly basePath = inject(CONFIGURACAO_BASE_PATH);
+
+  /** GET `/api/configuracao/tipos-processo` — itens ativos, paginação por cursor opaco. */
+  listar(query: TiposProcessoQuery = {}): Observable<ApiResult<readonly TipoProcessoDto[]>> {
+    let params = new HttpParams();
+    if (query.cursor !== undefined) {
+      params = params.set('cursor', query.cursor).set('direction', query.direction ?? 'next');
+    } else {
+      params = params.set('limit', String(query.limit ?? 100));
+    }
+
+    return this.http.get<ApiResult<readonly TipoProcessoDto[]>>(
+      `${this.basePath}/api/configuracao/tipos-processo`,
+      { params, context: withVendorMime('tipo-processo', 1) },
+    );
+  }
+}

--- a/libs/shared-data/src/lib/api/selecao/index.ts
+++ b/libs/shared-data/src/lib/api/selecao/index.ts
@@ -1,5 +1,14 @@
 export { SELECAO_BASE_PATH } from './tokens';
 export {
+  ProcessosSeletivosApi,
+  type CriarProcessoSeletivoCommand,
+  type ProcessoSeletivoDto,
+  type ProcessoSeletivoResumoDto,
+  type ProcessosSeletivosQuery,
+  type TipoProcessoSnapshotDto,
+} from './processos-seletivos.api';
+export { OrigemCandidatos } from './schema';
+export {
   ObrigatoriedadesLegaisApi,
   type AtualizarObrigatoriedadeLegalCommand,
   type CategoriaObrigatoriedade,

--- a/libs/shared-data/src/lib/api/selecao/processos-seletivos.api.spec.ts
+++ b/libs/shared-data/src/lib/api/selecao/processos-seletivos.api.spec.ts
@@ -1,0 +1,108 @@
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  ApiResult,
+  apiResultInterceptor,
+  buildVendorMimeAccept,
+  isApiOk,
+  withIdempotencyKey,
+} from '@uniplus/shared-core/http';
+import {
+  CriarProcessoSeletivoCommand,
+  ProcessoSeletivoDto,
+  ProcessoSeletivoResumoDto,
+  ProcessosSeletivosApi,
+  TipoProcessoSnapshotDto,
+} from './processos-seletivos.api';
+import { OrigemCandidatos } from './schema';
+import { SELECAO_BASE_PATH } from './tokens';
+
+const BASE = 'http://localhost:5000';
+const ID = '01960000-0000-7000-0000-000000000515';
+const TIPO_ID = '01960000-0000-7000-0000-000000000516';
+
+const tipoProcesso: TipoProcessoSnapshotDto = {
+  origemId: TIPO_ID,
+  codigo: 'SISU',
+  nome: 'SiSU',
+};
+
+const resumoSeed: ProcessoSeletivoResumoDto = {
+  id: ID,
+  nome: 'Processo Seletivo 2027',
+  tipoProcesso,
+  status: 'rascunho',
+  criadoEm: '2026-08-11T12:00:00Z',
+};
+
+const criarCommand: CriarProcessoSeletivoCommand = {
+  nome: 'Processo Seletivo 2027',
+  tipoProcessoOrigemId: TIPO_ID,
+  origemCandidatos: OrigemCandidatos.inscricaoPropria,
+  unidadeAdministradoraOrigemId: '01960000-0000-7000-000000000517',
+};
+
+describe('ProcessosSeletivosApi', () => {
+  let api: ProcessosSeletivosApi;
+  let controller: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([apiResultInterceptor])),
+        provideHttpClientTesting(),
+        { provide: SELECAO_BASE_PATH, useValue: BASE },
+      ],
+    });
+    api = TestBed.inject(ProcessosSeletivosApi);
+    controller = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => controller.verify());
+
+  it('listar() lê o snapshot de tipo retornado por Seleção', async () => {
+    const promise = firstValueFrom(api.listar());
+    const req = controller.expectOne(`${BASE}/api/selecao/processos-seletivos?limit=100`);
+
+    expect(req.request.method).toBe('GET');
+    expect(req.request.headers.get('Accept')).toBe(buildVendorMimeAccept('processo-seletivo', 1));
+    req.flush([resumoSeed]);
+
+    const result = (await promise) as ApiResult<readonly ProcessoSeletivoResumoDto[]>;
+    expect(isApiOk(result)).toBe(true);
+    if (result.ok) expect(result.data[0].tipoProcesso).toEqual(tipoProcesso);
+  });
+
+  it('obter() preserva o snapshot no detalhe sem consultar Configuração', async () => {
+    const promise = firstValueFrom(api.obter(ID));
+    const req = controller.expectOne(`${BASE}/api/selecao/processos-seletivos/${ID}`);
+
+    expect(req.request.method).toBe('GET');
+    req.flush({ ...resumoSeed } as ProcessoSeletivoDto);
+
+    const result = (await promise) as ApiResult<ProcessoSeletivoDto>;
+    expect(isApiOk(result)).toBe(true);
+    if (result.ok) expect(result.data.tipoProcesso.nome).toBe('SiSU');
+  });
+
+  it('criar() envia somente tipoProcessoOrigemId e preserva a Idempotency-Key', async () => {
+    const promise = firstValueFrom(
+      api.criar(criarCommand, withIdempotencyKey('processo-create-key')),
+    );
+    const req = controller.expectOne(`${BASE}/api/selecao/processos-seletivos`);
+
+    expect(req.request.method).toBe('POST');
+    expect(req.request.headers.get('Idempotency-Key')).toBe('processo-create-key');
+    expect(req.request.headers.get('Accept')).toBe('application/json');
+    expect(req.request.body).toEqual(criarCommand);
+    expect(req.request.body).toHaveProperty('tipoProcessoOrigemId', TIPO_ID);
+    expect(req.request.body).not.toHaveProperty('tipo');
+    req.flush(ID, { status: 201, statusText: 'Created' });
+
+    const result = (await promise) as ApiResult<string>;
+    expect(isApiOk(result)).toBe(true);
+  });
+});

--- a/libs/shared-data/src/lib/api/selecao/processos-seletivos.api.ts
+++ b/libs/shared-data/src/lib/api/selecao/processos-seletivos.api.ts
@@ -1,0 +1,68 @@
+import { HttpClient, HttpContext, HttpHeaders, HttpParams } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiResult, withVendorMime } from '@uniplus/shared-core/http';
+import type { components } from './schema';
+import { SELECAO_BASE_PATH } from './tokens';
+
+export type CriarProcessoSeletivoCommand = components['schemas']['CriarProcessoSeletivoCommand'];
+export type ProcessoSeletivoDto = components['schemas']['ProcessoSeletivoDto'];
+export type ProcessoSeletivoResumoDto = components['schemas']['ProcessoSeletivoResumoDto'];
+export type TipoProcessoSnapshotDto = components['schemas']['TipoProcessoSnapshotDto'];
+
+/** Filtro da listagem de Processos Seletivos (cursor opaco, ADR-0026). */
+export interface ProcessosSeletivosQuery {
+  readonly cursor?: string;
+  readonly direction?: 'next' | 'prev';
+  readonly limit?: number;
+}
+
+/**
+ * Cliente do agregado raiz Processo Seletivo.
+ *
+ * Criação referencia um tipo ativo por UUID. Consultas leem o snapshot
+ * `tipoProcesso` retornado por Seleção, que não deve ser substituído por uma
+ * nova consulta ao catálogo vivo (ADR-0122 da API).
+ */
+@Injectable({ providedIn: 'root' })
+export class ProcessosSeletivosApi {
+  private readonly http = inject(HttpClient);
+  private readonly basePath = inject(SELECAO_BASE_PATH);
+
+  /** GET `/api/selecao/processos-seletivos` — lista paginada por cursor opaco. */
+  listar(
+    query: ProcessosSeletivosQuery = {},
+  ): Observable<ApiResult<readonly ProcessoSeletivoResumoDto[]>> {
+    let params = new HttpParams();
+    if (query.cursor !== undefined) {
+      params = params.set('cursor', query.cursor).set('direction', query.direction ?? 'next');
+    } else {
+      params = params.set('limit', String(query.limit ?? 100));
+    }
+
+    return this.http.get<ApiResult<readonly ProcessoSeletivoResumoDto[]>>(
+      `${this.basePath}/api/selecao/processos-seletivos`,
+      { params, context: withVendorMime('processo-seletivo', 1) },
+    );
+  }
+
+  /** GET `/api/selecao/processos-seletivos/{id}` — detalhe e snapshot do tipo. */
+  obter(id: string): Observable<ApiResult<ProcessoSeletivoDto>> {
+    return this.http.get<ApiResult<ProcessoSeletivoDto>>(
+      `${this.basePath}/api/selecao/processos-seletivos/${encodeURIComponent(id)}`,
+      { context: withVendorMime('processo-seletivo', 1) },
+    );
+  }
+
+  /** POST `/api/selecao/processos-seletivos` — criação idempotente. */
+  criar(
+    command: CriarProcessoSeletivoCommand,
+    context: HttpContext,
+  ): Observable<ApiResult<string>> {
+    return this.http.post<ApiResult<string>>(
+      `${this.basePath}/api/selecao/processos-seletivos`,
+      command,
+      { context, headers: new HttpHeaders({ Accept: 'application/json' }) },
+    );
+  }
+}

--- a/libs/shared-data/src/lib/api/selecao/schema.ts
+++ b/libs/shared-data/src/lib/api/selecao/schema.ts
@@ -1747,6 +1747,134 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/api/selecao/processos-seletivos/{id}/divulgacao": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put: {
+            readonly parameters: {
+                readonly query?: never;
+                readonly header: {
+                    readonly "If-Match"?: string;
+                    /** @description Chave opaca (1-255 ASCII printable, sem ',' ou ';') para retry seguro do comando. Replay com mesma key + mesmo body retorna response cacheada (ADR-0027). */
+                    readonly "Idempotency-Key": string;
+                };
+                readonly path: {
+                    readonly id: string;
+                };
+                readonly cookie?: never;
+            };
+            readonly requestBody: {
+                readonly content: {
+                    readonly "application/json": components["schemas"]["DefinirConfiguracaoDivulgacaoRequest"];
+                    readonly "text/json": components["schemas"]["DefinirConfiguracaoDivulgacaoRequest"];
+                    readonly "application/*+json": components["schemas"]["DefinirConfiguracaoDivulgacaoRequest"];
+                };
+            };
+            readonly responses: {
+                /** @description No Content */
+                readonly 204: {
+                    headers: {
+                        /** @description ETag forte da sessão editorial de retificação, no formato "{idDaSessao}:{revisao}". Devolva-o no If-Match da próxima mutação. Toda mutação aceita INCREMENTA a revisão e emite o tag novo aqui — o cliente encadeia sem um GET no meio. Ausente quando não há sessão em curso (o processo em rascunho não tem precondição a satisfazer). */
+                        readonly ETag?: string;
+                        readonly [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Bad Request */
+                readonly 400: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Requisição não autenticada — token ausente ou inválido (a rota exige autenticação). Também emitido quando o principal é exigido e não está presente (uniplus.idempotency.principal_requerido). */
+                readonly 401: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Autenticado, mas sem a autorização exigida pela rota (ex.: a role plataforma-admin). */
+                readonly 403: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Not Found */
+                readonly 404: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Requisição concorrente com a mesma Idempotency-Key ainda em processamento (uniplus.idempotency.processing_conflict). Repetir depois — a operação anterior ainda não concluiu. */
+                readonly 409: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Precondition Failed */
+                readonly 412: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Corpo acima do limite dos endpoints idempotentes (uniplus.idempotency.body_muito_grande). O limite é do filtro, não do servidor. */
+                readonly 413: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Unprocessable Entity */
+                readonly 422: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Precondition Required */
+                readonly 428: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/api/selecao/processos-seletivos/{id}/cascata-remanejamento": {
         readonly parameters: {
             readonly query?: never;
@@ -3810,6 +3938,10 @@ export interface components {
             readonly modalidadeIds: readonly string[];
             readonly quadro: readonly components["schemas"]["QuantidadeVagaInput"][];
         };
+        readonly ConfiguracaoDivulgacaoDto: {
+            readonly camposPublicos: readonly string[];
+            readonly justificativa: null | string;
+        };
         readonly ConformidadeLegalProcessoSeletivoDto: {
             /** Format: uuid */
             readonly processoSeletivoId: string;
@@ -3839,7 +3971,8 @@ export interface components {
         };
         readonly CriarProcessoSeletivoCommand: {
             readonly nome: string;
-            readonly tipo: components["schemas"]["TipoProcesso"];
+            /** Format: uuid */
+            readonly tipoProcessoOrigemId: string;
             readonly origemCandidatos: components["schemas"]["OrigemCandidatos"];
             /** Format: uuid */
             readonly unidadeAdministradoraOrigemId: string;
@@ -3910,6 +4043,10 @@ export interface components {
             readonly nOpcoesAlocacao: number | string;
             readonly regrasEliminacao: readonly components["schemas"]["RegraEliminacaoInput"][];
             readonly baseadoEmEnem: boolean;
+        };
+        readonly DefinirConfiguracaoDivulgacaoRequest: {
+            readonly camposPublicos: null | readonly string[];
+            readonly justificativa: null | string;
         };
         readonly DefinirFormularioRequest: {
             readonly titulo: null | string;
@@ -4054,6 +4191,16 @@ export interface components {
             readonly obrigatorio: boolean;
             readonly precondicao: null | readonly (readonly components["schemas"]["CondicaoPrecondicaoInput"][])[];
         };
+        readonly FatoFormularioRenderizavelDto: {
+            readonly fatoCodigo: string;
+            /** Format: int32 */
+            readonly ordem: number | string;
+            readonly rotulo: string;
+            readonly tipoRenderizacao: string;
+            readonly obrigatorio: boolean;
+            readonly precondicao: null | readonly (readonly components["schemas"]["CondicaoPrecondicaoDto"][])[];
+            readonly valoresSelecionaveis: null | readonly components["schemas"]["ValorSelecionavelDto"][];
+        };
         readonly FecharRetificacaoRequest: {
             readonly numero: null | string;
             /** Format: date */
@@ -4067,7 +4214,7 @@ export interface components {
         readonly FormularioRenderizavelDto: {
             readonly titulo: null | string;
             readonly termoAceiteTexto: null | string;
-            readonly fatosColetados: readonly components["schemas"]["FatoColetadoDto"][];
+            readonly fatosColetados: readonly components["schemas"]["FatoFormularioRenderizavelDto"][];
         };
         readonly IdadeMaximaEmissaoDto: {
             /** Format: int32 */
@@ -4269,7 +4416,7 @@ export interface components {
             /** Format: uuid */
             readonly id: string;
             readonly nome: string;
-            readonly tipo: string;
+            readonly tipoProcesso: components["schemas"]["TipoProcessoSnapshotDto"];
             readonly status: string;
             readonly origemCandidatos: string;
             readonly unidadeAdministradora: components["schemas"]["UnidadeAdministradoraSnapshotDto"];
@@ -4288,6 +4435,7 @@ export interface components {
             readonly regrasDerivacao: readonly components["schemas"]["ConfiguracaoDerivacaoDto"][];
             readonly formularioTitulo: null | string;
             readonly formularioTermoAceiteTexto: null | string;
+            readonly configuracaoDivulgacao: null | components["schemas"]["ConfiguracaoDivulgacaoDto"];
             /** Format: date-time */
             readonly criadoEm: string;
             readonly _links?: null | {
@@ -4298,7 +4446,7 @@ export interface components {
             /** Format: uuid */
             readonly id: string;
             readonly nome: string;
-            readonly tipo: string;
+            readonly tipoProcesso: components["schemas"]["TipoProcessoSnapshotDto"];
             readonly status: string;
             /** Format: date-time */
             readonly criadoEm: string;
@@ -4454,8 +4602,12 @@ export interface components {
             readonly hashEdital: string;
             readonly configuracao: components["schemas"]["JsonNode"];
         };
-        /** @enum {string} */
-        readonly TipoProcesso: TipoProcesso;
+        readonly TipoProcessoSnapshotDto: {
+            /** Format: uuid */
+            readonly origemId: string;
+            readonly codigo: string;
+            readonly nome: string;
+        };
         readonly UnidadeAdministradoraSnapshotDto: {
             /** Format: uuid */
             readonly origemId: string;
@@ -4485,6 +4637,12 @@ export interface components {
             readonly modalidadeCodigo: string;
             /** Format: int32 */
             readonly quantidade: number | string;
+        };
+        readonly ValorSelecionavelDto: {
+            readonly codigo: string;
+            readonly descricao: null | string;
+            /** Format: int32 */
+            readonly ordem: number | string;
         };
     };
     responses: never;
@@ -4603,17 +4761,6 @@ export enum PredicadoObrigatoriedadeEtapaObrigatoria$tipo {
 }
 export enum PredicadoObrigatoriedadeModalidadesMinimas$tipo {
     modalidadesMinimas = "modalidadesMinimas"
-}
-export enum TipoProcesso {
-    nenhum = "nenhum",
-    siSU = "siSU",
-    psiq = "psiq",
-    pseCampo = "pseCampo",
-    psvr = "psvr",
-    transferenciaInterna = "transferenciaInterna",
-    transferenciaExterna = "transferenciaExterna",
-    portadorDiploma = "portadorDiploma",
-    reopcao = "reopcao"
 }
 export enum UnidadePrazo {
     nenhuma = "nenhuma",


### PR DESCRIPTION
## Resumo

- sincroniza os contratos OpenAPI de Configuração e Seleção com a API estabilizada;
- adiciona clientes tipados para catálogo de tipos de processo e Processo Seletivo, com cursor opaco, vendor MIME, idempotência e snapshots;
- substitui a lista local do primeiro passo pelo catálogo configurável, com estados de carregamento, vazio, erro e nova tentativa;
- estabiliza a matriz E2E com o contrato do catálogo, sem depender de dados hardcoded nem da API ausente no CI;
- cobre URL, headers, payload com tipoProcessoOrigemId, snapshot, falha HTTP normalizada e acessibilidade do passo.

## Impacto

O frontend deixa de tratar Edital como sinônimo do agregado e deixa de manter tipos de processo em código. A criação referencia o UUID configurado pela API.

## Validação

- npm run generate:api
- npx nx run shared-data:codegen-api-check --skip-nx-cache
- npx nx lint shared-data --skip-nx-cache
- npx nx lint selecao --skip-nx-cache
- npx nx lint selecao-e2e --skip-nx-cache
- npx nx vite:test shared-data --skip-nx-cache — 252 testes
- npx nx vite:test selecao --skip-nx-cache — 51 testes
- npx nx build shared-data --skip-nx-cache
- npx nx build selecao --configuration=production --skip-nx-cache
- CI do GitHub concluído verde, incluindo a matriz E2E

O build de Seleção conclui com o aviso de orçamento já presente na main: 528,38 kB neste branch, ante 525,26 kB na base, para limite de 500 kB.

Closes #515