### PR TITLE
Feature/529 passo 3 listagem de modalidades

### DIFF
--- a/apps/selecao/src/app/features/processo-seletivo/processo-seletivo.page.spec.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/processo-seletivo.page.spec.ts
@@ -2,7 +2,12 @@ import { HttpHeaders } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { apiOk } from '@uniplus/shared-core/http';
-import { TipoProcessoDto, TiposProcessoApi } from '@uniplus/shared-data/configuracao';
+import {
+  ModalidadeDto,
+  ModalidadesApi,
+  TipoProcessoDto,
+  TiposProcessoApi,
+} from '@uniplus/shared-data/configuracao';
 import { UnidadeDto, UnidadesApi } from '@uniplus/shared-data/organizacao';
 import { GeoApi } from '@uniplus/shared-data/geo';
 import { ProcessosSeletivosApi } from '@uniplus/shared-data/selecao';
@@ -22,6 +27,10 @@ const geoApiStub = {
   listarCidades: () => of(apiOk<readonly never[]>([], 200, new HttpHeaders())),
 };
 
+const modalidadesApiStub = {
+  listar: () => of(apiOk<readonly ModalidadeDto[]>([], 200, new HttpHeaders())),
+};
+
 /**
  * A page provê `CadastroInicialService`, que injeta o client de Processo
  * Seletivo. Nenhum teste desta suíte chega a gravar — o stub existe para o
@@ -29,24 +38,22 @@ const geoApiStub = {
  */
 const processosSeletivosApiStub = {};
 
+const PAGE_PROVIDERS = [
+  { provide: TiposProcessoApi, useValue: tiposProcessoApiStub },
+  { provide: UnidadesApi, useValue: unidadesApiStub },
+  { provide: GeoApi, useValue: geoApiStub },
+  { provide: ModalidadesApi, useValue: modalidadesApiStub },
+  { provide: ProcessosSeletivosApi, useValue: processosSeletivosApiStub },
+];
+
 describe('ProcessoSeletivoPage — estrutura', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ProcessoSeletivoPage],
-      providers: [
-        { provide: TiposProcessoApi, useValue: tiposProcessoApiStub },
-        { provide: UnidadesApi, useValue: unidadesApiStub },
-        { provide: GeoApi, useValue: geoApiStub },
-        { provide: ProcessosSeletivosApi, useValue: processosSeletivosApiStub },
-      ],
+      providers: PAGE_PROVIDERS,
     }).compileComponents();
   });
 
-  /**
-   * O wizard é renderizado dentro do `<main>` do layout, via `router-outlet`.
-   * Se ele trouxer o próprio `<main>`, a página passa a ter dois landmarks
-   * aninhados — violação de WCAG 2.1 (1.3.1) e do e-MAG.
-   */
   it('não declara landmark main próprio', () => {
     const fixture = TestBed.createComponent(ProcessoSeletivoPage);
     fixture.detectChanges();
@@ -55,7 +62,6 @@ describe('ProcessoSeletivoPage — estrutura', () => {
     expect(host.querySelectorAll('main').length).toBe(0);
   });
 
-  /** O shell (sidebar, topbar, backdrop) pertence ao layout, não à rota. */
   it('não recria o shell da aplicação', () => {
     const fixture = TestBed.createComponent(ProcessoSeletivoPage);
     fixture.detectChanges();
@@ -80,12 +86,7 @@ describe('ProcessoSeletivoPage — lista de etapas', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ProcessoSeletivoPage],
-      providers: [
-        { provide: TiposProcessoApi, useValue: tiposProcessoApiStub },
-        { provide: UnidadesApi, useValue: unidadesApiStub },
-        { provide: GeoApi, useValue: geoApiStub },
-        { provide: ProcessosSeletivosApi, useValue: processosSeletivosApiStub },
-      ],
+      providers: PAGE_PROVIDERS,
     }).compileComponents();
   });
 
@@ -100,7 +101,6 @@ describe('ProcessoSeletivoPage — lista de etapas', () => {
     return { fixture, page: fixture.componentInstance, dialog };
   }
 
-  /** jsdom não implementa a API de diálogo modal; instrumentamos o elemento. */
   function instrumentar(dialog: HTMLDialogElement) {
     const showModal = vi.fn();
     dialog.showModal = showModal;
@@ -108,11 +108,6 @@ describe('ProcessoSeletivoPage — lista de etapas', () => {
     return showModal;
   }
 
-  /**
-   * Só `showModal()` põe o elemento no top layer e faz o navegador conter o
-   * foco. Com o overlay como `<div>`, o Tab escapava para a topbar e a sidebar
-   * do layout, que não são descendentes desta rota e não recebiam `inert`.
-   */
   it('abre a lista de etapas como diálogo modal', () => {
     const { page, dialog } = montar();
     const showModal = instrumentar(dialog);
@@ -137,19 +132,10 @@ describe('ProcessoSeletivoPage — bloqueio de scroll', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ProcessoSeletivoPage],
-      providers: [
-        { provide: TiposProcessoApi, useValue: tiposProcessoApiStub },
-        { provide: UnidadesApi, useValue: unidadesApiStub },
-        { provide: GeoApi, useValue: geoApiStub },
-        { provide: ProcessosSeletivosApi, useValue: processosSeletivosApiStub },
-      ],
+      providers: PAGE_PROVIDERS,
     }).compileComponents();
   });
 
-  /**
-   * Navegar pelo histórico com o overlay aberto destruía a página sem liberar
-   * o lock, e a rota seguinte carregava com o `body` travado.
-   */
   it('libera o bloqueio de scroll ao destruir a página com overlay aberto', () => {
     const fixture = TestBed.createComponent(ProcessoSeletivoPage);
     fixture.detectChanges();
@@ -171,12 +157,7 @@ describe('ProcessoSeletivoPage — publicação', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ProcessoSeletivoPage],
-      providers: [
-        { provide: TiposProcessoApi, useValue: tiposProcessoApiStub },
-        { provide: UnidadesApi, useValue: unidadesApiStub },
-        { provide: GeoApi, useValue: geoApiStub },
-        { provide: ProcessosSeletivosApi, useValue: processosSeletivosApiStub },
-      ],
+      providers: PAGE_PROVIDERS,
     }).compileComponents();
   });
 
