### PR TITLE
feat(selecao): cria o processo seletivo e anexa o edital no passo 2

### DIFF
--- a/apps/selecao-e2e/playwright.config.ts
+++ b/apps/selecao-e2e/playwright.config.ts
@@ -26,7 +26,16 @@ const storageStateAdmin = path.resolve(__dirname, STORAGE_STATE_PATH_ADMIN);
  * Adicionar novos sufixos especiais à alternation; demais projects herdam
  * automaticamente. Reduz drift quando 3º+ sufixo surgir (ex.: `.smoke`).
  */
-const EXCLUDED_FROM_UI_LOGIN_PROJECTS = /(.*\.(authenticated|ds-matrix|aaa)\.spec\.ts|auth\.setup\.ts)$/;
+const EXCLUDED_FROM_UI_LOGIN_PROJECTS =
+  /(.*\.(authenticated|ds-matrix|aaa|backend)\.spec\.ts|auth\.setup\.ts)$/;
+
+/**
+ * Specs `*.backend.spec.ts` exercitam a API, o Keycloak e o storage de verdade
+ * — criam registros e sobem arquivos. O CI só provisiona o Keycloak, então o
+ * project fica atrás de `E2E_BACKEND_REAL=1` e roda sob demanda, com a stack do
+ * `uniplus-api` no ar. Ver `docs/guia-testar-frontend-com-backend-local.md`.
+ */
+const RODAR_CONTRA_BACKEND_REAL = process.env['E2E_BACKEND_REAL'] === '1';
 
 const DS_MATRIX_VIEWPORTS = [
   { name: '320', viewport: { width: 320, height: 720 }, isMobile: true, hasTouch: true },
@@ -131,6 +140,20 @@ export default defineConfig({
         storageState: storageStateAdmin,
       },
     },
+
+    ...(RODAR_CONTRA_BACKEND_REAL
+      ? [
+          {
+            name: 'selecao-backend-real',
+            testMatch: /.*\.backend\.spec\.ts/,
+            dependencies: ['auth-setup'],
+            use: {
+              ...devices['Desktop Chrome'],
+              storageState: storageStateAdmin,
+            },
+          },
+        ]
+      : []),
 
     ...DS_MATRIX_PROJECTS,
     ...AAA_PROJECTS,

--- a/apps/selecao-e2e/src/specs/cadastro-inicial.backend.spec.ts
+++ b/apps/selecao-e2e/src/specs/cadastro-inicial.backend.spec.ts
@@ -1,0 +1,117 @@
+import { expect, test } from '../fixtures/auth.fixture';
+
+/**
+ * Exercita o cadastro inicial do Processo Seletivo contra a API real: criação
+ * do agregado, upload do edital direto ao storage por URL pré-assinada e
+ * confirmação server-side. O que este teste cobre e o unitário não: CORS do
+ * storage, a assinatura do PUT (o content type entra na assinatura), o papel
+ * exigido pelas rotas administrativas e o encadeamento real das três fases.
+ *
+ * Roda apenas com `E2E_BACKEND_REAL=1` e a stack do `uniplus-api` no ar — o CI
+ * provisiona só o Keycloak. Como escreve de verdade (cria processo e sobe
+ * arquivo), o ambiente alvo tem de ser descartável.
+ *
+ * ```bash
+ * E2E_BACKEND_REAL=1 npx nx e2e selecao-e2e --project=selecao-backend-real
+ * ```
+ *
+ * Duas dependências do ambiente, ambas verificáveis no seed:
+ * a unidade administradora escolhida precisa ter cidade cadastrada, e o papel
+ * administrativo precisa chegar no token do client `selecao-web`.
+ */
+
+/** PDF mínimo válido: a API confere a assinatura `%PDF-` do conteúdo. */
+const PDF_MINIMO = Buffer.from(
+  '%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n' +
+    '2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n' +
+    '3 0 obj<</Type/Page/MediaBox[0 0 200 200]/Parent 2 0 R>>endobj\n' +
+    'trailer<</Root 1 0 R>>\n%%EOF\n',
+  'utf-8',
+);
+
+test.describe('Cadastro inicial do processo seletivo', () => {
+  test('cria o processo e anexa o edital pelo fluxo real de upload', async ({ page }) => {
+    const sufixo = `${Date.now()}`;
+
+    await page.goto('/processo-seletivo');
+    await expect(page.getByRole('heading', { level: 1, name: /Tipo do processo/i })).toBeVisible();
+
+    // Passo 1 — o tipo vem do catálogo de Configuração; o rascunho guarda o UUID.
+    const primeiroTipo = page.locator('.type-card').first();
+    await expect(primeiroTipo).toBeVisible({ timeout: 15_000 });
+    await primeiroTipo.click();
+    await expect(primeiroTipo).toHaveClass(/is-selected/);
+    await page.getByRole('button', { name: 'Próximo' }).click();
+
+    // Passo 2 — identificação.
+    await expect(page.getByRole('heading', { level: 1, name: /Identificação/i })).toBeVisible();
+    await page.locator('#f-num').fill(`E2E-${sufixo}`);
+    await page.locator('#f-ano').fill('2027');
+    await page.locator('#f-data').fill('2027-03-01');
+    await page.locator('#f-orgao').fill('CEPS');
+    await page.locator('#f-periodo').selectOption('1º semestre');
+    await page.locator('#f-nome').fill(`Processo Seletivo E2E ${sufixo}`);
+
+    // A unidade precisa ter cidade cadastrada: a API recusa a criação sem ela
+    // (`ProcessoSeletivo.UnidadeAdministradoraSemCidade`). No seed local, a
+    // Pró-Reitoria de Ensino de Graduação é a que tem cidade.
+    const unidade = page.locator('#f-unidade');
+    const opcaoComCidade = unidade.locator('option', { hasText: 'PROEG' });
+    await expect(opcaoComCidade).toHaveCount(1, { timeout: 15_000 });
+    // O value é o UUID da unidade, gerado pelo seed — daí a leitura, em vez de
+    // um valor fixo no teste.
+    const valorUnidade = await opcaoComCidade.evaluate(
+      (option) => (option as HTMLOptionElement).value,
+    );
+    expect(valorUnidade).toBeTruthy();
+    await unidade.selectOption(valorUnidade);
+    await page.locator('#f-origem').selectOption('inscricaoPropria');
+
+    // Anexar dispara criação + iniciação + PUT no storage + confirmação.
+    await page.locator('#f-file').setInputFiles({
+      name: `edital-${sufixo}.pdf`,
+      mimeType: 'application/pdf',
+      buffer: PDF_MINIMO,
+    });
+
+    await expect(page.locator('.file-status')).toHaveText('Edital anexado', { timeout: 30_000 });
+    await expect(page.locator('.file-progress')).toHaveAttribute('aria-valuenow', '100');
+
+    // Criado o processo, os campos do comando não aceitam mais alteração.
+    await expect(page.locator('#f-nome')).toBeDisabled();
+    await expect(page.locator('#f-unidade')).toBeDisabled();
+    await expect(page.locator('#f-origem')).toBeDisabled();
+
+    // Com o edital confirmado, o passo libera o avanço.
+    await page.getByRole('button', { name: 'Próximo' }).click();
+    await expect(page.getByRole('heading', { level: 1, name: /Modalidades/i })).toBeVisible();
+  });
+
+  test('recusa arquivo que não é PDF antes de qualquer requisição', async ({ page }) => {
+    const requisicoesDeCriacao: string[] = [];
+    page.on('request', (req) => {
+      if (req.method() === 'POST' && req.url().includes('/api/selecao/processos-seletivos')) {
+        requisicoesDeCriacao.push(req.url());
+      }
+    });
+
+    await page.goto('/processo-seletivo');
+    const primeiroTipo = page.locator('.type-card').first();
+    await expect(primeiroTipo).toBeVisible({ timeout: 15_000 });
+    await primeiroTipo.click();
+    await page.getByRole('button', { name: 'Próximo' }).click();
+
+    // Todos os passos ficam montados no DOM, então sem esta âncora o teste
+    // passaria mesmo que o avanço tivesse falhado.
+    await expect(page.getByRole('heading', { level: 1, name: /Identificação/i })).toBeVisible();
+
+    await page.locator('#f-file').setInputFiles({
+      name: 'edital.docx',
+      mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      buffer: Buffer.from('conteudo qualquer', 'utf-8'),
+    });
+
+    await expect(page.getByRole('alert')).toContainText('deve ser um arquivo PDF');
+    expect(requisicoesDeCriacao).toEqual([]);
+  });
+});

--- a/apps/selecao-e2e/src/specs/cadastro-inicial.backend.spec.ts
+++ b/apps/selecao-e2e/src/specs/cadastro-inicial.backend.spec.ts
@@ -18,6 +18,10 @@ import { expect, test } from '../fixtures/auth.fixture';
  * Duas dependências do ambiente, ambas verificáveis no seed:
  * a unidade administradora escolhida precisa ter cidade cadastrada, e o papel
  * administrativo precisa chegar no token do client `selecao-web`.
+ *
+ * O conteúdo exercitado é o do certame de Medicina 2027 do CEPS — o mesmo que a
+ * coleção Newman de cadastro monta chamando a API direto. Aqui ele passa pela
+ * interface, que é o que a coleção não cobre.
  */
 
 /** PDF mínimo válido: a API confere a assinatura `%PDF-` do conteúdo. */
@@ -43,18 +47,20 @@ test.describe('Cadastro inicial do processo seletivo', () => {
     await expect(primeiroTipo).toHaveClass(/is-selected/);
     await page.getByRole('button', { name: 'Próximo' }).click();
 
-    // Passo 2 — identificação.
+    // Passo 2 — identificação, com o conteúdo do certame de Medicina: o mesmo
+    // que a coleção Newman de cadastro monta pela API, aqui percorrido pela
+    // interface.
     await expect(page.getByRole('heading', { level: 1, name: /Identificação/i })).toBeVisible();
-    await page.locator('#f-num').fill(`E2E-${sufixo}`);
-    await page.locator('#f-ano').fill('2027');
-    await page.locator('#f-data').fill('2027-03-01');
+    await page.locator('#f-num').fill(`${sufixo.slice(-3)}/2026`);
+    await page.locator('#f-ano').fill('2026');
+    await page.locator('#f-data').fill('2026-09-23');
     await page.locator('#f-orgao').fill('CEPS');
     await page.locator('#f-periodo').selectOption('1º semestre');
-    await page.locator('#f-nome').fill(`Processo Seletivo E2E ${sufixo}`);
+    await page.locator('#f-nome').fill(`Medicina 2027 — CEPS — E2E ${sufixo}`);
 
     // A unidade precisa ter cidade cadastrada: a API recusa a criação sem ela
-    // (`ProcessoSeletivo.UnidadeAdministradoraSemCidade`). No seed local, a
-    // Pró-Reitoria de Ensino de Graduação é a que tem cidade.
+    // (`ProcessoSeletivo.UnidadeAdministradoraSemCidade`). A Pró-Reitoria de
+    // Ensino de Graduação, em Marabá, é a administradora do certame.
     const unidade = page.locator('#f-unidade');
     const opcaoComCidade = unidade.locator('option', { hasText: 'PROEG' });
     await expect(opcaoComCidade).toHaveCount(1, { timeout: 15_000 });

--- a/apps/selecao/src/app/app.routes.ts
+++ b/apps/selecao/src/app/app.routes.ts
@@ -11,10 +11,11 @@ export const appRoutes: Routes = [
   },
   {
     // Backoffice Seleção: todas as rotas exigem autenticação.
-    // Roles elegíveis nesta SPA: admin, gestor, avaliador.
+    // Roles elegíveis nesta SPA: admin, gestor, avaliador e plataforma-admin —
+    // este último para a administração do certame, restrita por rota abaixo.
     path: '',
     loadComponent: () => import('./layout/layout').then((m) => m.LayoutComponent),
-    canActivate: [authGuard, roleGuard('admin', 'gestor', 'avaliador')],
+    canActivate: [authGuard, roleGuard('admin', 'gestor', 'avaliador', 'plataforma-admin')],
     children: [
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
       {
@@ -23,7 +24,12 @@ export const appRoutes: Routes = [
           import('./features/dashboard/dashboard.routes').then((m) => m.DASHBOARD_ROUTES),
       },
       {
+        // Cadastro e configuração do certame são administração de plataforma:
+        // as rotas correspondentes da API exigem `plataforma-admin`, e sem o
+        // mesmo papel aqui um gestor entraria na tela só para receber 403 na
+        // primeira gravação.
         path: 'processo-seletivo',
+        canActivate: [roleGuard('plataforma-admin')],
         loadChildren: () =>
           import('./features/processo-seletivo/processo-seletivo.routes').then((m) => m.PROCESSO_SELETIVO_ROUTES),
       },

--- a/apps/selecao/src/app/features/dashboard/dashboard.page.spec.ts
+++ b/apps/selecao/src/app/features/dashboard/dashboard.page.spec.ts
@@ -1,12 +1,18 @@
+import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
+import { AuthService } from '@uniplus/shared-auth/bootstrap';
 import { DashboardPage } from './dashboard.page';
+
+/** Papéis de quem está autenticado — o atalho de cadastro depende deles. */
+const papeis = signal<readonly string[]>(['plataforma-admin']);
+const authServiceStub = { roles: papeis };
 
 describe('DashboardPage — acessibilidade', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [DashboardPage],
-      providers: [provideRouter([])],
+      providers: [provideRouter([]), { provide: AuthService, useValue: authServiceStub }],
     }).compileComponents();
   });
 
@@ -60,11 +66,27 @@ describe('DashboardPage — acessibilidade', () => {
   });
 
   it('leva ao cadastro pelo atalho de novo processo', () => {
+    papeis.set(['plataforma-admin']);
     const host = montar();
     const atalho = [...host.querySelectorAll('a')].find((a) =>
       a.textContent?.includes('Novo Processo'),
     );
 
     expect(atalho?.getAttribute('href')).toBe('/processo-seletivo');
+  });
+
+  /**
+   * O cadastro do certame é restrito a `plataforma-admin` na rota e na API.
+   * Oferecer o atalho a quem não tem o papel levaria direto ao acesso negado.
+   */
+  it('esconde o atalho de novo processo de quem não administra a plataforma', () => {
+    papeis.set(['gestor']);
+    const host = montar();
+    const atalho = [...host.querySelectorAll('a')].find((a) =>
+      a.textContent?.includes('Novo Processo'),
+    );
+
+    expect(atalho).toBeUndefined();
+    papeis.set(['plataforma-admin']);
   });
 });

--- a/apps/selecao/src/app/features/dashboard/dashboard.page.ts
+++ b/apps/selecao/src/app/features/dashboard/dashboard.page.ts
@@ -1,4 +1,5 @@
-import { Component, ChangeDetectionStrategy, signal, computed } from '@angular/core';
+import { Component, ChangeDetectionStrategy, inject, signal, computed } from '@angular/core';
+import { AuthService } from '@uniplus/shared-auth/bootstrap';
 import { EmptyStateComponent, TagComponent } from '@uniplus/shared-ui/components';
 import { DatePipe, DecimalPipe } from '@angular/common';
 import { RouterLink } from '@angular/router';
@@ -15,10 +16,12 @@ import { RouterLink } from '@angular/router';
         <h1 class="page-header__title">Painel de Processos</h1>
         <p class="page-header__desc">Visão geral dos processos seletivos, inscrições e prazos.</p>
       </div>
-      <a class="btn btn--primary" routerLink="/processo-seletivo">
-        <i class="pi pi-plus" aria-hidden="true"></i>
-        Novo Processo
-      </a>
+      @if (podeCadastrarProcesso()) {
+        <a class="btn btn--primary" routerLink="/processo-seletivo">
+          <i class="pi pi-plus" aria-hidden="true"></i>
+          Novo Processo
+        </a>
+      }
     </div>
     <div class="kpis">
       <div class="kpi">
@@ -181,10 +184,18 @@ import { RouterLink } from '@angular/router';
   `,
 })
 export class DashboardPage {
+  private readonly authService = inject(AuthService);
   protected readonly loading = signal(false);
   protected readonly errorMessage = computed<string | null>(() => null);
   protected readonly processos = signal(PROCESSO_SELETIVOS_DTO);
   protected readonly temFiltro = signal(false);
+  /**
+   * O atalho só aparece para quem a rota admite — sem isso, um gestor clicaria
+   * em "Novo Processo" para cair em `/acesso-negado`.
+   */
+  protected readonly podeCadastrarProcesso = computed(() =>
+    this.authService.roles().includes('plataforma-admin'),
+  );
 }
 
 interface ProcessoSeletivoDTO {

--- a/apps/selecao/src/app/features/processo-seletivo/components/type-card/type-card.component.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/components/type-card/type-card.component.ts
@@ -6,13 +6,14 @@ import { TipoProcessoOption } from '../../steps/processo-seletivo.models';
   standalone: true,
   styleUrl: './type-card.component.css',
   template: `
-    <label class="type-card" [class.is-selected]="selected()">
+    <label class="type-card" [class.is-selected]="selected()" [class.is-disabled]="disabled()">
       <input
         class="sr-only"
         type="radio"
         name="tipo-processo"
         [value]="option().value"
         [checked]="selected()"
+        [disabled]="disabled()"
         (change)="selectChange.emit(option().value)"
       />
       <div class="type-card__head">
@@ -49,5 +50,7 @@ import { TipoProcessoOption } from '../../steps/processo-seletivo.models';
 export class TypeCardComponent {
   readonly option = input.required<TipoProcessoOption>();
   readonly selected = input(false);
+  /** Escolha travada — o tipo entrou no comando que criou o processo. */
+  readonly disabled = input(false);
   readonly selectChange = output<string>();
 }

--- a/apps/selecao/src/app/features/processo-seletivo/processo-seletivo.css
+++ b/apps/selecao/src/app/features/processo-seletivo/processo-seletivo.css
@@ -761,6 +761,47 @@
   grid-column: 1 / -1;
 }
 
