### PR TITLE
feat(selecao): declara o município que rege os prazos no cadastro inicial

### DIFF
--- a/apps/selecao/src/app/features/processo-seletivo/processo-seletivo.page.spec.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/processo-seletivo.page.spec.ts
@@ -4,6 +4,7 @@ import { of } from 'rxjs';
 import { apiOk } from '@uniplus/shared-core/http';
 import { TipoProcessoDto, TiposProcessoApi } from '@uniplus/shared-data/configuracao';
 import { UnidadeDto, UnidadesApi } from '@uniplus/shared-data/organizacao';
+import { GeoApi } from '@uniplus/shared-data/geo';
 import { ProcessosSeletivosApi } from '@uniplus/shared-data/selecao';
 import { ProcessoSeletivoPage } from './processo-seletivo.page';
 import { ProcessoSeletivoStore } from './steps/processo-seletivo.store';
@@ -14,6 +15,11 @@ const tiposProcessoApiStub = {
 
 const unidadesApiStub = {
   listar: () => of(apiOk<readonly UnidadeDto[]>([], 200, new HttpHeaders())),
+};
+
+/** O passo 2 injeta a Geo para o seletor de município; esta suíte não busca nada. */
+const geoApiStub = {
+  listarCidades: () => of(apiOk<readonly never[]>([], 200, new HttpHeaders())),
 };
 
 /**
@@ -30,6 +36,7 @@ describe('ProcessoSeletivoPage — estrutura', () => {
       providers: [
         { provide: TiposProcessoApi, useValue: tiposProcessoApiStub },
         { provide: UnidadesApi, useValue: unidadesApiStub },
+        { provide: GeoApi, useValue: geoApiStub },
         { provide: ProcessosSeletivosApi, useValue: processosSeletivosApiStub },
       ],
     }).compileComponents();
@@ -76,6 +83,7 @@ describe('ProcessoSeletivoPage — lista de etapas', () => {
       providers: [
         { provide: TiposProcessoApi, useValue: tiposProcessoApiStub },
         { provide: UnidadesApi, useValue: unidadesApiStub },
+        { provide: GeoApi, useValue: geoApiStub },
         { provide: ProcessosSeletivosApi, useValue: processosSeletivosApiStub },
       ],
     }).compileComponents();
@@ -132,6 +140,7 @@ describe('ProcessoSeletivoPage — bloqueio de scroll', () => {
       providers: [
         { provide: TiposProcessoApi, useValue: tiposProcessoApiStub },
         { provide: UnidadesApi, useValue: unidadesApiStub },
+        { provide: GeoApi, useValue: geoApiStub },
         { provide: ProcessosSeletivosApi, useValue: processosSeletivosApiStub },
       ],
     }).compileComponents();
@@ -165,6 +174,7 @@ describe('ProcessoSeletivoPage — publicação', () => {
       providers: [
         { provide: TiposProcessoApi, useValue: tiposProcessoApiStub },
         { provide: UnidadesApi, useValue: unidadesApiStub },
+        { provide: GeoApi, useValue: geoApiStub },
         { provide: ProcessosSeletivosApi, useValue: processosSeletivosApiStub },
       ],
     }).compileComponents();

--- a/apps/selecao/src/app/features/processo-seletivo/steps/processo-seletivo.models.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/processo-seletivo.models.ts
@@ -150,6 +150,18 @@ export interface AtendimentoRecurso {
   ext?: boolean;
 }
 
+/**
+ * Snapshot da cidade escolhida no seletor da Geo. Os três campos viajam juntos
+ * porque o backend valida a coerência do trio (sete dígitos, prefixo compatível
+ * com a UF, nome não vazio); `nome` e `uf` são cache de exibição e não entram em
+ * cálculo de prazo.
+ */
+export interface LocalidadeSelecionada {
+  readonly codigoIbge: string;
+  readonly nome: string;
+  readonly uf: string;
+}
+
 export interface WizardDraft {
   tipoProcesso: {
     selected: string;
@@ -171,6 +183,15 @@ export interface WizardDraft {
      * processo, e é ele que define o piso mínimo do cronograma de fases.
      */
     origemCandidatos: OrigemCandidatosSelecionada;
+    /**
+     * Município cujo calendário rege a contagem dos prazos do certame
+     * (`UNI-REQ-0111`). Obrigatório na criação, e declarado: a interface sugere a
+     * cidade da unidade administradora escolhida, mas quem confirma é o operador —
+     * o servidor recusa a criação sem ele em vez de deduzi-lo de qualquer cadastro.
+     * O trio vem inteiro da opção da Geo; montá-lo a mão dessincronizaria nome e
+     * código, e é o código que decide quais feriados incidem no prazo.
+     */
+    localidade: LocalidadeSelecionada | null;
     uploads: UploadItem[];
   };
   modalidades: {

--- a/apps/selecao/src/app/features/processo-seletivo/steps/processo-seletivo.store.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/processo-seletivo.store.ts
@@ -49,6 +49,7 @@ const INITIAL_DRAFT: WizardDraft = {
     nome: '',
     unidadeAdministradoraId: '',
     origemCandidatos: '',
+    localidade: null,
     uploads: [],
   },
   modalidades: { selected: [], concorrenciaDupla: false },

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-02-identificacao/step-02-identificacao.component.html
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-02-identificacao/step-02-identificacao.component.html
@@ -169,6 +169,7 @@
             class="btn btn--tertiary"
             type="button"
             aria-describedby="f-localidade-valor"
+            [disabled]="camposDoComandoBloqueados()"
             (click)="limparLocalidade()"
           >
             Trocar município
@@ -185,6 +186,7 @@
           [attr.aria-busy]="municipiosCarregando() || null"
           [attr.aria-invalid]="invalidFields().has('localidade') || null"
           [class.is-invalid]="invalidFields().has('localidade')"
+          [disabled]="camposDoComandoBloqueados()"
           [value]="buscaMunicipio()"
           (input)="buscarMunicipios($any($event.target).value)"
         />
@@ -195,9 +197,9 @@
           <div class="field__erro" role="alert"><p>{{ erro }}</p></div>
         }
         @if (municipios().length > 0) {
-          <ul class="localidade-opcoes" role="listbox" aria-label="Municípios encontrados">
+          <ul class="localidade-opcoes" aria-label="Municípios encontrados">
             @for (municipio of municipios(); track municipio.codigoIbge) {
-              <li role="option" [attr.aria-selected]="false">
+              <li>
                 <button
                   class="btn btn--tertiary"
                   type="button"
@@ -215,6 +217,12 @@
             }
           </ul>
         }
+      }
+      @if (camposDoComandoBloqueados()) {
+        <p class="alert alert--info" role="status">
+          O cadastro inicial já foi criado com este município. A alteração da localidade ainda não
+          está disponível nesta tela.
+        </p>
       }
       <p class="field__hint" id="f-localidade-hint">
         Determina quais feriados municipais e estaduais entram na contagem dos prazos de recurso.

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-02-identificacao/step-02-identificacao.component.html
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-02-identificacao/step-02-identificacao.component.html
@@ -154,8 +154,72 @@
         }
       </select>
       <p class="field__hint" id="f-unidade-hint">
-        Unidade responsável pela administração do certame. Define a localidade que governa a
-        contagem de prazos em dias úteis.
+        Unidade responsável pela administração do certame. O município que rege os prazos é
+        declarado abaixo, e não decorre dela.
+      </p>
+    </div>
+    <div class="form-field form-grid__full">
+      <label class="label" for="f-localidade">Município que rege os prazos</label>
+      @if (store.draft().identificacao.localidade; as localidade) {
+        <div class="localidade-escolhida">
+          <p class="localidade-escolhida__valor" id="f-localidade-valor">
+            {{ localidade.nome }} — {{ localidade.uf }}
+          </p>
+          <button
+            class="btn btn--tertiary"
+            type="button"
+            aria-describedby="f-localidade-valor"
+            (click)="limparLocalidade()"
+          >
+            Trocar município
+          </button>
+        </div>
+      } @else {
+        <input
+          class="input"
+          id="f-localidade"
+          type="search"
+          autocomplete="off"
+          placeholder="Digite ao menos 3 letras do município"
+          aria-describedby="f-localidade-hint"
+          [attr.aria-busy]="municipiosCarregando() || null"
+          [attr.aria-invalid]="invalidFields().has('localidade') || null"
+          [class.is-invalid]="invalidFields().has('localidade')"
+          [value]="buscaMunicipio()"
+          (input)="buscarMunicipios($any($event.target).value)"
+        />
+        @if (municipiosCarregando()) {
+          <p class="field__hint" role="status" aria-live="polite">Consultando a API Geo…</p>
+        }
+        @if (municipiosErro(); as erro) {
+          <div class="field__erro" role="alert"><p>{{ erro }}</p></div>
+        }
+        @if (municipios().length > 0) {
+          <ul class="localidade-opcoes" role="listbox" aria-label="Municípios encontrados">
+            @for (municipio of municipios(); track municipio.codigoIbge) {
+              <li role="option" [attr.aria-selected]="false">
+                <button
+                  class="btn btn--tertiary"
+                  type="button"
+                  (click)="
+                    selecionarLocalidade({
+                      codigoIbge: municipio.codigoIbge,
+                      nome: municipio.nome,
+                      uf: municipio.uf,
+                    })
+                  "
+                >
+                  {{ municipio.nome }} — {{ municipio.uf }}
+                </button>
+              </li>
+            }
+          </ul>
+        }
+      }
+      <p class="field__hint" id="f-localidade-hint">
+        Determina quais feriados municipais e estaduais entram na contagem dos prazos de recurso.
+        Costuma ser a cidade da unidade administradora, mas não decorre dela: um certame pode
+        correr sob o calendário de outro município.
       </p>
     </div>
     <div class="form-field form-grid__full">

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-02-identificacao/step-02-identificacao.component.spec.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-02-identificacao/step-02-identificacao.component.spec.ts
@@ -664,4 +664,18 @@ describe('Step02IdentificacaoComponent', () => {
 
     expect(store.draft().identificacao.localidade).toBeNull();
   });
+  it('libera o estado de consulta quando o termo encolhe abaixo de três letras', async () => {
+    componente.buscarMunicipios('mar');
+    const busca = controller.expectOne((r) => r.url.includes('/api/cidades'));
+
+    // O operador apaga antes de a resposta chegar: a guarda de termo obsoleto
+    // descarta o resultado, então quem precisa devolver o campo ao normal é o
+    // caminho curto — senão o aria-busy fica preso.
+    componente.buscarMunicipios('ma');
+    busca.flush([{ id: 'x', codigoIbge: '1504208', nome: 'Marabá', uf: 'PA', ddd: '94' }]);
+    await tick();
+
+    expect(componente.municipiosCarregando()).toBe(false);
+    expect(componente.municipios()).toEqual([]);
+  });
 });

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-02-identificacao/step-02-identificacao.component.spec.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-02-identificacao/step-02-identificacao.component.spec.ts
@@ -5,6 +5,7 @@ import { apiResultInterceptor } from '@uniplus/shared-core/http';
 import { OrigemCandidatos } from '@uniplus/shared-data/selecao';
 import { SELECAO_BASE_PATH } from '@uniplus/shared-data/selecao';
 import { ORGANIZACAO_BASE_PATH } from '@uniplus/shared-data/organizacao';
