### PR TITLE
fix(shared-ui): adiciona entrypoint de pipes no módulo shared-ui

### DIFF
--- a/libs/shared-data/src/lib/__fitness__/public-entrypoints.fitness.spec.ts
+++ b/libs/shared-data/src/lib/__fitness__/public-entrypoints.fitness.spec.ts
@@ -24,6 +24,7 @@ const ENTRYPOINTS = {
   '@uniplus/shared-ui/shell': 'libs/shared-ui/shell',
   '@uniplus/shared-auth/bootstrap': 'libs/shared-auth/bootstrap',
   '@uniplus/shared-auth/components': 'libs/shared-auth/components',
+  '@uniplus/shared-ui/pipes': 'libs/shared-ui/pipes',
   '@uniplus/shared-auth/guards': 'libs/shared-auth/guards',
   '@uniplus/shared-auth/interceptors': 'libs/shared-auth/interceptors',
   '@uniplus/shared-data/config': 'libs/shared-data/config',

--- a/libs/shared-ui/pipes/README.md
+++ b/libs/shared-ui/pipes/README.md
@@ -1,0 +1,3 @@
+# @uniplus/shared-ui/pipes
+
+Secondary entry point of `@uniplus/shared-ui`. It can be used by importing from `@uniplus/shared-ui/pipes`.

--- a/libs/shared-ui/pipes/ng-package.json
+++ b/libs/shared-ui/pipes/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "../src/lib/pipes/index.ts"
+  }
+}

--- a/libs/shared-ui/pipes/src/index.ts
+++ b/libs/shared-ui/pipes/src/index.ts
@@ -1,0 +1,4 @@
+export { CpfPipe } from '../../src/lib/pipes/cpf.pipe';
+export { DateBrPipe } from '../../src/lib/pipes/date-br.pipe';
+export { NomeSocialPipe } from '../../src/lib/pipes/nome-social.pipe';
+

--- a/libs/shared-ui/src/lib/pipes/index.ts
+++ b/libs/shared-ui/src/lib/pipes/index.ts
@@ -1,0 +1,3 @@
+export { CpfPipe } from './cpf.pipe';
+export { DateBrPipe } from './date-br.pipe';
+export { NomeSocialPipe } from './nome-social.pipe';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -29,6 +29,7 @@
       "@uniplus/shared-ui/shell": ["libs/shared-ui/shell/src/index.ts"],
       "@uniplus/shared-ui/notifications": ["libs/shared-ui/notifications/src/index.ts"],
       "@uniplus/shared-ui/components": ["libs/shared-ui/components/src/index.ts"],
+      "@uniplus/shared-ui/pipes": ["libs/shared-ui/pipes/src/index.ts"],
       "@uniplus/shared-auth/bootstrap": ["libs/shared-auth/bootstrap/src/index.ts"],
       "@uniplus/shared-auth/guards": ["libs/shared-auth/guards/src/index.ts"],
       "@uniplus/shared-auth/components": ["libs/shared-auth/components/src/index.ts"],


### PR DESCRIPTION
## Resumo

Adiciona entrypoint de pipes para o módulo `shared-ui`.

Closes #519

## Mudanças

<!-- Lista detalhada das mudanças por categoria -->

### Novos arquivos
- libs/shared-ui/pipes/README.md
- libs/shared-ui/pipes/ng-package.json
- libs/shared-ui/pipes/src/index.ts
- libs/shared-ui/src/lib/pipes/index.ts

### Modificados
- libs/shared-data/src/lib/__fitness__/public-entrypoints.fitness.spec.ts
- tsconfig.base.json

## Testes

- [x] Testes unitários passando.

## Checklist

- [x] Pipes importando de `@shared-ui/pipes` ao invés de `@shared-ui`
- [x] Path criado em tsconfig.base.json
- [x] Criar ng-package.json configurado e README.md com a descrição correspondente.
- [x] Entrypoint em libs/shared-data/src/lib/__fitness__/public-entrypoints.fitness.spec.ts
- [x] Testes unitários passando: nx run shared-ui:test