+/*
+ * Item de grid tem `min-width: auto`, então o conteúdo intrínseco decide o piso
+ * da largura: um `<select>` com opção longa — nome de unidade, rótulo de origem
+ * dos candidatos — esticava a coluna e o passo transbordava na horizontal em
+ * 320 px. O piso zero devolve a decisão à coluna; o campo então respeita a
+ * largura disponível qualquer que seja a fonte em uso.
+ */
+.sel-processo .form-grid > * {
+  min-width: 0;
+}
+
+.sel-processo .form-field .input,
+.sel-processo .form-field select.input {
+  max-width: 100%;
+  min-width: 0;
+}
+
+/* Rótulo comprido de opção não deve vazar o campo enquanto fechado. */
+.sel-processo .form-field select.input {
+  text-overflow: ellipsis;
+}
+
+/*
+ * Recusa de carregamento com ação de repetir: texto e botão em blocos, nunca
+ * lado a lado. Em 320 px o botão inline não quebra linha e leva o passo inteiro
+ * a transbordar na horizontal — mesmo arranjo já usado no passo 1.
+ */
+.sel-processo .field__erro {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-2);
+  margin-block-end: var(--space-2);
+  color: var(--color-danger-fg, currentColor);
+}
+
+.sel-processo .field__erro p {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
 @media (max-width: 479px) {
   .sel-processo .form-grid {
     grid-template-columns: 1fr;

--- a/apps/selecao/src/app/features/processo-seletivo/processo-seletivo.page.html
+++ b/apps/selecao/src/app/features/processo-seletivo/processo-seletivo.page.html
@@ -126,6 +126,7 @@
       <button
         class="btn btn--tertiary"
         type="button"
+        [disabled]="store.salvando()"
         [hidden]="store.isFirst()"
         (click)="previous()"
       >
@@ -138,9 +139,19 @@
         >
           <path d="M19 12H5M12 19l-7-7 7-7" /></svg
         >Anterior</button
-      ><button class="btn btn--primary" type="button" (click)="nextOrPublish()">
-        {{ store.isLast() ? 'Publicar' : 'Próximo' }}
-        @if (!store.isLast()) {
+      ><button
+        class="btn btn--primary"
+        type="button"
+        [attr.aria-busy]="store.salvando() || null"
+        [disabled]="store.salvando()"
+        (click)="nextOrPublish()"
+      >
+        @if (store.salvando()) {
+          Salvando…
+        } @else {
+          {{ store.isLast() ? 'Publicar' : 'Próximo' }}
+        }
+        @if (!store.isLast() && !store.salvando()) {
           <svg
             class="btn__icon"
             viewBox="0 0 24 24"

--- a/apps/selecao/src/app/features/processo-seletivo/processo-seletivo.page.spec.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/processo-seletivo.page.spec.ts
@@ -3,6 +3,8 @@ import { TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { apiOk } from '@uniplus/shared-core/http';
 import { TipoProcessoDto, TiposProcessoApi } from '@uniplus/shared-data/configuracao';
+import { UnidadeDto, UnidadesApi } from '@uniplus/shared-data/organizacao';
+import { ProcessosSeletivosApi } from '@uniplus/shared-data/selecao';
 import { ProcessoSeletivoPage } from './processo-seletivo.page';
 import { ProcessoSeletivoStore } from './steps/processo-seletivo.store';
 
@@ -10,11 +12,26 @@ const tiposProcessoApiStub = {
   listar: () => of(apiOk<readonly TipoProcessoDto[]>([], 200, new HttpHeaders())),
 };
 
+const unidadesApiStub = {
+  listar: () => of(apiOk<readonly UnidadeDto[]>([], 200, new HttpHeaders())),
+};
+
+/**
+ * A page provê `CadastroInicialService`, que injeta o client de Processo
+ * Seletivo. Nenhum teste desta suíte chega a gravar — o stub existe para o
+ * grafo de injeção fechar sem `HttpClient` real.
+ */
+const processosSeletivosApiStub = {};
+
 describe('ProcessoSeletivoPage — estrutura', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ProcessoSeletivoPage],
-      providers: [{ provide: TiposProcessoApi, useValue: tiposProcessoApiStub }],
+      providers: [
+        { provide: TiposProcessoApi, useValue: tiposProcessoApiStub },
+        { provide: UnidadesApi, useValue: unidadesApiStub },
+        { provide: ProcessosSeletivosApi, useValue: processosSeletivosApiStub },
+      ],
     }).compileComponents();
   });
 
@@ -56,7 +73,11 @@ describe('ProcessoSeletivoPage — lista de etapas', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ProcessoSeletivoPage],
-      providers: [{ provide: TiposProcessoApi, useValue: tiposProcessoApiStub }],
+      providers: [
+        { provide: TiposProcessoApi, useValue: tiposProcessoApiStub },
+        { provide: UnidadesApi, useValue: unidadesApiStub },
+        { provide: ProcessosSeletivosApi, useValue: processosSeletivosApiStub },
+      ],
     }).compileComponents();
   });
 
@@ -108,7 +129,11 @@ describe('ProcessoSeletivoPage — bloqueio de scroll', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ProcessoSeletivoPage],
-      providers: [{ provide: TiposProcessoApi, useValue: tiposProcessoApiStub }],
+      providers: [
+        { provide: TiposProcessoApi, useValue: tiposProcessoApiStub },
+        { provide: UnidadesApi, useValue: unidadesApiStub },
+        { provide: ProcessosSeletivosApi, useValue: processosSeletivosApiStub },
+      ],
     }).compileComponents();
   });
 
@@ -137,7 +162,11 @@ describe('ProcessoSeletivoPage — publicação', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ProcessoSeletivoPage],
-      providers: [{ provide: TiposProcessoApi, useValue: tiposProcessoApiStub }],
+      providers: [
+        { provide: TiposProcessoApi, useValue: tiposProcessoApiStub },
+        { provide: UnidadesApi, useValue: unidadesApiStub },
+        { provide: ProcessosSeletivosApi, useValue: processosSeletivosApiStub },
+      ],
     }).compileComponents();
   });
 

--- a/apps/selecao/src/app/features/processo-seletivo/processo-seletivo.page.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/processo-seletivo.page.ts
@@ -12,6 +12,7 @@ import {
 } from '@angular/core';
 import { ProcessoSeletivoStore } from './steps/processo-seletivo.store';
 import { StepValidation } from './steps/processo-seletivo.models';
+import { CadastroInicialService } from './steps/shared/cadastro-inicial.service';
 import { OverlayScrollService } from './steps/shared/overlay-scroll.service';
 import { WizardStepperComponent } from './steps/shared/wizard-stepper.component';
 import { Step01TipoProcessoComponent } from './steps/steps/step-01-tipo-processo/step-01-tipo-processo.component';
@@ -48,7 +49,7 @@ import { Step13RevisaoComponent } from './steps/steps/step-13-revisao/step-13-re
     Step12AtendimentoComponent,
     Step13RevisaoComponent,
   ],
-  providers: [ProcessoSeletivoStore],
+  providers: [ProcessoSeletivoStore, CadastroInicialService],
   templateUrl: './processo-seletivo.page.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -176,10 +177,15 @@ export class ProcessoSeletivoPage {
   }
 
   previous(): void {
+    if (this.store.salvando()) return;
     this.store.previous();
   }
 