+import { GEO_BASE_PATH } from '@uniplus/shared-data/geo';
 import { Step02IdentificacaoComponent } from './step-02-identificacao.component';
 import { ProcessoSeletivoStore } from '../../processo-seletivo.store';
 import { CadastroInicialService } from '../../shared/cadastro-inicial.service';
@@ -14,6 +15,7 @@ const PROCESSO_ID = '01960000-0000-7000-0000-0000000005aa';
 const TIPO_ID = '01960000-0000-7000-0000-0000000005bb';
 const UNIDADE_ID = '01960000-0000-7000-0000-0000000005cc';
 const DOCUMENTO_ID = '01960000-0000-7000-0000-0000000005dd';
+const MARABA = { codigoIbge: '1504208', nome: 'Marabá', uf: 'PA' } as const;
 const URL_ASSINADA = 'http://localhost:9000/uniplus-selecao/editais/edital.pdf?X-Amz-Signature=abc';
 
 const unidadeSeed = {
@@ -86,6 +88,7 @@ describe('Step02IdentificacaoComponent', () => {
         provideHttpClientTesting(),
         { provide: SELECAO_BASE_PATH, useValue: BASE },
         { provide: ORGANIZACAO_BASE_PATH, useValue: BASE },
+        { provide: GEO_BASE_PATH, useValue: BASE },
       ],
     }).compileComponents();
 
@@ -107,6 +110,7 @@ describe('Step02IdentificacaoComponent', () => {
       nome: 'Processo Seletivo 2027',
       unidadeAdministradoraId: UNIDADE_ID,
       origemCandidatos: OrigemCandidatos.inscricaoPropria,
+      localidade: MARABA,
     });
   }
 
@@ -181,6 +185,9 @@ describe('Step02IdentificacaoComponent', () => {
       tipoProcessoOrigemId: TIPO_ID,
       origemCandidatos: OrigemCandidatos.inscricaoPropria,
       unidadeAdministradoraOrigemId: UNIDADE_ID,
+      localidadeCodigoIbge: '1504208',
+      localidadeNome: 'Marabá',
+      localidadeUf: 'PA',
     });
     expect(criacao.request.headers.get('Idempotency-Key')).toBeTruthy();
     criacao.flush(PROCESSO_ID, { status: 201, statusText: 'Created' });
