### PR TITLE
feat(configuracao): apresenta a localidade do calendário pelo snapshot municipal

### DIFF
--- a/apps/configuracao-e2e/src/specs/calendario-dias-uteis.visual.spec.ts
+++ b/apps/configuracao-e2e/src/specs/calendario-dias-uteis.visual.spec.ts
@@ -1,0 +1,164 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test, type Page, type TestInfo } from '@playwright/test';
+import { mockConfiguracaoRuntimeConfig } from '../support/runtime-config';
+
+type VisualTheme = 'light' | 'dark' | 'contrast';
+
+const CALENDARIO_ID = '019ff7ee-3c00-7976-860c-eb2f61c9b2d1';
+
+const CORS_HEADERS = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'GET, POST, DELETE, OPTIONS',
+  'access-control-allow-headers': 'authorization, content-type, accept, idempotency-key',
+};
+
+/**
+ * Dataset com as três formas de localidade que o detalhe precisa apresentar:
+ * municipal (snapshot da ADR-0090), estadual (UF) e nacional (sem região).
+ */
+const CALENDARIO = {
+  id: CALENDARIO_ID,
+  versaoDataset: '2026.1',
+  vigente: true,
+  criadoEm: '2026-08-13T12:00:00Z',
+  diasNaoUteis: [
+    {
+      id: '019ff7ee-3c00-7976-860c-eb2f61c9b201',
+      abrangencia: 'MUNICIPAL',
+      municipioIbge: '1504208',
+      municipioNome: 'Marabá',
+      municipioUf: 'PA',
+      uf: null,
+      data: '2026-04-05',
+      descricao: 'Aniversário de Marabá',
+    },
+    {
+      id: '019ff7ee-3c00-7976-860c-eb2f61c9b202',
+      abrangencia: 'ESTADUAL',
+      municipioIbge: null,
+      municipioNome: null,
+      municipioUf: null,
+      uf: 'PA',
+      data: '2026-08-15',
+      descricao: 'Adesão do Grão-Pará à Independência',
+    },
+    {
+      id: '019ff7ee-3c00-7976-860c-eb2f61c9b203',
+      abrangencia: 'NACIONAL',
+      municipioIbge: null,
+      municipioNome: null,
+      municipioUf: null,
+      uf: null,
+      data: '2026-09-07',
+      descricao: 'Independência do Brasil',
+    },
+  ],
+} as const;
+
+test.describe('Calendário de dias úteis — localidade no detalhe (#524)', () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    const theme = metadataTheme(testInfo);
+    await mockConfiguracaoRuntimeConfig(page);
+    await page.addInitScript((dsTheme: VisualTheme) => {
+      window.localStorage.setItem(
+        'uniplus.a11y',
+        JSON.stringify({
+          theme: dsTheme === 'contrast' ? 'auto' : dsTheme,
+          contrast: dsTheme === 'contrast',
+          fontMode: 'default',
+        }),
+      );
+    }, theme);
+    await mockCalendarioApi(page);
+  });
+
+  test('exibe a localidade legível sem consultar a Geo', async ({ page }, testInfo) => {
+    const chamadasGeo = await rastrearChamadasGeo(page);
+    await page.goto(`/calendario-dias-uteis/${CALENDARIO_ID}`);
+
+    await expect(page.locator('html')).toHaveAttribute('data-theme', metadataTheme(testInfo));
+    await expect(page.getByRole('heading', { name: 'Detalhes', level: 1 })).toBeVisible();
+
+    await expect(page.getByText('Marabá — PA', { exact: true })).toBeVisible();
+    await expect(page.getByText('Código IBGE: 1504208', { exact: true })).toBeVisible();
+    await expect(page.getByText('Pará — PA', { exact: true })).toBeVisible();
+
+    // Localidade é conteúdo, não controle desabilitado.
+    await expect(page.locator('output.field__readonly')).toHaveCount(2);
+
+    expect(chamadasGeo).toEqual([]);
+
+    await assertNoHorizontalOverflow(page);
+    await testInfo.attach(`${testInfo.project.name}-calendario-detalhe`, {
+      body: await page.screenshot({ fullPage: true }),
+      contentType: 'image/png',
+    });
+
+    // 320 px é o piso de largura exigido pelo e-MAG/WCAG para reflow.
+    await page.setViewportSize({ width: 320, height: 720 });
+    await expect(page.getByText('Marabá — PA', { exact: true })).toBeVisible();
+    await assertNoHorizontalOverflow(page);
+    await testInfo.attach(`${testInfo.project.name}-calendario-detalhe-320`, {
+      body: await page.screenshot({ fullPage: true }),
+      contentType: 'image/png',
+    });
+  });
+
+  test('detalhe não tem violações serious/critical', async ({ page }) => {
+    await page.goto(`/calendario-dias-uteis/${CALENDARIO_ID}`);
+    await expect(page.getByText('Marabá — PA', { exact: true })).toBeVisible();
+
+    const resultado = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21aa'])
+      .analyze();
+    const graves = resultado.violations.filter(
+      (violacao) => violacao.impact === 'serious' || violacao.impact === 'critical',
+    );
+    expect(graves, JSON.stringify(graves, null, 2)).toEqual([]);
+  });
+});
+
+async function mockCalendarioApi(page: Page): Promise<void> {
+  await page.route(/\/api\/configuracao\/calendarios-dias-uteis\/[^/?]+$/, async (route, request) => {
+    if (request.method() === 'OPTIONS') {
+      await route.fulfill({ status: 204, headers: CORS_HEADERS });
+      return;
+    }
+    if (request.method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      headers: { ...CORS_HEADERS, 'content-type': 'application/json' },
+      body: JSON.stringify(CALENDARIO),
+    });
+  });
+}
+
+/** Registra qualquer leitura do módulo Geo — o detalhe não pode fazer nenhuma. */
+async function rastrearChamadasGeo(page: Page): Promise<string[]> {
+  const chamadas: string[] = [];
+  await page.route(/\/api\/(cidades|cep)(\/|\?|$)/, async (route, request) => {
+    chamadas.push(request.url());
+    await route.fulfill({
+      status: 200,
+      headers: { ...CORS_HEADERS, 'content-type': 'application/json' },
+      body: '[]',
+    });
+  });
+  return chamadas;
+}
+
+async function assertNoHorizontalOverflow(page: Page): Promise<void> {
+  const viewport = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+  }));
+  expect(viewport.scrollWidth).toBeLessThanOrEqual(viewport.clientWidth);
+}
+
+function metadataTheme(testInfo: TestInfo): VisualTheme {
+  const theme = testInfo.project.metadata['theme'];
+  return theme === 'dark' || theme === 'contrast' ? theme : 'light';
+}

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.spec.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.spec.ts
@@ -12,6 +12,29 @@ import { CalendarioDiasUteisDetalhePage } from './calendario-dias-uteis-detalhe.
 
 const BASE = 'http://localhost:5000';
 const CALENDARIO_ID = '019f41cf-69fd-759a-ac6d-09acabc1b027';
+const URL = `${BASE}/api/configuracao/calendarios-dias-uteis/${CALENDARIO_ID}`;
+
+const DIA_MUNICIPAL = {
+  id: '019f41cf-69fd-759a-ac6d-09acabc1b100',
+  abrangencia: 'MUNICIPAL',
+  municipioIbge: '1504208',
+  municipioNome: 'Marabá',
+  municipioUf: 'PA',
+  uf: null,
+  data: '2026-04-05',
+  descricao: 'Aniversário de Marabá',
+};
+
+const DIA_ESTADUAL = {
+  id: '019f41cf-69fd-759a-ac6d-09acabc1b101',
+  abrangencia: 'ESTADUAL',
+  municipioIbge: null,
+  municipioNome: null,
+  municipioUf: null,
+  uf: 'PA',
+  data: '2026-08-15',
+  descricao: 'Adesão do Grão-Pará à Independência',
+};
 
 describe('CalendarioDiasUteisDetalhePage', () => {
   let fixture: ComponentFixture<CalendarioDiasUteisDetalhePage>;
@@ -34,6 +57,9 @@ describe('CalendarioDiasUteisDetalhePage', () => {
           },
         },
       ],
+      // GEO_BASE_PATH deliberadamente ausente: se a página injetasse a GeoApi,
+      // o TestBed falharia em criar o componente (ADR-0090 — a localidade
+      // persistida é lida do snapshot, sem consultar a Geo).
     });
     fixture = TestBed.createComponent(CalendarioDiasUteisDetalhePage);
     controller = TestBed.inject(HttpTestingController);