-  nextOrPublish(): void {
+  async nextOrPublish(): Promise<void> {
+    // Single-flight: o passo 2 grava na API, e um duplo clique criaria dois
+    // processos com chaves de idempotência diferentes.
+    if (this.store.salvando()) return;
+
     if (this.store.isLast()) {
       this.publicar();
       return;
@@ -190,7 +196,24 @@ export class ProcessoSeletivoPage {
 
     if (result && !result.valid) {
       this.store.setStepError(mensagensDe(result));
+      this.revelarErro();
       return;
+    }
+
+    // Passos que persistem expõem `persistir()`; os demais avançam direto.
+    const persistivel = validator as Partial<StepCommit> | undefined;
+    if (persistivel?.persistir) {
+      const commit = await persistivel.persistir().catch(
+        (): StepValidation => ({
+          valid: false,
+          messages: ['Não foi possível concluir a operação. Tente novamente.'],
+        }),
+      );
+      if (!commit.valid) {
+        this.store.setStepError(mensagensDe(commit));
+        this.revelarErro();
+        return;
+      }
     }
 
     this.store.setStepError(null);
@@ -267,6 +290,15 @@ export class ProcessoSeletivoPage {
     this.wizContent?.nativeElement.scrollTo({ top: 0, behavior: 'smooth' });
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }
+}
+
+/**
+ * Passo que grava na API antes de liberar o avanço. `validate()` continua
+ * síncrono e responde pela consistência do rascunho; `persistir()` responde
+ * pelo efeito remoto.
+ */
+interface StepCommit {
+  persistir(): Promise<StepValidation>;
 }
 
 /** Normaliza `message` (forma simples) e `messages` (lista) para `string[]`. */

--- a/apps/selecao/src/app/features/processo-seletivo/steps/processo-seletivo.models.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/processo-seletivo.models.ts
@@ -1,6 +1,16 @@
-import { ModalidadeConcorrencia } from '@uniplus/shared-data/selecao';
+import { ModalidadeConcorrencia, OrigemCandidatos } from '@uniplus/shared-data/selecao';
 
 export type StepStatus = 'active' | 'done' | 'pending' | 'unvisited';
+
+/**
+ * Origem dos candidatos no rascunho: `''` representa "ainda não escolhida".
+ * `OrigemCandidatos.nenhuma` existe no contrato mas é recusada pela criação do
+ * processo, então não é oferecida como opção.
+ */
+export type OrigemCandidatosSelecionada =
+  | ''
+  | OrigemCandidatos.inscricaoPropria
+  | OrigemCandidatos.importacaoExterna;
 
 /**
  * Resultado da validação declarativa de um step. Steps de domínio
@@ -27,11 +37,41 @@ export interface TipoProcessoOption {
   legal?: string;
 }
 
+/**
+ * Fase do anexo do edital, na ordem em que a API a executa: o registro é
+ * criado com a URL pré-assinada (`iniciando`), o arquivo vai direto ao storage
+ * (`enviando`), e a API lê o objeto para validar e selar (`confirmando`).
+ * Guardar a fase é o que permite retomar do ponto certo depois de uma falha —
+ * repetir a confirmação não muda um objeto que nunca chegou ao storage.
+ */
+export type FaseUpload = 'iniciando' | 'enviando' | 'confirmando' | 'confirmado' | 'erro';
+
 export interface UploadItem {
   id: string;
   name: string;
-  extension: 'pdf' | 'png' | 'jpeg' | 'jpg' | 'docx';
+  /** O contrato do documento do edital aceita somente PDF. */
+  extension: 'pdf';
   progress: number;
+  fase: FaseUpload;
+  /** Id do registro criado na iniciação — necessário para confirmar. */
+  documentoEditalId?: string;
+  /** Instante em que a URL pré-assinada deixa de valer. */
+  expiraEm?: string;
+  /**
+   * O arquivo já chegou ao storage. Distingue "falhou antes de subir" de
+   * "subiu e a confirmação não concluiu": no segundo caso, repetir o PUT é
+   * desperdício e pode até esbarrar na URL já expirada, enquanto repetir só a
+   * confirmação recupera o replay do comando anterior.
+   */
+  enviado?: boolean;
+  /**
+   * A confirmação ficou sem resposta definitiva. O documento pode já estar
+   * selado — imutável — no servidor, então trocar o arquivo criaria um segundo
+   * edital e perderia a referência do primeiro: só a retentativa da mesma
+   * confirmação resolve.
+   */
+  confirmacaoIndefinida?: boolean;
+  mensagemErro?: string;
 }
 
 export interface Curso {
@@ -121,6 +161,16 @@ export interface WizardDraft {
     orgao: string;
     periodo: string;
     nome: string;
+    /**
+     * Unidade que administra o certame, escolhida no catálogo de Organização
+     * Institucional. Obrigatória na criação e imutável depois dela.
+     */
+    unidadeAdministradoraId: string;
+    /**
+     * De onde vêm os candidatos. Atributo declarado — não se deriva do tipo do
+     * processo, e é ele que define o piso mínimo do cronograma de fases.
+     */
+    origemCandidatos: OrigemCandidatosSelecionada;
     uploads: UploadItem[];
   };
   modalidades: {

--- a/apps/selecao/src/app/features/processo-seletivo/steps/processo-seletivo.store.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/processo-seletivo.store.ts
@@ -47,6 +47,8 @@ const INITIAL_DRAFT: WizardDraft = {
     orgao: '',
     periodo: '',
     nome: '',
+    unidadeAdministradoraId: '',
+    origemCandidatos: '',
     uploads: [],
   },
   modalidades: { selected: [], concorrenciaDupla: false },
@@ -80,6 +82,30 @@ export class ProcessoSeletivoStore {
   readonly draft = signal<WizardDraft>(structuredClone(INITIAL_DRAFT));
   /** Mensagens de validação do step ativo. `null` indica sem erro. */
   readonly stepError = signal<string[] | null>(null);
+  /**
+   * Id do Processo Seletivo já criado na API. `null` enquanto o cadastro
+   * inicial não foi persistido.
+   */
+  readonly processoSeletivoId = signal<string | null>(null);
+  /** Mutação em curso — usado para impedir disparo duplo e travar a navegação. */
+  readonly salvando = signal(false);
+  /**
+   * Uma criação ficou sem resposta definitiva (rede ou 5xx): o servidor pode
+   * tê-la executado. A retentativa repete o mesmo comando, então alterar o
+   * rascunho agora só faria a tela divergir do que existe no servidor.
+   */
+  readonly criacaoIndefinida = signal(false);
+
+  /**
+   * Depois de criado, os dados que compuseram o comando de criação não podem
+   * mais ser alterados: o contrato não expõe atualização de identificação e a
+   * unidade administradora é imutável no agregado por definição. Vale também
+   * enquanto uma criação inconclusiva aguarda retentativa — inclusive para o
+   * tipo, escolhido no passo 1.
+   */
+  readonly cadastroInicialCongelado = computed(
+    () => this.processoSeletivoId() !== null || this.salvando() || this.criacaoIndefinida(),
+  );
 
   readonly currentLabel = computed(() => this.labels[this.currentStep()]);
   readonly currentMeta = computed(() => {
@@ -155,5 +181,8 @@ export class ProcessoSeletivoStore {
     this.completedSteps.set(new Set());
     this.draft.set(structuredClone(INITIAL_DRAFT));
     this.stepError.set(null);
+    this.processoSeletivoId.set(null);
+    this.salvando.set(false);
+    this.criacaoIndefinida.set(false);
   }
 }

--- a/apps/selecao/src/app/features/processo-seletivo/steps/shared/cadastro-inicial.service.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/shared/cadastro-inicial.service.ts
@@ -1,0 +1,230 @@
+import { HttpContext, HttpEventType } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import {
+  ApiFailure,
+  ProblemDetails,
+  SignedUploadClient,
+  idempotencyKey,
+  isApiOk,
+  withIdempotencyKey,
+} from '@uniplus/shared-core/http';
+import {
+  CriarProcessoSeletivoCommand,
+  IniciarUploadDocumentoEditalDto,
+  ProcessosSeletivosApi,
+} from '@uniplus/shared-data/selecao';
+
+/** Recusa nomeada por `ProblemDetails`, para o chamador exibir e decidir o retry. */
+export interface FalhaOperacao {
+  readonly ok: false;
+  readonly problem: ProblemDetails;
+}
+
+export type ResultadoCriacao = { readonly ok: true; readonly processoSeletivoId: string } | FalhaOperacao;
+
+export type ResultadoIniciacao =
+  | { readonly ok: true; readonly iniciacao: IniciarUploadDocumentoEditalDto }
+  | FalhaOperacao;
+
+export type ResultadoConfirmacao = { readonly ok: true } | FalhaOperacao;
+
+/**
+ * Falha do envio ao storage. `expirada` separa o caso em que repetir o mesmo
+ * PUT é inútil — a assinatura da URL não volta a valer.
+ */
+export interface EnvioFalhou {
+  readonly ok: false;
+  readonly status: number;
+  readonly expirada: boolean;
+}
+
+export type ResultadoEnvio = { readonly ok: true } | EnvioFalhou;
+
+const PROCESSING_CONFLICT = 'uniplus.idempotency.processing_conflict';
+const NETWORK_ERROR = 'uniplus.client.network_error';
+
+/**
+ * Orquestra o cadastro inicial do Processo Seletivo e o anexo do edital,
+ * escondendo dos componentes as duas mecânicas que erram fácil: quando a
+ * `Idempotency-Key` pode ser reaproveitada e o que significa repetir cada fase
+ * do upload.
+ *
+ * Uma chave por operação — criar, iniciar e confirmar são comandos distintos e
+ * não compartilham chave.
+ */
+@Injectable()
+export class CadastroInicialService {
+  private readonly api = inject(ProcessosSeletivosApi);
+  private readonly upload = inject(SignedUploadClient);
+
+  private chaveCriacao = idempotencyKey.create();
+  private chaveIniciacao = idempotencyKey.create();
+  private chaveConfirmacao = idempotencyKey.create();
+
+  /**
+   * Comando de uma criação que ficou sem resposta definitiva (falha de rede ou
+   * 5xx). O servidor pode tê-la executado, então a retentativa precisa repetir
+   * o **mesmo corpo com a mesma chave** para receber o replay em vez de criar
+   * um segundo processo. Enquanto isso não se resolve, editar os campos não
+   * muda o que será reenviado — daí o congelamento na interface.
+   */
+  private criacaoPendente: CriarProcessoSeletivoCommand | null = null;
+
+  /** Há criação sem resposta definitiva aguardando retentativa. */
+  temCriacaoPendente(): boolean {
+    return this.criacaoPendente !== null;
+  }
+
+  /**
+   * Cria o processo em rascunho. O comando recebido já é um instantâneo do
+   * rascunho: quem chama congela os campos antes, para que a resposta nunca
+   * descreva um estado diferente do que foi enviado.
+   */
+  async criar(command: CriarProcessoSeletivoCommand): Promise<ResultadoCriacao> {
+    const comando = this.criacaoPendente ?? command;
+    const result = await firstValueFrom(this.api.criar(comando, contextoCom(this.chaveCriacao)));
+
+    if (isApiOk(result)) {
+      this.chaveCriacao = idempotencyKey.create();
+      this.criacaoPendente = null;
+      return { ok: true, processoSeletivoId: result.data };
+    }
+
+    const chaveAnterior = this.chaveCriacao;
+    this.chaveCriacao = proximaChave(chaveAnterior, result);
+    // Chave preservada significa resposta inconclusiva: o comando fica retido
+    // para ser repetido igual. Chave nova significa recusa definitiva, e o
+    // próximo envio parte do rascunho corrigido.
+    this.criacaoPendente = this.chaveCriacao === chaveAnterior ? comando : null;
+    return { ok: false, problem: result.problem };
+  }
+
+  /** Passo 1 do anexo: registro pendente + URL pré-assinada. */
+  async iniciarUpload(processoSeletivoId: string): Promise<ResultadoIniciacao> {
+    const result = await firstValueFrom(
+      this.api.iniciarUploadDocumentoEdital(processoSeletivoId, contextoCom(this.chaveIniciacao)),
+    );
+
+    if (isApiOk(result)) {
+      this.chaveIniciacao = idempotencyKey.create();
+      return { ok: true, iniciacao: result.data };
+    }
+
+    this.chaveIniciacao = proximaChave(this.chaveIniciacao, result);
+    return { ok: false, problem: result.problem };
+  }
+
+  /**
+   * Passo 2: envia o arquivo direto ao storage, relatando o progresso em bytes.
+   *
+   * Este PUT não passa pelos interceptors da aplicação, então a falha chega
+   * como erro HTTP de verdade. 403 é como o storage recusa assinatura inválida
+   * — na prática, URL expirada: repetir o mesmo PUT nunca funciona, e o
+   * chamador precisa recomeçar da iniciação.
+   */
+  enviarArquivo(
+    iniciacao: IniciarUploadDocumentoEditalDto,
+    arquivo: File,
+    onProgresso: (percentual: number) => void,
+  ): Promise<ResultadoEnvio> {
+    return new Promise<ResultadoEnvio>((resolve) => {
+      this.upload
+        .enviar(iniciacao.urlUpload, arquivo, iniciacao.contentTypeExigido)
+        .subscribe({
+          next: (evento) => {
+            if (evento.type === HttpEventType.UploadProgress) {
+              onProgresso(percentualDe(evento.loaded, evento.total));
+            }
+          },
+          error: (erro: unknown) => {
+            const status = statusDe(erro);
+            resolve({ ok: false, status, expirada: status === 403 });
+          },
+          complete: () => {
+            onProgresso(100);
+            resolve({ ok: true });
+          },
+        });
+    });
+  }
+
+  /**
+   * Confirmação que ficou sem resposta definitiva. O documento pode já estar
+   * selado no servidor — imutável, portanto — e a única saída correta é repetir
+   * esta mesma confirmação com a mesma chave até obter resposta. Trocar de
+   * arquivo aqui criaria um segundo edital imutável e perderia a referência do
+   * primeiro.
+   */
+  private confirmacaoPendente = false;
+
+  /** Há confirmação sem resposta definitiva aguardando retentativa. */
+  temConfirmacaoPendente(): boolean {
+    return this.confirmacaoPendente;
+  }
+
+  /** Passo 3: a API valida o objeto no storage e sela o documento. */
+  async confirmarUpload(
+    processoSeletivoId: string,
+    documentoEditalId: string,
+  ): Promise<ResultadoConfirmacao> {
+    const result = await firstValueFrom(
+      this.api.confirmarUploadDocumentoEdital(
+        processoSeletivoId,
+        documentoEditalId,
+        contextoCom(this.chaveConfirmacao),
+      ),
+    );
+
+    if (isApiOk(result)) {
+      this.chaveConfirmacao = idempotencyKey.create();
+      this.confirmacaoPendente = false;
+      return { ok: true };
+    }
+
+    const chaveAnterior = this.chaveConfirmacao;
+    this.chaveConfirmacao = proximaChave(chaveAnterior, result);
+    // Mesma leitura da criação: chave preservada é resposta inconclusiva.
+    this.confirmacaoPendente = this.chaveConfirmacao === chaveAnterior;
+    return { ok: false, problem: result.problem };
+  }
+}
+
+/**
+ * Regra de rotação da `Idempotency-Key`, por código antes de status: o filtro
+ * do backend guarda a resposta de qualquer status abaixo de 500, então reenviar
+ * um corpo corrigido com a mesma chave devolveria `body_mismatch` em vez de
+ * processar o comando novo. As exceções vão na direção oposta —
+ * `processing_conflict` e falha sem resposta pedem retry com a mesma chave,
+ * porque a execução anterior ainda pode concluir.
+ */
+function proximaChave(chaveAtual: string, falha: ApiFailure): string {
+  const { code, status } = falha.problem;
+
+  // Só estes três casos deixam em aberto se o comando foi executado.
+  if (code === PROCESSING_CONFLICT || code === NETWORK_ERROR || status >= 500) {
+    return chaveAtual;
+  }
+  // Todo o resto é recusa definitiva — inclusive `body_mismatch` e o 413 de
+  // corpo acima do limite do filtro de idempotência. Manter a chave nesses
+  // casos prenderia a tela repetindo para sempre um comando que o servidor
+  // nunca vai aceitar.
+  return idempotencyKey.create();
+}
+
+function contextoCom(chave: string): HttpContext {
+  return withIdempotencyKey(chave);
+}
+
+function percentualDe(loaded: number, total: number | undefined): number {
+  if (total === undefined || total <= 0) return 0;
+  return Math.min(100, Math.max(0, Math.round((loaded / total) * 100)));
+}
+
+function statusDe(erro: unknown): number {
+  if (typeof erro === 'object' && erro !== null && 'status' in erro) {
+    const status = (erro as { status: unknown }).status;
+    return typeof status === 'number' ? status : 0;
+  }
+  return 0;
+}

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-01-tipo-processo/step-01-tipo-processo.component.html
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-01-tipo-processo/step-01-tipo-processo.component.html
@@ -39,12 +39,19 @@
       />
     </div>
   </div>
-  <fieldset class="type-grid">
+  @if (store.cadastroInicialCongelado()) {
+    <p class="alert alert--info" role="status">
+      O cadastro inicial já foi criado com este tipo. Para usar outro tipo, cadastre um novo
+      processo seletivo.
+    </p>
+  }
+  <fieldset class="type-grid" [disabled]="store.cadastroInicialCongelado()">
     <legend class="sr-only">Tipo do processo seletivo</legend>
     @for (option of filteredOptions(); track option.value) {
       <sel-type-card
         [option]="option"
         [selected]="store.draft().tipoProcesso.selected === option.value"
+        [disabled]="store.cadastroInicialCongelado()"
         (selectChange)="select($event)"
       />
     }

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-01-tipo-processo/step-01-tipo-processo.component.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-01-tipo-processo/step-01-tipo-processo.component.ts
@@ -77,6 +77,8 @@ export class Step01TipoProcessoComponent {
   }
 
   select(value: string): void {
+    // O tipo compõe o comando de criação e não é atualizável depois dele.
+    if (this.store.cadastroInicialCongelado()) return;
     this.store.patchObjectSection('tipoProcesso', { selected: value });
   }
 

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-02-identificacao/step-02-identificacao.component.html
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-02-identificacao/step-02-identificacao.component.html
@@ -5,6 +5,12 @@
 <p class="step-subtitle">
   Dados de identificação do edital. O PDF é obrigatório para auditoria (RNo08 + LGPD).
 </p>
+@if (camposDoComandoBloqueados()) {
+  <p class="alert alert--info" role="status">
+    O cadastro inicial já foi criado no sistema. Nome, tipo do processo, unidade administradora e
+    origem dos candidatos não podem mais ser alterados por aqui.
+  </p>
+}
 <div class="step-card">
   <div class="form-grid">
     <div class="form-field">
@@ -13,6 +19,7 @@
         class="input"
         id="f-num"
         placeholder="Ex.: 12/2026"
+        [attr.aria-invalid]="invalidFields().has('numero') || null"
         [class.is-invalid]="invalidFields().has('numero')"
         [value]="store.draft().identificacao.numero"
         (input)="patch('numero', $any($event.target).value)"
@@ -25,6 +32,7 @@
           class="input"
           id="f-ano"
           type="number"
+          [attr.aria-invalid]="invalidFields().has('ano') || null"
           [class.is-invalid]="invalidFields().has('ano')"
           [value]="store.draft().identificacao.ano"
           (input)="patch('ano', +$any($event.target).value)"
@@ -52,6 +60,7 @@
           class="input"
           id="f-data"
           type="date"
+          [attr.aria-invalid]="invalidFields().has('data') || null"
           [class.is-invalid]="invalidFields().has('data')"
           [value]="store.draft().identificacao.data"
           (input)="patch('data', $any($event.target).value)"
@@ -83,6 +92,7 @@
       <input
         class="input"
         id="f-orgao"
+        [attr.aria-invalid]="invalidFields().has('orgao') || null"
         [class.is-invalid]="invalidFields().has('orgao')"
         [value]="store.draft().identificacao.orgao"
         (input)="patch('orgao', $any($event.target).value)"
@@ -93,6 +103,7 @@
       <select
         class="input"
         id="f-periodo"
+        [attr.aria-invalid]="invalidFields().has('periodo') || null"
         [class.is-invalid]="invalidFields().has('periodo')"
         [value]="store.draft().identificacao.periodo"
         (change)="patch('periodo', $any($event.target).value)"
@@ -109,10 +120,66 @@
         class="input"
         id="f-nome"
         placeholder="Processo Seletivo Seriado"
+        [attr.aria-invalid]="invalidFields().has('nome') || null"
         [class.is-invalid]="invalidFields().has('nome')"
+        [disabled]="camposDoComandoBloqueados()"
         [value]="store.draft().identificacao.nome"
         (input)="patch('nome', $any($event.target).value)"
       />
+    </div>
+    <div class="form-field form-grid__full">
+      <label class="label" for="f-unidade">Unidade administradora</label>
+      @if (unidadesErro(); as erro) {
+        <div class="field__erro" role="alert">
+          <p>{{ erro }}</p>
+          <button class="btn btn--tertiary" type="button" (click)="carregarUnidades()">
+            Tentar novamente
+          </button>
+        </div>
+      }
+      <select
+        class="input"
+        id="f-unidade"
+        aria-describedby="f-unidade-hint"
+        [attr.aria-busy]="unidadesCarregando() || null"
+        [attr.aria-invalid]="invalidFields().has('unidadeAdministradoraId') || null"
+        [class.is-invalid]="invalidFields().has('unidadeAdministradoraId')"
+        [disabled]="camposDoComandoBloqueados() || unidadesCarregando()"
+        [value]="store.draft().identificacao.unidadeAdministradoraId"
+        (change)="patch('unidadeAdministradoraId', $any($event.target).value)"
+      >
+        <option value="">{{ unidadesCarregando() ? 'Carregando…' : 'Selecione' }}</option>
+        @for (unidade of unidades(); track unidade.id) {
+          <option [value]="unidade.id">{{ unidade.rotulo }}</option>
+        }
+      </select>
+      <p class="field__hint" id="f-unidade-hint">
+        Unidade responsável pela administração do certame. Define a localidade que governa a
+        contagem de prazos em dias úteis.
+      </p>
+    </div>
+    <div class="form-field form-grid__full">
+      <label class="label" for="f-origem">Origem dos candidatos</label>
+      <select
+        class="input"
+        id="f-origem"
+        aria-describedby="f-origem-hint"
+        [attr.aria-invalid]="invalidFields().has('origemCandidatos') || null"
+        [class.is-invalid]="invalidFields().has('origemCandidatos')"
+        [disabled]="camposDoComandoBloqueados()"
+        [value]="store.draft().identificacao.origemCandidatos"
+        (change)="patch('origemCandidatos', $any($event.target).value)"
+      >
+        <option value="">Selecione</option>
+        @for (origem of origens; track origem.value) {
+          <option [value]="origem.value">{{ origem.label }}</option>
+        }
+      </select>
+      <p class="field__hint" id="f-origem-hint">
+        <strong>Inscrição neste sistema:</strong> o candidato se inscreve no Uni+, e o cronograma
+        precisa de ao menos uma fase de inscrição. <strong>Importação externa:</strong> os
+        candidatos vêm de outra base, como o SiSU/MEC.
+      </p>
     </div>
   </div>
 </div>
@@ -129,9 +196,8 @@
     id="f-file"
     class="sr-only"
     type="file"
-    accept=".pdf,.png,.jpeg,.jpg,.docx"
-    multiple
-    aria-label="Selecionar arquivo PDF"
+    accept="application/pdf,.pdf"
+    aria-label="Selecionar o arquivo PDF do edital"
     (change)="onFileInput($event)"
   />
   <div class="upload-layout">
@@ -139,7 +205,8 @@
       class="upload-zone"
       role="button"
       tabindex="0"
-      aria-label="Clique ou arraste arquivos aqui"
+      aria-label="Clique ou arraste o PDF do edital aqui"
+      [attr.aria-disabled]="anexoBloqueado() || null"
       [class.is-dragover]="dragging()"
       [class.is-invalid]="invalidFields().has('uploads')"
       (click)="chooseFiles()"
@@ -164,54 +231,63 @@
         <polyline points="17 8 12 3 7 8" />
         <line x1="12" x2="12" y1="3" y2="15" />
       </svg>
-      <span>Arraste e solte um arquivo ou <span class="upload-zone__link">Procure</span></span>
-      <span class="upload-zone__hint">Formatos aceitos: PDF, PNG, JPEG, JPG ou DOCX</span>
+      <span>Arraste e solte o arquivo ou <span class="upload-zone__link">Procure</span></span>
+      <span class="upload-zone__hint">Somente PDF, até 20 MB</span>
     </div>
     <div class="file-list">
-      @if (!store.draft().identificacao.uploads.length) {
-        <p class="file-list-empty">Nenhum arquivo adicionado.</p>
-      }
-      @for (file of store.draft().identificacao.uploads; track file.id) {
+      @if (anexo(); as file) {
         <div class="file-item">
-          <span
-            class="file-badge"
-            [class.file-badge--pdf]="file.extension === 'pdf'"
-            [class.file-badge--png]="file.extension === 'png'"
-            >{{ file.extension.toUpperCase() }}</span
-          >
+          <span class="file-badge file-badge--pdf">PDF</span>
           <div class="file-info">
             <span class="file-name" [title]="file.name">{{ truncateFileName(file.name) }}</span>
-            <div class="file-progress">
+            <div
+              class="file-progress"
+              role="progressbar"
+              aria-label="Progresso do envio do edital"
+              aria-valuemin="0"
+              aria-valuemax="100"
+              [attr.aria-valuenow]="file.progress"
+            >
               <div
                 class="file-progress__bar"
-                [class.is-complete]="file.progress >= 100"
+                [class.is-complete]="file.fase === 'confirmado'"
                 [style.width.%]="file.progress"
               ></div>
             </div>
+            <span class="file-status" aria-live="polite">{{ descricaoFase(file) }}</span>
+            @if (file.fase === 'erro') {
+              <button class="btn btn--tertiary" type="button" (click)="retomarUpload()">
+                Tentar novamente
+              </button>
+            }
           </div>
-          <button
-            class="file-delete"
-            type="button"
-            [attr.aria-label]="'Remover ' + file.name"
-            (click)="$event.stopPropagation(); removeUpload(file.id)"
-          >
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-              aria-hidden="true"
+          @if (!anexoBloqueado()) {
+            <button
+              class="file-delete"
+              type="button"
+              [attr.aria-label]="'Remover ' + file.name"
+              (click)="$event.stopPropagation(); removeUpload()"
             >
-              <polyline points="3 6 5 6 21 6" />
-              <path d="M19 6l-1 14H6L5 6" />
-              <path d="M10 11v6M14 11v6" />
-              <path d="M9 6V4h6v2" />
-            </svg>
-          </button>
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                aria-hidden="true"
+              >
+                <polyline points="3 6 5 6 21 6" />
+                <path d="M19 6l-1 14H6L5 6" />
+                <path d="M10 11v6M14 11v6" />
+                <path d="M9 6V4h6v2" />
+              </svg>
+            </button>
+          }
         </div>
+      } @else {
+        <p class="file-list-empty">Nenhum arquivo adicionado.</p>
       }
     </div>
   </div>

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-02-identificacao/step-02-identificacao.component.spec.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-02-identificacao/step-02-identificacao.component.spec.ts
@@ -1,0 +1,583 @@
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { apiResultInterceptor } from '@uniplus/shared-core/http';
+import { OrigemCandidatos } from '@uniplus/shared-data/selecao';
+import { SELECAO_BASE_PATH } from '@uniplus/shared-data/selecao';
+import { ORGANIZACAO_BASE_PATH } from '@uniplus/shared-data/organizacao';
+import { Step02IdentificacaoComponent } from './step-02-identificacao.component';
+import { ProcessoSeletivoStore } from '../../processo-seletivo.store';
+import { CadastroInicialService } from '../../shared/cadastro-inicial.service';
+
+const BASE = 'http://localhost:5000';
+const PROCESSO_ID = '01960000-0000-7000-0000-0000000005aa';
+const TIPO_ID = '01960000-0000-7000-0000-0000000005bb';
+const UNIDADE_ID = '01960000-0000-7000-0000-0000000005cc';
+const DOCUMENTO_ID = '01960000-0000-7000-0000-0000000005dd';
+const URL_ASSINADA = 'http://localhost:9000/uniplus-selecao/editais/edital.pdf?X-Amz-Signature=abc';
+
+const unidadeSeed = {
+  id: UNIDADE_ID,
+  nome: 'Instituto de Ciências Exatas',
+  alias: 'ICE',
+  slug: 'ice',
+  sigla: 'ICE',
+  codigo: 'ICE',
+  unidadeSuperiorId: null,
+  tipo: 'Instituto',
+  unidadeAcademica: true,
+  vigenciaInicio: '2026-01-01',
+  vigenciaFim: null,
+  criadoEm: '2026-06-10T12:00:00Z',
+};
+
+/** Um PDF mínimo: a assinatura importa para a recusa client-side. */
+function pdf(nome = 'edital.pdf', bytes = 2048): File {
+  return new File([new Uint8Array(bytes).fill(37)], nome, { type: 'application/pdf' });
+}
+
+/**
+ * Cede o event loop para que a cadeia de `await` do componente avance até a
+ * próxima requisição. `Promise.resolve()` sozinho não basta: cada fase do
+ * fluxo passa por `firstValueFrom` e por mais de um microtask.
+ */
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/**
+ * Recusa no formato que a API realmente emite. O `apiResultInterceptor` só
+ * parseia o `code` quando o content type é `application/problem+json` — sem o
+ * header, tudo vira `unexpected_response` e a regra de rotação de chave não
+ * chega a ser exercida.
+ */
+function problema(status: number, code: string, title: string) {
+  return {
+    body: { type: 'about:blank', title, status, code, traceId: 'trace-1' },
+    opts: {
+      status,
+      statusText: title,
+      headers: { 'Content-Type': 'application/problem+json' },
+    },
+  };
+}
+
+function iniciacao(expiraEmMs = Date.now() + 900_000) {
+  return {
+    documentoEditalId: DOCUMENTO_ID,
+    urlUpload: URL_ASSINADA,
+    contentTypeExigido: 'application/pdf',
+    expiraEm: new Date(expiraEmMs).toISOString(),
+  };
+}
+
+describe('Step02IdentificacaoComponent', () => {
+  let componente: Step02IdentificacaoComponent;
+  let store: ProcessoSeletivoStore;
+  let controller: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [Step02IdentificacaoComponent],
+      providers: [
+        ProcessoSeletivoStore,
+        CadastroInicialService,
+        provideHttpClient(withInterceptors([apiResultInterceptor])),
+        provideHttpClientTesting(),
+        { provide: SELECAO_BASE_PATH, useValue: BASE },
+        { provide: ORGANIZACAO_BASE_PATH, useValue: BASE },
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(Step02IdentificacaoComponent);
+    componente = fixture.componentInstance;
+    store = TestBed.inject(ProcessoSeletivoStore);
+    controller = TestBed.inject(HttpTestingController);
+
+    // O componente carrega as unidades no construtor.
+    controller.expectOne(`${BASE}/api/organizacao/unidades?limit=100`).flush([unidadeSeed]);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => controller.verify());
+
+  function preencherCamposDoComando(): void {
+    store.patchObjectSection('tipoProcesso', { selected: TIPO_ID });
+    store.patchObjectSection('identificacao', {
+      nome: 'Processo Seletivo 2027',
+      unidadeAdministradoraId: UNIDADE_ID,
+      origemCandidatos: OrigemCandidatos.inscricaoPropria,
+    });
+  }
+
+  /** Tudo que `validate()` exige, menos o anexo do edital. */
+  function preencherPassoInteiro(): void {
+    preencherCamposDoComando();
+    store.patchObjectSection('identificacao', {
+      numero: '12/2026',
+      ano: 2026,
+      data: '2026-09-01',
+      orgao: 'CEPS',
+      periodo: '1º semestre',
+    });
+  }
+
+  it('carrega as unidades administradoras da API de Organização', () => {
+    expect(componente.unidades()).toEqual([{ id: UNIDADE_ID, rotulo: 'ICE — Instituto de Ciências Exatas' }]);
+    expect(componente.unidadesCarregando()).toBe(false);
+  });
+
+  it('exige unidade administradora e origem dos candidatos para avançar', () => {
+    store.patchObjectSection('identificacao', {
+      numero: '12/2026',
+      ano: 2026,
+      data: '2026-09-01',
+      orgao: 'CEPS',
+      periodo: '1º semestre',
+      nome: 'Processo Seletivo 2027',
+    });
+
+    const resultado = componente.validate();
+
+    expect(resultado.valid).toBe(false);
+    expect(resultado.messages).toContain('Selecione a unidade administradora.');
+    expect(resultado.messages).toContain('Informe a origem dos candidatos.');
+  });
+
+  it('recusa arquivo que não é PDF sem chamar a API', () => {
+    preencherCamposDoComando();
+
+    componente['anexar'](new File(['x'], 'edital.docx', { type: 'application/msword' }));
+
+    expect(componente.uploadError()).toContain('deve ser um arquivo PDF');
+    expect(store.processoSeletivoId()).toBeNull();
+  });
+
+  it('recusa PDF acima de 20 MB sem chamar a API', () => {
+    preencherCamposDoComando();
+
+    componente['anexar'](pdf('grande.pdf', 20 * 1024 * 1024 + 1));
+
+    expect(componente.uploadError()).toContain('20 MB');
+    expect(store.processoSeletivoId()).toBeNull();
+  });
+
+  it('nomeia os campos que faltam antes de criar o cadastro', async () => {
+    await componente['anexar'](pdf());
+
+    expect(componente.uploadError()).toContain('tipo do processo (passo 1)');
+    expect(componente.uploadError()).toContain('unidade administradora');
+    expect(componente.uploadError()).toContain('origem dos candidatos');
+    expect(store.processoSeletivoId()).toBeNull();
+  });
+
+  it('cria o processo, envia o arquivo e confirma o documento ao anexar', async () => {
+    preencherPassoInteiro();
+    const anexo = componente['anexar'](pdf());
+
+    const criacao = controller.expectOne(`${BASE}/api/selecao/processos-seletivos`);
+    expect(criacao.request.body).toEqual({
+      nome: 'Processo Seletivo 2027',
+      tipoProcessoOrigemId: TIPO_ID,
+      origemCandidatos: OrigemCandidatos.inscricaoPropria,
+      unidadeAdministradoraOrigemId: UNIDADE_ID,
+    });
+    expect(criacao.request.headers.get('Idempotency-Key')).toBeTruthy();
+    criacao.flush(PROCESSO_ID, { status: 201, statusText: 'Created' });
+    await tick();
+
+    const inicio = controller.expectOne(
+      `${BASE}/api/selecao/processos-seletivos/${PROCESSO_ID}/documentos-edital`,
+    );
+    inicio.flush(iniciacao(), { status: 201, statusText: 'Created' });
+    await tick();
+
+    controller.expectOne(URL_ASSINADA).flush(null);
+    await tick();
+
+    const confirmacao = controller.expectOne(
+      `${BASE}/api/selecao/processos-seletivos/${PROCESSO_ID}/documentos-edital/${DOCUMENTO_ID}/confirmacao`,
+    );
+    confirmacao.flush({
+      id: DOCUMENTO_ID,
+      processoSeletivoId: PROCESSO_ID,
+      status: 'Confirmado',
+      tamanhoBytes: 2048,
+      hashSha256: 'a'.repeat(64),
+      confirmadoEm: '2026-08-13T12:00:00Z',
+    });
+    await anexo;
+
+    expect(store.processoSeletivoId()).toBe(PROCESSO_ID);
+    expect(componente.anexo()?.fase).toBe('confirmado');
+    expect(componente.anexo()?.progress).toBe(100);
+    expect(componente.validate().valid).toBe(true);
+  });
+
+  it('congela os campos do comando depois de criar o processo', async () => {
+    preencherCamposDoComando();
+    const anexo = componente['anexar'](pdf());
+
+    controller
+      .expectOne(`${BASE}/api/selecao/processos-seletivos`)
+      .flush(PROCESSO_ID, { status: 201, statusText: 'Created' });
+    await tick();
+    expect(componente.camposDoComandoBloqueados()).toBe(true);
+
+    // Encerra o fluxo para não deixar requisições pendentes.
+    const falha = problema(422, 'DocumentoEdital.Invalido', 'Documento recusado');
+    controller
+      .expectOne(`${BASE}/api/selecao/processos-seletivos/${PROCESSO_ID}/documentos-edital`)
+      .flush(falha.body, falha.opts);
+    await anexo;
+  });
+
+  /**
+   * O filtro de idempotência guarda a resposta de qualquer status abaixo de 500:
+   * reenviar o comando corrigido com a mesma chave devolveria `body_mismatch`
+   * em vez de criar o processo.
+   */
+  it('renova a Idempotency-Key após 422 de validação', async () => {
+    preencherCamposDoComando();
+    const primeira = componente['persistir']();
+
+    const req1 = controller.expectOne(`${BASE}/api/selecao/processos-seletivos`);
+    const chave1 = req1.request.headers.get('Idempotency-Key');
+    const recusa = problema(422, 'ProcessoSeletivo.NomeDuplicado', 'Nome já utilizado');
+    req1.flush(recusa.body, recusa.opts);
+    expect((await primeira).valid).toBe(false);
+
+    store.patchObjectSection('identificacao', { nome: 'Processo Seletivo 2027 — retificado' });
+    const segunda = componente['persistir']();
+
+    const req2 = controller.expectOne(`${BASE}/api/selecao/processos-seletivos`);
+    const chave2 = req2.request.headers.get('Idempotency-Key');
+    expect(chave2).not.toBe(chave1);
+    req2.flush(PROCESSO_ID, { status: 201, statusText: 'Created' });
+    expect((await segunda).valid).toBe(true);
+  });
+
+  /**
+   * `processing_conflict` é o único 409 em que o backend pede retry com a mesma
+   * chave — a execução anterior ainda pode concluir.
+   */
+  it('preserva a Idempotency-Key em processing_conflict', async () => {
+    preencherCamposDoComando();
+    const primeira = componente['persistir']();
+
+    const req1 = controller.expectOne(`${BASE}/api/selecao/processos-seletivos`);
+    const chave1 = req1.request.headers.get('Idempotency-Key');
+    const conflito = problema(
+      409,
+      'uniplus.idempotency.processing_conflict',
+      'Requisição concorrente em processamento',
+    );
+    req1.flush(conflito.body, conflito.opts);
+    await primeira;
+
+    const segunda = componente['persistir']();
+    const req2 = controller.expectOne(`${BASE}/api/selecao/processos-seletivos`);
+    expect(req2.request.headers.get('Idempotency-Key')).toBe(chave1);
+    req2.flush(PROCESSO_ID, { status: 201, statusText: 'Created' });
+    await segunda;
+  });
+
+  /**
+   * A URL pré-assinada não volta a valer: repetir o mesmo PUT depois de um 403
+   * do storage é inútil, então o retry precisa pedir outra iniciação.
+   */
+  it('descarta a iniciação quando o storage recusa a URL expirada', async () => {
+    preencherCamposDoComando();
+    store.processoSeletivoId.set(PROCESSO_ID);
+    const anexo = componente['anexar'](pdf());
+    await tick();
+
+    controller
+      .expectOne(`${BASE}/api/selecao/processos-seletivos/${PROCESSO_ID}/documentos-edital`)
+      .flush(iniciacao(), { status: 201, statusText: 'Created' });
+    await tick();
+
+    controller
+      .expectOne(URL_ASSINADA)
+      .flush('<Error><Code>AccessDenied</Code></Error>', { status: 403, statusText: 'Forbidden' });
+    await anexo;
+
+    expect(componente.anexo()?.fase).toBe('erro');
+    expect(componente.anexo()?.mensagemErro).toContain('não é mais válido');
+    expect(componente.anexo()?.documentoEditalId).toBeUndefined();
+    expect(componente.anexo()?.enviado).toBeFalsy();
+
+    const retomada = componente.retomarUpload();
+    await tick();
+    controller
+      .expectOne(`${BASE}/api/selecao/processos-seletivos/${PROCESSO_ID}/documentos-edital`)
+      .flush(iniciacao(), { status: 201, statusText: 'Created' });
+    await tick();
+    controller.expectOne(URL_ASSINADA).flush(null);
+    await tick();
+    controller
+      .expectOne(
+        `${BASE}/api/selecao/processos-seletivos/${PROCESSO_ID}/documentos-edital/${DOCUMENTO_ID}/confirmacao`,
+      )
+      .flush({
+        id: DOCUMENTO_ID,
+        processoSeletivoId: PROCESSO_ID,
+        status: 'Confirmado',
+        tamanhoBytes: 2048,
+        hashSha256: 'a'.repeat(64),
+        confirmadoEm: '2026-08-13T12:00:00Z',
+      });
+    await retomada;
+
+    expect(componente.anexo()?.fase).toBe('confirmado');
+  });
+
+  /**
+   * A segunda escolha durante a criação trocaria o arquivo sob os pés do fluxo
+   * em curso: o anexo exibiria o nome do primeiro e o storage receberia os
+   * bytes do segundo — que o backend selaria como documento imutável.
+   */
+  it('ignora um segundo arquivo escolhido enquanto a operação está em curso', async () => {
+    preencherPassoInteiro();
+    const primeiro = componente['anexar'](pdf('primeiro.pdf'));
+    await tick();
+
+    await componente['anexar'](pdf('segundo.pdf'));
+
+    const criacao = controller.expectOne(`${BASE}/api/selecao/processos-seletivos`);
+    criacao.flush(PROCESSO_ID, { status: 201, statusText: 'Created' });
+    await tick();
+
+    expect(componente.anexo()?.name).toBe('primeiro.pdf');
+
+    const falha = problema(422, 'DocumentoEdital.Invalido', 'Documento recusado');
+    controller
+      .expectOne(`${BASE}/api/selecao/processos-seletivos/${PROCESSO_ID}/documentos-edital`)
+      .flush(falha.body, falha.opts);
+    await primeiro;
+  });
+
+  /**
+   * Falha de rede na criação não diz se o servidor executou o comando. Repetir
+   * com o mesmo corpo e a mesma chave devolve o replay; repetir com o rascunho
+   * editado devolveria `body_mismatch` e a correção seguinte criaria um
+   * segundo processo.
+   */
+  it('repete a criação inconclusiva com o mesmo corpo, ignorando edição posterior', async () => {
+    preencherPassoInteiro();
+    const primeira = componente['persistir']();
+
+    const req1 = controller.expectOne(`${BASE}/api/selecao/processos-seletivos`);
+    const chave1 = req1.request.headers.get('Idempotency-Key');
+    const corpoOriginal = req1.request.body;
+    req1.error(new ProgressEvent('error'), { status: 0, statusText: 'Unknown Error' });
+    await primeira;
+
+    expect(componente.criacaoIndefinida()).toBe(true);
+    store.patchObjectSection('identificacao', { nome: 'Nome editado depois da falha' });
+
+    const segunda = componente['persistir']();
+    const req2 = controller.expectOne(`${BASE}/api/selecao/processos-seletivos`);
+    expect(req2.request.headers.get('Idempotency-Key')).toBe(chave1);
+    expect(req2.request.body).toEqual(corpoOriginal);
+    req2.flush(PROCESSO_ID, { status: 201, statusText: 'Created' });
+    await segunda;
+
+    expect(componente.criacaoIndefinida()).toBe(false);
+  });
+
+  /**
+   * Se o arquivo já chegou ao storage, repetir o PUT é desperdício e pode
+   * esbarrar numa URL expirada — só a confirmação falta.
+   */
+  it('retoma direto da confirmação quando o arquivo já foi enviado', async () => {
+    preencherCamposDoComando();
+    store.processoSeletivoId.set(PROCESSO_ID);
+    const anexo = componente['anexar'](pdf());
+    await tick();
+
+    controller
+      .expectOne(`${BASE}/api/selecao/processos-seletivos/${PROCESSO_ID}/documentos-edital`)
+      .flush(iniciacao(), { status: 201, statusText: 'Created' });
+    await tick();
+    controller.expectOne(URL_ASSINADA).flush(null);
+    await tick();
+
+    const falha = problema(422, 'DocumentoEdital.ObjetoNaoEncontrado', 'Objeto ausente');
+    controller
+      .expectOne(
+        `${BASE}/api/selecao/processos-seletivos/${PROCESSO_ID}/documentos-edital/${DOCUMENTO_ID}/confirmacao`,
+      )
+      .flush(falha.body, falha.opts);
+    await anexo;
+    expect(componente.anexo()?.enviado).toBe(true);
+
+    const retomada = componente.retomarUpload();
+    await tick();
+
+    // Nenhuma nova iniciação e nenhum novo PUT: só a confirmação.
+    controller.expectNone(
+      `${BASE}/api/selecao/processos-seletivos/${PROCESSO_ID}/documentos-edital`,
+    );
+    controller.expectNone(URL_ASSINADA);
+    controller
+      .expectOne(
+        `${BASE}/api/selecao/processos-seletivos/${PROCESSO_ID}/documentos-edital/${DOCUMENTO_ID}/confirmacao`,
+      )
+      .flush({
+        id: DOCUMENTO_ID,
+        processoSeletivoId: PROCESSO_ID,
+        status: 'Confirmado',
+        tamanhoBytes: 2048,
+        hashSha256: 'a'.repeat(64),
+        confirmadoEm: '2026-08-13T12:00:00Z',
+      });
+    await retomada;
+
+    expect(componente.anexo()?.fase).toBe('confirmado');
+  });
+
+  /**
+   * O tipo é escolhido no passo 1 e entra no comando retido. Deixá-lo editável
+   * durante a espera faria o rascunho exibir um tipo diferente do processo que
+   * a retentativa vai confirmar no servidor.
+   */
+  it('congela também o passo 1 enquanto a criação está indefinida', async () => {
+    preencherPassoInteiro();
+    const primeira = componente['persistir']();
+
+    controller
+      .expectOne(`${BASE}/api/selecao/processos-seletivos`)
+      .error(new ProgressEvent('error'), { status: 0, statusText: 'Unknown Error' });
+    await primeira;
+
+    expect(store.cadastroInicialCongelado()).toBe(true);
+  });
+
+  /** Sem anexo registrado, a falha da criação não teria onde oferecer o retry. */
+  it('registra o anexo em erro quando a criação falha, com retomada disponível', async () => {
+    preencherPassoInteiro();
+    const anexo = componente['anexar'](pdf());
+    await tick();
+
+    const recusa = problema(422, 'ProcessoSeletivo.NomeDuplicado', 'Nome já utilizado');
+    controller.expectOne(`${BASE}/api/selecao/processos-seletivos`).flush(recusa.body, recusa.opts);
+    await anexo;
+
+    expect(componente.anexo()?.fase).toBe('erro');
+    expect(componente.anexo()?.mensagemErro).toContain('Nome já utilizado');
+  });
+
+  /**
+   * 413 é recusa definitiva do filtro de idempotência: manter a chave prenderia
+   * a tela repetindo para sempre um comando que o servidor não aceita.
+   */
+  it('rotaciona a chave e libera os campos após 413', async () => {
+    preencherPassoInteiro();
+    const primeira = componente['persistir']();
+
+    const req1 = controller.expectOne(`${BASE}/api/selecao/processos-seletivos`);
+    const chave1 = req1.request.headers.get('Idempotency-Key');
+    const grande = problema(413, 'uniplus.idempotency.body_muito_grande', 'Corpo muito grande');
+    req1.flush(grande.body, grande.opts);
+    await primeira;
+
+    expect(componente.criacaoIndefinida()).toBe(false);
+
+    const segunda = componente['persistir']();
+    const req2 = controller.expectOne(`${BASE}/api/selecao/processos-seletivos`);
+    expect(req2.request.headers.get('Idempotency-Key')).not.toBe(chave1);
+    req2.flush(PROCESSO_ID, { status: 201, statusText: 'Created' });
+    await segunda;
+  });
+
+  /**
+   * O campo de arquivo continua alcançável pelo teclado mesmo com a zona de
+   * upload marcada como indisponível — e cada anexo confirmado vira um
+   * documento imutável a mais no processo.
+   */
+  it('recusa substituir um edital já confirmado', async () => {
+    preencherPassoInteiro();
+    store.processoSeletivoId.set(PROCESSO_ID);
+    store.patchObjectSection('identificacao', {
+      uploads: [
+        { id: 'a', name: 'edital.pdf', extension: 'pdf', progress: 100, fase: 'confirmado' },
+      ],
+    });
+
+    await componente['anexar'](pdf('outro.pdf'));
+
+    expect(componente.uploadError()).toContain('não pode ser substituído');
+    expect(componente.anexo()?.name).toBe('edital.pdf');
+  });
+
+  /**
+   * Confirmação sem resposta pode ter selado o documento no servidor. Trocar o
+   * arquivo aqui criaria um segundo edital imutável e perderia a referência do
+   * primeiro — só a retentativa da mesma confirmação resolve.
+   */
+  it('não deixa trocar nem remover o anexo com confirmação indefinida', async () => {
+    preencherCamposDoComando();
+    store.processoSeletivoId.set(PROCESSO_ID);
+    const anexo = componente['anexar'](pdf('primeiro.pdf'));
+    await tick();
+
+    controller
+      .expectOne(`${BASE}/api/selecao/processos-seletivos/${PROCESSO_ID}/documentos-edital`)
+      .flush(iniciacao(), { status: 201, statusText: 'Created' });
+    await tick();
+    controller.expectOne(URL_ASSINADA).flush(null);
+    await tick();
+
+    // Confirmação sem resposta: erro de rede, sem status.
+    controller
+      .expectOne(
+        `${BASE}/api/selecao/processos-seletivos/${PROCESSO_ID}/documentos-edital/${DOCUMENTO_ID}/confirmacao`,
+      )
+      .error(new ProgressEvent('error'), { status: 0, statusText: 'Unknown Error' });
+    await anexo;
+
+    expect(componente.anexo()?.confirmacaoIndefinida).toBe(true);
+    expect(componente.anexoBloqueado()).toBe(true);
+
+    await componente['anexar'](pdf('segundo.pdf'));
+    expect(componente.anexo()?.name).toBe('primeiro.pdf');
+    expect(componente.uploadError()).toContain('sem resposta');
+
+    componente.removeUpload();
+    expect(componente.anexo()).toBeDefined();
+
+    // A retentativa repete só a confirmação, com a mesma chave.
+    const retomada = componente.retomarUpload();
+    await tick();
+    controller.expectNone(URL_ASSINADA);
+    controller
+      .expectOne(
+        `${BASE}/api/selecao/processos-seletivos/${PROCESSO_ID}/documentos-edital/${DOCUMENTO_ID}/confirmacao`,
+      )
+      .flush({
+        id: DOCUMENTO_ID,
+        processoSeletivoId: PROCESSO_ID,
+        status: 'Confirmado',
+        tamanhoBytes: 2048,
+        hashSha256: 'a'.repeat(64),
+        confirmadoEm: '2026-08-13T12:00:00Z',
+      });
+    await retomada;
+
+    expect(componente.anexo()?.fase).toBe('confirmado');
+    expect(componente.anexo()?.confirmacaoIndefinida).toBe(false);
+  });
+
+  it('não remove o anexo já confirmado', async () => {
+    preencherCamposDoComando();
+    store.processoSeletivoId.set(PROCESSO_ID);
+    store.patchObjectSection('identificacao', {
+      uploads: [{ id: 'a', name: 'edital.pdf', extension: 'pdf', progress: 100, fase: 'confirmado' }],
+    });
+
+    componente.removeUpload();
+
+    expect(componente.anexo()).toBeDefined();
+  });
+});

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-02-identificacao/step-02-identificacao.component.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-02-identificacao/step-02-identificacao.component.ts
@@ -3,12 +3,44 @@ import {
   Component,
   DestroyRef,
   ElementRef,
+  ViewChild,
+  computed,
   inject,
   signal,
-  ViewChild,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ProblemI18nService, extractNextCursor, isApiOk } from '@uniplus/shared-core/http';
+import { UnidadeDto, UnidadesApi } from '@uniplus/shared-data/organizacao';
+import { IniciarUploadDocumentoEditalDto, OrigemCandidatos } from '@uniplus/shared-data/selecao';
 import { ProcessoSeletivoStore } from '../../processo-seletivo.store';
-import { StepValidation, UploadItem } from '../../processo-seletivo.models';
+import {
+  OrigemCandidatosSelecionada,
+  StepValidation,
+  UploadItem,
+} from '../../processo-seletivo.models';
+import { CadastroInicialService } from '../../shared/cadastro-inicial.service';
+
+/** Limite do documento do edital no domínio: 20 MB. */
+const TAMANHO_MAXIMO_BYTES = 20 * 1024 * 1024;
+const CONTENT_TYPE_PDF = 'application/pdf';
+
+interface UnidadeOption {
+  readonly id: string;
+  readonly rotulo: string;
+}
+
+/**
+ * Rótulos curtos de propósito: em 320 px, a largura intrínseca da opção mais
+ * longa é o que decide o piso do campo. O sentido completo fica no texto de
+ * apoio do campo, que quebra em várias linhas sem esticar nada.
+ */
+export const ORIGENS_CANDIDATOS: readonly {
+  readonly value: OrigemCandidatosSelecionada;
+  readonly label: string;
+}[] = [
+  { value: OrigemCandidatos.inscricaoPropria, label: 'Inscrição neste sistema' },
+  { value: OrigemCandidatos.importacaoExterna, label: 'Importação externa' },
+];
 
 @Component({
   selector: 'sel-step-02-identificacao',
@@ -18,29 +50,118 @@ import { StepValidation, UploadItem } from '../../processo-seletivo.models';
 })
 export class Step02IdentificacaoComponent {
   readonly store = inject(ProcessoSeletivoStore);
+  private readonly cadastro = inject(CadastroInicialService);
+  private readonly unidadesApi = inject(UnidadesApi);
+  private readonly problemI18n = inject(ProblemI18nService);
   private readonly destroyRef = inject(DestroyRef);
+
   readonly dragging = signal(false);
   /** Campos inválidos detectados na última validação (chave → `.is-invalid`). */
   readonly invalidFields = signal<ReadonlySet<string>>(new Set());
-  /** Mensagem de erro do upload (formato não permitido). `null` = sem erro. */
+  /** Mensagem de recusa do anexo, antes de qualquer requisição. `null` = sem erro. */
   readonly uploadError = signal<string | null>(null);
-  /** Extensões permitidas no upload do edital. */
-  readonly allowedExtensions = ['pdf', 'png', 'jpeg', 'jpg', 'docx'] as const;
-  private readonly timers = new Map<string, ReturnType<typeof setInterval>>();
+  readonly origens = ORIGENS_CANDIDATOS;
+
+  readonly unidades = signal<readonly UnidadeOption[]>([]);
+  readonly unidadesCarregando = signal(true);
+  readonly unidadesErro = signal<string | null>(null);
+
+  /**
+   * Enquanto o cadastro inicial não existe, o operador pode corrigir tudo;
+   * depois de criado, o contrato não expõe atualização de identificação, então
+   * os campos que compuseram o comando ficam somente-leitura.
+   */
+  readonly camposDoComandoBloqueados = computed(() => this.store.cadastroInicialCongelado());
+  /**
+   * Uma criação sem resposta definitiva precisa ser repetida com o mesmo corpo,
+   * senão a mesma chave devolve `body_mismatch` e a correção seguinte cria um
+   * segundo processo. Editar não adiantaria — daí manter os campos travados,
+   * aqui e no passo 1.
+   */
+  readonly criacaoIndefinida = this.store.criacaoIndefinida;
+  readonly anexo = computed<UploadItem | undefined>(
+    () => this.store.draft().identificacao.uploads[0],
+  );
+  readonly anexoConfirmado = computed(() => this.anexo()?.fase === 'confirmado');
+  readonly anexoEmCurso = computed(() => {
+    const fase = this.anexo()?.fase;
+    return fase === 'iniciando' || fase === 'enviando' || fase === 'confirmando';
+  });
+
   @ViewChild('fileInput') private fileInput?: ElementRef<HTMLInputElement>;
+  /** Arquivo escolhido, preservado em memória para permitir repetir o envio. */
+  private arquivoSelecionado: File | null = null;
+  /**
+   * URL pré-assinada da iniciação corrente. Fica só em memória, nunca no
+   * rascunho: é credencial de escrita no storage, com validade curta.
+   */
+  private iniciacaoAtual: IniciarUploadDocumentoEditalDto | null = null;
+  /** Impede que uma segunda escolha de arquivo se atravesse na operação em curso. */
+  private operacaoEmCurso = false;
 
   constructor() {
-    this.destroyRef.onDestroy(() => this.timers.forEach((timer) => clearInterval(timer)));
+    this.carregarUnidades();
   }
 
   patch(
-    field: 'numero' | 'ano' | 'data' | 'orgao' | 'periodo' | 'nome',
+    field:
+      | 'numero'
+      | 'ano'
+      | 'data'
+      | 'orgao'
+      | 'periodo'
+      | 'nome'
+      | 'unidadeAdministradoraId'
+      | 'origemCandidatos',
     value: string | number | null,
   ): void {
     if (field === 'ano' && typeof value === 'number' && !Number.isFinite(value)) {
       value = null; // input numérico vazio
     }
     this.store.patchObjectSection('identificacao', { [field]: value });
+  }
+
+  carregarUnidades(): void {
+    this.unidadesCarregando.set(true);
+    this.unidadesErro.set(null);
+    this.carregarPaginaDeUnidades();
+  }
+
+  private carregarPaginaDeUnidades(
+    cursor?: string,
+    acumuladas: readonly UnidadeOption[] = [],
+  ): void {
+    const consulta =
+      cursor === undefined
+        ? this.unidadesApi.listar()
+        : this.unidadesApi.listar({ cursor, direction: 'next' });
+
+    consulta.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (result) => {
+        if (!isApiOk(result)) {
+          this.exibirErroDeUnidades();
+          return;
+        }
+
+        const unidades = [...acumuladas, ...result.data.map((item) => toOption(item))];
+        const proximoCursor = extractNextCursor(result.headers.get('Link'));
+        if (proximoCursor !== null) {
+          this.carregarPaginaDeUnidades(proximoCursor, unidades);
+          return;
+        }
+
+        this.unidades.set(unidades);
+        this.unidadesCarregando.set(false);
+      },
+      error: () => this.exibirErroDeUnidades(),
+    });
+  }
+
+  private exibirErroDeUnidades(): void {
+    this.unidadesCarregando.set(false);
+    this.unidadesErro.set(
+      'Não foi possível carregar as unidades administradoras. Tente novamente.',
+    );
   }
 
   openDatePicker(input: HTMLInputElement): void {
@@ -51,29 +172,289 @@ export class Step02IdentificacaoComponent {
     }
   }
 
+  /**
+   * O anexo fica indisponível enquanto qualquer gravação está em curso, depois
+   * de confirmado, e também quando a confirmação ficou sem resposta: nesse
+   * último caso o documento pode já estar selado no servidor, e substituí-lo
+   * criaria um segundo edital imutável.
+   */
+  readonly anexoBloqueado = computed(
+    () =>
+      this.anexoEmCurso() ||
+      this.anexoConfirmado() ||
+      this.store.salvando() ||
+      this.anexo()?.confirmacaoIndefinida === true,
+  );
+
   chooseFiles(): void {
+    if (this.anexoBloqueado()) return;
     this.fileInput?.nativeElement.click();
   }
 
   onFileInput(event: Event): void {
     const input = event.target as HTMLInputElement;
-    if (input.files) this.addFiles(input.files);
+    const arquivo = input.files?.[0];
     input.value = '';
+    if (arquivo) void this.anexar(arquivo);
   }
 
   onDrop(event: DragEvent): void {
     event.preventDefault();
     this.dragging.set(false);
-    if (event.dataTransfer?.files) this.addFiles(event.dataTransfer.files);
+    if (this.anexoBloqueado()) return;
+    const arquivo = event.dataTransfer?.files?.[0];
+    if (arquivo) void this.anexar(arquivo);
   }
 
-  removeUpload(id: string): void {
-    const timer = this.timers.get(id);
-    if (timer) clearInterval(timer);
-    this.timers.delete(id);
-    this.store.patchObjectSection('identificacao', {
-      uploads: this.store.draft().identificacao.uploads.filter((item) => item.id !== id),
+  /**
+   * Anexar o edital exige o processo já criado — a rota do documento é
+   * `/{processoSeletivoId}/documentos-edital`. Por isso o anexo é o gatilho da
+   * criação: sem isso, "Próximo" nunca criaria o processo (a validação barra
+   * antes, exigindo o edital) e o operador ficaria preso.
+   */
+  private async anexar(arquivo: File): Promise<void> {
+    // Sem esta guarda, uma segunda escolha durante a criação trocaria o arquivo
+    // sob os pés do fluxo em andamento: o anexo exibiria o nome do primeiro e o
+    // storage receberia os bytes do segundo — que o backend selaria como
+    // documento imutável.
+    if (this.operacaoEmCurso) return;
+
+    // O campo de arquivo é alcançável pelo teclado mesmo com a zona de upload
+    // marcada como indisponível, então a recusa precisa estar aqui também:
+    // cada anexo confirmado vira um documento imutável a mais no processo.
+    if (this.anexoConfirmado()) {
+      this.uploadError.set(
+        'O edital já foi anexado e não pode ser substituído. Para trocar o arquivo, cadastre um novo processo seletivo.',
+      );
+      return;
+    }
+    if (this.anexo()?.confirmacaoIndefinida === true) {
+      this.uploadError.set(
+        'A confirmação do edital anterior ficou sem resposta e pode ter sido registrada. Use "Tentar novamente" antes de escolher outro arquivo.',
+      );
+      return;
+    }
+
+    const recusa = recusarArquivo(arquivo);
+    if (recusa !== null) {
+      this.uploadError.set(recusa);
+      return;
+    }
+
+    // Campos do comando conferidos antes de registrar o anexo: faltando algum,
+    // não há operação a retomar e a mensagem tem de apontar o que preencher.
+    const faltando = this.camposFaltantesDoComando();
+    if (faltando.length > 0) {
+      this.uploadError.set(
+        `Antes de anexar o edital, preencha: ${faltando.join(', ')}. O cadastro é criado no sistema neste momento.`,
+      );
+      return;
+    }
+
+    this.uploadError.set(null);
+    this.operacaoEmCurso = true;
+    try {
+      this.arquivoSelecionado = arquivo;
+      this.iniciacaoAtual = null;
+
+      // O anexo é registrado antes da criação para que qualquer falha do fluxo
+      // — inclusive a da própria criação — apareça no mesmo lugar, com o botão
+      // de retomar.
+      this.registrarAnexo(arquivo);
+
+      const processoId = await this.garantirProcessoCriado();
+      if (processoId === null) {
+        this.falharAnexo(this.uploadError() ?? 'Não foi possível criar o cadastro inicial.');
+        return;
+      }
+
+      await this.executarUpload(processoId, arquivo);
+    } finally {
+      this.operacaoEmCurso = false;
+    }
+  }
+
+  /** Retoma da fase que falhou, sem repetir o que já concluiu. */
+  async retomarUpload(): Promise<void> {
+    if (this.operacaoEmCurso) return;
+    const arquivo = this.arquivoSelecionado;
+    if (arquivo === null) return;
+
+    this.operacaoEmCurso = true;
+    try {
+      const processoId = this.store.processoSeletivoId() ?? (await this.garantirProcessoCriado());
+      if (processoId === null) return;
+      await this.executarUpload(processoId, arquivo);
+    } finally {
+      this.operacaoEmCurso = false;
+    }
+  }
+
+  /**
+   * Cria o processo se ainda não existe, a partir de um instantâneo do rascunho
+   * — os campos ficam bloqueados durante a requisição, para que a resposta
+   * nunca descreva um estado diferente do enviado.
+   */
+  private async garantirProcessoCriado(): Promise<string | null> {
+    const existente = this.store.processoSeletivoId();
+    if (existente !== null) return existente;
+    if (this.store.salvando()) return null;
+
+    const identificacao = this.store.draft().identificacao;
+    const tipoProcessoOrigemId = this.store.draft().tipoProcesso.selected;
+    const faltando = this.camposFaltantesDoComando();
+    if (faltando.length > 0) {
+      this.uploadError.set(
+        `Antes de anexar o edital, preencha: ${faltando.join(', ')}. O cadastro é criado no sistema neste momento.`,
+      );
+      return null;
+    }
+
+    this.store.salvando.set(true);
+    try {
+      const resultado = await this.cadastro.criar({
+        nome: identificacao.nome.trim(),
+        tipoProcessoOrigemId,
+        origemCandidatos: identificacao.origemCandidatos as OrigemCandidatos,
+        unidadeAdministradoraOrigemId: identificacao.unidadeAdministradoraId,
+      });
+
+      if (!resultado.ok) {
+        this.store.criacaoIndefinida.set(this.cadastro.temCriacaoPendente());
+        this.uploadError.set(
+          this.criacaoIndefinida()
+            ? `${this.problemI18n.resolve(resultado.problem).title} Não é possível saber se o cadastro chegou a ser criado; use "Tentar novamente" para repetir o mesmo envio.`
+            : this.problemI18n.resolve(resultado.problem).title,
+        );
+        return null;
+      }
+
+      this.store.criacaoIndefinida.set(false);
+      this.store.processoSeletivoId.set(resultado.processoSeletivoId);
+      return resultado.processoSeletivoId;
+    } finally {
+      this.store.salvando.set(false);
+    }
+  }
+
+  /** Campos que compõem o comando de criação e ainda estão vazios. */
+  private camposFaltantesDoComando(): string[] {
+    const identificacao = this.store.draft().identificacao;
+    const faltando: string[] = [];
+    if (!this.store.draft().tipoProcesso.selected) faltando.push('tipo do processo (passo 1)');
+    if (!identificacao.nome.trim()) faltando.push('nome do processo seletivo');
+    if (!identificacao.unidadeAdministradoraId) faltando.push('unidade administradora');
+    if (!identificacao.origemCandidatos) faltando.push('origem dos candidatos');
+    return faltando;
+  }
+
+  private registrarAnexo(arquivo: File): void {
+    const item: UploadItem = {
+      id: crypto.randomUUID(),
+      name: arquivo.name,
+      extension: 'pdf',
+      progress: 0,
+      fase: 'iniciando',
+    };
+    this.store.patchObjectSection('identificacao', { uploads: [item] });
+  }
+
+  /**
+   * Percorre as três fases do anexo. Cada falha registra a fase, para que o
+   * retry recomece do ponto certo: repetir a confirmação de um objeto que nunca
+   * chegou ao storage, ou repetir um PUT cuja URL expirou, nunca funciona.
+   */
+  private async executarUpload(processoId: string, arquivo: File): Promise<void> {
+    const atual = this.anexo();
+    if (atual === undefined) return;
+
+    // O arquivo já chegou ao storage numa tentativa anterior: repetir o PUT
+    // seria desperdício e esbarraria numa URL possivelmente expirada. Só a
+    // confirmação falta, e repeti-la com a mesma chave recupera o replay.
+    if (atual.enviado === true && atual.documentoEditalId !== undefined) {
+      await this.confirmar(processoId, atual.documentoEditalId);
+      return;
+    }
+
+    let iniciacao = this.iniciacaoAtual;
+    if (iniciacao === null || iniciacaoExpirada(iniciacao)) {
+      this.atualizarAnexo({ fase: 'iniciando', progress: 0, mensagemErro: undefined });
+      const inicio = await this.cadastro.iniciarUpload(processoId);
+      if (!inicio.ok) {
+        this.falharAnexo(this.problemI18n.resolve(inicio.problem).title);
+        return;
+      }
+      iniciacao = inicio.iniciacao;
+      this.iniciacaoAtual = iniciacao;
+      this.atualizarAnexo({
+        documentoEditalId: iniciacao.documentoEditalId,
+        expiraEm: iniciacao.expiraEm,
+      });
+    }
+
+    this.atualizarAnexo({ fase: 'enviando' });
+    const envio = await this.cadastro.enviarArquivo(iniciacao, arquivo, (pct) =>
+      this.atualizarAnexo({ progress: pct }),
+    );
+    if (!envio.ok) {
+      // A assinatura não volta a valer — nem por expiração, nem por divergência
+      // de content type ou política do bucket. Em todos esses casos o caminho é
+      // pedir outra URL, então a iniciação é descartada.
+      if (envio.expirada) {
+        this.iniciacaoAtual = null;
+        this.atualizarAnexo({ documentoEditalId: undefined, expiraEm: undefined });
+        this.falharAnexo(
+          'O endereço de envio não é mais válido. Tente novamente para obter um novo.',
+        );
+        return;
+      }
+      this.falharAnexo('Falha ao enviar o arquivo. Verifique a conexão e tente novamente.');
+      return;
+    }
+
+    this.atualizarAnexo({ enviado: true, progress: 100 });
+    // A URL cumpriu o papel; some da memória para não ficar credencial viva à toa.
+    this.iniciacaoAtual = null;
+    await this.confirmar(processoId, iniciacao.documentoEditalId);
+  }
+
+  private async confirmar(processoId: string, documentoEditalId: string): Promise<void> {
+    this.atualizarAnexo({ fase: 'confirmando', progress: 100 });
+    const confirmacao = await this.cadastro.confirmarUpload(processoId, documentoEditalId);
+    if (!confirmacao.ok) {
+      const indefinida = this.cadastro.temConfirmacaoPendente();
+      this.atualizarAnexo({ confirmacaoIndefinida: indefinida });
+      this.falharAnexo(
+        indefinida
+          ? `${this.problemI18n.resolve(confirmacao.problem).title} Não é possível saber se o edital foi registrado; use "Tentar novamente" para repetir a mesma confirmação.`
+          : this.problemI18n.resolve(confirmacao.problem).title,
+      );
+      return;
+    }
+
+    this.atualizarAnexo({
+      fase: 'confirmado',
+      progress: 100,
+      mensagemErro: undefined,
+      confirmacaoIndefinida: false,
     });
+  }
+
+  private atualizarAnexo(patch: Partial<UploadItem>): void {
+    const atual = this.anexo();
+    if (atual === undefined) return;
+    this.store.patchObjectSection('identificacao', { uploads: [{ ...atual, ...patch }] });
+  }
+
+  private falharAnexo(mensagem: string): void {
+    this.atualizarAnexo({ fase: 'erro', mensagemErro: mensagem });
+  }
+
+  /** Só antes da confirmação: o documento confirmado é imutável no backend. */
+  removeUpload(): void {
+    if (this.anexoBloqueado()) return;
+    this.arquivoSelecionado = null;
+    this.store.patchObjectSection('identificacao', { uploads: [] });
   }
 
   /**
@@ -91,38 +472,20 @@ export class Step02IdentificacaoComponent {
     return `${base.slice(0, available)}...${extension}`;
   }
 
-  private addFiles(files: FileList): void {
-    const rejected: string[] = [];
-    const accepted: UploadItem[] = [];
-
-    Array.from(files).forEach((file) => {
-      const extension = file.name.split('.').pop()?.toLowerCase() ?? '';
-      if (!this.allowedExtensions.includes(extension as (typeof this.allowedExtensions)[number])) {
-        rejected.push(file.name);
-        return;
-      }
-      accepted.push({
-        id: crypto.randomUUID(),
-        name: file.name,
-        extension: extension as UploadItem['extension'],
-        progress: 0,
-      });
-    });
-
-    if (rejected.length) {
-      this.uploadError.set(
-        rejected.length === 1
-          ? `Formato não permitido: "${rejected[0]}". Use apenas PDF, PNG, JPEG, JPG ou DOCX.`
-          : `Formatos não permitidos: ${rejected.map((name) => `"${name}"`).join(', ')}. Use apenas PDF, PNG, JPEG, JPG ou DOCX.`,
-      );
-      return; // não carrega nenhum arquivo inválido
+  /** Rótulo da fase, para o leitor de tela acompanhar o andamento. */
+  descricaoFase(item: UploadItem): string {
+    switch (item.fase) {
+      case 'iniciando':
+        return 'Preparando o envio';
+      case 'enviando':
+        return `Enviando: ${item.progress}%`;
+      case 'confirmando':
+        return 'Validando o arquivo';
+      case 'confirmado':
+        return 'Edital anexado';
+      case 'erro':
+        return item.mensagemErro ?? 'Falha no envio';
     }
-
-    this.uploadError.set(null);
-    this.store.patchObjectSection('identificacao', {
-      uploads: [...this.store.draft().identificacao.uploads, ...accepted],
-    });
-    accepted.forEach((item) => this.animate(item.id));
   }
 
   /** Validação declarativa — acionada pela page ao clicar em "Próximo". */
@@ -155,11 +518,20 @@ export class Step02IdentificacaoComponent {
       messages.push('Informe o nome do processo seletivo.');
       invalid.add('nome');
     }
-    if (!id.uploads.length) {
+    if (!id.unidadeAdministradoraId) {
+      messages.push('Selecione a unidade administradora.');
+      invalid.add('unidadeAdministradoraId');
+    }
+    if (!id.origemCandidatos) {
+      messages.push('Informe a origem dos candidatos.');
+      invalid.add('origemCandidatos');
+    }
+    const anexo = id.uploads[0];
+    if (anexo === undefined) {
       messages.push('Anexe o edital em PDF (obrigatório para auditoria).');
       invalid.add('uploads');
-    } else if (id.uploads.some((file) => file.progress < 100)) {
-      messages.push('Aguarde o upload do edital concluir.');
+    } else if (anexo.fase !== 'confirmado') {
+      messages.push('Aguarde a conclusão do envio do edital.');
       invalid.add('uploads');
     }
 
@@ -167,24 +539,48 @@ export class Step02IdentificacaoComponent {
     return messages.length ? { valid: false, messages } : { valid: true };
   }
 
-  private animate(id: string): void {
-    const timer = setInterval(() => {
-      const uploads = this.store.draft().identificacao.uploads;
-      const item = uploads.find((upload) => upload.id === id);
-      if (!item) {
-        clearInterval(timer);
-        this.timers.delete(id);
-        return;
-      }
-      const progress = Math.min(item.progress + Math.random() * 18 + 7, 100);
-      this.store.patchObjectSection('identificacao', {
-        uploads: uploads.map((upload) => (upload.id === id ? { ...upload, progress } : upload)),
-      });
-      if (progress >= 100) {
-        clearInterval(timer);
-        this.timers.delete(id);
-      }
-    }, 80);
-    this.timers.set(id, timer);
+  /**
+   * Commit assíncrono do passo: garante que o cadastro inicial exista antes de
+   * avançar. Em uso normal o processo já foi criado no anexo; isto cobre o caso
+   * de a criação ter falhado e o operador reagir pelo rodapé.
+   */
+  async persistir(): Promise<StepValidation> {
+    if (this.store.processoSeletivoId() !== null) return { valid: true };
+
+    const processoId = await this.garantirProcessoCriado();
+    if (processoId === null) {
+      return {
+        valid: false,
+        messages: [
+          this.uploadError() ?? 'Não foi possível criar o cadastro inicial. Tente novamente.',
+        ],
+      };
+    }
+    return { valid: true };
   }
+}
+
+function toOption(unidade: UnidadeDto): UnidadeOption {
+  return { id: unidade.id, rotulo: `${unidade.sigla} — ${unidade.nome}` };
+}
+
+/** Recusa client-side do que o backend recusaria de todo modo. */
+function recusarArquivo(arquivo: File): string | null {
+  const extensao = arquivo.name.split('.').pop()?.toLowerCase() ?? '';
+  if (extensao !== 'pdf' || (arquivo.type !== '' && arquivo.type !== CONTENT_TYPE_PDF)) {
+    return `Formato não permitido: "${arquivo.name}". O edital deve ser um arquivo PDF.`;
+  }
+  if (arquivo.size > TAMANHO_MAXIMO_BYTES) {
+    return 'O edital excede o tamanho máximo permitido de 20 MB.';
+  }
+  if (arquivo.size === 0) {
+    return 'O arquivo está vazio.';
+  }
+  return null;
+}
+
+/** A URL pré-assinada tem TTL curto; passado o prazo, só uma nova iniciação serve. */
+function iniciacaoExpirada(iniciacao: IniciarUploadDocumentoEditalDto): boolean {
+  const expiraEm = Date.parse(iniciacao.expiraEm);
+  return Number.isNaN(expiraEm) || expiraEm <= Date.now();
 }

--- a/apps/selecao/src/app/layout/layout.spec.ts
+++ b/apps/selecao/src/app/layout/layout.spec.ts
@@ -1,0 +1,70 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { AuthService, UserContextService } from '@uniplus/shared-auth/bootstrap';
+import { LayoutComponent } from './layout';
+
+const papeis = signal<readonly string[]>([]);
+const authServiceStub = { roles: papeis, logout: () => undefined };
+const userContextStub = {
+  user: signal({ id: 'u-1', nome: 'Admin Teste', email: 'admin@teste.br', roles: [] }),
+  displayName: signal('Admin Teste'),
+  firstDisplayName: signal('Admin'),
+};
+
+/**
+ * A navegação tem de espelhar os `roleGuard` das rotas: item visível que o
+ * guard recusa é um clique que sempre termina em `/acesso-negado`.
+ */
+describe('LayoutComponent — navegação por papel', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LayoutComponent],
+      providers: [
+        provideRouter([]),
+        { provide: AuthService, useValue: authServiceStub },
+        { provide: UserContextService, useValue: userContextStub },
+      ],
+    }).compileComponents();
+  });
+
+  function rotulosDeNavegacao(): string[] {
+    const fixture = TestBed.createComponent(LayoutComponent);
+    fixture.detectChanges();
+    const host = fixture.nativeElement as HTMLElement;
+    return [...host.querySelectorAll('nav a')]
+      .map((a) => a.textContent?.trim() ?? '')
+      .filter((texto) => texto.length > 0);
+  }
+
+  it('oferece o cadastro do certame a quem administra a plataforma', () => {
+    papeis.set(['plataforma-admin']);
+
+    expect(rotulosDeNavegacao().join(' | ')).toContain('Processo seletivo');
+  });
+
+  it('esconde o cadastro do certame de um gestor', () => {
+    papeis.set(['gestor']);
+    const rotulos = rotulosDeNavegacao().join(' | ');
+
+    expect(rotulos).not.toContain('Processo seletivo');
+    expect(rotulos).toContain('Inscrições');
+  });
+
+  /** Quem entra só como plataforma-admin não deve ver as telas operacionais. */
+  it('esconde as telas operacionais de quem só administra a plataforma', () => {
+    papeis.set(['plataforma-admin']);
+    const rotulos = rotulosDeNavegacao().join(' | ');
+
+    expect(rotulos).not.toContain('Inscrições');
+    expect(rotulos).not.toContain('Homologação');
+  });
+
+  it('mantém o painel disponível para qualquer papel do backoffice', () => {
+    papeis.set(['avaliador']);
+    const rotulos = rotulosDeNavegacao().join(' | ');
+
+    expect(rotulos).toContain('Painel de processos');
+    expect(rotulos).toContain('Homologação');
+  });
+});

--- a/apps/selecao/src/app/layout/layout.ts
+++ b/apps/selecao/src/app/layout/layout.ts
@@ -34,6 +34,13 @@ interface ConfigNavItem {
   readonly icon: string;
   readonly routerLink?: string;
   readonly exact?: boolean;
+  /**
+   * Papéis que abrem o destino, espelhando o `roleGuard` da rota. Ausente
+   * significa disponível para quem já entrou no backoffice. Sem isso, o item
+   * apareceria para quem o guard recusa, e o clique terminaria em
+   * `/acesso-negado`.
+   */
+  readonly roles?: readonly string[];
 }
 
 interface ConfigNavGroup {
@@ -85,7 +92,7 @@ interface ConfigNavGroup {
         </div>
 
         <nav aria-label="Navegação administrativa">
-          @for (group of navGroups; track group.label) {
+          @for (group of navGroups(); track group.label) {
             <div class="sidebar__label">{{ group.label }}</div>
             @for (item of group.items; track item.label) {
               @if (item.routerLink) {
@@ -214,17 +221,49 @@ export class LayoutComponent {
     return role ? (ROLE_LABELS[role] ?? role) : '';
   });
 
-  protected readonly navGroups: readonly ConfigNavGroup[] = [
+  /** Navegação declarada, com os papéis que cada destino exige na rota. */
+  private readonly navGroupsDeclarados: readonly ConfigNavGroup[] = [
     {
       label: 'Painéis',
       items: [
         { label: 'Painel de processos', icon: 'pi-table', routerLink: '/dashboard' },
-        { label: 'Processo seletivo', icon: 'pi-file', routerLink: '/processo-seletivo' },
-        { label: 'Inscrições', icon: 'pi-user', routerLink: '/inscricoes' },
-        { label: 'Homologação', icon: 'pi-sitemap', routerLink: '/homologacao' },
+        {
+          label: 'Processo seletivo',
+          icon: 'pi-file',
+          routerLink: '/processo-seletivo',
+          roles: ['plataforma-admin'],
+        },
+        {
+          label: 'Inscrições',
+          icon: 'pi-user',
+          routerLink: '/inscricoes',
+          roles: ['admin', 'gestor'],
+        },
+        {
+          label: 'Homologação',
+          icon: 'pi-sitemap',
+          routerLink: '/homologacao',
+          roles: ['admin', 'gestor', 'avaliador'],
+        },
       ],
     },
   ];
+
+  /**
+   * Só os destinos que o papel de quem está autenticado consegue abrir. Grupo
+   * que fica sem item algum desaparece, em vez de virar um cabeçalho vazio.
+   */
+  protected readonly navGroups = computed<readonly ConfigNavGroup[]>(() => {
+    const papeis = new Set(this.authService.roles());
+    return this.navGroupsDeclarados
+      .map((grupo) => ({
+        ...grupo,
+        items: grupo.items.filter(
+          (item) => item.roles === undefined || item.roles.some((papel) => papeis.has(papel)),
+        ),
+      }))
+      .filter((grupo) => grupo.items.length > 0);
+  });
 
   protected alternarSidebarCompacta(): void {
     this.sidebarMobileOpen.update((aberta) => !aberta);

--- a/docs/guia-testar-frontend-com-backend-local.md
+++ b/docs/guia-testar-frontend-com-backend-local.md
@@ -68,6 +68,8 @@ trocar no primeiro login; basta repetir a mesma senha):
 | Sintoma                                               | Causa                                                              | Correção                                                               |
 | ----------------------------------------------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------- |
 | Listas carregam, mas salvar dá erro e volta pro login | APIs não foram iniciadas com o override atual do realm `unifesspa` | Refaça o passo 1 com os dois arquivos compose e a lista de serviços    |
+| Catálogos carregam, mas toda escrita responde `401`   | API subida com `docker-compose.smoke.yml`, que valida o realm `unifesspa-dev-local` — leitura de reference data é pública e mascara o problema | `docker inspect docker-uniplus-api-1 ... \| grep -i authority` e recrie a API sem o override de smoke |
+| Escrita responde `403` e cai em `/acesso-negado`      | O papel exigido pela rota não está no scope mapping do client no Keycloak, então não chega ao token | Confira `clients/<id>/scope-mappings/realm` na API admin do Keycloak  |
 | `404` em `/api/cidades` ou `/api/cep`                 | `geo-api` ou Traefik fora do ar                                    | Confirme ambos os serviços healthy no Compose do passo 1               |
 | `404` em `/api/{modulo}/...`                          | Monólito, portal-api ou gateway fora do ar                         | Confirme `uniplus-api`, `portal-api` e `traefik` no Compose do passo 1 |
 | `ERR_CONNECTION_REFUSED` em :420x                     | Dev server caiu                                                    | `npx nx serve <app>`                                                   |
@@ -77,4 +79,28 @@ trocar no primeiro login; basta repetir a mesma senha):
 
 As specs visuais (`apps/<app>-e2e/src/specs/*.visual.spec.ts`) **mockam** a API via
 `page.route` e não dependem do backend real — rodam com `npx nx e2e <app>-e2e`.
-Este guia cobre o teste **manual/exploratório** contra o backend de verdade.
+
+### Specs contra o backend real
+
+Specs `*.backend.spec.ts` exercitam API, Keycloak e storage de verdade — criam registros e
+sobem arquivos. Ficam atrás de `E2E_BACKEND_REAL=1`: sem a variável, o project Playwright
+nem é declarado, porque o CI provisiona apenas o Keycloak.
+
+```bash
+# 1. Stack do uniplus-api no ar (passo 1 deste guia)
+# 2. Libere a porta do redirect do app — o container serve o build antigo nela
+docker stop docker-selecao-web-1
+npx nx serve selecao --port 4200
+
+# 3. Rode as specs
+export KEYCLOAK_ADMIN_PASSWORD=<senha do Keycloak>
+E2E_BACKEND_REAL=1 npx nx e2e selecao-e2e -- --project=selecao-backend-real
+
+# 4. Devolva o container ao terminar
+docker start docker-selecao-web-1
+```
+
+A porta importa: o redirect do client OIDC é fixo por app (`selecao-web` → `:4200`), então
+servir em outra porta quebra o login.
+
+Este guia cobre também o teste **manual/exploratório** contra o backend de verdade.

--- a/libs/shared-core/src/lib/http/index.ts
+++ b/libs/shared-core/src/lib/http/index.ts
@@ -36,6 +36,8 @@ export type {
   ProblemValidationError,
 } from './problem-details';
 
+export { SignedUploadClient } from './signed-upload';
+
 export { ProblemI18nService } from './problem-i18n.service';
 export type {
   ProblemAction,

--- a/libs/shared-core/src/lib/http/signed-upload.spec.ts
+++ b/libs/shared-core/src/lib/http/signed-upload.spec.ts
@@ -1,0 +1,78 @@
+import { HttpEventType, provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { lastValueFrom, toArray } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { apiResultInterceptor } from './api-result.interceptor';
+import { SignedUploadClient } from './signed-upload';
+
+const URL_ASSINADA =
+  'http://localhost:9000/uniplus-selecao/editais/documento.pdf?X-Amz-Signature=abc';
+
+describe('SignedUploadClient', () => {
+  let client: SignedUploadClient;
+  let controller: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        // O interceptor é registrado de propósito: o cliente roda sobre
+        // HttpBackend e não deve ser afetado por ele.
+        provideHttpClient(withInterceptors([apiResultInterceptor])),
+        provideHttpClientTesting(),
+      ],
+    });
+    client = TestBed.inject(SignedUploadClient);
+    controller = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => controller.verify());
+
+  it('faz PUT com o content type assinado e reporta progresso', async () => {
+    const arquivo = new Blob(['%PDF-1.7'], { type: 'application/pdf' });
+    const eventos = lastValueFrom(
+      client.enviar(URL_ASSINADA, arquivo, 'application/pdf').pipe(toArray()),
+    );
+
+    const req = controller.expectOne(URL_ASSINADA);
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.headers.get('Content-Type')).toBe('application/pdf');
+    expect(req.request.reportProgress).toBe(true);
+    req.event({ type: HttpEventType.UploadProgress, loaded: 4, total: 8 });
+    req.flush(null);
+
+    const tipos = (await eventos).map((evento) => evento.type);
+    expect(tipos).toContain(HttpEventType.UploadProgress);
+    expect(tipos).toContain(HttpEventType.Response);
+  });
+
+  it('não anexa Authorization nem Accept versionado ao destino do storage', async () => {
+    const arquivo = new Blob(['%PDF-1.7'], { type: 'application/pdf' });
+    const promise = lastValueFrom(client.enviar(URL_ASSINADA, arquivo, 'application/pdf'));
+
+    const req = controller.expectOne(URL_ASSINADA);
+    expect(req.request.headers.has('Authorization')).toBe(false);
+    expect(req.request.headers.get('Accept')).toBeNull();
+    req.flush(null);
+
+    await promise;
+  });
+
+  /**
+   * O 403 do storage significa assinatura inválida — quase sempre URL expirada.
+   * Envelopado pelo `apiResultInterceptor`, viraria resposta de sucesso e o
+   * `authErrorInterceptor` mandaria o operador para `/acesso-negado`; o
+   * chamador precisa vê-lo como erro para pedir uma URL nova.
+   */
+  it('propaga o 403 do storage como erro HTTP, sem envelope', async () => {
+    const arquivo = new Blob(['%PDF-1.7'], { type: 'application/pdf' });
+    const promise = lastValueFrom(client.enviar(URL_ASSINADA, arquivo, 'application/pdf'));
+
+    controller.expectOne(URL_ASSINADA).flush('<Error><Code>AccessDenied</Code></Error>', {
+      status: 403,
+      statusText: 'Forbidden',
+    });
+
+    await expect(promise).rejects.toMatchObject({ status: 403 });
+  });
+});

--- a/libs/shared-core/src/lib/http/signed-upload.ts
+++ b/libs/shared-core/src/lib/http/signed-upload.ts
@@ -1,0 +1,40 @@
+import { HttpBackend, HttpClient, HttpEvent, HttpHeaders } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+
+/**
+ * Envia arquivo direto a um storage compatível com S3, por URL pré-assinada.
+ *
+ * Não é cliente de API do Uni+ e por isso não devolve `ApiResult`: o destino é
+ * o storage, a resposta de erro é XML do próprio serviço e não `ProblemDetails`,
+ * e o chamador precisa dos eventos de progresso do envio.
+ *
+ * Roda sobre `HttpBackend`, fora da cadeia de interceptors da aplicação. Isso é
+ * deliberado:
+ *
+ * - o `authErrorInterceptor` navegaria para `/acesso-negado` diante do 403 com
+ *   que o storage recusa assinatura inválida (na prática, URL expirada), em vez
+ *   de deixar o chamador pedir uma URL nova;
+ * - o `apiResultInterceptor` envelopa a resposta e transformaria o erro em
+ *   resposta de sucesso com `ApiFailure` dentro;
+ * - o `tokenInterceptor` não deve ser consultado para um destino que jamais
+ *   recebe o Bearer da aplicação;
+ * - o `loadingInterceptor` prenderia o spinner global durante todo o envio.
+ */
+@Injectable({ providedIn: 'root' })
+export class SignedUploadClient {
+  private readonly http = new HttpClient(inject(HttpBackend));
+
+  /**
+   * `contentType` tem de ser exatamente o exigido por quem assinou a URL — o
+   * header entra na assinatura SigV4, e qualquer divergência é recusada com
+   * `SignatureDoesNotMatch` antes de qualquer validação de negócio.
+   */
+  enviar(url: string, arquivo: Blob, contentType: string): Observable<HttpEvent<unknown>> {
+    return this.http.put(url, arquivo, {
+      headers: new HttpHeaders({ 'Content-Type': contentType }),
+      observe: 'events',
+      reportProgress: true,
+    });
+  }
+}

--- a/libs/shared-data/src/lib/api/organizacao/index.ts
+++ b/libs/shared-data/src/lib/api/organizacao/index.ts
@@ -16,5 +16,6 @@ export {
   type AtualizarUnidadeCommand,
   type CriarUnidadeCommand,
   type UnidadeDto,
+  type UnidadesQuery,
   type UnidadeTipoOption,
 } from './unidades.api';

--- a/libs/shared-data/src/lib/api/organizacao/unidades.api.spec.ts
+++ b/libs/shared-data/src/lib/api/organizacao/unidades.api.spec.ts
@@ -83,6 +83,31 @@ describe('UnidadesApi', () => {
 
   afterEach(() => controller.verify());
 
+  it('listar() faz GET /api/organizacao/unidades com limite default e vendor MIME', async () => {
+    const promise = firstValueFrom(api.listar());
+
+    const req = controller.expectOne(`${BASE}/api/organizacao/unidades?limit=100`);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.headers.get('Accept')).toBe(buildVendorMimeAccept('unidade', 1));
+    req.flush([unidadeSeed]);
+
+    const result = (await promise) as ApiResult<readonly UnidadeDto[]>;
+    expect(isApiOk(result)).toBe(true);
+    if (result.ok) expect(result.data[0].sigla).toBe('IEDAR');
+  });
+
+  it('listar() com cursor troca o limite pelo par cursor/direction', async () => {
+    const promise = firstValueFrom(api.listar({ cursor: 'cur-1', direction: 'prev', q: 'iedar' }));
+
+    const req = controller.expectOne(
+      `${BASE}/api/organizacao/unidades?q=iedar&cursor=cur-1&direction=prev`,
+    );
+    expect(req.request.method).toBe('GET');
+    req.flush([unidadeSeed]);
+
+    await promise;
+  });
+
   it('obter() faz GET /api/organizacao/unidades/{id} com encoding seguro', async () => {
     const id = 'id com espaço/01';
     const promise = firstValueFrom(api.obter(id));

--- a/libs/shared-data/src/lib/api/organizacao/unidades.api.ts
+++ b/libs/shared-data/src/lib/api/organizacao/unidades.api.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpContext, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpContext, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { ApiResult, withVendorMime } from '@uniplus/shared-core/http';
@@ -10,6 +10,15 @@ export type UnidadeDto = components['schemas']['UnidadeDto'];
 export type CriarUnidadeCommand = components['schemas']['CriarUnidadeCommand'];
 export type AtualizarUnidadeCommand = components['schemas']['AtualizarUnidadeCommand'];
 export { TipoUnidade };
+
+/** Filtro da listagem paginada de unidades (cursor opaco, ADR-0026). */
+export interface UnidadesQuery {
+  /** Busca textual por nome, sigla ou código. */
+  readonly q?: string;
+  readonly cursor?: string;
+  readonly direction?: 'next' | 'prev';
+  readonly limit?: number;
+}
 
 export interface UnidadeTipoOption {
   readonly value: TipoUnidade;
@@ -34,6 +43,24 @@ export const TIPOS_UNIDADE: readonly UnidadeTipoOption[] = [
 export class UnidadesApi {
   private readonly http = inject(HttpClient);
   private readonly basePath = inject(ORGANIZACAO_BASE_PATH);
+
+  /** GET `/api/organizacao/unidades` — paginação por cursor opaco. */
+  listar(query: UnidadesQuery = {}): Observable<ApiResult<readonly UnidadeDto[]>> {
+    let params = new HttpParams();
+    if (query.q !== undefined) {
+      params = params.set('q', query.q);
+    }
+    if (query.cursor !== undefined) {
+      params = params.set('cursor', query.cursor).set('direction', query.direction ?? 'next');
+    } else {
+      params = params.set('limit', String(query.limit ?? 100));
+    }
+
+    return this.http.get<ApiResult<readonly UnidadeDto[]>>(
+      `${this.basePath}/api/organizacao/unidades`,
+      { params, context: withVendorMime('unidade', 1) },
+    );
+  }
 
   obter(id: string): Observable<ApiResult<UnidadeDto>> {
     return this.http.get<ApiResult<UnidadeDto>>(

--- a/libs/shared-data/src/lib/api/selecao/index.ts
+++ b/libs/shared-data/src/lib/api/selecao/index.ts
@@ -2,6 +2,8 @@ export { SELECAO_BASE_PATH } from './tokens';
 export {
   ProcessosSeletivosApi,
   type CriarProcessoSeletivoCommand,
+  type DocumentoEditalDto,
+  type IniciarUploadDocumentoEditalDto,
   type ProcessoSeletivoDto,
   type ProcessoSeletivoResumoDto,
   type ProcessosSeletivosQuery,

--- a/libs/shared-data/src/lib/api/selecao/processos-seletivos.api.spec.ts
+++ b/libs/shared-data/src/lib/api/selecao/processos-seletivos.api.spec.ts
@@ -12,6 +12,8 @@ import {
 } from '@uniplus/shared-core/http';
 import {
   CriarProcessoSeletivoCommand,
+  DocumentoEditalDto,
+  IniciarUploadDocumentoEditalDto,
   ProcessoSeletivoDto,
   ProcessoSeletivoResumoDto,
   ProcessosSeletivosApi,
@@ -23,6 +25,9 @@ import { SELECAO_BASE_PATH } from './tokens';
 const BASE = 'http://localhost:5000';
 const ID = '01960000-0000-7000-0000-000000000515';
 const TIPO_ID = '01960000-0000-7000-0000-000000000516';
+const DOCUMENTO_ID = '01960000-0000-7000-0000-000000000518';
+const URL_ASSINADA =
+  'http://localhost:9000/uniplus-selecao/editais/documento.pdf?X-Amz-Signature=abc';
 
 const tipoProcesso: TipoProcessoSnapshotDto = {
   origemId: TIPO_ID,
@@ -36,6 +41,22 @@ const resumoSeed: ProcessoSeletivoResumoDto = {
   tipoProcesso,
   status: 'rascunho',
   criadoEm: '2026-08-11T12:00:00Z',
+};
+
+const iniciacaoSeed: IniciarUploadDocumentoEditalDto = {
+  documentoEditalId: DOCUMENTO_ID,
+  urlUpload: URL_ASSINADA,
+  contentTypeExigido: 'application/pdf',
+  expiraEm: '2026-08-13T12:15:00Z',
+};
+
+const documentoSeed: DocumentoEditalDto = {
+  id: DOCUMENTO_ID,
+  processoSeletivoId: ID,
+  status: 'Confirmado',
+  tamanhoBytes: 2048,
+  hashSha256: 'a'.repeat(64),
+  confirmadoEm: '2026-08-13T12:05:00Z',
 };
 
 const criarCommand: CriarProcessoSeletivoCommand = {
@@ -105,4 +126,41 @@ describe('ProcessosSeletivosApi', () => {
     const result = (await promise) as ApiResult<string>;
     expect(isApiOk(result)).toBe(true);
   });
+
+  it('iniciarUploadDocumentoEdital() posta sem corpo e devolve a URL assinada', async () => {
+    const promise = firstValueFrom(
+      api.iniciarUploadDocumentoEdital(ID, withIdempotencyKey('documento-init-key')),
+    );
+    const req = controller.expectOne(
+      `${BASE}/api/selecao/processos-seletivos/${ID}/documentos-edital`,
+    );
+
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toBeNull();
+    expect(req.request.headers.get('Idempotency-Key')).toBe('documento-init-key');
+    req.flush(iniciacaoSeed, { status: 201, statusText: 'Created' });
+
+    const result = (await promise) as ApiResult<IniciarUploadDocumentoEditalDto>;
+    expect(isApiOk(result)).toBe(true);
+    if (result.ok) expect(result.data.contentTypeExigido).toBe('application/pdf');
+  });
+
+  it('confirmarUploadDocumentoEdital() usa os dois ids na rota de confirmação', async () => {
+    const promise = firstValueFrom(
+      api.confirmarUploadDocumentoEdital(ID, DOCUMENTO_ID, withIdempotencyKey('documento-conf-key')),
+    );
+    const req = controller.expectOne(
+      `${BASE}/api/selecao/processos-seletivos/${ID}/documentos-edital/${DOCUMENTO_ID}/confirmacao`,
+    );
+
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toBeNull();
+    expect(req.request.headers.get('Idempotency-Key')).toBe('documento-conf-key');
+    req.flush(documentoSeed);
+
+    const result = (await promise) as ApiResult<DocumentoEditalDto>;
+    expect(isApiOk(result)).toBe(true);
+    if (result.ok) expect(result.data.status).toBe('Confirmado');
+  });
+
 });

--- a/libs/shared-data/src/lib/api/selecao/processos-seletivos.api.ts
+++ b/libs/shared-data/src/lib/api/selecao/processos-seletivos.api.ts
@@ -9,6 +9,9 @@ export type CriarProcessoSeletivoCommand = components['schemas']['CriarProcessoS
 export type ProcessoSeletivoDto = components['schemas']['ProcessoSeletivoDto'];
 export type ProcessoSeletivoResumoDto = components['schemas']['ProcessoSeletivoResumoDto'];
 export type TipoProcessoSnapshotDto = components['schemas']['TipoProcessoSnapshotDto'];
+export type IniciarUploadDocumentoEditalDto =
+  components['schemas']['IniciarUploadDocumentoEditalDto'];
+export type DocumentoEditalDto = components['schemas']['DocumentoEditalDto'];
 
 /** Filtro da listagem de Processos Seletivos (cursor opaco, ADR-0026). */
 export interface ProcessosSeletivosQuery {
@@ -62,6 +65,43 @@ export class ProcessosSeletivosApi {
     return this.http.post<ApiResult<string>>(
       `${this.basePath}/api/selecao/processos-seletivos`,
       command,
+      { context, headers: new HttpHeaders({ Accept: 'application/json' }) },
+    );
+  }
+
+  /**
+   * POST `/api/selecao/processos-seletivos/{id}/documentos-edital` — primeiro
+   * dos três passos do anexo do edital: cria o registro pendente e devolve a
+   * URL pré-assinada de PUT, o content type que a assinatura exige e o
+   * instante em que ela expira. O endpoint não recebe corpo.
+   */
+  iniciarUploadDocumentoEdital(
+    processoSeletivoId: string,
+    context: HttpContext,
+  ): Observable<ApiResult<IniciarUploadDocumentoEditalDto>> {
+    return this.http.post<ApiResult<IniciarUploadDocumentoEditalDto>>(
+      `${this.basePath}/api/selecao/processos-seletivos/${encodeURIComponent(processoSeletivoId)}/documentos-edital`,
+      null,
+      { context, headers: new HttpHeaders({ Accept: 'application/json' }) },
+    );
+  }
+
+  /**
+   * Terceiro passo: a API lê o objeto no storage, confere content type,
+   * tamanho e assinatura de arquivo, calcula o hash e sela o documento como
+   * imutável. Também não recebe corpo.
+   *
+   * O segundo passo — o PUT na URL pré-assinada — não é rota do Uni+ e não
+   * devolve `ApiResult`: fica no `SignedUploadClient` de `shared-core/http`.
+   */
+  confirmarUploadDocumentoEdital(
+    processoSeletivoId: string,
+    documentoEditalId: string,
+    context: HttpContext,
+  ): Observable<ApiResult<DocumentoEditalDto>> {
+    return this.http.post<ApiResult<DocumentoEditalDto>>(
+      `${this.basePath}/api/selecao/processos-seletivos/${encodeURIComponent(processoSeletivoId)}/documentos-edital/${encodeURIComponent(documentoEditalId)}/confirmacao`,
+      null,
       { context, headers: new HttpHeaders({ Accept: 'application/json' }) },
     );
   }

--- a/tools/e2e-docker/keycloak/realm-export.json
+++ b/tools/e2e-docker/keycloak/realm-export.json
@@ -591,7 +591,8 @@
         "admin",
         "gestor",
         "avaliador",
-        "candidato"
+        "candidato",
+        "plataforma-admin"
       ]
     },
     {


### PR DESCRIPTION
## Resumo

O passo 2 do wizard deixa de guardar o cadastro apenas no rascunho local: ao anexar o edital, o Processo Seletivo é criado na API e o PDF sobe de verdade, em três fases — iniciar, enviar ao storage por URL pré-assinada e confirmar. A animação de progresso com `setInterval` e `Math.random()` sai; o percentual passa a vir dos bytes efetivamente enviados.

Closes #522

## O que muda

- **Dois campos novos no passo 2**, ambos obrigatórios no comando de criação e ausentes até aqui: **unidade administradora**, lida do catálogo de Organização, e **origem dos candidatos**, atributo declarado que não se deriva do tipo do processo.
- **Anexo do edital restrito a um PDF de até 20 MB**, o limite do domínio — antes eram cinco extensões e vários arquivos, nenhum deles com destino no backend.
- **Cliente de upload por URL pré-assinada** em `shared-core`, sobre `HttpBackend`.
- **`UnidadesApi.listar()`** e os dois passos de documento do edital em `ProcessosSeletivosApi`.

## Decisões que valem explicação

**O anexo é o gatilho da criação.** A rota do documento é `/{processoSeletivoId}/documentos-edital` e exige o processo já criado; a validação do passo exige o edital anexado para avançar. Criar apenas no "Próximo" travaria os dois lados. Faltando algum dos quatro campos do comando, o anexo é recusado nomeando o que preencher.

**O PUT ao storage fica fora da cadeia de interceptors.** O 403 com que o storage recusa assinatura inválida — na prática, URL expirada — seria envelopado como resposta de sucesso pelo `apiResultInterceptor`, e o `authErrorInterceptor` mandaria o operador para `/acesso-negado` em vez de deixar o fluxo pedir uma URL nova. De quebra, o Bearer da aplicação não é cogitado para destino externo e o spinner global não fica preso durante o envio.

**Rotação de `Idempotency-Key` por código, não por status.** Só `processing_conflict`, erro de rede e 5xx deixam em aberto se o comando foi executado; nesses casos a chave é preservada **e o corpo fica retido**, para a retentativa receber o replay em vez de criar um segundo processo. Todo o resto — incluindo `body_mismatch` e o 413 de corpo grande — é recusa definitiva e rotaciona a chave.

**Campos do comando congelam após a criação**, inclusive o tipo no passo 1: o contrato não expõe atualização de identificação e a unidade administradora é imutável no agregado. O congelamento vale também enquanto uma criação inconclusiva aguarda retentativa.

**Retomada por fase.** Confirmação pendente não repete o envio ao storage; URL sem validade é trocada por outra em vez de reenviada.

## Validação

Além dos testes unitários, o fluxo foi exercitado **contra a stack real** (API, Keycloak, MinIO) com o conteúdo do certame de **Medicina 2027 do CEPS** — o mesmo que a coleção Newman de cadastro monta chamando a API direto, aqui percorrido pela interface. O banco mostra o processo criado pela tela ao lado dos criados pela coleção, com a mesma origem de candidatos e o documento de edital confirmado, com o tamanho do arquivo enviado e hash calculado server-side.

- `nx run-many -t lint test build typecheck` nos quatro projetos tocados — verde
- 68 testes em `selecao`, 260 em `shared-data`, 137 em `shared-core`
- `E2E_BACKEND_REAL=1 nx e2e selecao-e2e --project=selecao-backend-real` — 3 verdes
- Matriz DS (320/768/desktop/tv × claro/escuro/contraste) — 91 verdes

O spec contra backend real fica atrás de `E2E_BACKEND_REAL=1`, em project próprio: ele escreve de verdade, e o CI provisiona só o Keycloak.

## Autorização alinhada à da API

As rotas administrativas de Processo Seletivo exigem `plataforma-admin`, e dois pontos impediam o papel de valer:

- o client `selecao-web` tem `fullScopeAllowed: false` e seu scope mapping não listava `plataforma-admin`, então o papel não entrava no token nem para quem o tem atribuído — corrigido em `tools/e2e-docker/keycloak/realm-export.json`;
- a rota `processo-seletivo` admitia os papéis de negócio, deixando um gestor entrar na tela para descobrir a recusa só na primeira gravação — agora exige `roleGuard('plataforma-admin')`. As demais rotas (inscrições, homologação, notas, classificação) seguem com os papéis de negócio: a restrição administrativa é da jornada do certame, não da SPA inteira.

**Falta fora deste repositório:** o realm que serve o ambiente local completo (`uniplus-api/docker/keycloak/realm-export.json`) tem o mesmo buraco de escopo. Registrado em unifesspa-edu-br/uniplus-api#1133 — sem ele, o fluxo continua respondendo 403 em ambiente local até o ajuste.

## Limitações declaradas

- **Rascunho não é retomável.** O estado segue em memória; recarregar a página perde o vínculo com o processo já criado, deixando um rascunho órfão no servidor. Retomar exige rota com id e reidratação — escopo da story de fundação (#478).
- **`numero`, `ano`, `data`, `orgao` e `periodo` continuam só no rascunho local**: o comando de criação não os aceita, e não há endpoint que os receba.
- **O `roleGuard` da rota admite `admin/gestor/avaliador`**, enquanto a API exige `plataforma-admin`. Um `gestor` passa o guard e cai em `/acesso-negado` pelo tratamento global de 403. Alinhar o guard é escopo da #478 (CA-02).