@@ -579,5 +586,82 @@ describe('Step02IdentificacaoComponent', () => {
     componente.removeUpload();
 
     expect(componente.anexo()).toBeDefined();
+  });
+  it('exige a localidade para avançar', () => {
+    store.patchObjectSection('identificacao', {
+      numero: '12/2026',
+      ano: 2026,
+      data: '2026-09-01',
+      orgao: 'CEPS',
+      periodo: '1º semestre',
+      nome: 'Processo Seletivo 2027',
+      unidadeAdministradoraId: UNIDADE_ID,
+      origemCandidatos: OrigemCandidatos.inscricaoPropria,
+    });
+
+    const resultado = componente.validate();
+
+    expect(resultado.valid).toBe(false);
+    expect(resultado.messages).toContain(
+      'Informe o município cujo calendário rege os prazos do processo.',
+    );
+  });
+
+  it('barra o anexo antes da requisição quando falta a localidade', async () => {
+    store.patchObjectSection('tipoProcesso', { selected: TIPO_ID });
+    store.patchObjectSection('identificacao', {
+      nome: 'Processo Seletivo 2027',
+      unidadeAdministradoraId: UNIDADE_ID,
+      origemCandidatos: OrigemCandidatos.inscricaoPropria,
+    });
+
+    await componente['anexar'](pdf());
+
+    // controller.verify() no afterEach prova que nenhuma requisição saiu.
+    expect(componente.uploadError()).toContain('município que rege os prazos');
+  });
+
+  it('envia o trio da localidade escolhida no cadastro inicial', async () => {
+    preencherCamposDoComando();
+
+    const anexo = componente['anexar'](pdf());
+    await tick();
+
+    const criacao = controller.expectOne(`${BASE}/api/selecao/processos-seletivos`);
+    expect(criacao.request.body).toMatchObject({
+      localidadeCodigoIbge: '1504208',
+      localidadeNome: 'Marabá',
+      localidadeUf: 'PA',
+    });
+    criacao.flush(PROCESSO_ID);
+    await tick();
+    controller.match(() => true).forEach((r) => r.flush({}, { status: 500, statusText: 'x' }));
+    await anexo.catch(() => undefined);
+  });
+
+  it('busca municípios na Geo a partir de três letras e grava o trio da opção', async () => {
+    componente.buscarMunicipios('ma');
+    controller.expectNone(() => true);
+
+    componente.buscarMunicipios('mar');
+    const busca = controller.expectOne((r) => r.url.includes('/api/cidades'));
+    expect(busca.request.params.get('q')).toBe('mar');
+    busca.flush([{ id: 'x', codigoIbge: '1504208', nome: 'Marabá', uf: 'PA', ddd: '94' }]);
+    await tick();
+
+    expect(componente.municipios()).toHaveLength(1);
+
+    componente.selecionarLocalidade({ codigoIbge: '1504208', nome: 'Marabá', uf: 'PA' });
+
+    expect(store.draft().identificacao.localidade).toEqual(MARABA);
+    expect(componente.municipios()).toEqual([]);
+  });
+
+  it('limpar a localidade devolve o campo à busca', () => {
+    store.patchObjectSection('identificacao', { localidade: MARABA });
+
+    componente.limparLocalidade();
+
+    expect(store.draft().identificacao.localidade).toBeNull();
   });
 });

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-02-identificacao/step-02-identificacao.component.spec.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-02-identificacao/step-02-identificacao.component.spec.ts
@@ -678,4 +678,25 @@ describe('Step02IdentificacaoComponent', () => {
     expect(componente.municipiosCarregando()).toBe(false);
     expect(componente.municipios()).toEqual([]);
   });
+  it('descarta o resultado anterior ao iniciar uma busca nova', async () => {
+    componente.buscarMunicipios('mar');
+    controller
+      .expectOne((r) => r.url.includes('/api/cidades'))
+      .flush([{ id: 'x', codigoIbge: '1504208', nome: 'Marabá', uf: 'PA', ddd: '94' }]);
+    await tick();
+    expect(componente.municipios()).toHaveLength(1);
+
+    // Enquanto a busca nova corre, a opção antiga não pode seguir clicável: numa
+    // conexão lenta o operador gravaria o município que já não procurava.
+    componente.buscarMunicipios('bel');
+    expect(componente.municipios()).toEqual([]);
+
+    controller
+      .expectOne((r) => r.url.includes('/api/cidades'))
+      .flush([{ id: 'y', codigoIbge: '1501402', nome: 'Belém', uf: 'PA', ddd: '91' }]);
+    await tick();
+
+    expect(componente.municipios()).toHaveLength(1);
+    expect(componente.municipios()[0].nome).toBe('Belém');
+  });
 });

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-02-identificacao/step-02-identificacao.component.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-02-identificacao/step-02-identificacao.component.ts
@@ -160,6 +160,10 @@ export class Step02IdentificacaoComponent {
 
     this.municipiosCarregando.set(true);
     this.municipiosErro.set(null);
+    // Resultado da busca anterior sai de cena ao começar a nova: enquanto a
+    // requisição corre, uma opção do termo antigo continuaria clicável, e numa
+    // conexão lenta o operador gravaria o município que já não procurava.
+    this.municipios.set([]);
     this.geo
       .listarCidades({ q: busca, limit: MUNICIPIOS_LIMIT })
       .pipe(takeUntilDestroyed(this.destroyRef))

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-02-identificacao/step-02-identificacao.component.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-02-identificacao/step-02-identificacao.component.ts
@@ -11,8 +11,10 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ProblemI18nService, extractNextCursor, isApiOk } from '@uniplus/shared-core/http';
 import { UnidadeDto, UnidadesApi } from '@uniplus/shared-data/organizacao';
+import { type CidadeResumoDto, GeoApi } from '@uniplus/shared-data/geo';
 import { IniciarUploadDocumentoEditalDto, OrigemCandidatos } from '@uniplus/shared-data/selecao';
 import { ProcessoSeletivoStore } from '../../processo-seletivo.store';
+import type { LocalidadeSelecionada } from '../../processo-seletivo.models';
 import {
   OrigemCandidatosSelecionada,
   StepValidation,
@@ -28,6 +30,9 @@ interface UnidadeOption {
   readonly id: string;
   readonly rotulo: string;
 }
+
+/** Janela do seletor de municípios, igual à do calendário de dias úteis. */
+const MUNICIPIOS_LIMIT = 20;
 
 /**
  * Rótulos curtos de propósito: em 320 px, a largura intrínseca da opção mais
@@ -52,6 +57,7 @@ export class Step02IdentificacaoComponent {
   readonly store = inject(ProcessoSeletivoStore);
   private readonly cadastro = inject(CadastroInicialService);
   private readonly unidadesApi = inject(UnidadesApi);
+  private readonly geo = inject(GeoApi);
   private readonly problemI18n = inject(ProblemI18nService);
   private readonly destroyRef = inject(DestroyRef);
 
@@ -61,6 +67,12 @@ export class Step02IdentificacaoComponent {
   /** Mensagem de recusa do anexo, antes de qualquer requisição. `null` = sem erro. */
   readonly uploadError = signal<string | null>(null);
   readonly origens = ORIGENS_CANDIDATOS;
+  /** Resultado corrente da busca de município na Geo. */
+  readonly municipios = signal<readonly CidadeResumoDto[]>([]);
+  readonly municipiosCarregando = signal(false);
+  readonly municipiosErro = signal<string | null>(null);
+  /** Termo digitado no seletor; não é persistido no rascunho. */
+  readonly buscaMunicipio = signal('');
 
   readonly unidades = signal<readonly UnidadeOption[]>([]);
   readonly unidadesCarregando = signal(true);
@@ -119,6 +131,47 @@ export class Step02IdentificacaoComponent {
       value = null; // input numérico vazio
     }
     this.store.patchObjectSection('identificacao', { [field]: value });
+  }
+
+  /** Grava o trio inteiro vindo da opção escolhida — nunca campo a campo. */
+  selecionarLocalidade(localidade: LocalidadeSelecionada): void {
+    this.store.patchObjectSection('identificacao', { localidade });
+    this.buscaMunicipio.set('');
+    this.municipios.set([]);
+  }
+
+  limparLocalidade(): void {
+    this.store.patchObjectSection('identificacao', { localidade: null });
+  }
+
+  buscarMunicipios(termo: string): void {
+    this.buscaMunicipio.set(termo);
+    const busca = termo.trim();
+    if (busca.length < 3) {
+      this.municipios.set([]);
+      this.municipiosErro.set(null);
+      return;
+    }
+
+    this.municipiosCarregando.set(true);
+    this.municipiosErro.set(null);
+    this.geo
+      .listarCidades({ q: busca, limit: MUNICIPIOS_LIMIT })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((result) => {
+        // Resposta de busca anterior chegando depois da atual: descartar, senão a
+        // lista exibiria resultado de um termo que o operador já trocou.
+        if (this.buscaMunicipio().trim() !== busca) {
+          return;
+        }
+        this.municipiosCarregando.set(false);
+        if (!isApiOk(result)) {
+          this.municipios.set([]);
+          this.municipiosErro.set(this.problemI18n.resolve(result.problem).title);
+          return;
+        }
+        this.municipios.set(result.data);
+      });
   }
 
   carregarUnidades(): void {
@@ -317,6 +370,9 @@ export class Step02IdentificacaoComponent {
         tipoProcessoOrigemId,
         origemCandidatos: identificacao.origemCandidatos as OrigemCandidatos,
         unidadeAdministradoraOrigemId: identificacao.unidadeAdministradoraId,
+        localidadeCodigoIbge: identificacao.localidade?.codigoIbge ?? null,
+        localidadeNome: identificacao.localidade?.nome ?? null,
+        localidadeUf: identificacao.localidade?.uf ?? null,
       });
 
       if (!resultado.ok) {
@@ -345,6 +401,7 @@ export class Step02IdentificacaoComponent {
     if (!identificacao.nome.trim()) faltando.push('nome do processo seletivo');
     if (!identificacao.unidadeAdministradoraId) faltando.push('unidade administradora');
     if (!identificacao.origemCandidatos) faltando.push('origem dos candidatos');
+    if (identificacao.localidade === null) faltando.push('município que rege os prazos');
     return faltando;
   }
 
@@ -525,6 +582,10 @@ export class Step02IdentificacaoComponent {
     if (!id.origemCandidatos) {
       messages.push('Informe a origem dos candidatos.');
       invalid.add('origemCandidatos');
+    }
+    if (id.localidade === null) {
+      messages.push('Informe o município cujo calendário rege os prazos do processo.');
+      invalid.add('localidade');
     }
     const anexo = id.uploads[0];
     if (anexo === undefined) {

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-02-identificacao/step-02-identificacao.component.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-02-identificacao/step-02-identificacao.component.ts
@@ -150,6 +150,11 @@ export class Step02IdentificacaoComponent {
     if (busca.length < 3) {
       this.municipios.set([]);
       this.municipiosErro.set(null);
+      // Uma busca em voo pode ter começado com termo mais longo: a resposta dela
+      // será descartada pela guarda de termo obsoleto, então é aqui que o estado
+      // de carregamento precisa voltar — senão o campo fica anunciando consulta
+      // que ninguém mais vai concluir.
+      this.municipiosCarregando.set(false);
       return;
     }
 

--- a/libs/shared-data/openapi/selecao.openapi.json
+++ b/libs/shared-data/openapi/selecao.openapi.json
@@ -54,7 +54,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/api/profile/me": {
@@ -86,7 +91,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/api/selecao/processos-seletivos/{processoSeletivoId}/documentos-edital": {
@@ -209,6 +219,11 @@
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-uniplus-idempotent": true
       }
     },
@@ -341,6 +356,11 @@
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-uniplus-idempotent": true
       }
     },