@@ -48,10 +74,20 @@ describe('CalendarioDiasUteisDetalhePage', () => {
     appRef.tick();
   };
 
+  const carregar = async (diasNaoUteis: readonly unknown[]): Promise<void> => {
+    controller.expectOne(URL).flush({
+      id: CALENDARIO_ID,
+      versaoDataset: '2026.1',
+      vigente: false,
+      criadoEm: '2026-08-13T00:00:00Z',
+      diasNaoUteis,
+    });
+    await propagate();
+  };
+
   it('exibe erro de carregamento e permite tentar novamente', async () => {
-    const url = `${BASE}/api/configuracao/calendarios-dias-uteis/${CALENDARIO_ID}`;
     controller
-      .expectOne(url)
+      .expectOne(URL)
       .flush(mockProblemDetails({ status: 404, title: 'Calendário não encontrado' }), {
         status: 404,
         statusText: 'Not Found',
@@ -68,15 +104,40 @@ describe('CalendarioDiasUteisDetalhePage', () => {
     retry.click();
     fixture.detectChanges();
 
-    controller.expectOne(url).flush({
-      id: CALENDARIO_ID,
-      versaoDataset: '2026.1',
-      vigente: false,
-      criadoEm: '2026-08-13T00:00:00Z',
-      diasNaoUteis: [],
-    });
-    await propagate();
+    await carregar([]);
 
     expect((fixture.nativeElement.querySelector('input') as HTMLInputElement).value).toBe('2026.1');
+  });
+
+  it('apresenta o município pelo snapshot persistido, com o código IBGE como apoio', async () => {
+    await carregar([DIA_MUNICIPAL]);
+
+    const texto = fixture.nativeElement.textContent as string;
+    expect(texto).toContain('Marabá — PA');
+    expect(texto).toContain('Código IBGE: 1504208');
+    // Nenhuma requisição à Geo: `controller.verify()` no afterEach falharia.
+    controller.expectNone((request) => request.url.includes('/api/cidades'));
+  });
+
+  it('não escreve "null" quando o dia municipal é anterior ao snapshot', async () => {
+    await carregar([{ ...DIA_MUNICIPAL, municipioNome: null, municipioUf: null }]);
+
+    const texto = fixture.nativeElement.textContent as string;
+    expect(texto).not.toContain('null');
+    expect(texto).toContain('Código IBGE: 1504208');
+  });
+
+  it('apresenta a abrangência estadual com a UF por extenso', async () => {
+    await carregar([DIA_ESTADUAL]);
+
+    expect(fixture.nativeElement.textContent).toContain('Pará — PA');
+  });
+
+  it('não usa controles de formulário para exibir a localidade', async () => {
+    await carregar([DIA_MUNICIPAL, DIA_ESTADUAL]);
+
+    const saidas = fixture.nativeElement.querySelectorAll('output.field__readonly');
+    expect(saidas).toHaveLength(2);
+    expect(fixture.nativeElement.querySelectorAll('input[type="text"]')).toHaveLength(1);
   });
 });

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.ts
@@ -11,7 +11,12 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { ProblemI18nService, useApiResource, withVendorMime } from '@uniplus/shared-core/http';
-import { CalendarioDiasUteisDto, CONFIGURACAO_BASE_PATH } from '@uniplus/shared-data/configuracao';
+import {
+  CalendarioDiasUteisDto,
+  CONFIGURACAO_BASE_PATH,
+  DiaNaoUtilDto,
+  UNIDADES_FEDERATIVAS,
+} from '@uniplus/shared-data/configuracao';
 import { AlertComponent, SpinnerComponent } from '@uniplus/shared-ui/components';
 import { tap } from 'rxjs';
 
@@ -88,25 +93,21 @@ import { tap } from 'rxjs';
                 </select>
               </label>
               @if (diaNaoUtil.abrangencia === 'MUNICIPAL') {
-                <label class="field">
-                  <span class="field__label is-required">Município (Código IBGE)</span>
-                  <input
-                    type="text"
-                    class="input"
-                    [value]="diaNaoUtil.municipioIbge"
-                    [disabled]="true"
-                  />
-                </label>
+                <div class="field">
+                  <span class="field__label">Município</span>
+                  <output class="field__readonly" aria-label="Município do dia não útil">{{
+                    municipioLegivel(diaNaoUtil)
+                  }}</output>
+                  <span class="field__hint">Código IBGE: {{ diaNaoUtil.municipioIbge }}</span>
+                </div>
               }
               @if (diaNaoUtil.abrangencia === 'ESTADUAL') {
-                <label class="field">
-                  <span class="field__label is-required">Unidade Federativa (UF)</span>
-                  <select class="select" [disabled]="true">
-                    <option>
-                      {{ diaNaoUtil.uf }}
-                    </option>
-                  </select>
-                </label>
+                <div class="field">
+                  <span class="field__label">Unidade Federativa (UF)</span>
+                  <output class="field__readonly" aria-label="Unidade federativa do dia não útil">{{
+                    ufLegivel(diaNaoUtil.uf)
+                  }}</output>
+                </div>
               }
               <label class="field">
                 <span class="field__label">Data</span>
@@ -162,5 +163,22 @@ export class CalendarioDiasUteisDetalhePage {
     if (!this.calendarioResource.isLoading()) {
       this.calendarioResource.reload();
     }
+  }
+
+  /**
+   * Nome e UF do município vêm do snapshot persistido no dataset (ADR-0090) —
+   * a tela não consulta a Geo para resolver localidade já gravada. Registros
+   * anteriores ao snapshot ficam sem nome e sem UF; não há fallback para eles
+   * (a base de desenvolvimento é recriada), mas o que falta some da tela em vez
+   * de virar a palavra "null" ao lado do código IBGE.
+   */
+  protected municipioLegivel(diaNaoUtil: DiaNaoUtilDto): string {
+    return [diaNaoUtil.municipioNome, diaNaoUtil.municipioUf].filter(Boolean).join(' — ');
+  }
+
+  /** UF por extenso mais a sigla, ex.: `Pará — PA`. */
+  protected ufLegivel(uf: string | null): string {
+    const unidade = UNIDADES_FEDERATIVAS.find((candidata) => candidata.sigla === uf);
+    return unidade ? `${unidade.nome} — ${unidade.sigla}` : (uf ?? '');
   }
 }

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-novo.page.spec.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-novo.page.spec.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
-import { provideRouter } from '@angular/router';
+import { provideRouter, Router } from '@angular/router';
 
 import { CONFIGURACAO_BASE_PATH } from '@uniplus/shared-data/configuracao';
 import { GEO_BASE_PATH } from '@uniplus/shared-data/geo';
@@ -10,6 +10,8 @@ import { apiResultInterceptor, mockProblemDetails } from '@uniplus/shared-core/h
 import { CalendarioDiasUteisNovoPage } from './calendario-dias-uteis-novo.page';
 
 const BASE = 'http://localhost:5000';
+const MARABA = { codigoIbge: '1504208', nome: 'Marabá', uf: 'PA' } as const;
+const PARAUAPEBAS = { codigoIbge: '1505536', nome: 'Parauapebas', uf: 'PA' } as const;
 
 describe('CalendarioDiasUteisNovoPage', async () => {
   let fixture: ComponentFixture<CalendarioDiasUteisNovoPage>;
@@ -22,7 +24,8 @@ describe('CalendarioDiasUteisNovoPage', async () => {
       providers: [
         provideHttpClient(withInterceptors([apiResultInterceptor])),
         provideHttpClientTesting(),
-        provideRouter([]),
+        // A rota da lista existe para que o redirect pós-criação resolva.
+        provideRouter([{ path: 'calendario-dias-uteis', children: [] }]),
         { provide: CONFIGURACAO_BASE_PATH, useValue: BASE },
         { provide: GEO_BASE_PATH, useValue: BASE },
       ],
@@ -47,6 +50,29 @@ describe('CalendarioDiasUteisNovoPage', async () => {
     return index;
   }
 
+  /**
+   * Percorre o caminho real de seleção: busca na Geo, resposta do serviço e
+   * escolha da opção no `<select>`. É o único caminho que grava o snapshot.
+   */
+  async function selecionarMunicipioViaGeo(
+    index: number,
+    municipio: { codigoIbge: string; nome: string; uf: string } = MARABA,
+  ): Promise<void> {
+    component['buscarMunicipios'](index, municipio.nome);
+    await new Promise((resolve) => setTimeout(resolve, 350));
+
+    controller
+      .expectOne((request) => request.url === `${BASE}/api/cidades`)
+      .flush([{ id: `cidade-${municipio.codigoIbge}`, ddd: '94', ...municipio }]);
+    fixture.detectChanges();
+
+    component['form'].controls.diasNaoUteis
+      .at(index)
+      .controls.codigoMunicipio.setValue(municipio.codigoIbge);
+    component['selecionarMunicipio'](index);
+    fixture.detectChanges();
+  }
+
   it('valida client-side quando tenta salvar sem dia não util', async () => {
     component['form'].controls.versaoDataset.setValue('2026.1');
     component['salvar']();
@@ -54,7 +80,7 @@ describe('CalendarioDiasUteisNovoPage', async () => {
     controller.expectNone(`${BASE}/api/configuracao/admin/calendarios-dias-uteis`);
   });
 
-  it('inicia nova linha como estadual com Pará e municipal com Marabá', () => {
+  it('inicia nova linha como estadual com Pará e sem município escolhido', () => {
     component['adicionaNovoDiaNaoUtilFormGroup']();
     const grupo = component['form'].controls.diasNaoUteis.at(0);
 
@@ -64,83 +90,135 @@ describe('CalendarioDiasUteisNovoPage', async () => {
     grupo.controls.abrangencia.setValue('MUNICIPAL');
     component['mudaAbrangencia'](0);
 
-    expect(grupo.controls.uf.value).toBe('PA');
-    expect(grupo.controls.codigoMunicipio.value).toBe('1504208');
-    expect(grupo.controls.buscaMunicipio.value).toBe('Marabá');
-    expect(component['municipioSelecionado'](0)).toMatchObject({
-      codigoIbge: '1504208',
-      nome: 'Marabá',
-      uf: 'PA',
-    });
+    // Nenhuma referência municipal nasce de constante do código (ADR-0090): o
+    // snapshot só existe depois de uma escolha na Geo.
+    expect(grupo.controls.codigoMunicipio.value).toBe('');
+    expect(grupo.controls.municipioNome.value).toBeNull();
+    expect(grupo.controls.municipioUf.value).toBeNull();
+    expect(grupo.controls.buscaMunicipio.value).toBe('');
+    expect(component['municipioSelecionado'](0)).toBeNull();
+    expect(component['estadoBuscaMunicipio'](0).opcoes).toEqual([]);
   });
 
-  it('mantém o formulário inválido quando a seleção municipal é removida', () => {
+  it('envia o snapshot da opção escolhida na Geo', async () => {
     component['form'].controls.versaoDataset.setValue('2026.1');
-    adicionarDia('MUNICIPAL');
+    const index = adicionarDia('MUNICIPAL', '2026-04-05');
+    await selecionarMunicipioViaGeo(index);
 
-    const municipio = component['form'].controls.diasNaoUteis.at(0).controls.codigoMunicipio;
-    municipio.setValue('');
+    expect(component['form'].valid).toBe(true);
+    component['salvar']();
 
-    expect(municipio.invalid).toBe(true);
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/calendarios-dias-uteis`);
+    expect(req.request.body.diasNaoUteis[0]).toMatchObject({
+      abrangencia: 'MUNICIPAL',
+      municipioIbge: '1504208',
+      municipioNome: 'Marabá',
+      municipioUf: 'PA',
+      uf: null,
+    });
+    req.flush('019f41cf-69fd-759a-ac6d-09acabc1b027');
+    await fixture.whenStable();
+
+    expect(TestBed.inject(Router).url).toBe('/calendario-dias-uteis');
+  });
+
+  it('impede o envio municipal enquanto não houver opção da Geo escolhida', () => {
+    component['form'].controls.versaoDataset.setValue('2026.1');
+    const index = adicionarDia('MUNICIPAL');
+
+    const grupo = component['form'].controls.diasNaoUteis.at(index);
+    expect(grupo.errors?.['snapshotMunicipal']).toBe(true);
+    expect(component['form'].invalid).toBe(true);
+
+    component['salvar']();
+
+    controller.expectNone(`${BASE}/api/configuracao/admin/calendarios-dias-uteis`);
+    expect(component['erroDoCampoDiasNaoUteis']('codigoMunicipio', index)).toBe(
+      'Selecione um município na busca.',
+    );
+  });
+
+  it('recusa snapshot cuja UF não corresponde ao prefixo do código IBGE', async () => {
+    component['form'].controls.versaoDataset.setValue('2026.1');
+    const index = adicionarDia('MUNICIPAL');
+    await selecionarMunicipioViaGeo(index);
+    const grupo = component['form'].controls.diasNaoUteis.at(index);
+    expect(grupo.errors).toBeNull();
+
+    grupo.controls.municipioUf.setValue('SP');
+
+    expect(grupo.errors?.['snapshotMunicipal']).toBe(true);
     expect(component['form'].invalid).toBe(true);
   });
 
-  it('rejeita código municipal cujo prefixo não corresponde a uma UF', () => {
-    component['form'].controls.versaoDataset.setValue('2026.1');
-    adicionarDia('MUNICIPAL');
+  it('descarta o snapshot inteiro quando a busca deixa de casar com o selecionado', async () => {
+    const index = adicionarDia('MUNICIPAL');
+    await selecionarMunicipioViaGeo(index);
+    const grupo = component['form'].controls.diasNaoUteis.at(index);
 
-    const municipio = component['form'].controls.diasNaoUteis.at(0).controls.codigoMunicipio;
-    municipio.setValue('9904208');
-    expect(municipio.invalid).toBe(true);
-
-    municipio.setValue('1504208');
-    expect(municipio.valid).toBe(true);
-  });
-
-  it('limpa os campos regionais ao mudar para abrangência nacional', () => {
-    adicionarDia('MUNICIPAL');
-    const grupo = component['form'].controls.diasNaoUteis.at(0);
-    grupo.controls.codigoMunicipio.setValue('1504208');
-
-    grupo.controls.abrangencia.setValue('NACIONAL');
-    component['mudaAbrangencia'](0);
+    component['buscarMunicipios'](index, 'Belé');
 
     expect(grupo.controls.codigoMunicipio.value).toBe('');
+    expect(grupo.controls.municipioNome.value).toBeNull();
+    expect(grupo.controls.municipioUf.value).toBeNull();
+    expect(component['municipioSelecionado'](index)).toBeNull();
+  });
+
+  it('descarta o snapshot ao trocar o estado usado na busca', async () => {
+    const index = adicionarDia('MUNICIPAL');
+    await selecionarMunicipioViaGeo(index);
+    const grupo = component['form'].controls.diasNaoUteis.at(index);
+
+    grupo.controls.uf.setValue('SP');
+    component['mudaUf'](index);
+
+    expect(grupo.controls.codigoMunicipio.value).toBe('');
+    expect(grupo.controls.municipioNome.value).toBeNull();
+    expect(grupo.controls.municipioUf.value).toBeNull();
+    expect(grupo.controls.buscaMunicipio.value).toBe('');
+  });
+
+  it('limpa os campos regionais ao mudar para abrangência nacional', async () => {
+    const index = adicionarDia('MUNICIPAL');
+    await selecionarMunicipioViaGeo(index);
+    const grupo = component['form'].controls.diasNaoUteis.at(index);
+
+    grupo.controls.abrangencia.setValue('NACIONAL');
+    component['mudaAbrangencia'](index);
+
+    expect(grupo.controls.codigoMunicipio.value).toBe('');
+    expect(grupo.controls.municipioNome.value).toBeNull();
+    expect(grupo.controls.municipioUf.value).toBeNull();
     expect(grupo.controls.uf.value).toBe('');
     expect(grupo.controls.buscaMunicipio.value).toBe('');
     expect(grupo.controls.codigoMunicipio.validator).toBeNull();
+    expect(grupo.errors).toBeNull();
   });
 
   it('pesquisa municípios pelo nome e pela UF usando a API Geo', async () => {
-    adicionarDia('MUNICIPAL');
-    const grupo = component['form'].controls.diasNaoUteis.at(0);
+    const index = adicionarDia('MUNICIPAL');
+    const grupo = component['form'].controls.diasNaoUteis.at(index);
 
-    component['buscarMunicipios'](0, 'Parauapebas');
+    component['buscarMunicipios'](index, PARAUAPEBAS.nome);
     await new Promise((resolve) => setTimeout(resolve, 350));
 
     const req = controller.expectOne((request) => request.url === `${BASE}/api/cidades`);
     expect(req.request.params.get('uf')).toBe('PA');
     expect(req.request.params.get('q')).toBe('Parauapebas');
     expect(req.request.params.get('limit')).toBe('20');
-    req.flush([
-      {
-        id: 'cidade-parauapebas',
-        codigoIbge: '1505536',
-        nome: 'Parauapebas',
-        uf: 'PA',
-        ddd: '94',
-      },
-    ]);
+    req.flush([{ id: 'cidade-parauapebas', ddd: '94', ...PARAUAPEBAS }]);
     fixture.detectChanges();
 
-    expect(component['estadoBuscaMunicipio'](0).opcoes).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ codigoIbge: '1505536', nome: 'Parauapebas', uf: 'PA' }),
-      ]),
+    expect(component['estadoBuscaMunicipio'](index).opcoes).toEqual(
+      expect.arrayContaining([expect.objectContaining(PARAUAPEBAS)]),
     );
-    grupo.controls.codigoMunicipio.setValue('1505536');
-    component['selecionarMunicipio'](0);
+
+    grupo.controls.codigoMunicipio.setValue(PARAUAPEBAS.codigoIbge);
+    component['selecionarMunicipio'](index);
+
     expect(grupo.controls.buscaMunicipio.value).toBe('Parauapebas');
+    expect(grupo.controls.municipioNome.value).toBe('Parauapebas');
+    expect(grupo.controls.municipioUf.value).toBe('PA');
   });
 
   it('envia nulo nos campos regionais que não se aplicam', () => {
@@ -152,24 +230,8 @@ describe('CalendarioDiasUteisNovoPage', async () => {
     expect(req.request.body.diasNaoUteis[0]).toMatchObject({
       data: '2026-09-07',
       municipioIbge: null,
-      uf: null,
-    });
-    req.flush(mockProblemDetails({ status: 422, code: 'uniplus.test.validation' }), {
-      status: 422,
-      statusText: 'Unprocessable Entity',
-      headers: { 'Content-Type': 'application/problem+json' },
-    });
-  });
-
-  it('envia somente o código IBGE selecionado na abrangência municipal', () => {
-    component['form'].controls.versaoDataset.setValue('2026.1');
-    adicionarDia('MUNICIPAL');
-    component['salvar']();
-
-    const req = controller.expectOne(`${BASE}/api/configuracao/admin/calendarios-dias-uteis`);
-    expect(req.request.body.diasNaoUteis[0]).toMatchObject({
-      abrangencia: 'MUNICIPAL',
-      municipioIbge: '1504208',
+      municipioNome: null,
+      municipioUf: null,
       uf: null,
     });
     req.flush(mockProblemDetails({ status: 422, code: 'uniplus.test.validation' }), {
@@ -211,22 +273,20 @@ describe('CalendarioDiasUteisNovoPage', async () => {
     expect(component['form'].valid).toBe(true);
   });
 
-  it('associa erro de município à linha municipal com a mesma data', async () => {
+  it('associa o erro da referência de cidade à única linha municipal', async () => {
     component['form'].controls.versaoDataset.setValue('2026.1');
     adicionarDia('NACIONAL');
     const municipalIndex = adicionarDia('MUNICIPAL');
-    component['form'].controls.diasNaoUteis
-      .at(municipalIndex)
-      .controls.codigoMunicipio.setValue('1504208');
+    await selecionarMunicipioViaGeo(municipalIndex);
     component['salvar']();
 
     const req = controller.expectOne(`${BASE}/api/configuracao/admin/calendarios-dias-uteis`);
     req.flush(
       mockProblemDetails({
         status: 422,
-        code: 'uniplus.configuracao.calendario_dias_uteis.municipio_ibge_formato_invalido',
-        title: 'Código IBGE inválido',
-        detail: 'Código IBGE inválido (data 2026-09-07)',
+        code: 'uniplus.cidade_referencia.uf_incoerente',
+        title: 'UF informada incompatível com o prefixo do código IBGE',
+        detail: "O prefixo do código IBGE ('15') corresponde à UF 'PA', incompatível com 'SP'.",
       }),
       {
         status: 422,
@@ -235,10 +295,11 @@ describe('CalendarioDiasUteisNovoPage', async () => {
       },
     );
     await Promise.resolve();
+
     const dias = component['form'].controls.diasNaoUteis;
     expect(dias.at(0).controls.codigoMunicipio.errors?.['backend']).toBeUndefined();
     expect(dias.at(municipalIndex).controls.codigoMunicipio.errors?.['backend']).toMatchObject({
-      code: 'uniplus.configuracao.calendario_dias_uteis.municipio_ibge_formato_invalido',
+      code: 'uniplus.cidade_referencia.uf_incoerente',
     });
   });
 

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-novo.page.spec.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-novo.page.spec.ts
@@ -221,6 +221,58 @@ describe('CalendarioDiasUteisNovoPage', async () => {
     expect(grupo.controls.municipioUf.value).toBe('PA');
   });
 
+  it('busca em linhas municipais diferentes sem uma cancelar a outra', async () => {
+    const primeira = adicionarDia('MUNICIPAL', '2026-04-05');
+    const segunda = adicionarDia('MUNICIPAL', '2026-06-12');
+
+    component['buscarMunicipios'](primeira, MARABA.nome);
+    component['buscarMunicipios'](segunda, PARAUAPEBAS.nome);
+    await new Promise((resolve) => setTimeout(resolve, 350));
+
+    const requisicoes = controller.match((request) => request.url === `${BASE}/api/cidades`);
+    expect(requisicoes).toHaveLength(2);
+    for (const requisicao of requisicoes) {
+      const termo = requisicao.request.params.get('q');
+      const municipio = termo === MARABA.nome ? MARABA : PARAUAPEBAS;
+      requisicao.flush([{ id: `cidade-${municipio.codigoIbge}`, ddd: '94', ...municipio }]);
+    }
+    fixture.detectChanges();
+
+    // Nenhuma linha fica presa em "Buscando…" sem opções.
+    for (const [index, esperado] of [
+      [primeira, MARABA],
+      [segunda, PARAUAPEBAS],
+    ] as const) {
+      const estado = component['estadoBuscaMunicipio'](index);
+      expect(estado.carregando).toBe(false);
+      expect(estado.opcoes).toEqual(expect.arrayContaining([expect.objectContaining(esperado)]));
+    }
+  });
+
+  it('cancela a busca anterior da mesma linha em vez de aceitar duas respostas', async () => {
+    const index = adicionarDia('MUNICIPAL');
+
+    component['buscarMunicipios'](index, 'Marab');
+    await new Promise((resolve) => setTimeout(resolve, 350));
+    const primeira = controller.expectOne((request) => request.url === `${BASE}/api/cidades`);
+
+    component['buscarMunicipios'](index, 'Parauapebas');
+    await new Promise((resolve) => setTimeout(resolve, 350));
+    const segunda = controller.expectOne((request) => request.url === `${BASE}/api/cidades`);
+
+    // Sem cancelamento contínuo na linha, a resposta antiga ainda chegaria e
+    // sobrescreveria a recente (ou marcaria erro depois de um sucesso).
+    expect(primeira.cancelled).toBe(true);
+
+    segunda.flush([{ id: 'cidade-parauapebas', ddd: '94', ...PARAUAPEBAS }]);
+    fixture.detectChanges();
+
+    expect(component['estadoBuscaMunicipio'](index).opcoes).toEqual(
+      expect.arrayContaining([expect.objectContaining(PARAUAPEBAS)]),
+    );
+    expect(component['estadoBuscaMunicipio'](index).erro).toBe(false);
+  });
+
   it('envia nulo nos campos regionais que não se aplicam', () => {
     component['form'].controls.versaoDataset.setValue('2026.1');
     adicionarDia();

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-novo.page.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-novo.page.ts
@@ -11,7 +11,7 @@ import {
   Validators,
 } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
-import { debounceTime, map, Subject, switchMap } from 'rxjs';
+import { debounceTime, groupBy, map, mergeMap, Subject, switchMap } from 'rxjs';
 
 import {
   CalendarioDiasUteisApi,
@@ -700,11 +700,27 @@ export class CalendarioDiasUteisNovoPage {
   constructor() {
     this.buscaMunicipioRequests
       .pipe(
-        debounceTime(MUNICIPIO_BUSCA_DEBOUNCE_MS),
-        switchMap((request) =>
-          this.geo
-            .listarCidades({ uf: request.uf, q: request.termo, limit: MUNICIPIOS_LIMIT })
-            .pipe(map((result) => ({ request, result }))),
+        // Debounce e cancelamento são por linha: com um fluxo único, digitar
+        // numa segunda linha municipal descartava a busca da primeira, que
+        // ficava em "Buscando…" para sempre — e sem snapshot não há como salvar.
+        //
+        // O grupo de cada linha vive enquanto a página viver (encerrado em bloco
+        // pelo `takeUntilDestroyed`). Expirá-lo por inatividade quebraria o
+        // cancelamento: uma requisição ainda em voo sobreviveria ao grupo, e a
+        // busca seguinte nasceria noutro `switchMap`, sem cancelá-la — duas
+        // respostas para a mesma linha, com a antiga podendo chegar por último.
+        // O preço é reter o grupo de uma linha removida, que é irrisório perto
+        // de aceitar resultado obsoleto.
+        groupBy((request) => request.grupo),
+        mergeMap((linha) =>
+          linha.pipe(
+            debounceTime(MUNICIPIO_BUSCA_DEBOUNCE_MS),
+            switchMap((request) =>
+              this.geo
+                .listarCidades({ uf: request.uf, q: request.termo, limit: MUNICIPIOS_LIMIT })
+                .pipe(map((result) => ({ request, result }))),
+            ),
+          ),
         ),
         takeUntilDestroyed(this.destroyRef),
       )

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-novo.page.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-novo.page.ts
@@ -33,12 +33,19 @@ type DiaNaoUtilFormGroupCampoNome = 'codigoMunicipio' | 'uf' | 'abrangencia' | '
 interface DiaNaoUtilFormGroup {
   uf: FormControl<string | null>;
   codigoMunicipio: FormControl<string | null>;
+  municipioNome: FormControl<string | null>;
+  municipioUf: FormControl<string | null>;
   buscaMunicipio: FormControl<string>;
   abrangencia: FormControl<string>;
   data: FormControl<string>;
   descricao: FormControl<string>;
 }
 
+/**
+ * Snapshot municipal da ADR-0090 tal como o formulário o mantém: código IBGE,
+ * nome e UF chegam juntos da API Geo e são gravados juntos — nenhum dos três
+ * nasce de digitação livre nem de constante do código.
+ */
 interface MunicipioOpcao {
   readonly codigoIbge: string;
   readonly nome: string;
@@ -64,19 +71,55 @@ interface CalendarioDiaUtilFormGroup {
 
 export const DATA_DUPLICADA_DATASET_CODE =
   'uniplus.configuracao.calendario_dias_uteis.data_duplicada_no_dataset';
-export const MUNICIPIO_CODE_INVALID =
-  'uniplus.configuracao.calendario_dias_uteis.municipio_ibge_formato_invalido';
+/**
+ * Prefixo dos erros que o backend devolve ao validar a referência de cidade do
+ * Geo (`uniplus.cidade_referencia.*`, ADR-0090): código obrigatório/inválido,
+ * nome obrigatório/longo demais, UF obrigatória/incoerente com o prefixo. É
+ * prefixo, e não uma lista fechada, porque o registro cresce no backend.
+ */
+export const CIDADE_REFERENCIA_CODE_PREFIX = 'uniplus.cidade_referencia.';
 
 const CODIGO_MUNICIPIO_PATTERN = /^(?:1[1-7]|2[1-9]|3[1-35]|4[1-3]|5[0-3])\d{5}$/;
+/**
+ * Prefixo do código IBGE (dois primeiros dígitos) de cada UF — a mesma
+ * correspondência que `ReferenciaCidadeGeo` cobra no backend. Fica nesta página
+ * (chunk lazy) em vez do roster compartilhado, que é carregado no bundle
+ * inicial do painel.
+ */
+const PREFIXO_IBGE_POR_UF: Readonly<Record<string, string>> = {
+  RO: '11',
+  AC: '12',
+  AM: '13',
+  RR: '14',
+  PA: '15',
+  AP: '16',
+  TO: '17',
+  MA: '21',
+  PI: '22',
+  CE: '23',
+  RN: '24',
+  PB: '25',
+  PE: '26',
+  AL: '27',
+  SE: '28',
+  BA: '29',
+  MG: '31',
+  ES: '32',
+  RJ: '33',
+  SP: '35',
+  PR: '41',
+  SC: '42',
+  RS: '43',
+  MS: '50',
+  MT: '51',
+  GO: '52',
+  DF: '53',
+};
 const DATA_DUPLICADA_MESSAGE = 'Esta data está duplicada para a mesma abrangência e região.';
+const MUNICIPIO_OBRIGATORIO_MESSAGE = 'Selecione um município na busca.';
 const PARA_SIGLA = 'PA';
 const MUNICIPIOS_LIMIT = 20;
 const MUNICIPIO_BUSCA_DEBOUNCE_MS = 300;
-const MARABA: MunicipioOpcao = {
-  codigoIbge: '1504208',
-  nome: 'Marabá',
-  uf: PARA_SIGLA,
-};
 const MUNICIPIO_BUSCA_VAZIA: MunicipioBuscaState = {
   opcoes: [],
   carregando: false,
@@ -111,6 +154,28 @@ function chaveDuplicidade(grupo: FormGroup<DiaNaoUtilFormGroup>): string | null 
     return uf ? `${data}|${abrangencia}|${uf}` : null;
   }
   return `${data}|${abrangencia}`;
+}
+
+/**
+ * Exige, na linha municipal, o snapshot inteiro da opção escolhida na Geo:
+ * código IBGE de 7 dígitos, nome e UF cujo prefixo IBGE bate com o código. É a
+ * mesma coerência que `ReferenciaCidadeGeo.Validar` cobra no backend — validada
+ * aqui para que uma tripla incompleta não vire 422.
+ */
+function snapshotMunicipalCoerente(control: AbstractControl): ValidationErrors | null {
+  const grupo = control as FormGroup<DiaNaoUtilFormGroup>;
+  if (grupo.controls.abrangencia.value !== 'MUNICIPAL') {
+    return null;
+  }
+
+  const codigo = grupo.controls.codigoMunicipio.value?.trim() ?? '';
+  const nome = grupo.controls.municipioNome.value?.trim() ?? '';
+  const uf = grupo.controls.municipioUf.value?.trim().toUpperCase() ?? '';
+  if (!CODIGO_MUNICIPIO_PATTERN.test(codigo) || nome.length === 0) {
+    return { snapshotMunicipal: true };
+  }
+
+  return PREFIXO_IBGE_POR_UF[uf] === codigo.slice(0, 2) ? null : { snapshotMunicipal: true };
 }
 
 function datasNaoUteisSemDuplicidade(control: AbstractControl): ValidationErrors | null {
@@ -666,14 +731,18 @@ export class CalendarioDiasUteisNovoPage {
     this.saving.set(true);
     const command: CriarCalendarioDiasUteisCommand = {
       versaoDataset: this.form.controls.versaoDataset.value.trim(),
-      diasNaoUteis: this.form.controls.diasNaoUteis.controls.map((control) => {
+      diasNaoUteis: this.form.controls.diasNaoUteis.controls.map((control, index) => {
         const abrangencia = control.controls.abrangencia.value;
+        // Snapshot da ADR-0090: os três campos saem juntos da opção da Geo e só
+        // existem em MUNICIPAL — o backend recusa qualquer um deles fora dela.
+        const municipio = abrangencia === 'MUNICIPAL' ? this.municipioSelecionado(index) : null;
         return {
           abrangencia,
           data: control.controls.data.value,
           uf: abrangencia === 'ESTADUAL' ? control.controls.uf.value || null : null,
-          municipioIbge:
-            abrangencia === 'MUNICIPAL' ? control.controls.codigoMunicipio.value || null : null,
+          municipioIbge: municipio?.codigoIbge ?? null,
+          municipioNome: municipio?.nome ?? null,
+          municipioUf: municipio?.uf ?? null,
           descricao: control.controls.descricao.value.trim(),
         };
       }),
@@ -697,32 +766,23 @@ export class CalendarioDiasUteisNovoPage {
       return;
     }
 
-    if (problem.status === 422 && problem.code === MUNICIPIO_CODE_INVALID) {
+    if (problem.status === 422 && problem.code?.startsWith(CIDADE_REFERENCIA_CODE_PREFIX)) {
       this.notifications.errorFromProblem(problem);
       this.renovarIdempotencyKey();
-      const data = this.extrairData(problem);
-      if (data) {
-        const candidatos = this.diasNaoUteis.controls.filter(
-          (control) =>
-            control.controls.data.value === data &&
-            control.controls.abrangencia.value === 'MUNICIPAL',
-        );
-        const control =
-          candidatos.find(
-            (candidato) =>
-              !CODIGO_MUNICIPIO_PATTERN.test(candidato.controls.codigoMunicipio.value ?? ''),
-          ) ?? candidatos[0];
-        if (control && problem.detail) {
-          const message = problem.detail.replace(/\s*\(data \d{4}-\d{2}-\d{2}\)/, '');
-          const municipio = control.controls.codigoMunicipio;
-          municipio.setErrors({
-            ...municipio.errors,
-            backend: { code: problem.code, message },
-          });
-          municipio.markAsTouched();
-        }
-        return;
+      // O erro da referência de cidade não carrega a data no `detail`, então só
+      // dá para apontar a linha quando existe uma única municipal no dataset.
+      const municipais = this.diasNaoUteis.controls.filter(
+        (control) => control.controls.abrangencia.value === 'MUNICIPAL',
+      );
+      if (municipais.length === 1 && problem.detail) {
+        const municipio = municipais[0].controls.codigoMunicipio;
+        municipio.setErrors({
+          ...municipio.errors,
+          backend: { code: problem.code, message: problem.detail },
+        });
+        municipio.markAsTouched();
       }
+      return;
     }
 
     this.notifications.errorFromProblem(problem);
@@ -758,7 +818,8 @@ export class CalendarioDiasUteisNovoPage {
   }
 
   protected erroDoCampoDiasNaoUteis(nome: keyof DiaNaoUtilFormGroup, index: number): string | null {
-    const control = this.diasNaoUteis.controls[index].get(nome);
+    const grupo = this.diasNaoUteis.controls[index];
+    const control = grupo.get(nome);
     if (!control) {
       return null;
     }
@@ -768,6 +829,11 @@ export class CalendarioDiasUteisNovoPage {
     }
     if (nome === 'data' && this.linhaDuplicada(index)) {
       return DATA_DUPLICADA_MESSAGE;
+    }
+    // O snapshot incompleto é erro do grupo (nome e UF não têm campo próprio na
+    // tela), mas quem o resolve é a seleção no campo Município.
+    if (nome === 'codigoMunicipio' && grupo.errors?.['snapshotMunicipal']) {
+      return MUNICIPIO_OBRIGATORIO_MESSAGE;
     }
     if (control.errors === null) {
       return null;
@@ -812,26 +878,21 @@ export class CalendarioDiasUteisNovoPage {
 
     municipio.clearValidators();
     uf.clearValidators();
+    this.limparSnapshotMunicipal(control);
 
     if (abrangencia === 'MUNICIPAL') {
+      // A UF aqui é só o filtro da busca na Geo — não é persistida (o backend
+      // recusa `uf` fora de ESTADUAL); a UF do município vem no snapshot.
       uf.setValue(PARA_SIGLA);
-      municipio.setValue(MARABA.codigoIbge);
-      buscaMunicipio.setValue(MARABA.nome);
       uf.setValidators([Validators.required, Validators.pattern(/^[A-Z]{2}$/)]);
       municipio.setValidators([Validators.required, Validators.pattern(CODIGO_MUNICIPIO_PATTERN)]);
-      this.atualizarEstadoMunicipio(index, {
-        opcoes: [MARABA],
-        carregando: false,
-        erro: false,
-      });
+      this.atualizarEstadoMunicipio(index, MUNICIPIO_BUSCA_VAZIA);
     } else if (abrangencia === 'ESTADUAL') {
       uf.setValue(PARA_SIGLA);
-      municipio.reset('');
       buscaMunicipio.reset('');
       uf.setValidators([Validators.required, Validators.pattern(/^[A-Z]{2}$/)]);
       this.atualizarEstadoMunicipio(index, MUNICIPIO_BUSCA_VAZIA);
     } else {
-      municipio.reset('');
       uf.reset('');
       buscaMunicipio.reset('');
       this.atualizarEstadoMunicipio(index, MUNICIPIO_BUSCA_VAZIA);
@@ -841,25 +902,26 @@ export class CalendarioDiasUteisNovoPage {
     uf.updateValueAndValidity();
   }
 
+  /**
+   * Descarta a tripla inteira — código, nome e UF andam juntos, sob pena de
+   * sobrar um display cache de um município que não é mais o selecionado.
+   */
+  private limparSnapshotMunicipal(grupo: FormGroup<DiaNaoUtilFormGroup>): void {
+    grupo.controls.codigoMunicipio.reset('');
+    grupo.controls.municipioNome.reset(null);
+    grupo.controls.municipioUf.reset(null);
+  }
+
   protected mudaUf(index: number): void {
     const grupo = this.diasNaoUteis.at(index);
     if (!grupo || grupo.controls.abrangencia.value !== 'MUNICIPAL') {
       return;
     }
 
-    if (grupo.controls.uf.value === PARA_SIGLA) {
-      grupo.controls.codigoMunicipio.setValue(MARABA.codigoIbge);
-      grupo.controls.buscaMunicipio.setValue(MARABA.nome);
-      this.atualizarEstadoMunicipio(index, {
-        opcoes: [MARABA],
-        carregando: false,
-        erro: false,
-      });
-    } else {
-      grupo.controls.codigoMunicipio.reset('');
-      grupo.controls.buscaMunicipio.reset('');
-      this.atualizarEstadoMunicipio(index, MUNICIPIO_BUSCA_VAZIA);
-    }
+    // Trocar o estado da busca invalida o município escolhido no estado anterior.
+    this.limparSnapshotMunicipal(grupo);
+    grupo.controls.buscaMunicipio.reset('');
+    this.atualizarEstadoMunicipio(index, MUNICIPIO_BUSCA_VAZIA);
     grupo.controls.codigoMunicipio.updateValueAndValidity();
   }
 
@@ -877,7 +939,7 @@ export class CalendarioDiasUteisNovoPage {
       selecionado &&
       normalizado.localeCompare(selecionado.nome, 'pt-BR', { sensitivity: 'base' }) !== 0
     ) {
-      grupo.controls.codigoMunicipio.reset('');
+      this.limparSnapshotMunicipal(grupo);
     }
     if (normalizado.length < 2 || uf.length !== 2) {
       this.atualizarEstadoMunicipio(index, {
@@ -914,25 +976,39 @@ export class CalendarioDiasUteisNovoPage {
     this.buscaMunicipioRequests.next({ grupo, termo, uf });
   }
 
+  /**
+   * Grava a tripla da opção escolhida no `<select>` alimentado pela Geo. É o
+   * único ponto que escreve o snapshot: nome e UF nunca vêm do que foi digitado.
+   */
   protected selecionarMunicipio(index: number): void {
     const grupo = this.diasNaoUteis.at(index);
-    const selecionado = this.municipioSelecionado(index);
-    if (!grupo || !selecionado) {
+    if (!grupo) {
       return;
     }
-    grupo.controls.buscaMunicipio.setValue(selecionado.nome, { emitEvent: false });
+    const codigo = grupo.controls.codigoMunicipio.value;
+    const opcao = this.estadoBuscaMunicipio(index).opcoes.find(
+      (candidata) => candidata.codigoIbge === codigo,
+    );
+    if (!opcao) {
+      this.limparSnapshotMunicipal(grupo);
+      return;
+    }
+    grupo.controls.municipioNome.setValue(opcao.nome);
+    grupo.controls.municipioUf.setValue(opcao.uf);
+    grupo.controls.buscaMunicipio.setValue(opcao.nome, { emitEvent: false });
   }
 
   protected estadoBuscaMunicipio(index: number): MunicipioBuscaState {
     return this.estadosBuscaMunicipio()[index] ?? MUNICIPIO_BUSCA_VAZIA;
   }
 
+  /** Snapshot já gravado na linha — independe da lista de busca vigente. */
   protected municipioSelecionado(index: number): MunicipioOpcao | null {
     const grupo = this.diasNaoUteis.at(index);
-    const codigo = grupo?.controls.codigoMunicipio.value;
-    return (
-      this.estadoBuscaMunicipio(index).opcoes.find((opcao) => opcao.codigoIbge === codigo) ?? null
-    );
+    const codigoIbge = grupo?.controls.codigoMunicipio.value?.trim();
+    const nome = grupo?.controls.municipioNome.value?.trim();
+    const uf = grupo?.controls.municipioUf.value?.trim();
+    return codigoIbge && nome && uf ? { codigoIbge, nome, uf } : null;
   }
 
   protected buscaSemResultado(index: number): boolean {
@@ -965,9 +1041,7 @@ export class CalendarioDiasUteisNovoPage {
     }
 
     const state = this.estadoBuscaMunicipio(index);
-    const selecionado = state.opcoes.find(
-      (opcao) => opcao.codigoIbge === request.grupo.controls.codigoMunicipio.value,
-    );
+    const selecionado = this.municipioSelecionado(index);
     const opcoes: MunicipioOpcao[] = result.ok ? [...result.data] : [...state.opcoes];
     if (selecionado && !opcoes.some((opcao) => opcao.codigoIbge === selecionado.codigoIbge)) {
       opcoes.unshift(selecionado);
@@ -998,31 +1072,36 @@ export class CalendarioDiasUteisNovoPage {
   }
 
   private criaDiaNaoUtilFormGroup(): FormGroup<DiaNaoUtilFormGroup> {
-    return new FormGroup<DiaNaoUtilFormGroup>({
-      abrangencia: new FormControl('ESTADUAL', {
-        nonNullable: true,
-        validators: [Validators.required],
-      }),
-      codigoMunicipio: new FormControl('', {
-        nonNullable: false,
-        validators: [],
-      }),
-      buscaMunicipio: new FormControl('', {
-        nonNullable: true,
-      }),
-      uf: new FormControl(PARA_SIGLA, {
-        nonNullable: false,
-        validators: [Validators.required, Validators.pattern(/^[A-Z]{2}$/)],
-      }),
-      data: new FormControl('', {
-        nonNullable: true,
-        validators: [Validators.required],
-      }),
-      descricao: new FormControl('', {
-        nonNullable: true,
-        validators: [textoNormalizado(200)],
-      }),
-    });
+    return new FormGroup<DiaNaoUtilFormGroup>(
+      {
+        abrangencia: new FormControl('ESTADUAL', {
+          nonNullable: true,
+          validators: [Validators.required],
+        }),
+        codigoMunicipio: new FormControl('', {
+          nonNullable: false,
+          validators: [],
+        }),
+        municipioNome: new FormControl(null, { nonNullable: false }),
+        municipioUf: new FormControl(null, { nonNullable: false }),
+        buscaMunicipio: new FormControl('', {
+          nonNullable: true,
+        }),
+        uf: new FormControl(PARA_SIGLA, {
+          nonNullable: false,
+          validators: [Validators.required, Validators.pattern(/^[A-Z]{2}$/)],
+        }),
+        data: new FormControl('', {
+          nonNullable: true,
+          validators: [Validators.required],
+        }),
+        descricao: new FormControl('', {
+          nonNullable: true,
+          validators: [textoNormalizado(200)],
+        }),
+      },
+      { validators: [snapshotMunicipalCoerente] },
+    );
   }
 
   protected get diasNaoUteis(): FormArray<FormGroup<DiaNaoUtilFormGroup>> {

--- a/libs/shared-data/openapi/configuracao.openapi.json
+++ b/libs/shared-data/openapi/configuracao.openapi.json
@@ -10052,13 +10052,26 @@
         }
       },
       "DiaNaoUtilCommandItem": {
-        "required": ["abrangencia", "municipioIbge", "data", "descricao"],
+        "required": [
+          "abrangencia",
+          "municipioIbge",
+          "municipioNome",
+          "municipioUf",
+          "data",
+          "descricao"
+        ],
         "type": "object",
         "properties": {
           "abrangencia": {
             "type": "string"
           },
           "municipioIbge": {
+            "type": ["null", "string"]
+          },
+          "municipioNome": {
+            "type": ["null", "string"]
+          },
+          "municipioUf": {
             "type": ["null", "string"]
           },
           "data": {
@@ -10074,7 +10087,16 @@
         }
       },
       "DiaNaoUtilDto": {
-        "required": ["id", "abrangencia", "municipioIbge", "uf", "data", "descricao"],
+        "required": [
+          "id",
+          "abrangencia",
+          "municipioIbge",
+          "municipioNome",
+          "municipioUf",
+          "uf",
+          "data",
+          "descricao"
+        ],
         "type": "object",
         "properties": {
           "id": {
@@ -10085,6 +10107,12 @@
             "type": "string"
           },
           "municipioIbge": {
+            "type": ["null", "string"]
+          },
+          "municipioNome": {
+            "type": ["null", "string"]
+          },
+          "municipioUf": {
             "type": ["null", "string"]
           },
           "uf": {

--- a/libs/shared-data/src/lib/api/configuracao/calendario-dias-uteis.api.spec.ts
+++ b/libs/shared-data/src/lib/api/configuracao/calendario-dias-uteis.api.spec.ts
@@ -22,6 +22,7 @@ import { CONFIGURACAO_BASE_PATH } from './tokens';
 
 const BASE = 'http://localhost:5000';
 const CALENDARIO_ID = '019f41cf-69fd-759a-ac6d-09acabc1b027';
+const IDEMPOTENCY_KEY = '019f41cf-69fd-759a-ac6d-09acabc1b0ff';
 
 /**
  * Âncoras de contrato: os literais abaixo são tipados pelos aliases do
@@ -66,6 +67,22 @@ describe('CalendarioDiasUteisApi', () => {
   });
 
   afterEach(() => controller.verify());
+
+  it('listar() faz GET com paginação e Accept versionado', async () => {
+    const promise = firstValueFrom(api.listar({ limit: 50 }));
+
+    const req = controller.expectOne(
+      `${BASE}/api/configuracao/calendarios-dias-uteis?limit=50`,
+    );
+    expect(req.request.method).toBe('GET');
+    expect(req.request.headers.get('Accept')).toBe(
+      buildVendorMimeAccept('calendario-dias-uteis', 1),
+    );
+    req.flush([]);
+
+    const result = await promise;
+    expect(isApiOk(result)).toBe(true);
+  });
 
   it('deriva o item e o DTO do contrato que exige o snapshot municipal', () => {
     const baseline = JSON.parse(
@@ -120,11 +137,12 @@ describe('CalendarioDiasUteisApi', () => {
   });
 
   it('criar() envia o comando com o snapshot municipal e a Idempotency-Key', async () => {
-    const promise = firstValueFrom(
-      api.criar(comandoValido, withIdempotencyKey('019f41cf-69fd-759a-ac6d-09acabc1b0ff')),
-    );
+    const promise = firstValueFrom(api.criar(comandoValido, withIdempotencyKey(IDEMPOTENCY_KEY)));
 
     const req = controller.expectOne(`${BASE}/api/configuracao/admin/calendarios-dias-uteis`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.headers.get('Accept')).toBe('application/json');
+    expect(req.request.headers.get('Idempotency-Key')).toBe(IDEMPOTENCY_KEY);
     expect(req.request.body.diasNaoUteis[0]).toMatchObject({
       municipioIbge: '1504208',
       municipioNome: 'Marabá',
@@ -135,4 +153,20 @@ describe('CalendarioDiasUteisApi', () => {
     await promise;
   });
 
+  it('marcarVigente() faz POST sem command e preserva a Idempotency-Key', async () => {
+    const promise = firstValueFrom(
+      api.marcarVigente(CALENDARIO_ID, withIdempotencyKey(IDEMPOTENCY_KEY)),
+    );
+
+    const req = controller.expectOne(
+      `${BASE}/api/configuracao/admin/calendarios-dias-uteis/${CALENDARIO_ID}/vigente`,
+    );
+    expect(req.request.method).toBe('POST');
+    expect(req.request.headers.get('Idempotency-Key')).toBe(IDEMPOTENCY_KEY);
+    expect(req.request.body).toBeNull();
+    req.flush(null, { status: 204, statusText: 'No Content' });
+
+    const result = await promise;
+    expect(isApiOk(result)).toBe(true);
+  });
 });

--- a/libs/shared-data/src/lib/api/configuracao/calendario-dias-uteis.api.spec.ts
+++ b/libs/shared-data/src/lib/api/configuracao/calendario-dias-uteis.api.spec.ts
@@ -1,15 +1,53 @@
-import { provideHttpClient } from '@angular/common/http';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { VENDOR_MIME_TOKEN, withIdempotencyKey } from '@uniplus/shared-core/http';
+import { firstValueFrom } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { CalendarioDiasUteisApi } from './calendario-dias-uteis.api';
+import {
+  apiResultInterceptor,
+  buildVendorMimeAccept,
+  isApiOk,
+  withIdempotencyKey,
+} from '@uniplus/shared-core/http';
+import {
+  CalendarioDiasUteisApi,
+  CriarCalendarioDiasUteisCommand,
+  DiaNaoUtilCommandItem,
+  DiaNaoUtilDto,
+} from './calendario-dias-uteis.api';
 import { CONFIGURACAO_BASE_PATH } from './tokens';
 
 const BASE = 'http://localhost:5000';
 const CALENDARIO_ID = '019f41cf-69fd-759a-ac6d-09acabc1b027';
-const IDEMPOTENCY_KEY = '019f6a58-7f24-7d4a-b82c-3ff5c3c941f0';
+
+/**
+ * Âncoras de contrato: os literais abaixo são tipados pelos aliases do
+ * `schema.ts` gerado. Se o snapshot municipal (ADR-0090) sair do contrato ou
+ * deixar de ser obrigatório, o `typecheck` quebra aqui — é o gate contra um DTO
+ * manual divergir do OpenAPI committed.
+ */
+const itemMunicipal: DiaNaoUtilCommandItem = {
+  abrangencia: 'MUNICIPAL',
+  municipioIbge: '1504208',
+  municipioNome: 'Marabá',
+  municipioUf: 'PA',
+  uf: null,
+  data: '2026-04-05',
+  descricao: 'Aniversário de Marabá',
+};
+
+const diaMunicipal: DiaNaoUtilDto = {
+  id: '019f41cf-69fd-759a-ac6d-09acabc1b100',
+  ...itemMunicipal,
+};
+
+const comandoValido: CriarCalendarioDiasUteisCommand = {
+  versaoDataset: '2026.1',
+  diasNaoUteis: [itemMunicipal],
+};
 
 describe('CalendarioDiasUteisApi', () => {
   let api: CalendarioDiasUteisApi;
@@ -18,7 +56,7 @@ describe('CalendarioDiasUteisApi', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
-        provideHttpClient(),
+        provideHttpClient(withInterceptors([apiResultInterceptor])),
         provideHttpClientTesting(),
         { provide: CONFIGURACAO_BASE_PATH, useValue: BASE },
       ],
@@ -29,26 +67,72 @@ describe('CalendarioDiasUteisApi', () => {
 
   afterEach(() => controller.verify());
 
-  it('usa o vendor MIME do recurso ao listar', () => {
-    api.listar({ limit: 50 }).subscribe();
+  it('deriva o item e o DTO do contrato que exige o snapshot municipal', () => {
+    const baseline = JSON.parse(
+      fs.readFileSync(
+        path.resolve(__dirname, '../../../../openapi/configuracao.openapi.json'),
+        'utf8',
+      ),
+    ) as {
+      components: { schemas: Record<string, { required?: readonly string[] }> };
+    };
 
-    const req = controller.expectOne(`${BASE}/api/configuracao/calendarios-dias-uteis?limit=50`);
-    expect(req.request.context.get(VENDOR_MIME_TOKEN)).toEqual({
-      resource: 'calendario-dias-uteis',
-      version: 1,
-    });
-    expect(req.request.method).toBe('GET');
-    req.flush([]);
+    // O `codegen-api-check` garante que o `schema.ts` bate com este baseline; o
+    // que falta é alguém cobrar que o contrato continue exigindo os três campos
+    // que a tela envia. Sem isso, uma regressão do backend viraria 422 em runtime.
+    for (const nome of ['DiaNaoUtilCommandItem', 'DiaNaoUtilDto'] as const) {
+      expect(baseline.components.schemas[nome].required).toEqual(
+        expect.arrayContaining(['municipioIbge', 'municipioNome', 'municipioUf']),
+      );
+    }
+
+    expect(Object.keys(itemMunicipal)).toEqual(
+      expect.arrayContaining(['municipioIbge', 'municipioNome', 'municipioUf']),
+    );
   });
 
-  it('marca vigente sem enviar command no corpo', () => {
-    api.marcarVigente(CALENDARIO_ID, withIdempotencyKey(IDEMPOTENCY_KEY)).subscribe();
+  it('obter() faz GET com Accept versionado e devolve o snapshot do dia municipal', async () => {
+    const promise = firstValueFrom(api.obter(CALENDARIO_ID));
 
     const req = controller.expectOne(
-      `${BASE}/api/configuracao/admin/calendarios-dias-uteis/${CALENDARIO_ID}/vigente`,
+      `${BASE}/api/configuracao/calendarios-dias-uteis/${CALENDARIO_ID}`,
     );
-    expect(req.request.method).toBe('POST');
-    expect(req.request.body).toBeNull();
-    req.flush(null, { status: 204, statusText: 'No Content' });
+    expect(req.request.headers.get('Accept')).toBe(
+      buildVendorMimeAccept('calendario-dias-uteis', 1),
+    );
+    req.flush({
+      id: CALENDARIO_ID,
+      versaoDataset: '2026.1',
+      vigente: true,
+      criadoEm: '2026-08-13T00:00:00Z',
+      diasNaoUteis: [diaMunicipal],
+    });
+
+    const result = await promise;
+    expect(isApiOk(result)).toBe(true);
+    if (isApiOk(result)) {
+      expect(result.data.diasNaoUteis[0]).toMatchObject({
+        municipioIbge: '1504208',
+        municipioNome: 'Marabá',
+        municipioUf: 'PA',
+      });
+    }
   });
+
+  it('criar() envia o comando com o snapshot municipal e a Idempotency-Key', async () => {
+    const promise = firstValueFrom(
+      api.criar(comandoValido, withIdempotencyKey('019f41cf-69fd-759a-ac6d-09acabc1b0ff')),
+    );
+
+    const req = controller.expectOne(`${BASE}/api/configuracao/admin/calendarios-dias-uteis`);
+    expect(req.request.body.diasNaoUteis[0]).toMatchObject({
+      municipioIbge: '1504208',
+      municipioNome: 'Marabá',
+      municipioUf: 'PA',
+    });
+    req.flush(CALENDARIO_ID);
+
+    await promise;
+  });
+
 });

--- a/libs/shared-data/src/lib/api/configuracao/calendario-dias-uteis.api.ts
+++ b/libs/shared-data/src/lib/api/configuracao/calendario-dias-uteis.api.ts
@@ -36,12 +36,6 @@ export interface DominioOption<T extends string = string> {
 
 export type AbrangenciasToken = 'INSTITUCIONAL' | 'MUNICIPAL' | 'ESTADUAL' | 'NACIONAL';
 
-export interface Cidade {
-  id: string;
-  nome: string;
-  uf: string;
-}
-
 export interface UnidadeFederativa {
   id: number;
   nome: string;

--- a/libs/shared-data/src/lib/api/configuracao/schema.ts
+++ b/libs/shared-data/src/lib/api/configuracao/schema.ts
@@ -7880,6 +7880,8 @@ export interface components {
         readonly DiaNaoUtilCommandItem: {
             readonly abrangencia: string;
             readonly municipioIbge: null | string;
+            readonly municipioNome: null | string;
+            readonly municipioUf: null | string;
             /** Format: date */
             readonly data: string;
             readonly descricao: string;
@@ -7890,6 +7892,8 @@ export interface components {
             readonly id: string;
             readonly abrangencia: string;
             readonly municipioIbge: null | string;
+            readonly municipioNome: null | string;
+            readonly municipioUf: null | string;
             readonly uf: null | string;
             /** Format: date */
             readonly data: string;


### PR DESCRIPTION
## Contexto

O contrato do Calendário de Dias Úteis passou a publicar e persistir o snapshot de cidade da ADR-0090 (`uniplus-api` #1147 / PR #1149). Este PR liga o painel a esse contrato: o formulário envia `{ municipioIbge, municipioNome, municipioUf }` resolvidos pela API Geo, e o detalhe apresenta a localidade legível a partir do que está persistido, sem consultar a Geo.

Closes #524

## O que muda

**Contrato (`shared-data`)** — baseline `configuracao.openapi.json` sincronizado por inteiro com o contrato publicado e `schema.ts` regenerado. `DiaNaoUtilCommandItem` e `DiaNaoUtilDto` passam a exigir `municipioNome` e `municipioUf`. Removida a interface `Cidade`, sem consumidor.

**Formulário de criação** — a linha municipal guarda e envia a tripla da opção escolhida na Geo. Os três campos são escritos num ponto só (a seleção) e descartados juntos quando a escolha deixa de valer. O pré-preenchimento com Marabá foi removido: era um snapshot vindo de constante do código, que não passou pela Geo e permitia salvar sem escolher município. Passa a valer a coerência prefixo IBGE ↔ UF, a mesma que `ReferenciaCidadeGeo` cobra no servidor.

**Detalhe** — `Marabá — PA` com `Código IBGE: 1504208` como informação secundária, e `Pará — PA` na abrangência estadual, em conteúdo semântico no lugar dos campos desabilitados de localidade.

**Correção encontrada no caminho** — o debounce e o `switchMap` da busca de municípios viviam num fluxo único do formulário: buscar numa segunda linha municipal cancelava a busca da primeira, que ficava presa em "Buscando…" sem opções. Isso não incomodava enquanto havia município pré-preenchido; agora bloquearia o envio. As requisições passaram a ser agrupadas por linha.

## Recorte deliberado com a #525

A #525 vai substituir a tela de detalhe inteira por uma visão de calendário mensal com drawer. Para não produzir trabalho descartado, este PR mexe **apenas** nos dois campos de localidade e deixa como estão os controles desabilitados do restante do dataset. Consequência: os itens de rótulo humanizado de abrangência (`MUNICIPAL` → `Municipal`) e de data em `dd/MM/aaaa` fora de controle nativo, listados no escopo da #524, ficam com a #525, que já os cobre em CA-10 e CA-11.

## Verificação

- `nx affected -t lint test build typecheck` verde (`shared-data` 277, `configuracao` 311 testes).
- `shared-data:codegen-api-check` sem drift.
- Playwright `calendario-dias-uteis.visual.spec.ts`: 12 testes verdes nos 6 projetos (375 px e desktop × light/dark/contrast), com axe-core sem violações `serious`/`critical`, ausência de rolagem horizontal em 375 px e em 320 px, e verificação de que nenhuma requisição sai para a Geo ao abrir o detalhe.
- Testes que provam o que dizem provar: o teste de busca concorrente falha (1 requisição em vez de 2) sem a correção do agrupamento por linha; o teste de contrato falha ao remover `municipioNome` de `required` no baseline.

## Notas para a revisão

- O erro `uniplus.cidade_referencia.*` não traz a data no `detail`, então a linha só é apontada quando existe uma única municipal no dataset; nos demais casos fica a notificação, sem adivinhar a linha.
- O aviso de budget do bundle inicial (335 bytes acima) já existia na `main` e permanece no mesmo patamar: a tabela de prefixos IBGE ficou no chunk lazy da página, e não no roster compartilhado, justamente para não agravá-lo.