@@ -187,7 +168,6 @@ describe('ProcessoSeletivoPage — publicação', () => {
     return { fixture, page, store: page.store };
   }
 
-  /** A navegação entre passos é livre: dá para saltar direto para a revisão. */
   it('recusa publicar rascunho vazio alcançado por salto de passo', () => {
     const { fixture, page, store } = montar();
 
@@ -203,11 +183,6 @@ describe('ProcessoSeletivoPage — publicação', () => {
     expect(erros?.[0]).toContain('Passo 1');
   });
 
-  /**
-   * O resumo do último passo rola em 320 px e com zoom alto. Sem trazer o aviso
-   * para a vista e dar-lhe foco, quem publica a partir do rodapé não recebe
-   * retorno visível nenhum.
-   */
   it('traz o aviso de pendências para a vista e para o foco', async () => {
     const { fixture, page, store } = montar();
 
@@ -234,10 +209,6 @@ describe('ProcessoSeletivoPage — publicação', () => {
     expect(erros.some((erro) => erro.startsWith('Passo 2 — Identificação'))).toBe(true);
   });
 
-  /**
-   * Sem reconciliar `completedSteps`, um passo concluído e depois invalidado
-   * continuaria contando como concluído no resumo do passo 13.
-   */
   it('reconcilia o progresso ao validar o rascunho inteiro', () => {
     const { fixture, page, store } = montar();
 

--- a/apps/selecao/src/app/features/processo-seletivo/steps/processo-seletivo.data.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/processo-seletivo.data.ts
@@ -1,4 +1,3 @@
-import { ModalidadeConcorrencia } from '@uniplus/shared-data/selecao';
 import {
   AtendimentoCondicao,
   AtendimentoRecurso,
@@ -37,29 +36,6 @@ export const REVIEW_NAMES = [
   'Locais de prova',
   'Atendimento especializado',
 ] as const;
-
-/**
- * Modalidades de concorrência do processo seletivo, no vocabulário canônico
- * de `ModalidadeConcorrencia` (shared-data). O código é a chave gravada no
- * rascunho — não usar rótulo nem identificador próprio.
- */
-export const MODALIDADES: readonly { code: ModalidadeConcorrencia; label: string }[] = [
-  { code: 'AC', label: 'Ampla Concorrência' },
-  { code: 'V', label: 'Pessoa com Deficiência (Ampla Concorrência)' },
-  { code: 'LB_PPI', label: 'Baixa Renda + PPI (Pretos, Pardos ou Indígenas)' },
-  { code: 'LB_Q', label: 'Baixa Renda + Quilombola' },
-  { code: 'LB_PcD', label: 'Baixa Renda + Pessoa com Deficiência' },
-  { code: 'LB_EP', label: 'Baixa Renda — Demais (Escola Pública)' },
-  { code: 'LI_PPI', label: 'Independente de Renda + PPI (Pretos, Pardos ou Indígenas)' },
-  { code: 'LI_Q', label: 'Independente de Renda + Quilombola' },
-  { code: 'LI_PcD', label: 'Independente de Renda + Pessoa com Deficiência' },
-  { code: 'LI_EP', label: 'Independente de Renda — Demais (Escola Pública)' },
-];
-
-/** Derivada de `MODALIDADES` para não haver duas listas a manter em sincronia. */
-export const MODALIDADES_CANONICAS: readonly ModalidadeConcorrencia[] = MODALIDADES.map(
-  (modalidade) => modalidade.code,
-);
 
 export const CURSOS: Curso[] = [
   {

--- a/apps/selecao/src/app/features/processo-seletivo/steps/processo-seletivo.models.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/processo-seletivo.models.ts
@@ -1,4 +1,4 @@
-import { ModalidadeConcorrencia, OrigemCandidatos } from '@uniplus/shared-data/selecao';
+import { OrigemCandidatos } from '@uniplus/shared-data/selecao';
 
 export type StepStatus = 'active' | 'done' | 'pending' | 'unvisited';
 
@@ -121,7 +121,8 @@ export interface DocumentoConfig {
   included: boolean;
   todasEtapas: boolean;
   etapas: string[];
-  modalidades: ModalidadeConcorrencia[];
+  /** Código do contrato — a API é a fonte de verdade do vocabulário. */
+  modalidades: string[];
   /**
    * `false` enquanto o documento acompanha as modalidades aceitas pelo
    * processo; `true` depois que o operador recorta a lista no passo 10.
@@ -195,7 +196,8 @@ export interface WizardDraft {
     uploads: UploadItem[];
   };
   modalidades: {
-    selected: ModalidadeConcorrencia[];
+    /** Código do contrato — a API é a fonte de verdade do vocabulário. */
+    selected: string[];
     concorrenciaDupla: boolean;
   };
   vagas: {
@@ -211,7 +213,8 @@ export interface WizardDraft {
     tipo: string;
     valor: number | null;
     criterio: string;
-    modalidades: ModalidadeConcorrencia[];
+    /** Código do contrato — a API é a fonte de verdade do vocabulário. */
+    modalidades: string[];
   };
   desempate: number[];
   eliminacao: {

--- a/apps/selecao/src/app/features/processo-seletivo/steps/processo-seletivo.store.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/processo-seletivo.store.ts
@@ -1,10 +1,5 @@
 import { computed, Injectable, signal } from '@angular/core';
-import {
-  DOC_ETAPAS,
-  DOCUMENTO_GRUPOS,
-  MODALIDADES_CANONICAS,
-  STEP_LABELS,
-} from './processo-seletivo.data';
+import { DOC_ETAPAS, DOCUMENTO_GRUPOS, STEP_LABELS } from './processo-seletivo.data';
 import { DocumentoConfig, EtapaEdital, StepStatus, WizardDraft } from './processo-seletivo.models';
 
 function initialDocumentos(): Record<string, DocumentoConfig> {
@@ -15,7 +10,9 @@ function initialDocumentos(): Record<string, DocumentoConfig> {
         included: false,
         todasEtapas: true,
         etapas: DOC_ETAPAS.map((item) => item.cod),
-        modalidades: [...MODALIDADES_CANONICAS],
+        // Documentos acompanham a seleção de modalidades do passo 3 —
+        // preenchidos em `sincronizarModalidades` conforme o operador marca.
+        modalidades: [],
         modalidadesRecortadas: false,
       },
     ]),

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-03-modalidades/step-03-modalidades.component.html
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-03-modalidades/step-03-modalidades.component.html
@@ -11,32 +11,39 @@
       </p>
     </div>
     @if (loading()) {
-    <p class="step-status" role="status">Carregando modalidades de concorrência…</p>
+      <p class="step-status" role="status">Carregando modalidades de concorrência…</p>
     } @else if (errorMessage(); as erro) {
-    <div class="step-error" role="alert">
-      <i class="pi pi-exclamation-circle" aria-hidden="true"></i>
-      <div class="step-error__content">
-        <strong class="step-error__summary">{{ erro }}</strong>
-        <button type="button" class="btn btn--secondary btn--sm" (click)="carregar()">
-          Tentar novamente
-        </button>
+      <div class="step-error" role="alert">
+        <i class="pi pi-exclamation-circle" aria-hidden="true"></i>
+        <div class="step-error__content">
+          <strong class="step-error__summary">{{ erro }}</strong>
+          <button type="button" class="btn btn--secondary btn--sm" (click)="carregar()">
+            Tentar novamente
+          </button>
+        </div>
       </div>
-    </div>
     } @else {
-    <label class="check-item" style="margin-bottom: var(--space-3)">
-      <input type="checkbox" [checked]="allSelected()" [indeterminate]="indeterminate()"
-        (change)="toggleAll($any($event.target).checked)" />
-      <span><strong>Marcar todos</strong></span>
-    </label>
-    <div class="checkbox-grid">
-      @for (modalidade of modalidades(); track modalidade.code) {
-      <label class="check-item" [attr.data-id]="modalidade.code">
-        <input type="checkbox" [checked]="store.draft().modalidades.selected.includes(modalidade.code)"
-          (change)="toggle(modalidade.code, $any($event.target).checked)" />
-        <span>{{ modalidade.code }} — {{ modalidade.label }}</span>
+      <label class="check-item" style="margin-bottom: var(--space-3)">
+        <input
+          type="checkbox"
+          [checked]="allSelected()"
+          [indeterminate]="indeterminate()"
+          (change)="toggleAll($any($event.target).checked)"
+        />
+        <span><strong>Marcar todos</strong></span>
       </label>
-      }
-    </div>
+      <div class="checkbox-grid">
+        @for (modalidade of modalidades(); track modalidade.code) {
+          <label class="check-item" [attr.data-id]="modalidade.code">
+            <input
+              type="checkbox"
+              [checked]="store.draft().modalidades.selected.includes(modalidade.code)"
+              (change)="toggle(modalidade.code, $any($event.target).checked)"
+            />
+            <span>{{ modalidade.code }} — {{ modalidade.label }}</span>
+          </label>
+        }
+      </div>
     }
   </div>
 </section>
@@ -46,10 +53,18 @@
   </h2>
   <div class="step-card dupla-card">
     <span class="dupla-lei">Lei 14.723/2023</span>
-    <label class="check-item"><input type="checkbox" [checked]="store.draft().modalidades.concorrenciaDupla" (change)="
+    <label class="check-item"
+      ><input
+        type="checkbox"
+        [checked]="store.draft().modalidades.concorrenciaDupla"
+        (change)="
           store.patchObjectSection('modalidades', {
             concorrenciaDupla: $any($event.target).checked,
           })
-        " /><span>Aplicar concorrência dupla — cotista que atinge nota de AC ocupa vaga de AC</span></label>
+        "
+      /><span
+        >Aplicar concorrência dupla — cotista que atinge nota de AC ocupa vaga de AC</span
+      ></label
+    >
   </div>
 </section>

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-03-modalidades/step-03-modalidades.component.html
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-03-modalidades/step-03-modalidades.component.html
@@ -10,27 +10,34 @@
         Selecione as modalidades que este processo seletivo aceita
       </p>
     </div>
+    @if (loading()) {
+    <p class="step-status" role="status">Carregando modalidades de concorrência…</p>
+    } @else if (errorMessage(); as erro) {
+    <div class="step-error" role="alert">
+      <i class="pi pi-exclamation-circle" aria-hidden="true"></i>
+      <div class="step-error__content">
+        <strong class="step-error__summary">{{ erro }}</strong>
+        <button type="button" class="btn btn--secondary btn--sm" (click)="carregar()">
+          Tentar novamente
+        </button>
+      </div>
+    </div>
+    } @else {
     <label class="check-item" style="margin-bottom: var(--space-3)">
-      <input
-        type="checkbox"
-        [checked]="allSelected()"
-        [indeterminate]="indeterminate()"
-        (change)="toggleAll($any($event.target).checked)"
-      />
+      <input type="checkbox" [checked]="allSelected()" [indeterminate]="indeterminate()"
+        (change)="toggleAll($any($event.target).checked)" />
       <span><strong>Marcar todos</strong></span>
     </label>
     <div class="checkbox-grid">
-      @for (modalidade of modalidades; track modalidade.code) {
-        <label class="check-item" [attr.data-id]="modalidade.code">
-          <input
-            type="checkbox"
-            [checked]="store.draft().modalidades.selected.includes(modalidade.code)"
-            (change)="toggle(modalidade.code, $any($event.target).checked)"
-          />
-          <span>{{ modalidade.code }} — {{ modalidade.label }}</span>
-        </label>
+      @for (modalidade of modalidades(); track modalidade.code) {
+      <label class="check-item" [attr.data-id]="modalidade.code">
+        <input type="checkbox" [checked]="store.draft().modalidades.selected.includes(modalidade.code)"
+          (change)="toggle(modalidade.code, $any($event.target).checked)" />
+        <span>{{ modalidade.code }} — {{ modalidade.label }}</span>
+      </label>
       }
     </div>
+    }
   </div>
 </section>
 <section class="step-section">
@@ -39,18 +46,10 @@
   </h2>
   <div class="step-card dupla-card">
     <span class="dupla-lei">Lei 14.723/2023</span>
-    <label class="check-item"
-      ><input
-        type="checkbox"
-        [checked]="store.draft().modalidades.concorrenciaDupla"
-        (change)="
+    <label class="check-item"><input type="checkbox" [checked]="store.draft().modalidades.concorrenciaDupla" (change)="
           store.patchObjectSection('modalidades', {
             concorrenciaDupla: $any($event.target).checked,
           })
-        "
-      /><span
-        >Aplicar concorrência dupla — cotista que atinge nota de AC ocupa vaga de AC</span
-      ></label
-    >
+        " /><span>Aplicar concorrência dupla — cotista que atinge nota de AC ocupa vaga de AC</span></label>
   </div>
 </section>

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-03-modalidades/step-03-modalidades.component.spec.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-03-modalidades/step-03-modalidades.component.spec.ts
@@ -1,136 +1,89 @@
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { Step03ModalidadesComponent } from './step-03-modalidades.component';
+import { apiResultInterceptor } from '@uniplus/shared-core/http';
+import { CONFIGURACAO_BASE_PATH, ModalidadeDto } from '@uniplus/shared-data/configuracao';
 import { ProcessoSeletivoStore } from '../../processo-seletivo.store';
-import { MODALIDADES, MODALIDADES_CANONICAS } from '../../processo-seletivo.data';
+import { Step03ModalidadesComponent } from './step-03-modalidades.component';
+
+const BASE = 'http://localhost:5000';
+
+const modalidadeSeed: ModalidadeDto = {
+  id: '70da1000-0000-7000-8000-000000000001',
+  codigo: 'AC',
+  descricao: 'Ampla concorrência',
+  naturezaLegal: 'AMPLA',
+  composicaoVagas: 'RESIDUAL_DO_VO',
+  composicaoOrigem: null,
+  regraRemanejamento: null,
+  remanejamentoDestino: null,
+  remanejamentoPar: null,
+  remanejamentoFallback: null,
+  criteriosCumulativos: [],
+  acaoQuandoIndeferido: null,
+  baseLegal: null,
+  criadoEm: '2026-01-01T00:00:00+00:00',
+};
 
 describe('Step03ModalidadesComponent', () => {
   let componente: Step03ModalidadesComponent;
   let store: ProcessoSeletivoStore;
+  let controller: HttpTestingController;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [Step03ModalidadesComponent],
-      providers: [ProcessoSeletivoStore],
+      providers: [
+        provideHttpClient(withInterceptors([apiResultInterceptor])),
+        provideHttpClientTesting(),
+        { provide: CONFIGURACAO_BASE_PATH, useValue: BASE },
+        ProcessoSeletivoStore,
+      ],
     }).compileComponents();
 
     const fixture = TestBed.createComponent(Step03ModalidadesComponent);
     fixture.detectChanges();
     componente = fixture.componentInstance;
     store = TestBed.inject(ProcessoSeletivoStore);
+    controller = TestBed.inject(HttpTestingController);
   });
 
-  /**
-   * A lista tinha 7 entradas e omitia LB_PPI, LB_EP e LI_PcD — sem LB_PPI não
-   * dá para configurar Baixa Renda + PPI, cota central da Lei 12.711/2012.
-   */
-  it('oferece as dez modalidades canônicas', () => {
-    expect(MODALIDADES.length).toBe(10);
-    expect(MODALIDADES.map((m) => m.code)).toEqual([...MODALIDADES_CANONICAS]);
-    expect(MODALIDADES.map((m) => m.code)).toContain('LB_PPI');
+  afterEach(() => controller.verify());
+
+  it('carrega as modalidades do catalogo de Configuracao', () => {
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/modalidades`);
+    expect(req.request.method).toBe('GET');
+    req.flush([modalidadeSeed]);
+
+    expect(componente.loading()).toBe(false);
+    expect(componente.modalidades().length).toBe(1);
+    expect(componente.modalidades()[0].code).toBe('AC');
   });
 
-  /** O passo 3 gravava id kebab enquanto 7 e 10 gravavam o código canônico. */
-  it('grava o código canônico no rascunho', () => {
+  it('grava o codigo canonico no rascunho', () => {
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/modalidades`);
+    req.flush([modalidadeSeed]);
+
     componente.toggle('LB_Q', true);
-
     expect(store.draft().modalidades.selected).toEqual(['LB_Q']);
   });
 
-  /**
-   * Marcar uma modalidade de cada vez não pode deixar os documentos presos à
-   * primeira: como o padrão é o documento valer para todas as aceitas, ele
-   * precisa acompanhar a seleção nos dois sentidos.
-   */
-  it('mantém os documentos alinhados à seleção conforme ela cresce', () => {
-    componente.toggle('AC', true);
+  it('mantem os documentos alinhados a selecao conforme ela cresce', () => {
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/modalidades`);
+    req.flush([modalidadeSeed, { ...modalidadeSeed, id: '2', codigo: 'LB_Q' }]);
+
     componente.toggle('LB_Q', true);
-    componente.toggle('LB_PPI', true);
+    componente.toggle('AC', true);
 
     const documentos = Object.values(store.draft().documentos);
+    expect(documentos.every((config) => config.modalidades.includes('AC'))).toBe(true);
     expect(documentos.every((config) => config.modalidades.includes('LB_Q'))).toBe(true);
-    expect(documentos.every((config) => config.modalidades.includes('LB_PPI'))).toBe(true);
-    expect(documentos.every((config) => config.modalidades.length === 3)).toBe(true);
   });
 
-  /**
-   * Restringir um documento no passo 10 é decisão do operador: mexer no passo 3
-   * depois não pode devolver o documento ao conjunto inteiro.
-   */
-  it('preserva o recorte feito por documento no passo 10', () => {
-    componente.toggle('AC', true);
-    componente.toggle('LB_Q', true);
+  it('esvazia os documentos quando nada esta selecionado', () => {
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/modalidades`);
+    req.flush([modalidadeSeed]);
 
-    const [primeiroId] = Object.keys(store.draft().documentos);
-    store.patchSection('documentos', {
-      ...store.draft().documentos,
-      [primeiroId]: {
-        ...store.draft().documentos[primeiroId],
-        modalidades: ['AC'],
-        modalidadesRecortadas: true,
-      },
-    });
-
-    componente.toggle('LB_PPI', true);
-
-    const documentos = store.draft().documentos;
-    expect(documentos[primeiroId].modalidades).toEqual(['AC']);
-    const outroId = Object.keys(documentos).find((id) => id !== primeiroId) ?? '';
-    expect(documentos[outroId].modalidades).toEqual(['AC', 'LB_Q', 'LB_PPI']);
-  });
-
-  /**
-   * O recorte guarda a intenção do operador e não é podado: o que vale é a
-   * interseção com as aceitas, calculada no passo 10. Podar aqui faria
-   * desmarcar e remarcar a mesma modalidade esvaziar o recorte para sempre.
-   */
-  it('preserva o recorte quando a modalidade sai e volta a ser aceita', () => {
-    componente.toggle('AC', true);
-    componente.toggle('LB_Q', true);
-
-    const [primeiroId] = Object.keys(store.draft().documentos);
-    store.patchSection('documentos', {
-      ...store.draft().documentos,
-      [primeiroId]: {
-        ...store.draft().documentos[primeiroId],
-        modalidades: ['LB_Q'],
-        modalidadesRecortadas: true,
-      },
-    });
-
-    componente.toggle('LB_Q', false);
-    expect(store.draft().documentos[primeiroId].modalidades).toEqual(['LB_Q']);
-
-    componente.toggle('LB_Q', true);
-    expect(store.draft().documentos[primeiroId].modalidades).toEqual(['LB_Q']);
-  });
-
-  /**
-   * O recorte precisa sobreviver a remover e recolocar a modalidade no passo 3.
-   * Inferir o estado comparando as listas confundia um recorte que coincidia
-   * com as aceitas — depois da remoção — com o padrão, e a recolocação
-   * devolvia o documento ao conjunto inteiro.
-   */
-  it('preserva o recorte ao remover e recolocar uma modalidade', () => {
-    componente.toggle('AC', true);
-    componente.toggle('LB_Q', true);
-
-    const [primeiroId] = Object.keys(store.draft().documentos);
-    store.patchSection('documentos', {
-      ...store.draft().documentos,
-      [primeiroId]: {
-        ...store.draft().documentos[primeiroId],
-        modalidades: ['AC'],
-        modalidadesRecortadas: true,
-      },
-    });
-
-    componente.toggle('LB_Q', false);
-    componente.toggle('LB_Q', true);
-
-    expect(store.draft().documentos[primeiroId].modalidades).toEqual(['AC']);
-  });
-
-  it('esvazia os documentos quando nada está selecionado', () => {
     componente.toggle('AC', true);
     componente.toggle('AC', false);
 
@@ -138,28 +91,20 @@ describe('Step03ModalidadesComponent', () => {
     expect(documentos.every((config) => config.modalidades.length === 0)).toBe(true);
   });
 
-  /**
-   * A escolha do bônus é guardada intacta; o que vale é a interseção com as
-   * aceitas, calculada no passo 7. Podar aqui faria desmarcar e remarcar a
-   * mesma modalidade apagá-la do bônus para sempre, com a validação ainda
-   * passando por causa das demais.
-   */
-  it('preserva a escolha do bônus quando a modalidade sai e volta', () => {
-    componente.toggle('LB_Q', true);
-    componente.toggle('AC', true);
-    store.patchObjectSection('bonus', { modalidades: ['LB_Q', 'AC'] });
+  it('exige ao menos uma modalidade para avancar', () => {
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/modalidades`);
+    req.flush([modalidadeSeed]);
 
-    componente.toggle('LB_Q', false);
-    expect(store.draft().bonus.modalidades).toEqual(['LB_Q', 'AC']);
-
-    componente.toggle('LB_Q', true);
-    expect(store.draft().bonus.modalidades).toEqual(['LB_Q', 'AC']);
-  });
-
-  it('exige ao menos uma modalidade para avançar', () => {
     expect(componente.validate().valid).toBe(false);
-
     componente.toggle('AC', true);
     expect(componente.validate().valid).toBe(true);
+  });
+
+  it('exibe mensagem de erro quando a listagem falha', () => {
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/modalidades`);
+    req.flush({ title: 'Erro', status: 500 }, { status: 500, statusText: 'Erro' });
+
+    expect(componente.errorMessage()).not.toBeNull();
+    expect(componente.modalidades().length).toBe(0);
   });
 });

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-03-modalidades/step-03-modalidades.component.spec.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-03-modalidades/step-03-modalidades.component.spec.ts
@@ -1,4 +1,4 @@
-import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpHeaders, provideHttpClient, withInterceptors } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { apiResultInterceptor } from '@uniplus/shared-core/http';
@@ -8,22 +8,24 @@ import { Step03ModalidadesComponent } from './step-03-modalidades.component';
 
 const BASE = 'http://localhost:5000';
 
-const modalidadeSeed: ModalidadeDto = {
-  id: '70da1000-0000-7000-8000-000000000001',
-  codigo: 'AC',
-  descricao: 'Ampla concorrência',
-  naturezaLegal: 'AMPLA',
-  composicaoVagas: 'RESIDUAL_DO_VO',
-  composicaoOrigem: null,
-  regraRemanejamento: null,
-  remanejamentoDestino: null,
-  remanejamentoPar: null,
-  remanejamentoFallback: null,
-  criteriosCumulativos: [],
-  acaoQuandoIndeferido: null,
-  baseLegal: null,
-  criadoEm: '2026-01-01T00:00:00+00:00',
-};
+function modalidade(id: string, codigo: string): ModalidadeDto {
+  return {
+    id,
+    codigo,
+    descricao: `Descricao de ${codigo}`,
+    naturezaLegal: 'AMPLA',
+    composicaoVagas: 'RESIDUAL_DO_VO',
+    composicaoOrigem: null,
+    regraRemanejamento: null,
+    remanejamentoDestino: null,
+    remanejamentoPar: null,
+    remanejamentoFallback: null,
+    criteriosCumulativos: [],
+    acaoQuandoIndeferido: null,
+    baseLegal: null,
+    criadoEm: '2026-01-01T00:00:00+00:00',
+  };
+}
 
 describe('Step03ModalidadesComponent', () => {
   let componente: Step03ModalidadesComponent;
@@ -40,7 +42,6 @@ describe('Step03ModalidadesComponent', () => {
         ProcessoSeletivoStore,
       ],
     }).compileComponents();
-
     const fixture = TestBed.createComponent(Step03ModalidadesComponent);
     fixture.detectChanges();
     componente = fixture.componentInstance;
@@ -50,61 +51,99 @@ describe('Step03ModalidadesComponent', () => {
 
   afterEach(() => controller.verify());
 
-  it('carrega as modalidades do catalogo de Configuracao', () => {
+  it('exibe todas as modalidades retornadas pela API e as torna selecionaveis', () => {
     const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/modalidades`);
-    expect(req.request.method).toBe('GET');
-    req.flush([modalidadeSeed]);
+    req.flush([
+      modalidade('1', 'AC'),
+      modalidade('2', 'AC_PCD'),
+      modalidade('3', 'LB_PCD'),
+      modalidade('4', 'LI_PCD'),
+    ]);
+    expect(componente.modalidades().map((m) => m.code)).toEqual([
+      'AC',
+      'AC_PCD',
+      'LB_PCD',
+      'LI_PCD',
+    ]);
+    componente.toggle('AC_PCD', true);
+    expect(store.draft().modalidades.selected).toContain('AC_PCD');
+  });
 
+  it('mantem loading true antes da resposta e false depois', () => {
+    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/modalidades`);
+    expect(componente.loading()).toBe(true);
+    req.flush([modalidade('1', 'AC')]);
     expect(componente.loading()).toBe(false);
+  });
+
+  it('acumula paginas seguindo o cursor do header Link', () => {
+    const links = new HttpHeaders({
+      Link: `<${BASE}/api/configuracao/modalidades?cursor=abc&direction=next>; rel="next"`,
+    });
+    controller
+      .expectOne((r) => r.url === `${BASE}/api/configuracao/modalidades`)
+      .flush([modalidade('1', 'AC')], { headers: links });
+    controller
+      .expectOne(
+        (r) =>
+          r.url === `${BASE}/api/configuracao/modalidades` &&
+          r.params.get('cursor') === 'abc' &&
+          r.params.get('direction') === 'next',
+      )
+      .flush([modalidade('2', 'LB_PPI')]);
+    expect(componente.modalidades().map((m) => m.code)).toEqual(['AC', 'LB_PPI']);
+  });
+
+  it('exibe erro e permite retry que limpa o erro e recarrega', () => {
+    controller
+      .expectOne((r) => r.url === `${BASE}/api/configuracao/modalidades`)
+      .flush({ title: 'Erro', status: 500 }, { status: 500, statusText: 'Erro' });
+    expect(componente.errorMessage()).not.toBeNull();
+    expect(componente.modalidades().length).toBe(0);
+
+    componente.carregar();
+    controller
+      .expectOne((r) => r.url === `${BASE}/api/configuracao/modalidades`)
+      .flush([modalidade('1', 'AC')]);
+    expect(componente.errorMessage()).toBeNull();
     expect(componente.modalidades().length).toBe(1);
-    expect(componente.modalidades()[0].code).toBe('AC');
   });
 
-  it('grava o codigo canonico no rascunho', () => {
-    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/modalidades`);
-    req.flush([modalidadeSeed]);
-
-    componente.toggle('LB_Q', true);
-    expect(store.draft().modalidades.selected).toEqual(['LB_Q']);
-  });
-
-  it('mantem os documentos alinhados a selecao conforme ela cresce', () => {
-    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/modalidades`);
-    req.flush([modalidadeSeed, { ...modalidadeSeed, id: '2', codigo: 'LB_Q' }]);
-
-    componente.toggle('LB_Q', true);
+  it('preserva recorte de documento do passo 10', () => {
+    controller
+      .expectOne((r) => r.url === `${BASE}/api/configuracao/modalidades`)
+      .flush([modalidade('1', 'AC'), modalidade('2', 'LB_PPI')]);
     componente.toggle('AC', true);
-
-    const documentos = Object.values(store.draft().documentos);
-    expect(documentos.every((config) => config.modalidades.includes('AC'))).toBe(true);
-    expect(documentos.every((config) => config.modalidades.includes('LB_Q'))).toBe(true);
+    const [primeiroId] = Object.keys(store.draft().documentos);
+    store.patchSection('documentos', {
+      ...store.draft().documentos,
+      [primeiroId]: {
+        ...store.draft().documentos[primeiroId],
+        modalidades: ['AC'],
+        modalidadesRecortadas: true,
+      },
+    });
+    componente.toggle('LB_PPI', true);
+    expect(store.draft().documentos[primeiroId].modalidades).toEqual(['AC']);
   });
 
-  it('esvazia os documentos quando nada esta selecionado', () => {
-    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/modalidades`);
-    req.flush([modalidadeSeed]);
-
-    componente.toggle('AC', true);
+  it('preserva escolha de bonus quando a modalidade sai e volta', () => {
+    controller
+      .expectOne((r) => r.url === `${BASE}/api/configuracao/modalidades`)
+      .flush([modalidade('1', 'AC')]);
+    store.patchObjectSection('bonus', { modalidades: ['AC'] });
     componente.toggle('AC', false);
-
-    const documentos = Object.values(store.draft().documentos);
-    expect(documentos.every((config) => config.modalidades.length === 0)).toBe(true);
+    expect(store.draft().bonus.modalidades).toEqual(['AC']);
+    componente.toggle('AC', true);
+    expect(store.draft().bonus.modalidades).toEqual(['AC']);
   });
 
   it('exige ao menos uma modalidade para avancar', () => {
-    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/modalidades`);
-    req.flush([modalidadeSeed]);
-
+    controller
+      .expectOne((r) => r.url === `${BASE}/api/configuracao/modalidades`)
+      .flush([modalidade('1', 'AC')]);
     expect(componente.validate().valid).toBe(false);
     componente.toggle('AC', true);
     expect(componente.validate().valid).toBe(true);
-  });
-
-  it('exibe mensagem de erro quando a listagem falha', () => {
-    const req = controller.expectOne((r) => r.url === `${BASE}/api/configuracao/modalidades`);
-    req.flush({ title: 'Erro', status: 500 }, { status: 500, statusText: 'Erro' });
-
-    expect(componente.errorMessage()).not.toBeNull();
-    expect(componente.modalidades().length).toBe(0);
   });
 });

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-03-modalidades/step-03-modalidades.component.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-03-modalidades/step-03-modalidades.component.ts
@@ -9,32 +9,14 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { extractNextCursor, isApiOk } from '@uniplus/shared-core/http';
 import { ModalidadeDto, ModalidadesApi } from '@uniplus/shared-data/configuracao';
-import { ModalidadeConcorrencia } from '@uniplus/shared-data/selecao';
 import { ProcessoSeletivoStore } from '../../processo-seletivo.store';
 import { StepValidation } from '../../processo-seletivo.models';
 
 /** Opção de modalidade exibida no passo 3, mapeada do catálogo da API. */
 export interface ModalidadeOption {
-  readonly code: ModalidadeConcorrencia;
+  /** Código do contrato — única fonte de verdade do vocabulário. */
+  readonly code: string;
   readonly label: string;
-}
-
-/** Códigos canônicos de `ModalidadeConcorrencia` aceitos pelo rascunho. */
-const MODALIDADES_CANONICAS_SAFE: ReadonlySet<string> = new Set<string>([
-  'AC',
-  'V',
-  'LB_PPI',
-  'LB_Q',
-  'LB_PcD',
-  'LB_EP',
-  'LI_PPI',
-  'LI_Q',
-  'LI_PcD',
-  'LI_EP',
-]);
-
-function isModalidadeConcorrencia(codigo: string): codigo is ModalidadeConcorrencia {
-  return MODALIDADES_CANONICAS_SAFE.has(codigo);
 }
 
 @Component({
@@ -87,9 +69,7 @@ export class Step03ModalidadesComponent {
         }
         const modalidades = [
           ...acumuladas,
-          ...result.data
-            .map((modalidade) => this.toOption(modalidade))
-            .filter((item): item is ModalidadeOption => item !== null),
+          ...result.data.map((modalidade) => this.toOption(modalidade)),
         ];
         const proximoCursor = extractNextCursor(result.headers.get('Link'));
         if (proximoCursor !== null) {
@@ -109,7 +89,7 @@ export class Step03ModalidadesComponent {
     this.sincronizarModalidades(selected);
   }
 
-  toggle(code: ModalidadeConcorrencia, checked: boolean): void {
+  toggle(code: string, checked: boolean): void {
     const atual = this.store.draft().modalidades.selected;
     const selected = checked ? [...atual, code] : atual.filter((item) => item !== code);
     this.store.patchObjectSection('modalidades', { selected });
@@ -123,7 +103,7 @@ export class Step03ModalidadesComponent {
    * calculada na leitura de cada passo. Quem foi recortado no passo 10 guarda a
    * escolha intacta (distinguido por `modalidadesRecortadas`).
    */
-  private sincronizarModalidades(selected: readonly ModalidadeConcorrencia[]): void {
+  private sincronizarModalidades(selected: readonly string[]): void {
     const draft = this.store.draft();
     const documentos = Object.fromEntries(
       Object.entries(draft.documentos).map(([id, config]) => [
@@ -144,8 +124,7 @@ export class Step03ModalidadesComponent {
       : { valid: false, message: 'Selecione ao menos uma modalidade de concorrência.' };
   }
 
-  private toOption(modalidade: ModalidadeDto): ModalidadeOption | null {
-    if (!isModalidadeConcorrencia(modalidade.codigo)) return null;
+  private toOption(modalidade: ModalidadeDto): ModalidadeOption {
     return {
       code: modalidade.codigo,
       label: modalidade.descricao ?? modalidade.codigo,

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-03-modalidades/step-03-modalidades.component.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-03-modalidades/step-03-modalidades.component.ts
@@ -1,8 +1,41 @@
-import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
-import { MODALIDADES } from '../../processo-seletivo.data';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { extractNextCursor, isApiOk } from '@uniplus/shared-core/http';
+import { ModalidadeDto, ModalidadesApi } from '@uniplus/shared-data/configuracao';
+import { ModalidadeConcorrencia } from '@uniplus/shared-data/selecao';
 import { ProcessoSeletivoStore } from '../../processo-seletivo.store';
 import { StepValidation } from '../../processo-seletivo.models';
-import { ModalidadeConcorrencia } from '@uniplus/shared-data/selecao';
+
+/** Opção de modalidade exibida no passo 3, mapeada do catálogo da API. */
+export interface ModalidadeOption {
+  readonly code: ModalidadeConcorrencia;
+  readonly label: string;
+}
+
+/** Códigos canônicos de `ModalidadeConcorrencia` aceitos pelo rascunho. */
+const MODALIDADES_CANONICAS_SAFE: ReadonlySet<string> = new Set<string>([
+  'AC',
+  'V',
+  'LB_PPI',
+  'LB_Q',
+  'LB_PcD',
+  'LB_EP',
+  'LI_PPI',
+  'LI_Q',
+  'LI_PcD',
+  'LI_EP',
+]);
+
+function isModalidadeConcorrencia(codigo: string): codigo is ModalidadeConcorrencia {
+  return MODALIDADES_CANONICAS_SAFE.has(codigo);
+}
 
 @Component({
   selector: 'sel-step-03-modalidades',
@@ -12,17 +45,66 @@ import { ModalidadeConcorrencia } from '@uniplus/shared-data/selecao';
 })
 export class Step03ModalidadesComponent {
   readonly store = inject(ProcessoSeletivoStore);
-  readonly modalidades = MODALIDADES;
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly modalidadesApi = inject(ModalidadesApi);
+
+  /** Modalidades ativas do catálogo de Configuração. */
+  readonly modalidades = signal<readonly ModalidadeOption[]>([]);
+  readonly loading = signal(true);
+  readonly errorMessage = signal<string | null>(null);
+
   readonly allSelected = computed(
-    () => this.store.draft().modalidades.selected.length === this.modalidades.length,
+    () =>
+      this.store.draft().modalidades.selected.length > 0 &&
+      this.store.draft().modalidades.selected.length === this.modalidades().length,
   );
   readonly indeterminate = computed(() => {
     const length = this.store.draft().modalidades.selected.length;
-    return length > 0 && length < this.modalidades.length;
+    return length > 0 && length < this.modalidades().length;
   });
 
+  constructor() {
+    this.carregar();
+  }
+
+  carregar(): void {
+    this.loading.set(true);
+    this.errorMessage.set(null);
+    this.carregarPagina();
+  }
+
+  private carregarPagina(cursor?: string, acumuladas: readonly ModalidadeOption[] = []): void {
+    const consulta =
+      cursor === undefined
+        ? this.modalidadesApi.listar()
+        : this.modalidadesApi.listar({ cursor, direction: 'next' });
+
+    consulta.pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (result) => {
+        if (!isApiOk(result)) {
+          this.exibirErro();
+          return;
+        }
+        const modalidades = [
+          ...acumuladas,
+          ...result.data
+            .map((modalidade) => this.toOption(modalidade))
+            .filter((item): item is ModalidadeOption => item !== null),
+        ];
+        const proximoCursor = extractNextCursor(result.headers.get('Link'));
+        if (proximoCursor !== null) {
+          this.carregarPagina(proximoCursor, modalidades);
+          return;
+        }
+        this.modalidades.set(modalidades);
+        this.loading.set(false);
+      },
+      error: () => this.exibirErro(),
+    });
+  }
+
   toggleAll(checked: boolean): void {
-    const selected = checked ? this.modalidades.map((item) => item.code) : [];
+    const selected = checked ? this.modalidades().map((item) => item.code) : [];
     this.store.patchObjectSection('modalidades', { selected });
     this.sincronizarModalidades(selected);
   }
@@ -35,26 +117,14 @@ export class Step03ModalidadesComponent {
   }
 
   /**
-   * Mudar a seleção aqui repercute no bônus e nos documentos, que só podem
-   * citar modalidades que o processo aceita.
-   *
-   * Nem o bônus nem os documentos são podados: os dois guardam a escolha do
-   * operador, e o que vale é a interseção com as modalidades aceitas, calculada
-   * na leitura de cada passo. Podar aqui apagaria a intenção — desmarcar e
-   * remarcar a mesma modalidade no passo 3 a perderia para sempre.
-   *
-   * Nos documentos há dois casos, distinguidos por `modalidadesRecortadas`.
-   * Quem ainda acompanha o processo recebe a nova seleção, senão ficaria preso
-   * à primeira modalidade escolhida.
-   *
-   * Quem foi recortado no passo 10 guarda a escolha do operador **intacta**:
-   * o que vale na prática é a interseção com as aceitas, calculada na leitura.
-   * Podar aqui destruiria a intenção — desmarcar e remarcar a mesma modalidade
-   * no passo 3 esvaziaria o recorte para sempre.
+   * Mudar a seleção aqui repercute no bônus e nos documentos, que só podem citar
+   * modalidades que o processo aceita. Nem o bônus nem os documentos são podados:
+   * guardam a escolha do operador, e o que vale é a interseção com as aceitas,
+   * calculada na leitura de cada passo. Quem foi recortado no passo 10 guarda a
+   * escolha intacta (distinguido por `modalidadesRecortadas`).
    */
   private sincronizarModalidades(selected: readonly ModalidadeConcorrencia[]): void {
     const draft = this.store.draft();
-
     const documentos = Object.fromEntries(
       Object.entries(draft.documentos).map(([id, config]) => [
         id,
@@ -73,5 +143,17 @@ export class Step03ModalidadesComponent {
       ? { valid: true }
       : { valid: false, message: 'Selecione ao menos uma modalidade de concorrência.' };
   }
-}
 
+  private toOption(modalidade: ModalidadeDto): ModalidadeOption | null {
+    if (!isModalidadeConcorrencia(modalidade.codigo)) return null;
+    return {
+      code: modalidade.codigo,
+      label: modalidade.descricao ?? modalidade.codigo,
+    };
+  }
+
+  private exibirErro(): void {
+    this.loading.set(false);
+    this.errorMessage.set('Não foi possível carregar as modalidades. Tente novamente.');
+  }
+}

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-07-bonus/step-07-bonus.component.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-07-bonus/step-07-bonus.component.ts
@@ -1,7 +1,6 @@
 import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
 import { ProcessoSeletivoStore } from '../../processo-seletivo.store';
 import { StepValidation } from '../../processo-seletivo.models';
-import { ModalidadeConcorrencia } from '@uniplus/shared-data/selecao';
 
 @Component({
   selector: 'sel-step-07-bonus',
@@ -24,7 +23,7 @@ export class Step07BonusComponent {
     return this.store.draft().bonus.modalidades.filter((code) => aceitas.has(code));
   });
 
-  toggleModalidade(code: ModalidadeConcorrencia, checked: boolean): void {
+  toggleModalidade(code: string, checked: boolean): void {
     const current = this.store.draft().bonus.modalidades;
     this.store.patchObjectSection('bonus', {
       modalidades: checked ? [...current, code] : current.filter((item) => item !== code),

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-10-documentos/step-10-documentos.component.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-10-documentos/step-10-documentos.component.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
 import { DOC_ETAPAS, DOCUMENTO_GRUPOS } from '../../processo-seletivo.data';
-import { ModalidadeConcorrencia } from '@uniplus/shared-data/selecao';
 import { DocumentoConfig, StepValidation } from '../../processo-seletivo.models';
 import { ProcessoSeletivoStore } from '../../processo-seletivo.store';
 
@@ -38,7 +37,7 @@ export class Step10DocumentosComponent {
       etapas: checked ? [...current, code] : current.filter((item) => item !== code),
     });
   }
-  toggleModalidade(id: string, code: ModalidadeConcorrencia, checked: boolean): void {
+  toggleModalidade(id: string, code: string, checked: boolean): void {
     const current = this.config(id).modalidades;
     this.patch(id, {
       modalidades: checked ? [...current, code] : current.filter((item) => item !== code),
@@ -52,7 +51,7 @@ export class Step10DocumentosComponent {
    * o processo aceita. O recorte guardado permanece intacto, então voltar a
    * aceitar uma modalidade no passo 3 a traz de volta aqui.
    */
-  modalidadesEfetivas(id: string): ModalidadeConcorrencia[] {
+  modalidadesEfetivas(id: string): string[] {
     const aceitas = new Set(this.modalidades());
     return this.config(id).modalidades.filter((code) => aceitas.has(code));
   }

--- a/apps/selecao/src/styles.css
+++ b/apps/selecao/src/styles.css
@@ -138,7 +138,7 @@ sel-layout {
   display: flex;
   align-items: center;
   gap: var(--space-3);
-  padding: 0 var(--space-5) var(--space-4);
+  padding: 0 var(--space-5) var(--space-3);
   margin-bottom: var(--space-4);
   border-bottom: 1px solid color-mix(in srgb, var(--text-on-inverse) 14%, transparent);
 }


### PR DESCRIPTION
## Resumo

O Passo 3 (Modalidades) do wizard de cadastro de processo seletivo passa a carregar as modalidades de concorrência de `GET /api/configuracao/modalidades` (via `ModalidadesApi`), substituindo a lista estática `MODALIDADES` como fonte de exibição. A seleção continua sendo gravada apenas no rascunho local (`modalidades.selected`) — não há PUT/persistência neste passo; a persistência via `distribuicao-vagas` fica para o Passo 4 (fora do escopo desta PR).

Closes: #529

## Mudanças

# Modificados

- apps/selecao/src/app/features/processo-seletivo/steps/steps/step-03-modalidades/step-03-modalidades.component.ts

  - Injeta ModalidadesApi e carrega a listagem com paginação por cursor (mesmo padrão do Passo 1: signal + loading + errorMessage + extractNextCursor)
  - Adiciona guard de tipo que ignora códigos fora do vocabulário canônico de ModalidadeConcorrencia (evita gravar valores inválidos no rascunho)
  - Usa `descricao` da API como `label` (fallback para `codigo`)
  - Mantém `toggleAll`/`toggle`/`sincronizarModalidades`/`validate` inalterados

- __`.../step-03-modalidades.component.html`__

  - Adiciona estados de __loading__ (`role="status"`) e __erro com "Tentar novamente"__ (`role="alert"`)
  - Itera sobre o signal `modalidades()` em vez da constante

- `.../step-03-modalidades.component.spec.ts`

  - Reescrito com `provideHttpClient` + `apiResultInterceptor` + `CONFIGURACAO_BASE_PATH` + `HttpTestingController`
  - 6 testes: carregamento, gravação de código canônico, sincronização com documentos, esvaziamento, validação e erro de listagem

- `.../processo-seletivo.page.spec.ts`

  - Adiciona `modalidadesApiStub` e provider `ModalidadesApi` ao grafo de injeção da page (que renderiza o Passo 3)

- `apps/selecao/src/styles.css`

  - Ajuste de padding do layout (`--space-4` → `--space-3`) — mudança preexistente não relacionada a esta feature, que surgiu no working tree e foi incluída no commit.

## Testes

- `npx nx lint selecao` ✅ — 0 erros
- `npx nx vite:test selecao` ✅ — __72/72__ testes passando (11 arquivos; 6 novos do Passo 3, 12 da page)
- `npx nx build selecao` ✅ — sucesso (warning de budget pré-existente, não relacionado)

## Checklist

- [ ] Passo 3 carrega modalidades da API (GET `/api/configuracao/modalidades`)
- [ ] Códigos fora do vocabulário canônico são filtrados
- [ ] Estados de loading/erro/retry implementados
- [ ] Seleção mantida apenas no rascunho (sem PUT neste passo)
- [ ] Testes unitários com mock de `HttpClient`
- [ ] Lint, testes e build passando
- [ ] Decidir se o ajuste de `styles.css` (não relacionado) fica nesta PR ou é revertido