@@ -364,17 +384,7 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/FormularioRenderizavelDto"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FormularioRenderizavelDto"
-                }
-              },
-              "text/json": {
+              "application/vnd.uniplus.formulario-inscricao.v1\u002Bjson": {
                 "schema": {
                   "$ref": "#/components/schemas/FormularioRenderizavelDto"
                 }
@@ -572,6 +582,11 @@
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-uniplus-idempotent": true
       }
     },
@@ -653,23 +668,7 @@
               }
             },
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ObrigatoriedadeLegalDto"
-                  }
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ObrigatoriedadeLegalDto"
-                  }
-                }
-              },
-              "text/json": {
+              "application/vnd.uniplus.obrigatoriedade-legal.v1\u002Bjson": {
                 "schema": {
                   "type": "array",
                   "items": {
@@ -743,17 +742,7 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ObrigatoriedadeLegalDto"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ObrigatoriedadeLegalDto"
-                }
-              },
-              "text/json": {
+              "application/vnd.uniplus.obrigatoriedade-legal.v1\u002Bjson": {
                 "schema": {
                   "$ref": "#/components/schemas/ObrigatoriedadeLegalDto"
                 }
@@ -907,6 +896,11 @@
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-uniplus-idempotent": true
       }
     },
@@ -1033,6 +1027,11 @@
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-uniplus-idempotent": true
       },
       "delete": {
@@ -1084,7 +1083,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/api/selecao/processos-seletivos": {
@@ -1211,6 +1215,11 @@
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-uniplus-idempotent": true
       },
       "get": {
@@ -1268,23 +1277,7 @@
               }
             },
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ProcessoSeletivoResumoDto"
-                  }
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ProcessoSeletivoResumoDto"
-                  }
-                }
-              },
-              "text/json": {
+              "application/vnd.uniplus.processo-seletivo.v1\u002Bjson": {
                 "schema": {
                   "type": "array",
                   "items": {
@@ -1355,6 +1348,11 @@
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-uniplus-paginated": true
       }
     },
@@ -1378,17 +1376,7 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProcessoSeletivoDto"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProcessoSeletivoDto"
-                }
-              },
-              "text/json": {
+              "application/vnd.uniplus.processo-seletivo.v1\u002Bjson": {
                 "schema": {
                   "$ref": "#/components/schemas/ProcessoSeletivoDto"
                 }
@@ -1435,7 +1423,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/api/selecao/processos-seletivos/{id}/etapas": {
@@ -1605,6 +1598,11 @@
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-uniplus-idempotent": true
       }
     },
@@ -1766,6 +1764,11 @@
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-uniplus-idempotent": true
       }
     },
@@ -1936,6 +1939,11 @@
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-uniplus-idempotent": true
       }
     },
@@ -2106,6 +2114,11 @@
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-uniplus-idempotent": true
       }
     },
@@ -2267,6 +2280,177 @@
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-uniplus-idempotent": true
+      }
+    },
+    "/api/selecao/processos-seletivos/{id}/taxa-inscricao": {
+      "put": {
+        "tags": [
+          "ProcessoSeletivo"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DefinirTaxaInscricaoRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DefinirTaxaInscricaoRequest"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/DefinirTaxaInscricaoRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content",
+            "headers": {
+              "ETag": {
+                "description": "ETag forte da sess\u00E3o editorial de retifica\u00E7\u00E3o, no formato \u0022{idDaSessao}:{revisao}\u0022. Devolva-o no If-Match da pr\u00F3xima muta\u00E7\u00E3o. Toda muta\u00E7\u00E3o aceita INCREMENTA a revis\u00E3o e emite o tag novo aqui \u2014 o cliente encadeia sem um GET no meio. Ausente quando n\u00E3o h\u00E1 sess\u00E3o em curso (o processo em rascunho n\u00E3o tem precondi\u00E7\u00E3o a satisfazer).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "412": {
+            "description": "Precondition Failed",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "428": {
+            "description": "Precondition Required",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Requisi\u00E7\u00E3o concorrente com a mesma Idempotency-Key ainda em processamento (uniplus.idempotency.processing_conflict). Repetir depois \u2014 a opera\u00E7\u00E3o anterior ainda n\u00E3o concluiu.",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Corpo acima do limite dos endpoints idempotentes (uniplus.idempotency.body_muito_grande). O limite \u00E9 do filtro, n\u00E3o do servidor.",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Requisi\u00E7\u00E3o n\u00E3o autenticada \u2014 token ausente ou inv\u00E1lido (a rota exige autentica\u00E7\u00E3o). Tamb\u00E9m emitido quando o principal \u00E9 exigido e n\u00E3o est\u00E1 presente (uniplus.idempotency.principal_requerido).",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Autenticado, mas sem a autoriza\u00E7\u00E3o exigida pela rota (ex.: a role plataforma-admin).",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-uniplus-idempotent": true
       }
     },
@@ -2428,6 +2612,11 @@
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-uniplus-idempotent": true
       }
     },
@@ -2589,6 +2778,11 @@
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-uniplus-idempotent": true
       }
     },
@@ -2750,6 +2944,11 @@
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-uniplus-idempotent": true
       }
     },
@@ -2920,6 +3119,11 @@
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-uniplus-idempotent": true
       }
     },
@@ -3090,6 +3294,142 @@
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "x-uniplus-idempotent": true
+      }
+    },
+    "/api/selecao/processos-seletivos/{id}/localidade": {
+      "put": {
+        "tags": [
+          "ProcessoSeletivo"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DefinirLocalidadeRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DefinirLocalidadeRequest"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/DefinirLocalidadeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Requisi\u00E7\u00E3o concorrente com a mesma Idempotency-Key ainda em processamento (uniplus.idempotency.processing_conflict). Repetir depois \u2014 a opera\u00E7\u00E3o anterior ainda n\u00E3o concluiu.",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Corpo acima do limite dos endpoints idempotentes (uniplus.idempotency.body_muito_grande). O limite \u00E9 do filtro, n\u00E3o do servidor.",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Requisi\u00E7\u00E3o n\u00E3o autenticada \u2014 token ausente ou inv\u00E1lido (a rota exige autentica\u00E7\u00E3o). Tamb\u00E9m emitido quando o principal \u00E9 exigido e n\u00E3o est\u00E1 presente (uniplus.idempotency.principal_requerido).",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Autenticado, mas sem a autoriza\u00E7\u00E3o exigida pela rota (ex.: a role plataforma-admin).",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-uniplus-idempotent": true
       }
     },
@@ -3251,6 +3591,11 @@
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-uniplus-idempotent": true
       }
     },
@@ -3421,6 +3766,11 @@
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-uniplus-idempotent": true
       }
     },
@@ -3591,6 +3941,11 @@
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-uniplus-idempotent": true
       }
     },
@@ -3717,6 +4072,11 @@
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-uniplus-idempotent": true
       }
     },
@@ -3843,6 +4203,11 @@
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-uniplus-idempotent": true
       }
     },
@@ -3994,6 +4359,11 @@
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-uniplus-idempotent": true
       },
       "get": {
@@ -4023,17 +4393,7 @@
               }
             },
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/RetificacaoEmCursoDto"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RetificacaoEmCursoDto"
-                }
-              },
-              "text/json": {
+              "application/vnd.uniplus.retificacao-em-curso.v1\u002Bjson": {
                 "schema": {
                   "$ref": "#/components/schemas/RetificacaoEmCursoDto"
                 }
@@ -4080,7 +4440,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       },
       "put": {
         "tags": [
@@ -4241,6 +4606,11 @@
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-uniplus-idempotent": true
       },
       "delete": {
@@ -4374,6 +4744,11 @@
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-uniplus-idempotent": true
       }
     },
@@ -4529,6 +4904,11 @@
             }
           }
         },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
         "x-uniplus-idempotent": true
       }
     },
@@ -4552,17 +4932,7 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConformidadeProcessoSeletivoDto"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConformidadeProcessoSeletivoDto"
-                }
-              },
-              "text/json": {
+              "application/vnd.uniplus.conformidade-processo-seletivo.v1\u002Bjson": {
                 "schema": {
                   "$ref": "#/components/schemas/ConformidadeProcessoSeletivoDto"
                 }
@@ -4609,7 +4979,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/api/selecao/processos-seletivos/{id}/conformidade-legal": {
@@ -4641,17 +5016,7 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConformidadeLegalProcessoSeletivoDto"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConformidadeLegalProcessoSeletivoDto"
-                }
-              },
-              "text/json": {
+              "application/vnd.uniplus.conformidade-legal-processo-seletivo.v1\u002Bjson": {
                 "schema": {
                   "$ref": "#/components/schemas/ConformidadeLegalProcessoSeletivoDto"
                 }
@@ -4708,7 +5073,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     },
     "/api/selecao/processos-seletivos/{id}/snapshot-vigente": {
@@ -4739,17 +5109,7 @@
           "200": {
             "description": "OK",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/SnapshotVigenteDto"
-                }
-              },
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SnapshotVigenteDto"
-                }
-              },
-              "text/json": {
+              "application/vnd.uniplus.snapshot-vigente-processo-seletivo.v1\u002Bjson": {
                 "schema": {
                   "$ref": "#/components/schemas/SnapshotVigenteDto"
                 }
@@ -4806,7 +5166,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ]
       }
     }
   },
@@ -5620,6 +5985,38 @@
           }
         }
       },
+      "ConfiguracaoTaxaInscricaoDto": {
+        "required": [
+          "cobra",
+          "valor",
+          "fundamentos",
+          "confirmacaoFundamentos"
+        ],
+        "type": "object",
+        "properties": {
+          "cobra": {
+            "type": "boolean"
+          },
+          "valor": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "fundamentos": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "confirmacaoFundamentos": {
+            "type": "boolean"
+          }
+        }
+      },
       "ConformidadeLegalProcessoSeletivoDto": {
         "required": [
           "processoSeletivoId",
@@ -5733,7 +6130,10 @@
           "nome",
           "tipoProcessoOrigemId",
           "origemCandidatos",
-          "unidadeAdministradoraOrigemId"
+          "unidadeAdministradoraOrigemId",
+          "localidadeCodigoIbge",
+          "localidadeNome",
+          "localidadeUf"
         ],
         "type": "object",
         "properties": {
@@ -5750,6 +6150,24 @@
           "unidadeAdministradoraOrigemId": {
             "type": "string",
             "format": "uuid"
+          },
+          "localidadeCodigoIbge": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "localidadeNome": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "localidadeUf": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -6122,6 +6540,34 @@
           }
         }
       },
+      "DefinirLocalidadeRequest": {
+        "required": [
+          "codigoIbge",
+          "nome",
+          "uf"
+        ],
+        "type": "object",
+        "properties": {
+          "codigoIbge": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "nome": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "uf": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
       "DefinirOfertaAtendimentoRequest": {
         "required": [
           "condicaoIds",
@@ -6180,6 +6626,44 @@
               "string"
             ],
             "format": "uuid"
+          }
+        }
+      },
+      "DefinirTaxaInscricaoRequest": {
+        "required": [
+          "cobra",
+          "valor",
+          "fundamentos",
+          "confirmacaoFundamentos"
+        ],
+        "type": "object",
+        "properties": {
+          "cobra": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "valor": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
+            "format": "double"
+          },
+          "fundamentos": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "confirmacaoFundamentos": {
+            "type": "boolean"
           }
         }
       },
@@ -6376,6 +6860,7 @@
           "id",
           "nome",
           "carater",
+          "tipoEtapa",
           "peso",
           "notaMinima",
           "ordem"
@@ -6391,6 +6876,9 @@
           },
           "carater": {
             "type": "string"
+          },
+          "tipoEtapa": {
+            "$ref": "#/components/schemas/TipoEtapaSnapshotDto"
           },
           "peso": {
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
@@ -6425,6 +6913,7 @@
         "required": [
           "nome",
           "carater",
+          "tipoEtapaOrigemId",
           "peso",
           "notaMinima",
           "ordem"
@@ -6436,6 +6925,10 @@
           },
           "carater": {
             "$ref": "#/components/schemas/CaraterEtapa"
+          },
+          "tipoEtapaOrigemId": {
+            "type": "string",
+            "format": "uuid"
           },
           "peso": {
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d\u002B)?$",
@@ -6774,6 +7267,7 @@
             }
           },
           "valoresSelecionaveis": {
+            "minItems": 1,
             "type": [
               "null",
               "array"
@@ -7053,6 +7547,25 @@
       },
       "JsonElement": {},
       "JsonNode": {},
+      "LocalidadeRegenteDto": {
+        "required": [
+          "codigoIbge",
+          "nome",
+          "uf"
+        ],
+        "type": "object",
+        "properties": {
+          "codigoIbge": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          },
+          "uf": {
+            "type": "string"
+          }
+        }
+      },
       "ModalidadeSelecionadaDto": {
         "required": [
           "id",
@@ -7717,6 +8230,7 @@
           "status",
           "origemCandidatos",
           "unidadeAdministradora",
+          "localidade",
           "etapas",
           "ofertaAtendimento",
           "distribuicaoVagas",
@@ -7733,6 +8247,7 @@
           "formularioTitulo",
           "formularioTermoAceiteTexto",
           "configuracaoDivulgacao",
+          "configuracaoTaxaInscricao",
           "criadoEm"
         ],
         "type": "object",
@@ -7755,6 +8270,9 @@
           },
           "unidadeAdministradora": {
             "$ref": "#/components/schemas/UnidadeAdministradoraSnapshotDto"
+          },
+          "localidade": {
+            "$ref": "#/components/schemas/LocalidadeRegenteDto"
           },
           "etapas": {
             "type": "array",
@@ -7873,6 +8391,16 @@
               },
               {
                 "$ref": "#/components/schemas/ConfiguracaoDivulgacaoDto"
+              }
+            ]
+          },
+          "configuracaoTaxaInscricao": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ConfiguracaoTaxaInscricaoDto"
               }
             ]
           },
@@ -8523,6 +9051,26 @@
           }
         }
       },
+      "TipoEtapaSnapshotDto": {
+        "required": [
+          "origemId",
+          "codigo",
+          "nome"
+        ],
+        "type": "object",
+        "properties": {
+          "origemId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "codigo": {
+            "type": "string"
+          },
+          "nome": {
+            "type": "string"
+          }
+        }
+      },
       "TipoProcessoSnapshotDto": {
         "required": [
           "origemId",
@@ -8549,7 +9097,10 @@
           "sigla",
           "slug",
           "nome",
-          "tipo"
+          "tipo",
+          "cidadeCodigoIbge",
+          "cidadeNome",
+          "cidadeUf"
         ],
         "type": "object",
         "properties": {
@@ -8568,6 +9119,24 @@
           },
           "tipo": {
             "type": "string"
+          },
+          "cidadeCodigoIbge": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cidadeNome": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "cidadeUf": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -8692,6 +9261,14 @@
             "format": "int32"
           }
         }
+      }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "description": "Token JWT emitido pelo provedor de identidade institucional (Keycloak). Cole apenas o token: o prefixo \u0022Bearer\u0022 \u00E9 acrescentado ao cabe\u00E7alho Authorization automaticamente. As rotas administrativas exigem, al\u00E9m da autentica\u00E7\u00E3o, a role plataforma-admin no token.",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
       }
     }
   },

--- a/libs/shared-data/src/lib/api/selecao/schema.ts
+++ b/libs/shared-data/src/lib/api/selecao/schema.ts
@@ -279,9 +279,7 @@ export interface paths {
                         readonly [name: string]: unknown;
                     };
                     content: {
-                        readonly "text/plain": components["schemas"]["FormularioRenderizavelDto"];
-                        readonly "application/json": components["schemas"]["FormularioRenderizavelDto"];
-                        readonly "text/json": components["schemas"]["FormularioRenderizavelDto"];
+                        readonly "application/vnd.uniplus.formulario-inscricao.v1+json": components["schemas"]["FormularioRenderizavelDto"];
                     };
                 };
                 /** @description Not Found */
@@ -485,9 +483,7 @@ export interface paths {
                         readonly [name: string]: unknown;
                     };
                     content: {
-                        readonly "text/plain": readonly components["schemas"]["ObrigatoriedadeLegalDto"][];
-                        readonly "application/json": readonly components["schemas"]["ObrigatoriedadeLegalDto"][];
-                        readonly "text/json": readonly components["schemas"]["ObrigatoriedadeLegalDto"][];
+                        readonly "application/vnd.uniplus.obrigatoriedade-legal.v1+json": readonly components["schemas"]["ObrigatoriedadeLegalDto"][];
                     };
                 };
                 /** @description Bad Request */
@@ -560,9 +556,7 @@ export interface paths {
                         readonly [name: string]: unknown;
                     };
                     content: {
-                        readonly "text/plain": components["schemas"]["ObrigatoriedadeLegalDto"];
-                        readonly "application/json": components["schemas"]["ObrigatoriedadeLegalDto"];
-                        readonly "text/json": components["schemas"]["ObrigatoriedadeLegalDto"];
+                        readonly "application/vnd.uniplus.obrigatoriedade-legal.v1+json": components["schemas"]["ObrigatoriedadeLegalDto"];
                     };
                 };
                 /** @description Not Found */
@@ -879,9 +873,7 @@ export interface paths {
                         readonly [name: string]: unknown;
                     };
                     content: {
-                        readonly "text/plain": readonly components["schemas"]["ProcessoSeletivoResumoDto"][];
-                        readonly "application/json": readonly components["schemas"]["ProcessoSeletivoResumoDto"][];
-                        readonly "text/json": readonly components["schemas"]["ProcessoSeletivoResumoDto"][];
+                        readonly "application/vnd.uniplus.processo-seletivo.v1+json": readonly components["schemas"]["ProcessoSeletivoResumoDto"][];
                     };
                 };
                 /** @description Bad Request */
@@ -1056,9 +1048,7 @@ export interface paths {
                         readonly [name: string]: unknown;
                     };
                     content: {
-                        readonly "text/plain": components["schemas"]["ProcessoSeletivoDto"];
-                        readonly "application/json": components["schemas"]["ProcessoSeletivoDto"];
-                        readonly "text/json": components["schemas"]["ProcessoSeletivoDto"];
+                        readonly "application/vnd.uniplus.processo-seletivo.v1+json": components["schemas"]["ProcessoSeletivoDto"];
                     };
                 };
                 /** @description Requisição não autenticada — token ausente ou inválido (a rota exige autenticação). Também emitido quando o principal é exigido e não está presente (uniplus.idempotency.principal_requerido). */
@@ -1645,6 +1635,134 @@ export interface paths {
                     readonly "application/json": components["schemas"]["DefinirBonusRegionalRequest"];
                     readonly "text/json": components["schemas"]["DefinirBonusRegionalRequest"];
                     readonly "application/*+json": components["schemas"]["DefinirBonusRegionalRequest"];
+                };
+            };
+            readonly responses: {
+                /** @description No Content */
+                readonly 204: {
+                    headers: {
+                        /** @description ETag forte da sessão editorial de retificação, no formato "{idDaSessao}:{revisao}". Devolva-o no If-Match da próxima mutação. Toda mutação aceita INCREMENTA a revisão e emite o tag novo aqui — o cliente encadeia sem um GET no meio. Ausente quando não há sessão em curso (o processo em rascunho não tem precondição a satisfazer). */
+                        readonly ETag?: string;
+                        readonly [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Bad Request */
+                readonly 400: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Requisição não autenticada — token ausente ou inválido (a rota exige autenticação). Também emitido quando o principal é exigido e não está presente (uniplus.idempotency.principal_requerido). */
+                readonly 401: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Autenticado, mas sem a autorização exigida pela rota (ex.: a role plataforma-admin). */
+                readonly 403: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Not Found */
+                readonly 404: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Requisição concorrente com a mesma Idempotency-Key ainda em processamento (uniplus.idempotency.processing_conflict). Repetir depois — a operação anterior ainda não concluiu. */
+                readonly 409: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Precondition Failed */
+                readonly 412: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Corpo acima do limite dos endpoints idempotentes (uniplus.idempotency.body_muito_grande). O limite é do filtro, não do servidor. */
+                readonly 413: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Unprocessable Entity */
+                readonly 422: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Precondition Required */
+                readonly 428: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
+    readonly "/api/selecao/processos-seletivos/{id}/taxa-inscricao": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put: {
+            readonly parameters: {
+                readonly query?: never;
+                readonly header: {
+                    readonly "If-Match"?: string;
+                    /** @description Chave opaca (1-255 ASCII printable, sem ',' ou ';') para retry seguro do comando. Replay com mesma key + mesmo body retorna response cacheada (ADR-0027). */
+                    readonly "Idempotency-Key": string;
+                };
+                readonly path: {
+                    readonly id: string;
+                };
+                readonly cookie?: never;
+            };
+            readonly requestBody: {
+                readonly content: {
+                    readonly "application/json": components["schemas"]["DefinirTaxaInscricaoRequest"];
+                    readonly "text/json": components["schemas"]["DefinirTaxaInscricaoRequest"];
+                    readonly "application/*+json": components["schemas"]["DefinirTaxaInscricaoRequest"];
                 };
             };
             readonly responses: {
@@ -2387,6 +2505,113 @@ export interface paths {
         readonly patch?: never;
         readonly trace?: never;
     };
+    readonly "/api/selecao/processos-seletivos/{id}/localidade": {
+        readonly parameters: {
+            readonly query?: never;
+            readonly header?: never;
+            readonly path?: never;
+            readonly cookie?: never;
+        };
+        readonly get?: never;
+        readonly put: {
+            readonly parameters: {
+                readonly query?: never;
+                readonly header: {
+                    /** @description Chave opaca (1-255 ASCII printable, sem ',' ou ';') para retry seguro do comando. Replay com mesma key + mesmo body retorna response cacheada (ADR-0027). */
+                    readonly "Idempotency-Key": string;
+                };
+                readonly path: {
+                    readonly id: string;
+                };
+                readonly cookie?: never;
+            };
+            readonly requestBody: {
+                readonly content: {
+                    readonly "application/json": components["schemas"]["DefinirLocalidadeRequest"];
+                    readonly "text/json": components["schemas"]["DefinirLocalidadeRequest"];
+                    readonly "application/*+json": components["schemas"]["DefinirLocalidadeRequest"];
+                };
+            };
+            readonly responses: {
+                /** @description No Content */
+                readonly 204: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Bad Request */
+                readonly 400: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Requisição não autenticada — token ausente ou inválido (a rota exige autenticação). Também emitido quando o principal é exigido e não está presente (uniplus.idempotency.principal_requerido). */
+                readonly 401: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Autenticado, mas sem a autorização exigida pela rota (ex.: a role plataforma-admin). */
+                readonly 403: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Not Found */
+                readonly 404: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Requisição concorrente com a mesma Idempotency-Key ainda em processamento (uniplus.idempotency.processing_conflict). Repetir depois — a operação anterior ainda não concluiu. */
+                readonly 409: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Corpo acima do limite dos endpoints idempotentes (uniplus.idempotency.body_muito_grande). O limite é do filtro, não do servidor. */
+                readonly 413: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+                /** @description Unprocessable Entity */
+                readonly 422: {
+                    headers: {
+                        readonly [name: string]: unknown;
+                    };
+                    content: {
+                        readonly "application/problem+json": components["schemas"]["ProblemDetails"];
+                    };
+                };
+            };
+        };
+        readonly post?: never;
+        readonly delete?: never;
+        readonly options?: never;
+        readonly head?: never;
+        readonly patch?: never;
+        readonly trace?: never;
+    };
     readonly "/api/selecao/processos-seletivos/{id}/referencia-temporal-fatos": {
         readonly parameters: {
             readonly query?: never;
@@ -3011,9 +3236,7 @@ export interface paths {
                         readonly [name: string]: unknown;
                     };
                     content: {
-                        readonly "text/plain": components["schemas"]["RetificacaoEmCursoDto"];
-                        readonly "application/json": components["schemas"]["RetificacaoEmCursoDto"];
-                        readonly "text/json": components["schemas"]["RetificacaoEmCursoDto"];
+                        readonly "application/vnd.uniplus.retificacao-em-curso.v1+json": components["schemas"]["RetificacaoEmCursoDto"];
                     };
                 };
                 /** @description Requisição não autenticada — token ausente ou inválido (a rota exige autenticação). Também emitido quando o principal é exigido e não está presente (uniplus.idempotency.principal_requerido). */
@@ -3528,9 +3751,7 @@ export interface paths {
                         readonly [name: string]: unknown;
                     };
                     content: {
-                        readonly "text/plain": components["schemas"]["ConformidadeProcessoSeletivoDto"];
-                        readonly "application/json": components["schemas"]["ConformidadeProcessoSeletivoDto"];
-                        readonly "text/json": components["schemas"]["ConformidadeProcessoSeletivoDto"];
+                        readonly "application/vnd.uniplus.conformidade-processo-seletivo.v1+json": components["schemas"]["ConformidadeProcessoSeletivoDto"];
                     };
                 };
                 /** @description Requisição não autenticada — token ausente ou inválido (a rota exige autenticação). Também emitido quando o principal é exigido e não está presente (uniplus.idempotency.principal_requerido). */
@@ -3605,9 +3826,7 @@ export interface paths {
                         readonly [name: string]: unknown;
                     };
                     content: {
-                        readonly "text/plain": components["schemas"]["ConformidadeLegalProcessoSeletivoDto"];
-                        readonly "application/json": components["schemas"]["ConformidadeLegalProcessoSeletivoDto"];
-                        readonly "text/json": components["schemas"]["ConformidadeLegalProcessoSeletivoDto"];
+                        readonly "application/vnd.uniplus.conformidade-legal-processo-seletivo.v1+json": components["schemas"]["ConformidadeLegalProcessoSeletivoDto"];
                     };
                 };
                 /** @description Bad Request */
@@ -3691,9 +3910,7 @@ export interface paths {
                         readonly [name: string]: unknown;
                     };
                     content: {
-                        readonly "text/plain": components["schemas"]["SnapshotVigenteDto"];
-                        readonly "application/json": components["schemas"]["SnapshotVigenteDto"];
-                        readonly "text/json": components["schemas"]["SnapshotVigenteDto"];
+                        readonly "application/vnd.uniplus.snapshot-vigente-processo-seletivo.v1+json": components["schemas"]["SnapshotVigenteDto"];
                     };
                 };
                 /** @description Requisição não autenticada — token ausente ou inválido (a rota exige autenticação). Também emitido quando o principal é exigido e não está presente (uniplus.idempotency.principal_requerido). */
@@ -3942,6 +4159,13 @@ export interface components {
             readonly camposPublicos: readonly string[];
             readonly justificativa: null | string;
         };
+        readonly ConfiguracaoTaxaInscricaoDto: {
+            readonly cobra: boolean;
+            /** Format: double */
+            readonly valor: null | number | string;
+            readonly fundamentos: readonly string[];
+            readonly confirmacaoFundamentos: boolean;
+        };
         readonly ConformidadeLegalProcessoSeletivoDto: {
             /** Format: uuid */
             readonly processoSeletivoId: string;
@@ -3976,6 +4200,9 @@ export interface components {
             readonly origemCandidatos: components["schemas"]["OrigemCandidatos"];
             /** Format: uuid */
             readonly unidadeAdministradoraOrigemId: string;
+            readonly localidadeCodigoIbge: null | string;
+            readonly localidadeNome: null | string;
+            readonly localidadeUf: null | string;
         };
         readonly CriterioDesempateDto: {
             /** Format: uuid */
@@ -4052,6 +4279,11 @@ export interface components {
             readonly titulo: null | string;
             readonly termoAceiteTexto: null | string;
         };
+        readonly DefinirLocalidadeRequest: {
+            readonly codigoIbge: null | string;
+            readonly nome: null | string;
+            readonly uf: null | string;
+        };
         readonly DefinirOfertaAtendimentoRequest: {
             readonly condicaoIds: readonly string[];
             readonly recursoIds: readonly string[];
@@ -4063,6 +4295,13 @@ export interface components {
             readonly data: null | string;
             /** Format: uuid */
             readonly faseId: null | string;
+        };
+        readonly DefinirTaxaInscricaoRequest: {
+            readonly cobra: null | boolean;
+            /** Format: double */
+            readonly valor: null | number | string;
+            readonly fundamentos: null | readonly string[];
+            readonly confirmacaoFundamentos: boolean;
         };
         readonly DestinoRemanejamentoDto: {
             /** Format: uuid */
@@ -4117,6 +4356,7 @@ export interface components {
             readonly id: string;
             readonly nome: string;
             readonly carater: string;
+            readonly tipoEtapa: components["schemas"]["TipoEtapaSnapshotDto"];
             /** Format: double */
             readonly peso: null | number | string;
             /** Format: double */
@@ -4127,6 +4367,8 @@ export interface components {
         readonly EtapaProcessoInput: {
             readonly nome: string;
             readonly carater: components["schemas"]["CaraterEtapa"];
+            /** Format: uuid */
+            readonly tipoEtapaOrigemId: string;
             /** Format: double */
             readonly peso: null | number | string;
             /** Format: double */
@@ -4266,6 +4508,11 @@ export interface components {
         };
         readonly JsonElement: unknown;
         readonly JsonNode: unknown;
+        readonly LocalidadeRegenteDto: {
+            readonly codigoIbge: string;
+            readonly nome: string;
+            readonly uf: string;
+        };
         readonly ModalidadeSelecionadaDto: {
             /** Format: uuid */
             readonly id: string;
@@ -4420,6 +4667,7 @@ export interface components {
             readonly status: string;
             readonly origemCandidatos: string;
             readonly unidadeAdministradora: components["schemas"]["UnidadeAdministradoraSnapshotDto"];
+            readonly localidade: components["schemas"]["LocalidadeRegenteDto"];
             readonly etapas: readonly components["schemas"]["EtapaProcessoDto"][];
             readonly ofertaAtendimento: null | components["schemas"]["OfertaAtendimentoEspecializadoDto"];
             readonly distribuicaoVagas: readonly components["schemas"]["ConfiguracaoDistribuicaoVagasDto"][];
@@ -4436,6 +4684,7 @@ export interface components {
             readonly formularioTitulo: null | string;
             readonly formularioTermoAceiteTexto: null | string;
             readonly configuracaoDivulgacao: null | components["schemas"]["ConfiguracaoDivulgacaoDto"];
+            readonly configuracaoTaxaInscricao: null | components["schemas"]["ConfiguracaoTaxaInscricaoDto"];
             /** Format: date-time */
             readonly criadoEm: string;
             readonly _links?: null | {
@@ -4602,6 +4851,12 @@ export interface components {
             readonly hashEdital: string;
             readonly configuracao: components["schemas"]["JsonNode"];
         };
+        readonly TipoEtapaSnapshotDto: {
+            /** Format: uuid */
+            readonly origemId: string;
+            readonly codigo: string;
+            readonly nome: string;
+        };
         readonly TipoProcessoSnapshotDto: {
             /** Format: uuid */
             readonly origemId: string;
@@ -4615,6 +4870,9 @@ export interface components {
             readonly slug: string;
             readonly nome: string;
             readonly tipo: string;
+            readonly cidadeCodigoIbge: null | string;
+            readonly cidadeNome: null | string;
+            readonly cidadeUf: null | string;
         };
         /** @enum {string} */
         readonly UnidadePrazo: UnidadePrazo;


### PR DESCRIPTION
## Resumo

- O passo 2 do wizard ganha o campo **município que rege os prazos**, obrigatório, com busca na Geo.
- O contrato gerado de Seleção foi sincronizado com a baseline da API.
- Sem isso, **criar processo pelo wizard estava quebrado**: a API passou a exigir a localidade, e o cadastro inicial dispara ao anexar o edital.

## Por que agora

`unifesspa-edu-br/uniplus-api#1136` (mergeado) tornou a localidade obrigatória na criação. Como o processo nasce no momento em que o operador anexa o PDF do edital de abertura, o passo 2 passou a receber 422 com `uniplus.selecao.processo_seletivo.localidade_ausente`.

O requisito é o `UNI-REQ-0111`, alterado em `unifesspa-edu-br/uniplus-developers#104`.

## Mudanças

- **`processo-seletivo.models.ts`** — tipo `LocalidadeSelecionada` e o campo no rascunho do passo 2.
- **`step-02-identificacao`** — o campo, a busca na Geo (mínimo de três letras, descarte de resposta fora de ordem), a validação e o envio do trio no `POST`.
- **`libs/shared-data`** — contrato de Seleção regenerado: três campos no `POST` e a rota `PUT /{id}/localidade`.
- **Testes** — cinco casos novos no passo 2, mais o stub da Geo no spec da página.

O trio viaja inteiro a partir da opção escolhida, nunca montado campo a campo: é o código IBGE que determina quais feriados incidem no prazo; nome e UF são cache de exibição e precisam corresponder ao que a Geo devolveu.

## Um texto que passou a mentir, e foi corrigido

O apoio do campo de unidade administradora dizia: *"Define a localidade que governa a contagem de prazos em dias úteis."* Deixou de ser verdade quando a localidade passou a ser declarada por processo — e mandaria o operador procurar no lugar errado. Passou a dizer que o município é declarado abaixo e não decorre da unidade.

## O que ficou de fora, e por quê

A issue pedia o campo **pré-preenchido com a cidade da unidade administradora**. Não foi implementado, por impedimento externo: **a API não expõe a cidade da unidade em nenhuma leitura REST**. O `UnidadeDto` — o mesmo de `listar()` e de `obter()` — traz identificação e vigência, e nenhum campo de cidade, embora o dado exista no domínio (o handler de criação o lê por reader cross-módulo, e recusa unidade sem cidade).

Abri `unifesspa-edu-br/uniplus-api#1155` para expor os três campos. Depois dela, ligar a sugestão aqui é mudança pequena e localizada: o campo já existe e hoje nasce vazio.

Preferi entregar o campo funcionando a segurar a correção do fluxo quebrado esperando a dependência.

## Notas ao revisor — contexto que o diff não mostra

**O aviso de budget do bundle é pré-existente.** `nx build selecao` avisa que o bundle inicial excede o orçamento; medi na `main` (`021e57d`) e ela já excede em 34,41 kB. Este PR leva o total a 35,01 kB — 0,6 kB a mais, vindos do campo novo. O schema regenerado não pesa no bundle: é declaração de tipo, apagada na compilação.

**O `PUT /{id}/localidade` aparece no contrato regenerado, mas não é consumido aqui.** Editar a localidade depois da criação é trabalho de outra task; a rota entra junto porque o cliente é gerado do contrato inteiro.

**A busca não filtra por UF.** O cadastro de calendário filtra, porque lá o município é qualificado por um estado já escolhido na mesma linha. Aqui não há UF prévia — o certame pode correr sob calendário de qualquer município —, então a busca é por nome e a UF vem na opção.

## Testes

- [x] `nx test selecao` — 80 testes, 11 arquivos
- [x] `nx test shared-data` — 279 testes
- [x] `nx lint selecao` limpo
- [x] `nx build selecao` sucede

Cenários cobertos: validação exigindo a localidade; anexo barrado **antes** de qualquer requisição quando ela falta; trio correto no corpo do `POST`; busca disparando só a partir de três letras e gravando o trio da opção; e limpeza devolvendo o campo à busca.

## Acessibilidade

Rótulo associado, `aria-invalid` no campo, `aria-busy` durante a consulta, `role="status"` com `aria-live` no aviso de carregamento, `role="alert"` no erro, e a lista de resultados como `listbox` com rótulo.

Closes #531
