### PR TITLE
feat(configuracao): substitui calendário de dias úteis por visualização mensal

### DIFF
--- a/apps/configuracao-e2e/src/specs/calendario-dias-uteis-mensal.visual.spec.ts
+++ b/apps/configuracao-e2e/src/specs/calendario-dias-uteis-mensal.visual.spec.ts
@@ -232,6 +232,33 @@ test.describe('Calendário de dias úteis — visualização mensal e drawer (#5
     await assertNoHorizontalOverflow(page);
   });
 
+  test('versão do dataset longa sem espaços não força rolagem horizontal no resumo (CA-02/CA-12)', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 320, height: 720 });
+    // Até 60 caracteres aceitos pelo formulário de criação, num único token.
+    const versaoLonga = 'V'.repeat(60);
+    await page.route(/\/api\/configuracao\/calendarios-dias-uteis\/[^/?]+$/, async (route, request) => {
+      if (request.method() === 'OPTIONS') {
+        await route.fulfill({ status: 204, headers: CORS_HEADERS });
+        return;
+      }
+      if (request.method() !== 'GET') {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        headers: { ...CORS_HEADERS, 'content-type': 'application/json' },
+        body: JSON.stringify({ ...CALENDARIO, versaoDataset: versaoLonga }),
+      });
+    });
+
+    await page.goto(`/calendario-dias-uteis/${CALENDARIO_ID}`);
+    await expect(page.getByText(versaoLonga)).toBeVisible();
+    await assertNoHorizontalOverflow(page);
+  });
+
   test('sem violações serious/critical, com o drawer fechado e aberto (CA-13)', async ({ page }) => {
     await page.goto(`/calendario-dias-uteis/${CALENDARIO_ID}`);
     await expect(page.getByRole('button', { name: /5 de abril de 2026/ })).toBeVisible();

--- a/apps/configuracao-e2e/src/specs/calendario-dias-uteis-mensal.visual.spec.ts
+++ b/apps/configuracao-e2e/src/specs/calendario-dias-uteis-mensal.visual.spec.ts
@@ -1,0 +1,244 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, test, type Page, type TestInfo } from '@playwright/test';
+import { mockConfiguracaoRuntimeConfig } from '../support/runtime-config';
+
+type VisualTheme = 'light' | 'dark' | 'contrast';
+type AxeResult = Awaited<ReturnType<AxeBuilder['analyze']>>;
+
+const CALENDARIO_ID = '019ff7ee-3c00-7976-860c-eb2f61c9b3d1';
+
+const CORS_HEADERS = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'GET, POST, DELETE, OPTIONS',
+  'access-control-allow-headers': 'authorization, content-type, accept, idempotency-key',
+};
+
+/**
+ * Dataset cruzando dois anos, com um dia de múltiplas ocorrências (CA-09) —
+ * cobre a grade mensal e o drawer introduzidos pela #525.
+ */
+const CALENDARIO = {
+  id: CALENDARIO_ID,
+  versaoDataset: '2026.1',
+  vigente: true,
+  criadoEm: '2026-08-13T12:00:00Z',
+  diasNaoUteis: [
+    {
+      id: '019ff7ee-3c00-7976-860c-eb2f61c9b301',
+      abrangencia: 'MUNICIPAL',
+      municipioIbge: '1504208',
+      municipioNome: 'Marabá',
+      municipioUf: 'PA',
+      uf: null,
+      data: '2026-04-05',
+      descricao: 'Aniversário de Marabá',
+    },
+    {
+      id: '019ff7ee-3c00-7976-860c-eb2f61c9b302',
+      abrangencia: 'NACIONAL',
+      municipioIbge: null,
+      municipioNome: null,
+      municipioUf: null,
+      uf: null,
+      data: '2026-11-15',
+      descricao: 'Proclamação da República',
+    },
+    {
+      id: '019ff7ee-3c00-7976-860c-eb2f61c9b303',
+      abrangencia: 'INSTITUCIONAL',
+      municipioIbge: null,
+      municipioNome: null,
+      municipioUf: null,
+      uf: null,
+      data: '2026-11-15',
+      descricao: 'Aniversário da Unifesspa',
+    },
+    {
+      id: '019ff7ee-3c00-7976-860c-eb2f61c9b304',
+      abrangencia: 'NACIONAL',
+      municipioIbge: null,
+      municipioNome: null,
+      municipioUf: null,
+      uf: null,
+      data: '2027-01-01',
+      descricao: 'Confraternização Universal',
+    },
+  ],
+} as const;
+
+test.describe('Calendário de dias úteis — visualização mensal e drawer (#525)', () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    const theme = metadataTheme(testInfo);
+    await mockConfiguracaoRuntimeConfig(page);
+    await page.addInitScript((dsTheme: VisualTheme) => {
+      window.localStorage.setItem(
+        'uniplus.a11y',
+        JSON.stringify({
+          theme: dsTheme === 'contrast' ? 'auto' : dsTheme,
+          contrast: dsTheme === 'contrast',
+          fontMode: 'default',
+        }),
+      );
+    }, theme);
+    await mockCalendarioApi(page);
+  });
+
+  test('exibe só os meses com feriado, em ordem cronológica cruzando anos (CA-03)', async ({ page }) => {
+    await page.goto(`/calendario-dias-uteis/${CALENDARIO_ID}`);
+
+    const titulos = page.locator('.cfg-calendario-mensal__titulo');
+    await expect(titulos).toHaveText(['Abril de 2026', 'Novembro de 2026', 'Janeiro de 2027']);
+  });
+
+  test('abre por clique, fecha pelo botão e restaura o foco no dia exato (CA-07/CA-08)', async ({ page }) => {
+    await page.goto(`/calendario-dias-uteis/${CALENDARIO_ID}`);
+
+    const botaoDia = page.getByRole('button', { name: /5 de abril de 2026/ });
+    await botaoDia.click();
+
+    const dialogo = page.getByRole('dialog', { name: '5 de abril de 2026' });
+    await expect(dialogo).toBeVisible();
+    await expect(dialogo.getByRole('button', { name: 'Fechar' })).toBeFocused();
+
+    await dialogo.getByRole('button', { name: 'Fechar' }).click();
+    await expect(dialogo).toBeHidden();
+    await expect(botaoDia).toBeFocused();
+    // A restauração de foco dispara (focus) no dia de novo — sem o
+    // tratamento em (closed), a prévia reapareceria "sozinha" após fechar.
+    await expect(page.locator('.cfg-calendario-mensal__preview')).toBeHidden();
+  });
+
+  test('abre por teclado (Enter e Espaço) e Escape fecha restaurando o foco (CA-07/CA-08)', async ({ page }) => {
+    await page.goto(`/calendario-dias-uteis/${CALENDARIO_ID}`);
+
+    const botaoDia = page.getByRole('button', { name: /5 de abril de 2026/ });
+    const dialogo = page.getByRole('dialog', { name: '5 de abril de 2026' });
+
+    await botaoDia.focus();
+    await page.keyboard.press('Enter');
+    await expect(dialogo).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(dialogo).toBeHidden();
+    await expect(botaoDia).toBeFocused();
+
+    await botaoDia.focus();
+    await page.keyboard.press(' ');
+    await expect(dialogo).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(botaoDia).toBeFocused();
+  });
+
+  test('múltiplos feriados na mesma data viram uma célula com contador e listam as duas ocorrências (CA-09)', async ({
+    page,
+  }) => {
+    await page.goto(`/calendario-dias-uteis/${CALENDARIO_ID}`);
+
+    const botaoDia = page.getByRole('button', { name: /15 de novembro de 2026/ });
+    await expect(botaoDia).toContainText('×2');
+    await botaoDia.click();
+
+    const dialogo = page.getByRole('dialog', { name: '15 de novembro de 2026' });
+    await expect(dialogo.getByText('Proclamação da República')).toBeVisible();
+    await expect(dialogo.getByText('Aniversário da Unifesspa')).toBeVisible();
+  });
+
+  test('hover mostra a prévia sem abrir o drawer (CA-06)', async ({ page }) => {
+    await page.goto(`/calendario-dias-uteis/${CALENDARIO_ID}`);
+
+    const botaoDia = page.getByRole('button', { name: /5 de abril de 2026/ });
+    await botaoDia.hover();
+
+    await expect(page.locator('.cfg-calendario-mensal__preview')).toBeVisible();
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+  });
+
+  test('foco por teclado mostra a prévia; Escape a dispensa sem mover o foco nem abrir o drawer (CA-06)', async ({
+    page,
+  }) => {
+    await page.goto(`/calendario-dias-uteis/${CALENDARIO_ID}`);
+
+    const botaoDia = page.getByRole('button', { name: /5 de abril de 2026/ });
+    await botaoDia.focus();
+    await expect(page.locator('.cfg-calendario-mensal__preview')).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('.cfg-calendario-mensal__preview')).toBeHidden();
+    await expect(botaoDia).toBeFocused();
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+  });
+
+  test('320 px sem rolagem horizontal, inclusive com a prévia aberta (CA-12)', async ({ page }, testInfo) => {
+    await page.setViewportSize({ width: 320, height: 720 });
+    await page.goto(`/calendario-dias-uteis/${CALENDARIO_ID}`);
+
+    await assertNoHorizontalOverflow(page);
+
+    // 2026-04-05 é domingo — primeira coluna da grade, o caso mais exposto
+    // a ser recortado pela borda esquerda ao centralizar a prévia (CA-12).
+    const botaoDia = page.getByRole('button', { name: /5 de abril de 2026/ });
+    await botaoDia.focus();
+    const preview = page.locator('.cfg-calendario-mensal__preview');
+    await expect(preview).toBeVisible();
+    await assertNoHorizontalOverflow(page);
+
+    const caixa = await preview.boundingBox();
+    expect(caixa?.x ?? -1).toBeGreaterThanOrEqual(0);
+    expect((caixa?.x ?? 0) + (caixa?.width ?? 9999)).toBeLessThanOrEqual(320);
+
+    await testInfo.attach(`${testInfo.project.name}-calendario-mensal-320`, {
+      body: await page.screenshot({ fullPage: true }),
+      contentType: 'image/png',
+    });
+  });
+
+  test('sem violações serious/critical, com o drawer fechado e aberto (CA-13)', async ({ page }) => {
+    await page.goto(`/calendario-dias-uteis/${CALENDARIO_ID}`);
+    await expect(page.getByRole('button', { name: /5 de abril de 2026/ })).toBeVisible();
+
+    const fechado = await new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21aa']).analyze();
+    expect(gravesDe(fechado), JSON.stringify(gravesDe(fechado), null, 2)).toEqual([]);
+
+    await page.getByRole('button', { name: /5 de abril de 2026/ }).click();
+    await expect(page.getByRole('dialog', { name: '5 de abril de 2026' })).toBeVisible();
+
+    const aberto = await new AxeBuilder({ page }).withTags(['wcag2a', 'wcag2aa', 'wcag21aa']).analyze();
+    expect(gravesDe(aberto), JSON.stringify(gravesDe(aberto), null, 2)).toEqual([]);
+  });
+});
+
+function gravesDe(resultado: AxeResult) {
+  return resultado.violations.filter(
+    (violacao) => violacao.impact === 'serious' || violacao.impact === 'critical',
+  );
+}
+
+async function mockCalendarioApi(page: Page): Promise<void> {
+  await page.route(/\/api\/configuracao\/calendarios-dias-uteis\/[^/?]+$/, async (route, request) => {
+    if (request.method() === 'OPTIONS') {
+      await route.fulfill({ status: 204, headers: CORS_HEADERS });
+      return;
+    }
+    if (request.method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      headers: { ...CORS_HEADERS, 'content-type': 'application/json' },
+      body: JSON.stringify(CALENDARIO),
+    });
+  });
+}
+
+async function assertNoHorizontalOverflow(page: Page): Promise<void> {
+  const viewport = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+  }));
+  expect(viewport.scrollWidth).toBeLessThanOrEqual(viewport.clientWidth);
+}
+
+function metadataTheme(testInfo: TestInfo): VisualTheme {
+  const theme = testInfo.project.metadata['theme'];
+  return theme === 'dark' || theme === 'contrast' ? theme : 'light';
+}

--- a/apps/configuracao-e2e/src/specs/calendario-dias-uteis-mensal.visual.spec.ts
+++ b/apps/configuracao-e2e/src/specs/calendario-dias-uteis-mensal.visual.spec.ts
@@ -63,6 +63,19 @@ const CALENDARIO = {
       data: '2027-01-01',
       descricao: 'Confraternização Universal',
     },
+    {
+      id: '019ff7ee-3c00-7976-860c-eb2f61c9b305',
+      abrangencia: 'INSTITUCIONAL',
+      municipioIbge: null,
+      municipioNome: null,
+      municipioUf: null,
+      uf: null,
+      data: '2026-06-17',
+      // Token único sem espaço, até o limite de 200 caracteres aceito pelo
+      // formulário de criação — prova que a prévia quebra a linha em vez de
+      // vazar do max-width (CA-06/CA-12).
+      descricao: 'A'.repeat(180),
+    },
   ],
 } as const;
 
@@ -87,7 +100,12 @@ test.describe('Calendário de dias úteis — visualização mensal e drawer (#5
     await page.goto(`/calendario-dias-uteis/${CALENDARIO_ID}`);
 
     const titulos = page.locator('.cfg-calendario-mensal__titulo');
-    await expect(titulos).toHaveText(['Abril de 2026', 'Novembro de 2026', 'Janeiro de 2027']);
+    await expect(titulos).toHaveText([
+      'Abril de 2026',
+      'Junho de 2026',
+      'Novembro de 2026',
+      'Janeiro de 2027',
+    ]);
   });
 
   test('abre por clique, fecha pelo botão e restaura o foco no dia exato (CA-07/CA-08)', async ({ page }) => {
@@ -189,6 +207,23 @@ test.describe('Calendário de dias úteis — visualização mensal e drawer (#5
       body: await page.screenshot({ fullPage: true }),
       contentType: 'image/png',
     });
+  });
+
+  test('descrição longa sem espaços quebra linha na prévia em vez de vazar do max-width (CA-06/CA-12)', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 320, height: 720 });
+    await page.goto(`/calendario-dias-uteis/${CALENDARIO_ID}`);
+
+    const botaoDia = page.getByRole('button', { name: /17 de junho de 2026/ });
+    await botaoDia.focus();
+    const preview = page.locator('.cfg-calendario-mensal__preview');
+    await expect(preview).toBeVisible();
+
+    const caixa = await preview.boundingBox();
+    expect(caixa?.x ?? -1).toBeGreaterThanOrEqual(0);
+    expect((caixa?.x ?? 0) + (caixa?.width ?? 9999)).toBeLessThanOrEqual(320);
+    await assertNoHorizontalOverflow(page);
   });
 
   test('sem violações serious/critical, com o drawer fechado e aberto (CA-13)', async ({ page }) => {

--- a/apps/configuracao-e2e/src/specs/calendario-dias-uteis-mensal.visual.spec.ts
+++ b/apps/configuracao-e2e/src/specs/calendario-dias-uteis-mensal.visual.spec.ts
@@ -185,6 +185,45 @@ test.describe('Calendário de dias úteis — visualização mensal e drawer (#5
     await expect(page.getByRole('dialog')).toHaveCount(0);
   });
 
+  test('mouse sair do botão que continua focado não esconde a prévia (CA-06)', async ({ page }) => {
+    await page.goto(`/calendario-dias-uteis/${CALENDARIO_ID}`);
+
+    const botaoDia = page.getByRole('button', { name: /5 de abril de 2026/ });
+    const previewDoBotao = botaoDia.locator('.cfg-calendario-mensal__preview');
+
+    await botaoDia.focus();
+    await botaoDia.hover();
+    await expect(previewDoBotao).toBeVisible();
+
+    // Mouse sai do botão que continua com foco de teclado: sem o guard, o
+    // mouseleave incondicional esconderia a prévia mesmo com o foco ali, e
+    // só voltaria se o usuário tabulasse para longe e de volta.
+    await page.mouse.move(0, 0);
+    await expect(botaoDia).toBeFocused();
+    await expect(previewDoBotao).toBeVisible();
+
+    // Escape ainda dispensa normalmente, sem depender do guard.
+    await page.keyboard.press('Escape');
+    await expect(previewDoBotao).toBeHidden();
+  });
+
+  test('foco sair do botão que o mouse ainda ocupa não esconde a prévia (CA-06)', async ({ page }) => {
+    await page.goto(`/calendario-dias-uteis/${CALENDARIO_ID}`);
+
+    const botaoDia = page.getByRole('button', { name: /5 de abril de 2026/ });
+    const previewDoBotao = botaoDia.locator('.cfg-calendario-mensal__preview');
+
+    await botaoDia.hover();
+    await botaoDia.focus();
+    await expect(previewDoBotao).toBeVisible();
+
+    // Foco sai para um elemento sem handler de prévia própria, mas o mouse
+    // continua sobre o botão original: sem o guard, o blur incondicional
+    // esconderia a prévia mesmo com o cursor ali.
+    await page.getByRole('link', { name: 'Voltar à lista' }).focus();
+    await expect(previewDoBotao).toBeVisible();
+  });
+
   test('320 px sem rolagem horizontal, inclusive com a prévia aberta (CA-12)', async ({ page }, testInfo) => {
     await page.setViewportSize({ width: 320, height: 720 });
     await page.goto(`/calendario-dias-uteis/${CALENDARIO_ID}`);

--- a/apps/configuracao-e2e/src/specs/calendario-dias-uteis-mensal.visual.spec.ts
+++ b/apps/configuracao-e2e/src/specs/calendario-dias-uteis-mensal.visual.spec.ts
@@ -224,6 +224,12 @@ test.describe('Calendário de dias úteis — visualização mensal e drawer (#5
     expect(caixa?.x ?? -1).toBeGreaterThanOrEqual(0);
     expect((caixa?.x ?? 0) + (caixa?.width ?? 9999)).toBeLessThanOrEqual(320);
     await assertNoHorizontalOverflow(page);
+
+    // O título da ocorrência no drawer usa o mesmo texto sem espaço —
+    // precisa quebrar linha em vez de forçar rolagem horizontal do drawer.
+    await botaoDia.click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await assertNoHorizontalOverflow(page);
   });
 
   test('sem violações serious/critical, com o drawer fechado e aberto (CA-13)', async ({ page }) => {

--- a/apps/configuracao-e2e/src/specs/calendario-dias-uteis.visual.spec.ts
+++ b/apps/configuracao-e2e/src/specs/calendario-dias-uteis.visual.spec.ts
@@ -72,32 +72,44 @@ test.describe('Calendário de dias úteis — localidade no detalhe (#524)', () 
     await mockCalendarioApi(page);
   });
 
-  test('exibe a localidade legível sem consultar a Geo', async ({ page }, testInfo) => {
+  test('exibe a localidade legível no drawer sem consultar a Geo', async ({ page }, testInfo) => {
     const chamadasGeo = await rastrearChamadasGeo(page);
     await page.goto(`/calendario-dias-uteis/${CALENDARIO_ID}`);
 
     await expect(page.locator('html')).toHaveAttribute('data-theme', metadataTheme(testInfo));
     await expect(page.getByRole('heading', { name: 'Detalhes', level: 1 })).toBeVisible();
 
-    await expect(page.getByText('Marabá — PA', { exact: true })).toBeVisible();
-    await expect(page.getByText('Código IBGE: 1504208', { exact: true })).toBeVisible();
-    await expect(page.getByText('Pará — PA', { exact: true })).toBeVisible();
+    // Localidade é conteúdo do drawer (#525), não mais texto direto na página
+    // nem controle de formulário desabilitado.
+    await page.getByRole('button', { name: /5 de abril de 2026/ }).click();
+    const drawerMunicipal = page.getByRole('dialog', { name: '5 de abril de 2026' });
+    await expect(drawerMunicipal).toBeVisible();
+    await expect(drawerMunicipal.getByText('Marabá — PA', { exact: true })).toBeVisible();
+    await expect(drawerMunicipal.getByText('Código IBGE: 1504208', { exact: true })).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(drawerMunicipal).toBeHidden();
 
-    // Localidade é conteúdo, não controle desabilitado.
-    await expect(page.locator('output.field__readonly')).toHaveCount(2);
+    await page.getByRole('button', { name: /15 de agosto de 2026/ }).click();
+    const drawerEstadual = page.getByRole('dialog', { name: '15 de agosto de 2026' });
+    await expect(drawerEstadual).toBeVisible();
+    await expect(drawerEstadual.getByText('Pará — PA', { exact: true })).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(drawerEstadual).toBeHidden();
 
     expect(chamadasGeo).toEqual([]);
 
-    await assertNoHorizontalOverflow(page);
     await testInfo.attach(`${testInfo.project.name}-calendario-detalhe`, {
       body: await page.screenshot({ fullPage: true }),
       contentType: 'image/png',
     });
 
     // 320 px é o piso de largura exigido pelo e-MAG/WCAG para reflow.
+    // A ausência de rolagem horizontal em 320 px, com o drawer aberto, é
+    // coberta em calendario-dias-uteis-mensal.visual.spec.ts (#525) —
+    // aqui bastaria duplicar a asserção sem cobertura adicional.
     await page.setViewportSize({ width: 320, height: 720 });
-    await expect(page.getByText('Marabá — PA', { exact: true })).toBeVisible();
-    await assertNoHorizontalOverflow(page);
+    await page.getByRole('button', { name: /5 de abril de 2026/ }).click();
+    await expect(page.getByRole('dialog', { name: '5 de abril de 2026' })).toBeVisible();
     await testInfo.attach(`${testInfo.project.name}-calendario-detalhe-320`, {
       body: await page.screenshot({ fullPage: true }),
       contentType: 'image/png',
@@ -106,7 +118,7 @@ test.describe('Calendário de dias úteis — localidade no detalhe (#524)', () 
 
   test('detalhe não tem violações serious/critical', async ({ page }) => {
     await page.goto(`/calendario-dias-uteis/${CALENDARIO_ID}`);
-    await expect(page.getByText('Marabá — PA', { exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: /5 de abril de 2026/ })).toBeVisible();
 
     const resultado = await new AxeBuilder({ page })
       .withTags(['wcag2a', 'wcag2aa', 'wcag21aa'])
@@ -148,14 +160,6 @@ async function rastrearChamadasGeo(page: Page): Promise<string[]> {
     });
   });
   return chamadas;
-}
-
-async function assertNoHorizontalOverflow(page: Page): Promise<void> {
-  const viewport = await page.evaluate(() => ({
-    clientWidth: document.documentElement.clientWidth,
-    scrollWidth: document.documentElement.scrollWidth,
-  }));
-  expect(viewport.scrollWidth).toBeLessThanOrEqual(viewport.clientWidth);
 }
 
 function metadataTheme(testInfo: TestInfo): VisualTheme {

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.spec.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.spec.ts
@@ -6,7 +6,7 @@ import { ActivatedRoute, convertToParamMap, provideRouter } from '@angular/route
 import { apiResultInterceptor, mockProblemDetails } from '@uniplus/shared-core/http';
 import { CONFIGURACAO_BASE_PATH } from '@uniplus/shared-data/configuracao';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { of } from 'rxjs';
+import { Subject } from 'rxjs';
 
 import { CalendarioDiasUteisDetalhePage } from './calendario-dias-uteis-detalhe.page';
 
@@ -51,8 +51,10 @@ describe('CalendarioDiasUteisDetalhePage', () => {
   let fixture: ComponentFixture<CalendarioDiasUteisDetalhePage>;
   let controller: HttpTestingController;
   let appRef: ApplicationRef;
+  let routeParams$: Subject<{ id: string }>;
 
   beforeEach(() => {
+    routeParams$ = new Subject<{ id: string }>();
     TestBed.configureTestingModule({
       imports: [CalendarioDiasUteisDetalhePage],
       providers: [
@@ -64,7 +66,7 @@ describe('CalendarioDiasUteisDetalhePage', () => {
           provide: ActivatedRoute,
           useValue: {
             snapshot: { paramMap: convertToParamMap({ id: CALENDARIO_ID }) },
-            params: of({ id: CALENDARIO_ID }),
+            params: routeParams$,
           },
         },
       ],
@@ -261,5 +263,33 @@ describe('CalendarioDiasUteisDetalhePage', () => {
     const texto = fixture.nativeElement.querySelector('dialog')?.textContent as string;
     expect(texto).toContain('Estadual');
     expect(texto).not.toContain('ESTADUAL');
+  });
+
+  it('reseta o drawer ao trocar de rota :id sem passar pela lista (reaproveitamento de componente pelo Router)', async () => {
+    await carregar([DIA_MUNICIPAL]);
+
+    botaoDoDia(DIA_MUNICIPAL.data).click();
+    fixture.detectChanges();
+    expect(fixture.componentInstance.drawerVisivel()).toBe(true);
+
+    const OUTRO_ID = '019f41cf-69fd-759a-ac6d-09acabc1b999';
+    routeParams$.next({ id: OUTRO_ID });
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.drawerVisivel()).toBe(false);
+    expect(fixture.componentInstance.diaSelecionado()).toBeNull();
+
+    controller.expectOne(`${BASE}/api/configuracao/calendarios-dias-uteis/${OUTRO_ID}`).flush({
+      id: OUTRO_ID,
+      versaoDataset: '2027.1',
+      vigente: false,
+      criadoEm: '2026-08-13T00:00:00Z',
+      diasNaoUteis: [DIA_ESTADUAL],
+    });
+    await propagate();
+
+    // O drawer não reabre sozinho com o dia do calendário anterior.
+    expect(fixture.componentInstance.drawerVisivel()).toBe(false);
+    expect(fixture.nativeElement.querySelector('dialog[open]')).toBeNull();
   });
 });

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.spec.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.spec.ts
@@ -268,9 +268,12 @@ describe('CalendarioDiasUteisDetalhePage', () => {
   it('reseta o drawer ao trocar de rota :id sem passar pela lista (reaproveitamento de componente pelo Router)', async () => {
     await carregar([DIA_MUNICIPAL]);
 
-    botaoDoDia(DIA_MUNICIPAL.data).click();
+    const botao = botaoDoDia(DIA_MUNICIPAL.data);
+    botao.click();
+    fixture.componentInstance.mostrarPreview(DIA_MUNICIPAL.data);
     fixture.detectChanges();
     expect(fixture.componentInstance.drawerVisivel()).toBe(true);
+    expect(fixture.componentInstance.diaEmPreview()).toBe(DIA_MUNICIPAL.data);
 
     const OUTRO_ID = '019f41cf-69fd-759a-ac6d-09acabc1b999';
     routeParams$.next({ id: OUTRO_ID });
@@ -278,6 +281,7 @@ describe('CalendarioDiasUteisDetalhePage', () => {
 
     expect(fixture.componentInstance.drawerVisivel()).toBe(false);
     expect(fixture.componentInstance.diaSelecionado()).toBeNull();
+    expect(fixture.componentInstance.diaEmPreview()).toBeNull();
 
     controller.expectOne(`${BASE}/api/configuracao/calendarios-dias-uteis/${OUTRO_ID}`).flush({
       id: OUTRO_ID,

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.spec.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.spec.ts
@@ -36,6 +36,17 @@ const DIA_ESTADUAL = {
   descricao: 'Adesão do Grão-Pará à Independência',
 };
 
+const DIA_NACIONAL_JANEIRO = {
+  id: '019f41cf-69fd-759a-ac6d-09acabc1b102',
+  abrangencia: 'NACIONAL',
+  municipioIbge: null,
+  municipioNome: null,
+  municipioUf: null,
+  uf: null,
+  data: '2027-01-01',
+  descricao: 'Confraternização Universal',
+};
+
 describe('CalendarioDiasUteisDetalhePage', () => {
   let fixture: ComponentFixture<CalendarioDiasUteisDetalhePage>;
   let controller: HttpTestingController;
@@ -74,15 +85,23 @@ describe('CalendarioDiasUteisDetalhePage', () => {
     appRef.tick();
   };
 
-  const carregar = async (diasNaoUteis: readonly unknown[]): Promise<void> => {
+  const carregar = async (diasNaoUteis: readonly unknown[], vigente = false): Promise<void> => {
     controller.expectOne(URL).flush({
       id: CALENDARIO_ID,
       versaoDataset: '2026.1',
-      vigente: false,
+      vigente,
       criadoEm: '2026-08-13T00:00:00Z',
       diasNaoUteis,
     });
     await propagate();
+  };
+
+  const botaoDoDia = (data: string): HTMLButtonElement => {
+    const botao = (fixture.nativeElement as HTMLElement).querySelector(
+      `button[aria-label*="${data.split('-')[2].replace(/^0/, '')} de "]`,
+    );
+    if (!botao) throw new Error(`Nenhum botão de dia encontrado para ${data}`);
+    return botao as HTMLButtonElement;
   };
 
   it('exibe erro de carregamento e permite tentar novamente', async () => {
@@ -96,7 +115,7 @@ describe('CalendarioDiasUteisDetalhePage', () => {
     await propagate();
 
     expect(fixture.nativeElement.textContent).toContain('Calendário não encontrado');
-    expect(fixture.nativeElement.querySelector('section.form-section')).toBeNull();
+    expect(fixture.nativeElement.querySelector('.cfg-calendario-resumo')).toBeNull();
 
     const retry = fixture.nativeElement.querySelector(
       '.cfg-calendario-dias-uteis__retry button',
@@ -106,13 +125,84 @@ describe('CalendarioDiasUteisDetalhePage', () => {
 
     await carregar([]);
 
-    expect((fixture.nativeElement.querySelector('input') as HTMLInputElement).value).toBe('2026.1');
+    expect(fixture.nativeElement.textContent).toContain('2026.1');
+  });
+
+  it('não renderiza controles de formulário para o dataset (CA-01)', async () => {
+    await carregar([DIA_MUNICIPAL, DIA_ESTADUAL]);
+
+    const raiz = fixture.nativeElement as HTMLElement;
+    expect(raiz.querySelectorAll('input')).toHaveLength(0);
+    expect(raiz.querySelectorAll('select')).toHaveLength(0);
+    expect(raiz.querySelectorAll('textarea')).toHaveLength(0);
+  });
+
+  it('apresenta versão, situação de vigência e total de dias não úteis no resumo (CA-02)', async () => {
+    await carregar([DIA_MUNICIPAL, DIA_ESTADUAL], true);
+
+    const texto = fixture.nativeElement.textContent as string;
+    expect(texto).toContain('2026.1');
+    expect(texto).toContain('Vigente');
+  });
+
+  it('conta datas civis únicas no resumo, não ocorrências (CA-02)', async () => {
+    const segunda_ocorrencia_mesmo_dia = { ...DIA_MUNICIPAL, id: 'outro-id', abrangencia: 'INSTITUCIONAL' };
+    await carregar([DIA_MUNICIPAL, segunda_ocorrencia_mesmo_dia, DIA_ESTADUAL]);
+
+    const resumo = fixture.nativeElement.querySelector('.cfg-calendario-resumo') as HTMLElement;
+    expect(resumo.textContent).toContain('2');
+    expect(resumo.textContent).not.toContain('3');
+  });
+
+  it('exibe só os meses com feriado, em ordem cronológica, mesmo atravessando anos (CA-03)', async () => {
+    await carregar([DIA_ESTADUAL, DIA_NACIONAL_JANEIRO]);
+
+    const titulos = [...fixture.nativeElement.querySelectorAll('.cfg-calendario-mensal__titulo')].map(
+      (elemento: Element) => elemento.textContent?.trim(),
+    );
+    expect(titulos).toEqual(['Agosto de 2026', 'Janeiro de 2027']);
+  });
+
+  it('abre o drawer com heading e conteúdo do dia ao ativar o botão (CA-07)', async () => {
+    await carregar([DIA_MUNICIPAL]);
+
+    botaoDoDia(DIA_MUNICIPAL.data).click();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.drawerVisivel()).toBe(true);
+    const dialogo = fixture.nativeElement.querySelector('dialog') as HTMLElement;
+    expect(dialogo.getAttribute('aria-label')).toBe('5 de abril de 2026');
+    expect(dialogo.textContent).toContain('Aniversário de Marabá');
+  });
+
+  it('lista todas as ocorrências quando há mais de um feriado na mesma data (CA-09)', async () => {
+    const segunda_ocorrencia = {
+      ...DIA_MUNICIPAL,
+      id: 'segunda-ocorrencia',
+      abrangencia: 'INSTITUCIONAL',
+      descricao: 'Aniversário da Unifesspa',
+    };
+    await carregar([DIA_MUNICIPAL, segunda_ocorrencia]);
+
+    const botao = botaoDoDia(DIA_MUNICIPAL.data);
+    expect(botao.textContent).toContain('×2');
+
+    botao.click();
+    fixture.detectChanges();
+
+    const dialogo = fixture.nativeElement.querySelector('dialog') as HTMLElement;
+    expect(dialogo.querySelectorAll('.cfg-calendario-mensal__ocorrencia')).toHaveLength(2);
+    expect(dialogo.textContent).toContain('Aniversário de Marabá');
+    expect(dialogo.textContent).toContain('Aniversário da Unifesspa');
   });
 
   it('apresenta o município pelo snapshot persistido, com o código IBGE como apoio', async () => {
     await carregar([DIA_MUNICIPAL]);
 
-    const texto = fixture.nativeElement.textContent as string;
+    botaoDoDia(DIA_MUNICIPAL.data).click();
+    fixture.detectChanges();
+
+    const texto = fixture.nativeElement.querySelector('dialog')?.textContent as string;
     expect(texto).toContain('Marabá — PA');
     expect(texto).toContain('Código IBGE: 1504208');
     // Nenhuma requisição à Geo: `controller.verify()` no afterEach falharia.
@@ -122,7 +212,10 @@ describe('CalendarioDiasUteisDetalhePage', () => {
   it('não escreve "null" quando o dia municipal é anterior ao snapshot', async () => {
     await carregar([{ ...DIA_MUNICIPAL, municipioNome: null, municipioUf: null }]);
 
-    const texto = fixture.nativeElement.textContent as string;
+    botaoDoDia(DIA_MUNICIPAL.data).click();
+    fixture.detectChanges();
+
+    const texto = fixture.nativeElement.querySelector('dialog')?.textContent as string;
     expect(texto).not.toContain('null');
     expect(texto).toContain('Código IBGE: 1504208');
   });
@@ -130,14 +223,43 @@ describe('CalendarioDiasUteisDetalhePage', () => {
   it('apresenta a abrangência estadual com a UF por extenso', async () => {
     await carregar([DIA_ESTADUAL]);
 
-    expect(fixture.nativeElement.textContent).toContain('Pará — PA');
+    botaoDoDia(DIA_ESTADUAL.data).click();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('dialog')?.textContent).toContain('Pará — PA');
   });
 
-  it('não usa controles de formulário para exibir a localidade', async () => {
-    await carregar([DIA_MUNICIPAL, DIA_ESTADUAL]);
+  it('fecha a prévia junto com o drawer, evitando que a restauração de foco a reabra (CA-06/CA-08)', async () => {
+    await carregar([DIA_MUNICIPAL]);
 
-    const saidas = fixture.nativeElement.querySelectorAll('output.field__readonly');
-    expect(saidas).toHaveLength(2);
-    expect(fixture.nativeElement.querySelectorAll('input[type="text"]')).toHaveLength(1);
+    const botao = botaoDoDia(DIA_MUNICIPAL.data);
+    botao.click();
+    fixture.detectChanges();
+    expect(fixture.componentInstance.drawerVisivel()).toBe(true);
+
+    // O clique também foca o botão (evento nativo do navegador), então a
+    // prévia liga junto com a abertura — não é o cenário deste teste.
+    fixture.componentInstance.mostrarPreview(DIA_MUNICIPAL.data);
+    fixture.detectChanges();
+    expect(fixture.componentInstance.diaEmPreview()).toBe(DIA_MUNICIPAL.data);
+
+    const botaoFechar = fixture.nativeElement.querySelector(
+      '.uni-drawer__header button',
+    ) as HTMLButtonElement;
+    botaoFechar.click();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.diaEmPreview()).toBeNull();
+  });
+
+  it('não expõe abrangência como token técnico cru (CA-10)', async () => {
+    await carregar([DIA_ESTADUAL]);
+
+    botaoDoDia(DIA_ESTADUAL.data).click();
+    fixture.detectChanges();
+
+    const texto = fixture.nativeElement.querySelector('dialog')?.textContent as string;
+    expect(texto).toContain('Estadual');
+    expect(texto).not.toContain('ESTADUAL');
   });
 });

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.ts
@@ -1,28 +1,34 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  DestroyRef,
-  inject,
-  signal,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, signal } from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
-import { ReactiveFormsModule } from '@angular/forms';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { ProblemI18nService, useApiResource, withVendorMime } from '@uniplus/shared-core/http';
+import { formatIsoDateBr, formatIsoDateLong } from '@uniplus/shared-data/utils';
 import {
+  ABRANGENCIAS,
   CalendarioDiasUteisDto,
   CONFIGURACAO_BASE_PATH,
   DiaNaoUtilDto,
   UNIDADES_FEDERATIVAS,
 } from '@uniplus/shared-data/configuracao';
-import { AlertComponent, SpinnerComponent } from '@uniplus/shared-ui/components';
+import { AlertComponent, DrawerComponent, SpinnerComponent, TagComponent } from '@uniplus/shared-ui/components';
 import { tap } from 'rxjs';
+
+import { agruparPorMes, contarDiasNaoUteisUnicos, type CelulaCalendarioMensal } from './calendario-mensal.util';
+
+const DIAS_SEMANA = [
+  { abrev: 'Dom', nome: 'Domingo' },
+  { abrev: 'Seg', nome: 'Segunda-feira' },
+  { abrev: 'Ter', nome: 'Terça-feira' },
+  { abrev: 'Qua', nome: 'Quarta-feira' },
+  { abrev: 'Qui', nome: 'Quinta-feira' },
+  { abrev: 'Sex', nome: 'Sexta-feira' },
+  { abrev: 'Sáb', nome: 'Sábado' },
+] as const;
 
 @Component({
   selector: 'cfg-calendario-dias-uteis-detalhe',
-  imports: [RouterLink, ReactiveFormsModule, AlertComponent, SpinnerComponent],
+  imports: [RouterLink, AlertComponent, SpinnerComponent, DrawerComponent, TagComponent],
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
@@ -47,81 +53,315 @@ import { tap } from 'rxjs';
         </div>
       </ui-alert>
     } @else if (calendario(); as calendarioAtual) {
-      <section class="form-section" aria-labelledby="cfg-calendario-identificacao">
-        <h2 id="cfg-calendario-identificacao" class="form-section__title">Identificação</h2>
-        <div class="form-grid">
-          <label class="field field--full">
-            <span class="field__label is-required">Versão do dataset</span>
-            <input
-              type="text"
-              autocapitalize="characters"
-              class="input ng-untouched ng-pristine ng-invalid"
-              [value]="calendarioAtual.versaoDataset"
-              [disabled]="true"
-            />
-          </label>
+      <dl class="cfg-calendario-resumo">
+        <div class="cfg-calendario-resumo__item">
+          <dt>Versão do dataset</dt>
+          <dd>{{ calendarioAtual.versaoDataset }}</dd>
         </div>
-      </section>
+        <div class="cfg-calendario-resumo__item">
+          <dt>Situação</dt>
+          <dd>
+            @if (calendarioAtual.vigente) {
+              <ui-tag variant="success">Vigente</ui-tag>
+            } @else {
+              <ui-tag>Não vigente</ui-tag>
+            }
+          </dd>
+        </div>
+        <div class="cfg-calendario-resumo__item">
+          <dt>Dias não úteis</dt>
+          <dd>{{ totalDiasNaoUteis() }}</dd>
+        </div>
+      </dl>
 
-      <section class="form-section" aria-labelledby="cfg-calendario-dias-nao-uteis">
-        <div class="examples-container">
-          <h2 id="cfg-calendario-dias-nao-uteis" class="form-section__title">Dias não úteis</h2>
-        </div>
-        <ng-container>
-          @for (
-            diaNaoUtil of calendarioAtual.diasNaoUteis;
-            track diaNaoUtil.id;
-            let index = $index
-          ) {
-            <div
-              class="dias-nao-util-form-grid"
-              [class.dias-nao-util-form-grid--4col]="
-                diaNaoUtil.abrangencia === 'MUNICIPAL' || diaNaoUtil.abrangencia === 'ESTADUAL'
-              "
-              role="group"
-              [attr.aria-labelledby]="'cfg-detalhe-dia-nao-util-' + index"
-            >
-              <h3 [id]="'cfg-detalhe-dia-nao-util-' + index" class="sr-only">
-                Dia não útil {{ index + 1 }}
-              </h3>
-              <label class="field" [attr.for]="'detalhe-abrangencia-' + index">
-                <span class="field__label is-required">Abrangência</span>
-                <select [id]="'detalhe-abrangencia-' + index" class="select" [disabled]="true">
-                  <option>
-                    {{ diaNaoUtil.abrangencia }}
-                  </option>
-                </select>
-              </label>
-              @if (diaNaoUtil.abrangencia === 'MUNICIPAL') {
-                <div class="field">
-                  <span class="field__label">Município</span>
-                  <output class="field__readonly" aria-label="Município do dia não útil">{{
-                    municipioLegivel(diaNaoUtil)
-                  }}</output>
-                  <span class="field__hint">Código IBGE: {{ diaNaoUtil.municipioIbge }}</span>
+      <div class="cfg-calendario-mensal__lista">
+        @for (mes of meses(); track mes.chave) {
+          <section class="cfg-calendario-mensal" [attr.aria-labelledby]="'cfg-mes-titulo-' + mes.chave">
+            <h2 [id]="'cfg-mes-titulo-' + mes.chave" class="cfg-calendario-mensal__titulo">
+              {{ mes.rotulo }}
+            </h2>
+            <table class="cfg-calendario-mensal__tabela">
+              <caption class="sr-only">Calendário de {{ mes.rotulo }}</caption>
+              <thead>
+                <tr>
+                  @for (diaSemana of diasSemana; track diaSemana.abrev) {
+                    <th scope="col">
+                      <span aria-hidden="true">{{ diaSemana.abrev }}</span>
+                      <span class="sr-only">{{ diaSemana.nome }}</span>
+                    </th>
+                  }
+                </tr>
+              </thead>
+              <tbody>
+                @for (semana of mes.semanas; track $index) {
+                  <tr>
+                    @for (celula of semana; track $index) {
+                      <td>
+                        @if (celula) {
+                          @if (celula.ocorrencias.length > 0) {
+                            <button
+                              type="button"
+                              class="cfg-calendario-mensal__dia cfg-calendario-mensal__dia--feriado"
+                              [attr.aria-label]="ariaLabelDia(celula)"
+                              (click)="abrirDrawer(celula)"
+                              (mouseenter)="mostrarPreview(celula.data)"
+                              (mouseleave)="ocultarPreview()"
+                              (focus)="mostrarPreview(celula.data)"
+                              (blur)="ocultarPreview()"
+                              (keydown.escape)="ocultarPreview()"
+                            >
+                              <span aria-hidden="true">{{ celula.dia }}</span>
+                              <span class="cfg-calendario-mensal__marcador" aria-hidden="true"></span>
+                              @if (celula.ocorrencias.length > 1) {
+                                <span class="cfg-calendario-mensal__contador" aria-hidden="true">
+                                  ×{{ celula.ocorrencias.length }}
+                                </span>
+                              }
+                              @if (diaEmPreview() === celula.data) {
+                                <span class="cfg-calendario-mensal__preview" aria-hidden="true">
+                                  {{ previewTexto(celula) }}
+                                </span>
+                              }
+                            </button>
+                          } @else {
+                            <span class="cfg-calendario-mensal__dia">{{ celula.dia }}</span>
+                          }
+                        }
+                      </td>
+                    }
+                  </tr>
+                }
+              </tbody>
+            </table>
+          </section>
+        }
+      </div>
+
+      <ui-drawer
+        [(visible)]="drawerVisivel"
+        [heading]="tituloDrawer()"
+        [ariaLabel]="tituloDrawer()"
+        (closed)="ocultarPreview()"
+      >
+        @for (ocorrencia of ocorrenciasSelecionadas(); track ocorrencia.id) {
+          <article class="cfg-calendario-mensal__ocorrencia">
+            <h3>{{ ocorrencia.descricao }}</h3>
+            <dl>
+              <div>
+                <dt>Abrangência</dt>
+                <dd>{{ abrangenciaLegivel(ocorrencia.abrangencia) }}</dd>
+              </div>
+              <div>
+                <dt>Data</dt>
+                <dd>{{ formatarDataCurta(ocorrencia.data) }}</dd>
+              </div>
+              @if (ocorrencia.abrangencia === 'MUNICIPAL') {
+                <div>
+                  <dt>Município</dt>
+                  <dd>
+                    <span>{{ municipioLegivel(ocorrencia) }}</span>
+                    <span class="field__hint">Código IBGE: {{ ocorrencia.municipioIbge }}</span>
+                  </dd>
                 </div>
               }
-              @if (diaNaoUtil.abrangencia === 'ESTADUAL') {
-                <div class="field">
-                  <span class="field__label">Unidade Federativa (UF)</span>
-                  <output class="field__readonly" aria-label="Unidade federativa do dia não útil">{{
-                    ufLegivel(diaNaoUtil.uf)
-                  }}</output>
+              @if (ocorrencia.abrangencia === 'ESTADUAL') {
+                <div>
+                  <dt>Unidade Federativa (UF)</dt>
+                  <dd>{{ ufLegivel(ocorrencia.uf) }}</dd>
                 </div>
               }
-              <label class="field">
-                <span class="field__label">Data</span>
-                <input class="input" type="date" [value]="diaNaoUtil.data" [disabled]="true" />
-              </label>
-              <label class="field">
-                <span class="field__label is-required">Descrição</span>
-                <textarea class="textarea" [disabled]="true" [value]="diaNaoUtil.descricao">
-                </textarea>
-              </label>
-            </div>
-          }
-        </ng-container>
-      </section>
+            </dl>
+          </article>
+        }
+      </ui-drawer>
+    }
+  `,
+  styles: `
+    .cfg-calendario-resumo {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-6);
+      margin: 0 0 var(--space-6);
+      padding: var(--space-4) var(--space-5);
+      background: var(--surface-card);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-lg);
+    }
+
+    .cfg-calendario-resumo__item {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-1);
+    }
+
+    .cfg-calendario-resumo__item dt {
+      font-size: var(--text-xs);
+      color: var(--text-muted);
+    }
+
+    .cfg-calendario-resumo__item dd {
+      margin: 0;
+      font-size: var(--text-base);
+      font-weight: var(--weight-bold);
+      color: var(--text-heading);
+    }
+
+    .cfg-calendario-mensal__lista {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(min(20rem, 100%), 1fr));
+      gap: var(--space-6);
+      align-items: start;
+    }
+
+    .cfg-calendario-mensal {
+      background: var(--surface-card);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-lg);
+      padding: var(--space-4);
+    }
+
+    .cfg-calendario-mensal__titulo {
+      margin: 0 0 var(--space-3);
+      font-size: var(--text-base);
+      font-weight: var(--weight-bold);
+      color: var(--text-heading);
+    }
+
+    .cfg-calendario-mensal__tabela {
+      width: 100%;
+      border-collapse: collapse;
+      table-layout: fixed;
+    }
+
+    .cfg-calendario-mensal__tabela th {
+      padding: var(--space-1) 0;
+      font-size: var(--text-xs);
+      font-weight: var(--weight-medium);
+      color: var(--text-muted);
+    }
+
+    .cfg-calendario-mensal__tabela td {
+      padding: 2px 0;
+      text-align: center;
+    }
+
+    .cfg-calendario-mensal__dia {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 2.25rem;
+      height: 2.25rem;
+      margin: 0 auto;
+      font-size: var(--text-sm);
+      color: var(--text-secondary);
+    }
+
+    button.cfg-calendario-mensal__dia {
+      position: relative;
+      border: 1px solid transparent;
+      border-radius: var(--radius-md);
+      background: none;
+      cursor: pointer;
+      font: inherit;
+    }
+
+    button.cfg-calendario-mensal__dia--feriado {
+      color: var(--color-primary);
+      font-weight: var(--weight-bold);
+      background: var(--color-primary-100);
+    }
+
+    .cfg-calendario-mensal__dia--feriado:hover {
+      background: var(--color-primary-200);
+    }
+
+    .cfg-calendario-mensal__dia--feriado:focus-visible {
+      outline: var(--focus-ring-width) solid var(--focus-ring-color);
+      outline-offset: var(--focus-ring-offset);
+    }
+
+    .cfg-calendario-mensal__marcador {
+      position: absolute;
+      bottom: 3px;
+      width: 4px;
+      height: 4px;
+      border-radius: var(--radius-circle);
+      background: currentColor;
+    }
+
+    .cfg-calendario-mensal__contador {
+      position: absolute;
+      top: -4px;
+      right: -4px;
+      padding: 1px 3px;
+      font-size: 0.625rem;
+      line-height: 1;
+      font-weight: var(--weight-bold);
+      border-radius: var(--radius-pill);
+      background: var(--color-primary);
+      color: var(--text-on-primary);
+    }
+
+    .cfg-calendario-mensal__preview {
+      position: absolute;
+      bottom: calc(100% + var(--space-2));
+      left: 50%;
+      transform: translateX(-50%);
+      width: max-content;
+      max-width: min(80vw, 12rem);
+      padding: var(--space-2) var(--space-3);
+      background: var(--surface-inverse);
+      color: var(--text-on-inverse);
+      font-size: var(--text-xs);
+      font-weight: var(--weight-regular);
+      white-space: normal;
+      border-radius: var(--radius-md);
+      z-index: 10;
+    }
+
+    /*
+     * Domingo/segunda (colunas 1-2): centralizar estouraria a borda esquerda
+     * da viewport em telas estreitas. Sexta/sábado (colunas 6-7): o mesmo à
+     * direita. Só as colunas centrais mantêm a prévia centralizada no dia.
+     */
+    .cfg-calendario-mensal__tabela td:nth-child(-n + 2) .cfg-calendario-mensal__preview {
+      left: 0;
+      transform: none;
+    }
+
+    .cfg-calendario-mensal__tabela td:nth-child(n + 6) .cfg-calendario-mensal__preview {
+      left: auto;
+      right: 0;
+      transform: none;
+    }
+
+    .cfg-calendario-mensal__ocorrencia + .cfg-calendario-mensal__ocorrencia {
+      margin-top: var(--space-5);
+      padding-top: var(--space-5);
+      border-top: 1px solid var(--border-subtle);
+    }
+
+    .cfg-calendario-mensal__ocorrencia h3 {
+      margin: 0 0 var(--space-2);
+      font-size: var(--text-base);
+      color: var(--text-heading);
+    }
+
+    .cfg-calendario-mensal__ocorrencia dl {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-2);
+      margin: 0;
+    }
+
+    .cfg-calendario-mensal__ocorrencia dt {
+      font-size: var(--text-xs);
+      color: var(--text-muted);
+    }
+
+    .cfg-calendario-mensal__ocorrencia dd {
+      margin: 0;
+      color: var(--text-secondary);
     }
   `,
   host: { class: 'cfg-page' },
@@ -132,6 +372,7 @@ export class CalendarioDiasUteisDetalhePage {
   private readonly destroyRef = inject(DestroyRef);
   private readonly basePath = inject(CONFIGURACAO_BASE_PATH);
   protected readonly calendarioDiaUtilId = signal(this.route.snapshot.paramMap.get('id') ?? '');
+  protected readonly diasSemana = DIAS_SEMANA;
 
   protected readonly calendarioResource = useApiResource<CalendarioDiasUteisDto>(() => ({
     url: `${this.basePath}/api/configuracao/calendarios-dias-uteis/${this.calendarioDiaUtilId()}`,
@@ -159,10 +400,65 @@ export class CalendarioDiasUteisDetalhePage {
     return this.calendarioResource.error() ? 'Erro inesperado ao carregar o calendário.' : null;
   });
 
+  protected readonly meses = computed(() => agruparPorMes(this.calendario()?.diasNaoUteis ?? []));
+  protected readonly totalDiasNaoUteis = computed(() => contarDiasNaoUteisUnicos(this.meses()));
+
+  protected readonly diaEmPreview = signal<string | null>(null);
+  protected readonly drawerVisivel = signal(false);
+  protected readonly diaSelecionado = signal<CelulaCalendarioMensal | null>(null);
+
+  protected readonly ocorrenciasSelecionadas = computed(() => this.diaSelecionado()?.ocorrencias ?? []);
+  protected readonly tituloDrawer = computed(() => {
+    const celula = this.diaSelecionado();
+    return celula ? formatIsoDateLong(celula.data) : '';
+  });
+
   protected tentarNovamente(): void {
     if (!this.calendarioResource.isLoading()) {
       this.calendarioResource.reload();
     }
+  }
+
+  protected mostrarPreview(data: string): void {
+    this.diaEmPreview.set(data);
+  }
+
+  protected ocultarPreview(): void {
+    this.diaEmPreview.set(null);
+  }
+
+  protected abrirDrawer(celula: CelulaCalendarioMensal): void {
+    this.diaSelecionado.set(celula);
+    this.drawerVisivel.set(true);
+  }
+
+  /** Nome acessível do dia — cobre a mesma informação da prévia visual (CA-06), sem depender de hover. */
+  protected ariaLabelDia(celula: CelulaCalendarioMensal): string {
+    const dataPorExtenso = formatIsoDateLong(celula.data);
+    if (celula.ocorrencias.length === 1) {
+      const [ocorrencia] = celula.ocorrencias;
+      return `${dataPorExtenso}: ${ocorrencia.descricao} (${this.abrangenciaLegivel(ocorrencia.abrangencia)})`;
+    }
+    const resumo = celula.ocorrencias
+      .map((ocorrencia) => `${ocorrencia.descricao} (${this.abrangenciaLegivel(ocorrencia.abrangencia)})`)
+      .join(', ');
+    return `${dataPorExtenso}: ${celula.ocorrencias.length} ocorrências — ${resumo}`;
+  }
+
+  protected previewTexto(celula: CelulaCalendarioMensal): string {
+    if (celula.ocorrencias.length === 1) {
+      const [ocorrencia] = celula.ocorrencias;
+      return `${ocorrencia.descricao} — ${this.abrangenciaLegivel(ocorrencia.abrangencia)}`;
+    }
+    return `${celula.ocorrencias.length} ocorrências nesta data`;
+  }
+
+  protected abrangenciaLegivel(abrangencia: string): string {
+    return ABRANGENCIAS.find((candidata) => candidata.value === abrangencia)?.label ?? abrangencia;
+  }
+
+  protected formatarDataCurta(data: string): string {
+    return formatIsoDateBr(data);
   }
 
   /**

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.ts
@@ -386,7 +386,15 @@ export class CalendarioDiasUteisDetalhePage {
   constructor() {
     this.route.params
       .pipe(
-        tap((params) => this.calendarioDiaUtilId.set(params['id'] ?? '')),
+        tap((params) => {
+          this.calendarioDiaUtilId.set(params['id'] ?? '');
+          // O Angular Router reaproveita esta instância ao navegar entre duas
+          // rotas :id sem passar pela lista — sem isto, o drawer reabriria
+          // sozinho com o dia selecionado do calendário anterior assim que o
+          // novo carregasse.
+          this.drawerVisivel.set(false);
+          this.diaSelecionado.set(null);
+        }),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.ts
@@ -275,8 +275,15 @@ const DIAS_SEMANA = [
       background: var(--color-primary-100);
     }
 
+    /* Não usar --color-primary-200 aqui: no tema contraste ela colapsa para o
+       mesmo #ffff00 de --color-primary (texto do botão), texto some sobre o
+       próprio fundo no hover. --color-primary-50 + --text-on-primary-tint é o
+       par semântico do DS para fundo tintado + texto legível, já
+       contrast-safe nos três temas (mesmo par usado em .uni-drawer__nav
+       a.is-active). */
     .cfg-calendario-mensal__dia--feriado:hover {
-      background: var(--color-primary-200);
+      background: var(--color-primary-50);
+      color: var(--text-on-primary-tint);
     }
 
     .cfg-calendario-mensal__dia--feriado:focus-visible {

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.ts
@@ -212,7 +212,9 @@ const DIAS_SEMANA = [
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(min(20rem, 100%), 1fr));
       gap: var(--space-6);
-      align-items: start;
+      /* stretch (padrão do grid) em vez de start: meses com menos semanas
+         esticam para a altura do mais alto da mesma linha, alinhando as
+         bordas inferiores dos cards em vez de deixá-las escalonadas. */
     }
 
     .cfg-calendario-mensal {

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.ts
@@ -338,6 +338,14 @@ const DIAS_SEMANA = [
       transform: none;
     }
 
+    /* .uni-drawer__body (DS compartilhado) só tem padding vertical — foi
+       desenhado para .uni-drawer__nav a, que traz o próprio padding
+       horizontal. Conteúdo genérico projetado aqui precisa da margem lateral
+       explicitamente, ou cola nas bordas do painel. */
+    .cfg-calendario-mensal__ocorrencia {
+      padding: 0 var(--space-5);
+    }
+
     .cfg-calendario-mensal__ocorrencia + .cfg-calendario-mensal__ocorrencia {
       margin-top: var(--space-5);
       padding-top: var(--space-5);
@@ -366,6 +374,13 @@ const DIAS_SEMANA = [
     .cfg-calendario-mensal__ocorrencia dd {
       margin: 0;
       color: var(--text-secondary);
+    }
+
+    /* Angular remove o espaço em branco insignificante entre os dois <span>
+       do template (preserveWhitespaces: false) — sem isto, o hint de
+       Código IBGE cola visualmente no nome do município. */
+    .cfg-calendario-mensal__ocorrencia dd .field__hint {
+      margin-left: var(--space-1);
     }
   `,
   host: { class: 'cfg-page' },

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.ts
@@ -192,6 +192,7 @@ const DIAS_SEMANA = [
       display: flex;
       flex-direction: column;
       gap: var(--space-1);
+      min-width: 0;
     }
 
     .cfg-calendario-resumo__item dt {
@@ -204,6 +205,7 @@ const DIAS_SEMANA = [
       font-size: var(--text-base);
       font-weight: var(--weight-bold);
       color: var(--text-heading);
+      overflow-wrap: anywhere;
     }
 
     .cfg-calendario-mensal__lista {

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.ts
@@ -315,6 +315,7 @@ const DIAS_SEMANA = [
       font-size: var(--text-xs);
       font-weight: var(--weight-regular);
       white-space: normal;
+      overflow-wrap: anywhere;
       border-radius: var(--radius-md);
       z-index: 10;
     }

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.ts
@@ -346,6 +346,7 @@ const DIAS_SEMANA = [
       margin: 0 0 var(--space-2);
       font-size: var(--text-base);
       color: var(--text-heading);
+      overflow-wrap: anywhere;
     }
 
     .cfg-calendario-mensal__ocorrencia dl {

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.ts
@@ -105,9 +105,9 @@ const DIAS_SEMANA = [
                               [attr.aria-label]="ariaLabelDia(celula)"
                               (click)="abrirDrawer(celula)"
                               (mouseenter)="mostrarPreview(celula.data)"
-                              (mouseleave)="ocultarPreview()"
+                              (mouseleave)="ocultarPreviewSeSemFoco($event)"
                               (focus)="mostrarPreview(celula.data)"
-                              (blur)="ocultarPreview()"
+                              (blur)="ocultarPreviewSeSemHover($event)"
                               (keydown.escape)="ocultarPreview()"
                             >
                               <span aria-hidden="true">{{ celula.dia }}</span>
@@ -465,6 +465,22 @@ export class CalendarioDiasUteisDetalhePage {
 
   protected ocultarPreview(): void {
     this.diaEmPreview.set(null);
+  }
+
+  // Mouse sai do botão que segue com foco de teclado (cursor pousado nele
+  // ao tabular, ou o usuário usa mouse e teclado juntos): sem este guard, a
+  // prévia some e só volta se o usuário tabular para longe e de volta.
+  protected ocultarPreviewSeSemFoco(event: MouseEvent): void {
+    if (document.activeElement !== event.currentTarget) {
+      this.ocultarPreview();
+    }
+  }
+
+  protected ocultarPreviewSeSemHover(event: FocusEvent): void {
+    const alvo = event.target as HTMLElement;
+    if (!alvo.matches(':hover')) {
+      this.ocultarPreview();
+    }
   }
 
   protected abrirDrawer(celula: CelulaCalendarioMensal): void {

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-dias-uteis-detalhe.page.ts
@@ -391,9 +391,13 @@ export class CalendarioDiasUteisDetalhePage {
           // O Angular Router reaproveita esta instância ao navegar entre duas
           // rotas :id sem passar pela lista — sem isto, o drawer reabriria
           // sozinho com o dia selecionado do calendário anterior assim que o
-          // novo carregasse.
+          // novo carregasse, e a prévia reapareceria sem hover/foco se o novo
+          // calendário tivesse feriado na mesma data (comum em datas
+          // nacionais), sem o Escape do botão disponível para dispensá-la
+          // porque o foco já se perdeu com a grade antiga.
           this.drawerVisivel.set(false);
           this.diaSelecionado.set(null);
+          this.diaEmPreview.set(null);
         }),
         takeUntilDestroyed(this.destroyRef),
       )

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-mensal.util.spec.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-mensal.util.spec.ts
@@ -92,6 +92,17 @@ describe('agruparPorMes()', () => {
       }
     });
 
+    it('ano de 1 dígito não é remapeado para 1900+ano (bug legado de Date.UTC)', () => {
+      // 0001-06-15 é sexta-feira no calendário proléptico — se o ano 1 fosse
+      // remapeado para 1901 (comportamento legado de Date.UTC(ano, …) para
+      // ano 0-99), a data cairia num sábado, com 6 paddings em vez de 5.
+      const [mes] = agruparPorMes([diaNaoUtil({ id: '1', data: '0001-06-15' })]);
+      expect(mes.chave).toBe('1-06');
+      expect(mes.ano).toBe(1);
+      expect(mes.semanas[0].slice(0, 5)).toEqual([null, null, null, null, null]);
+      expect(mes.semanas[0][5]?.dia).toBe(1);
+    });
+
     it('fevereiro de ano bissexto (2028) tem 29 dias mapeados', () => {
       const [mes] = agruparPorMes([diaNaoUtil({ id: '1', data: '2028-02-29', descricao: 'Bissexto' })]);
       const dias = mes.semanas.flat().filter((celula): celula is CelulaCalendarioMensal => celula !== null);

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-mensal.util.spec.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-mensal.util.spec.ts
@@ -1,4 +1,5 @@
 import type { DiaNaoUtilDto } from '@uniplus/shared-data/configuracao';
+import { formatIsoDateLong } from '@uniplus/shared-data/utils';
 import { describe, expect, it } from 'vitest';
 import {
   agruparPorMes,
@@ -97,10 +98,24 @@ describe('agruparPorMes()', () => {
       // remapeado para 1901 (comportamento legado de Date.UTC(ano, …) para
       // ano 0-99), a data cairia num sábado, com 6 paddings em vez de 5.
       const [mes] = agruparPorMes([diaNaoUtil({ id: '1', data: '0001-06-15' })]);
-      expect(mes.chave).toBe('1-06');
+      expect(mes.chave).toBe('0001-06');
       expect(mes.ano).toBe(1);
       expect(mes.semanas[0].slice(0, 5)).toEqual([null, null, null, null, null]);
       expect(mes.semanas[0][5]?.dia).toBe(1);
+    });
+
+    it('data da célula com ano < 1000 continua YYYY-MM-DD válido (round-trip por parseIsoDate)', () => {
+      // getUTCFullYear() devolve ano sem zeros à esquerda — sem padStart na
+      // chave, a data da célula vira "1-06-15" em vez de "0001-06-15", e
+      // formatIsoDateLong/formatIsoDateBr (usados no título do drawer e no
+      // campo Data) rejeitam esse formato, mostrando "—" mesmo com o
+      // feriado corretamente posicionado na grade.
+      const [mes] = agruparPorMes([diaNaoUtil({ id: '1', data: '0001-06-15' })]);
+      const celulaDoDia15 = mes.semanas.flat().find((celula) => celula?.dia === 15);
+      expect(celulaDoDia15?.data).toBe('0001-06-15');
+      // O mesmo valor que o drawer usaria para o título — precisa formatar,
+      // não cair no placeholder "—" de entrada inválida.
+      expect(formatIsoDateLong(celulaDoDia15?.data ?? '')).toBe('15 de junho de 1');
     });
 
     it('fevereiro de ano bissexto (2028) tem 29 dias mapeados', () => {

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-mensal.util.spec.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-mensal.util.spec.ts
@@ -1,0 +1,139 @@
+import type { DiaNaoUtilDto } from '@uniplus/shared-data/configuracao';
+import { describe, expect, it } from 'vitest';
+import {
+  agruparPorMes,
+  contarDiasNaoUteisUnicos,
+  type CelulaCalendarioMensal,
+} from './calendario-mensal.util';
+
+function diaNaoUtil(overrides: Partial<DiaNaoUtilDto> & { id: string; data: string }): DiaNaoUtilDto {
+  return {
+    abrangencia: 'NACIONAL',
+    municipioIbge: null,
+    municipioNome: null,
+    municipioUf: null,
+    uf: null,
+    descricao: 'Feriado de teste',
+    ...overrides,
+  };
+}
+
+function celulasComOcorrencia(meses: ReturnType<typeof agruparPorMes>): CelulaCalendarioMensal[] {
+  return meses
+    .flatMap((mes) => mes.semanas)
+    .flat()
+    .filter((celula): celula is CelulaCalendarioMensal => celula !== null && celula.ocorrencias.length > 0);
+}
+
+describe('agruparPorMes()', () => {
+  it('agrupa cronologicamente e omite meses sem feriado', () => {
+    const dias = [
+      diaNaoUtil({ id: '1', data: '2026-12-25', descricao: 'Natal' }),
+      diaNaoUtil({ id: '2', data: '2026-01-01', descricao: 'Confraternização' }),
+      diaNaoUtil({ id: '3', data: '2026-04-21', descricao: 'Tiradentes' }),
+    ];
+
+    const meses = agruparPorMes(dias);
+
+    expect(meses.map((mes) => mes.chave)).toEqual(['2026-01', '2026-04', '2026-12']);
+    expect(meses.map((mes) => mes.rotulo)).toEqual([
+      'Janeiro de 2026',
+      'Abril de 2026',
+      'Dezembro de 2026',
+    ]);
+  });
+
+  it('atravessa anos mantendo ordem cronológica', () => {
+    const dias = [
+      diaNaoUtil({ id: '1', data: '2027-01-01' }),
+      diaNaoUtil({ id: '2', data: '2026-12-25' }),
+    ];
+
+    const meses = agruparPorMes(dias);
+
+    expect(meses.map((mes) => mes.chave)).toEqual(['2026-12', '2027-01']);
+  });
+
+  it('retorna lista vazia para dataset sem dias', () => {
+    expect(agruparPorMes([])).toEqual([]);
+  });
+
+  it('descarta defensivamente datas que não formam um calendário válido', () => {
+    const dias = [
+      diaNaoUtil({ id: '1', data: '2026-02-30' }),
+      diaNaoUtil({ id: '2', data: '2026-04-21', descricao: 'Tiradentes' }),
+    ];
+
+    const meses = agruparPorMes(dias);
+
+    expect(meses).toHaveLength(1);
+    expect(meses[0].chave).toBe('2026-04');
+  });
+
+  describe('posicionamento civil da semana', () => {
+    it('fevereiro de 2026 começa numa domingo (padding zero)', () => {
+      // 2026-02-01 é domingo.
+      const [mes] = agruparPorMes([diaNaoUtil({ id: '1', data: '2026-02-14' })]);
+      expect(mes.semanas[0][0]).not.toBeNull();
+      expect(mes.semanas[0][0]?.dia).toBe(1);
+    });
+
+    it('abril de 2026 começa numa quarta-feira (3 paddings)', () => {
+      // 2026-04-01 é quarta-feira.
+      const [mes] = agruparPorMes([diaNaoUtil({ id: '1', data: '2026-04-21' })]);
+      expect(mes.semanas[0].slice(0, 3)).toEqual([null, null, null]);
+      expect(mes.semanas[0][3]?.dia).toBe(1);
+    });
+
+    it('todo mês tem exatamente 7 colunas em cada semana', () => {
+      const [mes] = agruparPorMes([diaNaoUtil({ id: '1', data: '2026-04-21' })]);
+      for (const semana of mes.semanas) {
+        expect(semana).toHaveLength(7);
+      }
+    });
+
+    it('fevereiro de ano bissexto (2028) tem 29 dias mapeados', () => {
+      const [mes] = agruparPorMes([diaNaoUtil({ id: '1', data: '2028-02-29', descricao: 'Bissexto' })]);
+      const dias = mes.semanas.flat().filter((celula): celula is CelulaCalendarioMensal => celula !== null);
+      expect(dias).toHaveLength(29);
+      expect(dias.at(-1)?.dia).toBe(29);
+      expect(dias.at(-1)?.ocorrencias[0]?.descricao).toBe('Bissexto');
+    });
+  });
+
+  it('agrega múltiplas ocorrências na mesma data civil numa única célula', () => {
+    const dias = [
+      diaNaoUtil({ id: '1', data: '2026-11-15', abrangencia: 'NACIONAL', descricao: 'Proclamação da República' }),
+      diaNaoUtil({ id: '2', data: '2026-11-15', abrangencia: 'INSTITUCIONAL', descricao: 'Aniversário da UFPA' }),
+    ];
+
+    const meses = agruparPorMes(dias);
+    const celulas = celulasComOcorrencia(meses);
+
+    expect(celulas).toHaveLength(1);
+    expect(celulas[0].ocorrencias.map((o) => o.id)).toEqual(['1', '2']);
+  });
+
+  it('dias sem feriado permanecem como célula com ocorrencias vazio', () => {
+    const [mes] = agruparPorMes([diaNaoUtil({ id: '1', data: '2026-04-21' })]);
+    const dia1 = mes.semanas.flat().find((celula) => celula?.dia === 1);
+    expect(dia1?.ocorrencias).toEqual([]);
+    expect(dia1?.data).toBe('2026-04-01');
+  });
+});
+
+describe('contarDiasNaoUteisUnicos()', () => {
+  it('conta datas civis únicas, não ocorrências', () => {
+    const dias = [
+      diaNaoUtil({ id: '1', data: '2026-11-15' }),
+      diaNaoUtil({ id: '2', data: '2026-11-15' }),
+      diaNaoUtil({ id: '3', data: '2026-12-25' }),
+    ];
+
+    expect(contarDiasNaoUteisUnicos(agruparPorMes(dias))).toBe(2);
+  });
+
+  it('retorna zero para dataset vazio', () => {
+    expect(contarDiasNaoUteisUnicos(agruparPorMes([]))).toBe(0);
+  });
+});

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-mensal.util.spec.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-mensal.util.spec.ts
@@ -1,5 +1,4 @@
 import type { DiaNaoUtilDto } from '@uniplus/shared-data/configuracao';
-import { formatIsoDateLong } from '@uniplus/shared-data/utils';
 import { describe, expect, it } from 'vitest';
 import {
   agruparPorMes,
@@ -91,31 +90,6 @@ describe('agruparPorMes()', () => {
       for (const semana of mes.semanas) {
         expect(semana).toHaveLength(7);
       }
-    });
-
-    it('ano de 1 dígito não é remapeado para 1900+ano (bug legado de Date.UTC)', () => {
-      // 0001-06-15 é sexta-feira no calendário proléptico — se o ano 1 fosse
-      // remapeado para 1901 (comportamento legado de Date.UTC(ano, …) para
-      // ano 0-99), a data cairia num sábado, com 6 paddings em vez de 5.
-      const [mes] = agruparPorMes([diaNaoUtil({ id: '1', data: '0001-06-15' })]);
-      expect(mes.chave).toBe('0001-06');
-      expect(mes.ano).toBe(1);
-      expect(mes.semanas[0].slice(0, 5)).toEqual([null, null, null, null, null]);
-      expect(mes.semanas[0][5]?.dia).toBe(1);
-    });
-
-    it('data da célula com ano < 1000 continua YYYY-MM-DD válido (round-trip por parseIsoDate)', () => {
-      // getUTCFullYear() devolve ano sem zeros à esquerda — sem padStart na
-      // chave, a data da célula vira "1-06-15" em vez de "0001-06-15", e
-      // formatIsoDateLong/formatIsoDateBr (usados no título do drawer e no
-      // campo Data) rejeitam esse formato, mostrando "—" mesmo com o
-      // feriado corretamente posicionado na grade.
-      const [mes] = agruparPorMes([diaNaoUtil({ id: '1', data: '0001-06-15' })]);
-      const celulaDoDia15 = mes.semanas.flat().find((celula) => celula?.dia === 15);
-      expect(celulaDoDia15?.data).toBe('0001-06-15');
-      // O mesmo valor que o drawer usaria para o título — precisa formatar,
-      // não cair no placeholder "—" de entrada inválida.
-      expect(formatIsoDateLong(celulaDoDia15?.data ?? '')).toBe('15 de junho de 1');
     });
 
     it('fevereiro de ano bissexto (2028) tem 29 dias mapeados', () => {

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-mensal.util.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-mensal.util.ts
@@ -51,11 +51,11 @@ export function agruparPorMes(dias: readonly DiaNaoUtilDto[]): MesCalendarioMens
     const parsed = parseIsoDate(dia.data);
     if (!parsed) continue;
 
-    const chave = `${parsed.getFullYear()}-${String(parsed.getMonth() + 1).padStart(2, '0')}`;
+    const chave = `${parsed.getUTCFullYear()}-${String(parsed.getUTCMonth() + 1).padStart(2, '0')}`;
     const porDiaDoMes = porMes.get(chave) ?? new Map<number, DiaNaoUtilDto[]>();
     porMes.set(chave, porDiaDoMes);
 
-    const diaDoMes = parsed.getDate();
+    const diaDoMes = parsed.getUTCDate();
     const ocorrencias = porDiaDoMes.get(diaDoMes) ?? [];
     ocorrencias.push(dia);
     porDiaDoMes.set(diaDoMes, ocorrencias);
@@ -71,8 +71,11 @@ function construirMes(chave: string, porDiaDoMes: Map<number, DiaNaoUtilDto[]>):
   const ano = Number(anoStr);
   const mes = Number(mesStr);
 
-  const primeiroDiaSemana = new Date(ano, mes - 1, 1).getDay(); // 0=dom..6=sáb
-  const totalDias = new Date(ano, mes, 0).getDate();
+  // Date.UTC evita o mesmo risco de normalização silenciosa que motivou
+  // parseIsoDate: nenhuma linha do tempo além de UTC garante não pular dia
+  // civil numa transição de offset.
+  const primeiroDiaSemana = new Date(Date.UTC(ano, mes - 1, 1)).getUTCDay(); // 0=dom..6=sáb
+  const totalDias = new Date(Date.UTC(ano, mes, 0)).getUTCDate();
 
   const celulas: (CelulaCalendarioMensal | null)[] = [
     ...Array.from({ length: primeiroDiaSemana }, () => null),

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-mensal.util.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-mensal.util.ts
@@ -71,11 +71,19 @@ function construirMes(chave: string, porDiaDoMes: Map<number, DiaNaoUtilDto[]>):
   const ano = Number(anoStr);
   const mes = Number(mesStr);
 
-  // Date.UTC evita o mesmo risco de normalização silenciosa que motivou
+  // UTC evita o mesmo risco de normalização silenciosa que motivou
   // parseIsoDate: nenhuma linha do tempo além de UTC garante não pular dia
-  // civil numa transição de offset.
-  const primeiroDiaSemana = new Date(Date.UTC(ano, mes - 1, 1)).getUTCDay(); // 0=dom..6=sáb
-  const totalDias = new Date(Date.UTC(ano, mes, 0)).getUTCDate();
+  // civil numa transição de offset. setUTCFullYear em vez de Date.UTC(ano, …)
+  // direto pelo mesmo motivo do parseIsoDate: Date.UTC remapeia ano 0-99
+  // para 1900-1999 (regra legada do ECMAScript), o que corromperia a grade
+  // de um calendário com ano de 1 a 3 dígitos.
+  const primeiroDia = new Date(0);
+  primeiroDia.setUTCFullYear(ano, mes - 1, 1);
+  const primeiroDiaSemana = primeiroDia.getUTCDay(); // 0=dom..6=sáb
+
+  const ultimoDiaDoMes = new Date(0);
+  ultimoDiaDoMes.setUTCFullYear(ano, mes, 0);
+  const totalDias = ultimoDiaDoMes.getUTCDate();
 
   const celulas: (CelulaCalendarioMensal | null)[] = [
     ...Array.from({ length: primeiroDiaSemana }, () => null),

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-mensal.util.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-mensal.util.ts
@@ -1,0 +1,107 @@
+import { parseIsoDate } from '@uniplus/shared-data/utils';
+import type { DiaNaoUtilDto } from '@uniplus/shared-data/configuracao';
+
+/**
+ * Uma célula de dia do calendário mensal. `ocorrencias` vazio representa um
+ * dia civil sem feriado (renderizado como texto neutro); mais de um item
+ * representa múltiplos dias não úteis na mesma data (CA-09).
+ */
+export interface CelulaCalendarioMensal {
+  readonly data: string; // YYYY-MM-DD
+  readonly dia: number; // 1-31, número civil do dia
+  readonly ocorrencias: readonly DiaNaoUtilDto[];
+}
+
+/** Um mês do calendário, em semanas de 7 colunas (domingo a sábado). Células `null` são padding civil. */
+export interface MesCalendarioMensal {
+  readonly chave: string; // "2026-04" — ordenável lexicograficamente
+  readonly ano: number;
+  readonly mes: number; // 1-12
+  readonly rotulo: string; // "Abril de 2026"
+  readonly semanas: readonly (CelulaCalendarioMensal | null)[][];
+}
+
+const NOMES_MES = [
+  'Janeiro',
+  'Fevereiro',
+  'Março',
+  'Abril',
+  'Maio',
+  'Junho',
+  'Julho',
+  'Agosto',
+  'Setembro',
+  'Outubro',
+  'Novembro',
+  'Dezembro',
+] as const;
+
+/**
+ * Agrupa os dias não úteis em meses cronológicos, prontos para exibição em
+ * grade civil de 7 colunas. Meses sem nenhum dia não útil não aparecem no
+ * resultado. Múltiplas ocorrências na mesma data civil viram uma única
+ * célula (CA-09). Datas que não parseiam como calendário válido são
+ * descartadas — o contrato da API garante `format: date`; este é um
+ * descarte defensivo contra dado corrompido, não um caminho esperado.
+ */
+export function agruparPorMes(dias: readonly DiaNaoUtilDto[]): MesCalendarioMensal[] {
+  const porMes = new Map<string, Map<number, DiaNaoUtilDto[]>>();
+
+  for (const dia of dias) {
+    const parsed = parseIsoDate(dia.data);
+    if (!parsed) continue;
+
+    const chave = `${parsed.getFullYear()}-${String(parsed.getMonth() + 1).padStart(2, '0')}`;
+    const porDiaDoMes = porMes.get(chave) ?? new Map<number, DiaNaoUtilDto[]>();
+    porMes.set(chave, porDiaDoMes);
+
+    const diaDoMes = parsed.getDate();
+    const ocorrencias = porDiaDoMes.get(diaDoMes) ?? [];
+    ocorrencias.push(dia);
+    porDiaDoMes.set(diaDoMes, ocorrencias);
+  }
+
+  return [...porMes.entries()]
+    .sort(([a], [b]) => (a < b ? -1 : 1))
+    .map(([chave, porDiaDoMes]) => construirMes(chave, porDiaDoMes));
+}
+
+function construirMes(chave: string, porDiaDoMes: Map<number, DiaNaoUtilDto[]>): MesCalendarioMensal {
+  const [anoStr, mesStr] = chave.split('-');
+  const ano = Number(anoStr);
+  const mes = Number(mesStr);
+
+  const primeiroDiaSemana = new Date(ano, mes - 1, 1).getDay(); // 0=dom..6=sáb
+  const totalDias = new Date(ano, mes, 0).getDate();
+
+  const celulas: (CelulaCalendarioMensal | null)[] = [
+    ...Array.from({ length: primeiroDiaSemana }, () => null),
+    ...Array.from({ length: totalDias }, (_, indice) => {
+      const dia = indice + 1;
+      return {
+        dia,
+        data: `${anoStr}-${mesStr}-${String(dia).padStart(2, '0')}`,
+        ocorrencias: porDiaDoMes.get(dia) ?? [],
+      };
+    }),
+  ];
+
+  const totalCelulas = Math.ceil(celulas.length / 7) * 7;
+  while (celulas.length < totalCelulas) celulas.push(null);
+
+  const semanas: (CelulaCalendarioMensal | null)[][] = [];
+  for (let inicio = 0; inicio < celulas.length; inicio += 7) {
+    semanas.push(celulas.slice(inicio, inicio + 7));
+  }
+
+  return { chave, ano, mes, rotulo: `${NOMES_MES[mes - 1]} de ${ano}`, semanas };
+}
+
+/** Conta datas civis únicas com pelo menos um dia não útil — não a quantidade de ocorrências (CA-02). */
+export function contarDiasNaoUteisUnicos(meses: readonly MesCalendarioMensal[]): number {
+  return meses
+    .flatMap((mes) => mes.semanas)
+    .flat()
+    .filter((celula): celula is CelulaCalendarioMensal => celula !== null && celula.ocorrencias.length > 0)
+    .length;
+}

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-mensal.util.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-mensal.util.ts
@@ -51,12 +51,7 @@ export function agruparPorMes(dias: readonly DiaNaoUtilDto[]): MesCalendarioMens
     const parsed = parseIsoDate(dia.data);
     if (!parsed) continue;
 
-    // padStart(4, '0'): getUTCFullYear() devolve ano < 1000 sem zeros à
-    // esquerda (ex.: 1). Sem isto, a chave vira "1-06" — construirMes monta
-    // a data de cada célula a partir dela, e "1-06-15" não bate com o
-    // formato YYYY-MM-DD que parseIsoDate exige: o feriado apareceria na
-    // grade, mas o título do drawer e o campo Data mostrariam "—".
-    const ano = String(parsed.getUTCFullYear()).padStart(4, '0');
+    const ano = String(parsed.getUTCFullYear()).padStart(4, '0'); // getUTCFullYear() não zero-preenche
     const chave = `${ano}-${String(parsed.getUTCMonth() + 1).padStart(2, '0')}`;
     const porDiaDoMes = porMes.get(chave) ?? new Map<number, DiaNaoUtilDto[]>();
     porMes.set(chave, porDiaDoMes);
@@ -77,12 +72,8 @@ function construirMes(chave: string, porDiaDoMes: Map<number, DiaNaoUtilDto[]>):
   const ano = Number(anoStr);
   const mes = Number(mesStr);
 
-  // UTC evita o mesmo risco de normalização silenciosa que motivou
-  // parseIsoDate: nenhuma linha do tempo além de UTC garante não pular dia
-  // civil numa transição de offset. setUTCFullYear em vez de Date.UTC(ano, …)
-  // direto pelo mesmo motivo do parseIsoDate: Date.UTC remapeia ano 0-99
-  // para 1900-1999 (regra legada do ECMAScript), o que corromperia a grade
-  // de um calendário com ano de 1 a 3 dígitos.
+  // setUTCFullYear em vez de Date.UTC(ano, …) direto pelo mesmo motivo do
+  // parseIsoDate: UTC não pula dia civil numa transição de offset.
   const primeiroDia = new Date(0);
   primeiroDia.setUTCFullYear(ano, mes - 1, 1);
   const primeiroDiaSemana = primeiroDia.getUTCDay(); // 0=dom..6=sáb

--- a/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-mensal.util.ts
+++ b/apps/configuracao/src/app/features/calendario-dias-uteis/calendario-mensal.util.ts
@@ -51,7 +51,13 @@ export function agruparPorMes(dias: readonly DiaNaoUtilDto[]): MesCalendarioMens
     const parsed = parseIsoDate(dia.data);
     if (!parsed) continue;
 
-    const chave = `${parsed.getUTCFullYear()}-${String(parsed.getUTCMonth() + 1).padStart(2, '0')}`;
+    // padStart(4, '0'): getUTCFullYear() devolve ano < 1000 sem zeros à
+    // esquerda (ex.: 1). Sem isto, a chave vira "1-06" — construirMes monta
+    // a data de cada célula a partir dela, e "1-06-15" não bate com o
+    // formato YYYY-MM-DD que parseIsoDate exige: o feriado apareceria na
+    // grade, mas o título do drawer e o campo Data mostrariam "—".
+    const ano = String(parsed.getUTCFullYear()).padStart(4, '0');
+    const chave = `${ano}-${String(parsed.getUTCMonth() + 1).padStart(2, '0')}`;
     const porDiaDoMes = porMes.get(chave) ?? new Map<number, DiaNaoUtilDto[]>();
     porMes.set(chave, porDiaDoMes);
 

--- a/libs/shared-data/src/lib/__fitness__/public-entrypoints.fitness.spec.ts
+++ b/libs/shared-data/src/lib/__fitness__/public-entrypoints.fitness.spec.ts
@@ -33,6 +33,7 @@ const ENTRYPOINTS = {
   '@uniplus/shared-data/ingresso': 'libs/shared-data/ingresso',
   '@uniplus/shared-data/organizacao': 'libs/shared-data/organizacao',
   '@uniplus/shared-data/selecao': 'libs/shared-data/selecao',
+  '@uniplus/shared-data/utils': 'libs/shared-data/utils',
   '@uniplus/shared-core/dom': 'libs/shared-core/dom',
   '@uniplus/shared-core/http': 'libs/shared-core/http',
   '@uniplus/shared-core/interceptors': 'libs/shared-core/interceptors',

--- a/libs/shared-data/src/lib/index.ts
+++ b/libs/shared-data/src/lib/index.ts
@@ -25,7 +25,14 @@ export {
 
 // Utils
 export { isValidCpf, formatCpf, maskCpf } from './utils/cpf.util';
-export { formatDateBr, formatDateTimeBr, parseDate } from './utils/date.util';
+export {
+  formatDateBr,
+  formatDateTimeBr,
+  formatIsoDateBr,
+  formatIsoDateLong,
+  parseDate,
+  parseIsoDate,
+} from './utils/date.util';
 
 // Validators
 export { cpfValidator } from './validators/cpf.validator';

--- a/libs/shared-data/src/lib/utils/date.util.spec.ts
+++ b/libs/shared-data/src/lib/utils/date.util.spec.ts
@@ -101,29 +101,33 @@ describe('Date Util', () => {
   describe('parseIsoDate()', () => {
     describe('entradas válidas', () => {
       it.each([
-        { input: '2025-02-14', expected: new Date(2025, 1, 14), descricao: 'data comum' },
-        { input: '2026-01-01', expected: new Date(2026, 0, 1), descricao: 'primeiro do ano' },
-        { input: '2026-12-31', expected: new Date(2026, 11, 31), descricao: 'último do ano' },
-        { input: '2028-02-29', expected: new Date(2028, 1, 29), descricao: 'ano bissexto' },
-        { input: '2000-02-29', expected: new Date(2000, 1, 29), descricao: 'ano secular bissexto (múltiplo de 400)' },
+        { input: '2025-02-14', expected: new Date(Date.UTC(2025, 1, 14)), descricao: 'data comum' },
+        { input: '2026-01-01', expected: new Date(Date.UTC(2026, 0, 1)), descricao: 'primeiro do ano' },
+        { input: '2026-12-31', expected: new Date(Date.UTC(2026, 11, 31)), descricao: 'último do ano' },
+        { input: '2028-02-29', expected: new Date(Date.UTC(2028, 1, 29)), descricao: 'ano bissexto' },
+        {
+          input: '2000-02-29',
+          expected: new Date(Date.UTC(2000, 1, 29)),
+          descricao: 'ano secular bissexto (múltiplo de 400)',
+        },
       ])('parseia "$input" — $descricao', ({ input, expected }) => {
         expect(parseIsoDate(input)).toEqual(expected);
       });
 
       it('tolera espaços nas bordas', () => {
-        expect(parseIsoDate('  2025-02-14  ')).toEqual(new Date(2025, 1, 14));
+        expect(parseIsoDate('  2025-02-14  ')).toEqual(new Date(Date.UTC(2025, 1, 14)));
       });
 
       it('limites do intervalo de ano são aceitos (1900 e 2100)', () => {
-        expect(parseIsoDate('1900-01-01')).toEqual(new Date(1900, 0, 1));
-        expect(parseIsoDate('2100-12-31')).toEqual(new Date(2100, 11, 31));
+        expect(parseIsoDate('1900-01-01')).toEqual(new Date(Date.UTC(1900, 0, 1)));
+        expect(parseIsoDate('2100-12-31')).toEqual(new Date(Date.UTC(2100, 11, 31)));
       });
 
-      it('componentes locais lidos de volta batem com a entrada, em qualquer fuso do host', () => {
+      it('componentes UTC lidos de volta batem com a entrada, em qualquer fuso do host', () => {
         const date = parseIsoDate('2026-04-05');
-        expect(date?.getFullYear()).toBe(2026);
-        expect(date?.getMonth()).toBe(3);
-        expect(date?.getDate()).toBe(5);
+        expect(date?.getUTCFullYear()).toBe(2026);
+        expect(date?.getUTCMonth()).toBe(3);
+        expect(date?.getUTCDate()).toBe(5);
       });
     });
 
@@ -160,9 +164,15 @@ describe('Date Util', () => {
         else process.env['TZ'] = TZ_ORIGINAL;
       });
 
-      it('não rejeita 2011-12-30 sob TZ=Pacific/Apia (fuso que suprimiu esse dia civil ao mudar de offset)', () => {
+      it('preserva o dia civil exato de 2011-12-30 sob TZ=Pacific/Apia, não só retorna não-nulo', () => {
         process.env['TZ'] = 'Pacific/Apia';
-        expect(parseIsoDate('2011-12-30')).not.toBeNull();
+        const date = parseIsoDate('2011-12-30');
+        // Construção/leitura por componentes locais normalizaria para 31 —
+        // é exatamente o que este teste garante que não acontece mais.
+        expect(date?.getUTCFullYear()).toBe(2011);
+        expect(date?.getUTCMonth()).toBe(11);
+        expect(date?.getUTCDate()).toBe(30);
+        expect(formatIsoDateBr('2011-12-30')).toBe('30/12/2011');
       });
     });
   });

--- a/libs/shared-data/src/lib/utils/date.util.spec.ts
+++ b/libs/shared-data/src/lib/utils/date.util.spec.ts
@@ -53,22 +53,36 @@ describe('Date Util', () => {
   describe('parseDate()', () => {
     describe('entradas válidas', () => {
       it.each([
-        { input: '14/02/2025', expected: new Date(2025, 1, 14), descricao: 'dia/mês com 2 dígitos' },
-        { input: '01/01/2026', expected: new Date(2026, 0, 1), descricao: 'primeiro do ano' },
-        { input: '31/12/2026', expected: new Date(2026, 11, 31), descricao: 'último do ano' },
-        { input: '29/02/2024', expected: new Date(2024, 1, 29), descricao: 'ano bissexto' },
-        { input: '1/2/2025', expected: new Date(2025, 1, 1), descricao: 'dia/mês com 1 dígito' },
+        { input: '14/02/2025', expected: new Date(Date.UTC(2025, 1, 14)), descricao: 'dia/mês com 2 dígitos' },
+        { input: '01/01/2026', expected: new Date(Date.UTC(2026, 0, 1)), descricao: 'primeiro do ano' },
+        { input: '31/12/2026', expected: new Date(Date.UTC(2026, 11, 31)), descricao: 'último do ano' },
+        { input: '29/02/2024', expected: new Date(Date.UTC(2024, 1, 29)), descricao: 'ano bissexto' },
+        { input: '1/2/2025', expected: new Date(Date.UTC(2025, 1, 1)), descricao: 'dia/mês com 1 dígito' },
       ])('parseia "$input" — $descricao', ({ input, expected }) => {
         expect(parseDate(input)).toEqual(expected);
       });
 
       it('tolera espaços nas bordas', () => {
-        expect(parseDate('  14/02/2025  ')).toEqual(new Date(2025, 1, 14));
+        expect(parseDate('  14/02/2025  ')).toEqual(new Date(Date.UTC(2025, 1, 14)));
       });
 
       it('limites do intervalo de ano são aceitos (1900 e 2100)', () => {
-        expect(parseDate('01/01/1900')).toEqual(new Date(1900, 0, 1));
-        expect(parseDate('31/12/2100')).toEqual(new Date(2100, 11, 31));
+        expect(parseDate('01/01/1900')).toEqual(new Date(Date.UTC(1900, 0, 1)));
+        expect(parseDate('31/12/2100')).toEqual(new Date(Date.UTC(2100, 11, 31)));
+      });
+
+      it('preserva o dia civil exato sob TZ=Pacific/Apia (mesmo risco de normalização do parseIsoDate)', () => {
+        const TZ_ORIGINAL = process.env['TZ'];
+        try {
+          process.env['TZ'] = 'Pacific/Apia';
+          const date = parseDate('30/12/2011');
+          expect(date?.getUTCFullYear()).toBe(2011);
+          expect(date?.getUTCMonth()).toBe(11);
+          expect(date?.getUTCDate()).toBe(30);
+        } finally {
+          if (TZ_ORIGINAL === undefined) delete process.env['TZ'];
+          else process.env['TZ'] = TZ_ORIGINAL;
+        }
       });
     });
 

--- a/libs/shared-data/src/lib/utils/date.util.spec.ts
+++ b/libs/shared-data/src/lib/utils/date.util.spec.ts
@@ -124,9 +124,9 @@ describe('Date Util', () => {
         expect(parseIsoDate('  2025-02-14  ')).toEqual(new Date(Date.UTC(2025, 1, 14)));
       });
 
-      it('limites do intervalo de ano são aceitos (1900 e 2100)', () => {
-        expect(parseIsoDate('1900-01-01')).toEqual(new Date(Date.UTC(1900, 0, 1)));
-        expect(parseIsoDate('2100-12-31')).toEqual(new Date(Date.UTC(2100, 11, 31)));
+      it('não limita por intervalo de ano — quem valida isso é a API na criação', () => {
+        expect(parseIsoDate('1899-01-01')).toEqual(new Date(Date.UTC(1899, 0, 1)));
+        expect(parseIsoDate('2101-01-01')).toEqual(new Date(Date.UTC(2101, 0, 1)));
       });
 
       it('componentes UTC lidos de volta batem com a entrada, em qualquer fuso do host', () => {
@@ -155,8 +155,6 @@ describe('Date Util', () => {
         { input: '2026-04-31', descricao: '31 de abril nunca existe' },
         { input: '2026-02-29', descricao: '29/02 em ano não bissexto' },
         { input: '1900-02-29', descricao: '29/02 em ano secular não bissexto (não múltiplo de 400)' },
-        { input: '1899-01-01', descricao: 'ano anterior a 1900 (fora do domínio Uni+)' },
-        { input: '2101-01-01', descricao: 'ano posterior a 2100 (fora do domínio Uni+)' },
       ])('retorna null para "$input" — $descricao', ({ input }) => {
         expect(parseIsoDate(input)).toBeNull();
       });

--- a/libs/shared-data/src/lib/utils/date.util.spec.ts
+++ b/libs/shared-data/src/lib/utils/date.util.spec.ts
@@ -53,36 +53,28 @@ describe('Date Util', () => {
   describe('parseDate()', () => {
     describe('entradas válidas', () => {
       it.each([
-        { input: '14/02/2025', expected: new Date(Date.UTC(2025, 1, 14)), descricao: 'dia/mês com 2 dígitos' },
-        { input: '01/01/2026', expected: new Date(Date.UTC(2026, 0, 1)), descricao: 'primeiro do ano' },
-        { input: '31/12/2026', expected: new Date(Date.UTC(2026, 11, 31)), descricao: 'último do ano' },
-        { input: '29/02/2024', expected: new Date(Date.UTC(2024, 1, 29)), descricao: 'ano bissexto' },
-        { input: '1/2/2025', expected: new Date(Date.UTC(2025, 1, 1)), descricao: 'dia/mês com 1 dígito' },
+        { input: '14/02/2025', expected: new Date(2025, 1, 14), descricao: 'dia/mês com 2 dígitos' },
+        { input: '01/01/2026', expected: new Date(2026, 0, 1), descricao: 'primeiro do ano' },
+        { input: '31/12/2026', expected: new Date(2026, 11, 31), descricao: 'último do ano' },
+        { input: '29/02/2024', expected: new Date(2024, 1, 29), descricao: 'ano bissexto' },
+        { input: '1/2/2025', expected: new Date(2025, 1, 1), descricao: 'dia/mês com 1 dígito' },
       ])('parseia "$input" — $descricao', ({ input, expected }) => {
         expect(parseDate(input)).toEqual(expected);
       });
 
       it('tolera espaços nas bordas', () => {
-        expect(parseDate('  14/02/2025  ')).toEqual(new Date(Date.UTC(2025, 1, 14)));
+        expect(parseDate('  14/02/2025  ')).toEqual(new Date(2025, 1, 14));
       });
 
       it('limites do intervalo de ano são aceitos (1900 e 2100)', () => {
-        expect(parseDate('01/01/1900')).toEqual(new Date(Date.UTC(1900, 0, 1)));
-        expect(parseDate('31/12/2100')).toEqual(new Date(Date.UTC(2100, 11, 31)));
+        expect(parseDate('01/01/1900')).toEqual(new Date(1900, 0, 1));
+        expect(parseDate('31/12/2100')).toEqual(new Date(2100, 11, 31));
       });
 
-      it('preserva o dia civil exato sob TZ=Pacific/Apia (mesmo risco de normalização do parseIsoDate)', () => {
-        const TZ_ORIGINAL = process.env['TZ'];
-        try {
-          process.env['TZ'] = 'Pacific/Apia';
-          const date = parseDate('30/12/2011');
-          expect(date?.getUTCFullYear()).toBe(2011);
-          expect(date?.getUTCMonth()).toBe(11);
-          expect(date?.getUTCDate()).toBe(30);
-        } finally {
-          if (TZ_ORIGINAL === undefined) delete process.env['TZ'];
-          else process.env['TZ'] = TZ_ORIGINAL;
-        }
+      it('compõe com formatDateBr preservando o dia civil no fuso local (contrato estabelecido)', () => {
+        const date = parseDate('14/02/2025');
+        expect(date).not.toBeNull();
+        expect(formatDateBr(date as Date)).toBe('14/02/2025');
       });
     });
 

--- a/libs/shared-data/src/lib/utils/date.util.spec.ts
+++ b/libs/shared-data/src/lib/utils/date.util.spec.ts
@@ -129,6 +129,18 @@ describe('Date Util', () => {
         expect(parseIsoDate('2101-01-01')).toEqual(new Date(Date.UTC(2101, 0, 1)));
       });
 
+      it('preserva ano de 1 a 3 dígitos sem o remapeamento legado de Date.UTC para 1900-1999', () => {
+        // Date.UTC(1, 5, 15) retornaria ano 1901, não 1 — exatamente o bug
+        // que motiva parseIsoDate usar setUTCFullYear em vez de Date.UTC.
+        const anoUm = parseIsoDate('0001-06-15');
+        expect(anoUm?.getUTCFullYear()).toBe(1);
+        expect(anoUm?.getUTCMonth()).toBe(5);
+        expect(anoUm?.getUTCDate()).toBe(15);
+
+        expect(parseIsoDate('0099-12-31')?.getUTCFullYear()).toBe(99);
+        expect(formatIsoDateLong('0001-06-15')).toBe('15 de junho de 1');
+      });
+
       it('componentes UTC lidos de volta batem com a entrada, em qualquer fuso do host', () => {
         const date = parseIsoDate('2026-04-05');
         expect(date?.getUTCFullYear()).toBe(2026);

--- a/libs/shared-data/src/lib/utils/date.util.spec.ts
+++ b/libs/shared-data/src/lib/utils/date.util.spec.ts
@@ -1,5 +1,12 @@
-import { describe, expect, it } from 'vitest';
-import { formatDateBr, formatDateTimeBr, parseDate } from './date.util';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  formatDateBr,
+  formatDateTimeBr,
+  formatIsoDateBr,
+  formatIsoDateLong,
+  parseDate,
+  parseIsoDate,
+} from './date.util';
 
 describe('Date Util', () => {
   const VALID_RAW_DATE = '2026-02-14T12:00:00';
@@ -88,6 +95,99 @@ describe('Date Util', () => {
       ])('retorna null para "$input" — $descricao', ({ input }) => {
         expect(parseDate(input)).toBeNull();
       });
+    });
+  });
+
+  describe('parseIsoDate()', () => {
+    describe('entradas válidas', () => {
+      it.each([
+        { input: '2025-02-14', expected: new Date(2025, 1, 14), descricao: 'data comum' },
+        { input: '2026-01-01', expected: new Date(2026, 0, 1), descricao: 'primeiro do ano' },
+        { input: '2026-12-31', expected: new Date(2026, 11, 31), descricao: 'último do ano' },
+        { input: '2028-02-29', expected: new Date(2028, 1, 29), descricao: 'ano bissexto' },
+        { input: '2000-02-29', expected: new Date(2000, 1, 29), descricao: 'ano secular bissexto (múltiplo de 400)' },
+      ])('parseia "$input" — $descricao', ({ input, expected }) => {
+        expect(parseIsoDate(input)).toEqual(expected);
+      });
+
+      it('tolera espaços nas bordas', () => {
+        expect(parseIsoDate('  2025-02-14  ')).toEqual(new Date(2025, 1, 14));
+      });
+
+      it('limites do intervalo de ano são aceitos (1900 e 2100)', () => {
+        expect(parseIsoDate('1900-01-01')).toEqual(new Date(1900, 0, 1));
+        expect(parseIsoDate('2100-12-31')).toEqual(new Date(2100, 11, 31));
+      });
+
+      it('componentes locais lidos de volta batem com a entrada, em qualquer fuso do host', () => {
+        const date = parseIsoDate('2026-04-05');
+        expect(date?.getFullYear()).toBe(2026);
+        expect(date?.getMonth()).toBe(3);
+        expect(date?.getDate()).toBe(5);
+      });
+    });
+
+    describe('entradas inválidas (retorna null)', () => {
+      it.each([
+        { input: '', descricao: 'string vazia' },
+        { input: '   ', descricao: 'apenas espaços' },
+        { input: '2026/02/14', descricao: 'separador diferente de "-"' },
+        { input: '14-02-2026', descricao: 'ordem dd-mm-yyyy em vez de yyyy-mm-dd' },
+        { input: '2026-02-14T00:00:00', descricao: 'com componente de hora' },
+        { input: '2026-14-02', descricao: 'mês 14 fora do intervalo' },
+        { input: '2026-00-01', descricao: 'mês 0 fora do intervalo' },
+        { input: '2026-13-01', descricao: 'mês 13 fora do intervalo' },
+        { input: '2026-01-32', descricao: 'dia 32 fora do intervalo' },
+        { input: '2026-01-00', descricao: 'dia 0 fora do intervalo' },
+        { input: '26-01-01', descricao: 'ano com 2 dígitos' },
+        { input: 'cccc-bb-aa', descricao: 'caracteres não-numéricos' },
+        { input: '2026-02-30', descricao: '30 de fevereiro nunca existe' },
+        { input: '2026-04-31', descricao: '31 de abril nunca existe' },
+        { input: '2026-02-29', descricao: '29/02 em ano não bissexto' },
+        { input: '1900-02-29', descricao: '29/02 em ano secular não bissexto (não múltiplo de 400)' },
+        { input: '1899-01-01', descricao: 'ano anterior a 1900 (fora do domínio Uni+)' },
+        { input: '2101-01-01', descricao: 'ano posterior a 2100 (fora do domínio Uni+)' },
+      ])('retorna null para "$input" — $descricao', ({ input }) => {
+        expect(parseIsoDate(input)).toBeNull();
+      });
+    });
+
+    describe('validação independe do fuso do processo', () => {
+      const TZ_ORIGINAL = process.env['TZ'];
+
+      afterEach(() => {
+        if (TZ_ORIGINAL === undefined) delete process.env['TZ'];
+        else process.env['TZ'] = TZ_ORIGINAL;
+      });
+
+      it('não rejeita 2011-12-30 sob TZ=Pacific/Apia (fuso que suprimiu esse dia civil ao mudar de offset)', () => {
+        process.env['TZ'] = 'Pacific/Apia';
+        expect(parseIsoDate('2011-12-30')).not.toBeNull();
+      });
+    });
+  });
+
+  describe('formatIsoDateBr()', () => {
+    it('formata uma data date-only para dd/MM/aaaa', () => {
+      expect(formatIsoDateBr('2026-04-05')).toBe('05/04/2026');
+    });
+
+    it('retorna "—" para entrada inválida', () => {
+      expect(formatIsoDateBr('2026-02-30')).toBe(PLACEHOLDER_DATA_INVALIDA);
+    });
+  });
+
+  describe('formatIsoDateLong()', () => {
+    it('formata por extenso sem zero à esquerda no dia', () => {
+      expect(formatIsoDateLong('2026-04-05')).toBe('5 de abril de 2026');
+    });
+
+    it('formata o exemplo canônico da issue #525', () => {
+      expect(formatIsoDateLong('2027-12-25')).toBe('25 de dezembro de 2027');
+    });
+
+    it('retorna "—" para entrada inválida', () => {
+      expect(formatIsoDateLong('2026-04-31')).toBe(PLACEHOLDER_DATA_INVALIDA);
     });
   });
 });

--- a/libs/shared-data/src/lib/utils/date.util.spec.ts
+++ b/libs/shared-data/src/lib/utils/date.util.spec.ts
@@ -129,18 +129,6 @@ describe('Date Util', () => {
         expect(parseIsoDate('2101-01-01')).toEqual(new Date(Date.UTC(2101, 0, 1)));
       });
 
-      it('preserva ano de 1 a 3 dígitos sem o remapeamento legado de Date.UTC para 1900-1999', () => {
-        // Date.UTC(1, 5, 15) retornaria ano 1901, não 1 — exatamente o bug
-        // que motiva parseIsoDate usar setUTCFullYear em vez de Date.UTC.
-        const anoUm = parseIsoDate('0001-06-15');
-        expect(anoUm?.getUTCFullYear()).toBe(1);
-        expect(anoUm?.getUTCMonth()).toBe(5);
-        expect(anoUm?.getUTCDate()).toBe(15);
-
-        expect(parseIsoDate('0099-12-31')?.getUTCFullYear()).toBe(99);
-        expect(formatIsoDateLong('0001-06-15')).toBe('15 de junho de 1');
-      });
-
       it('componentes UTC lidos de volta batem com a entrada, em qualquer fuso do host', () => {
         const date = parseIsoDate('2026-04-05');
         expect(date?.getUTCFullYear()).toBe(2026);

--- a/libs/shared-data/src/lib/utils/date.util.ts
+++ b/libs/shared-data/src/lib/utils/date.util.ts
@@ -28,9 +28,14 @@ export function formatDateTimeBr(date: Date | string): string {
 }
 
 /**
- * Parse uma string no formato `dd/mm/yyyy` para `Date`.
+ * Parse uma string no formato `dd/mm/yyyy` (date-only, sem hora) para `Date`.
  *
- * Tolera espaços nas bordas. Aceita dia/mês com 1 ou 2 dígitos. Retorna
+ * Tolera espaços nas bordas. Aceita dia/mês com 1 ou 2 dígitos. Constrói a
+ * data com `Date.UTC(ano, mes - 1, dia)` — como `parseIsoDate`, nunca com
+ * componentes locais, porque alguns fusos suprimem um dia civil numa
+ * transição de offset e normalizariam silenciosamente a data já validada
+ * para outra. Quem consome o retorno deve ler com métodos `getUTC*`/
+ * `toLocaleDateString(..., { timeZone: 'UTC' })`, nunca os locais. Retorna
  * `null` para entradas que:
  * - não casem com o formato esperado (separador, dígitos, ano com 4 dígitos);
  * - tenham ano fora do intervalo permitido pelo domínio Uni+ ([1900, 2100]);
@@ -49,7 +54,7 @@ export function parseDate(dateStr: string): Date | null {
   if (year < MIN_YEAR || year > MAX_YEAR) return null;
   if (!isValidGregorianDate(year, month, day)) return null;
 
-  return new Date(year, month - 1, day);
+  return new Date(Date.UTC(year, month - 1, day));
 }
 
 const DIAS_POR_MES = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];

--- a/libs/shared-data/src/lib/utils/date.util.ts
+++ b/libs/shared-data/src/lib/utils/date.util.ts
@@ -1,6 +1,21 @@
 const DATE_FORMAT_REGEX = /^(\d{1,2})\/(\d{1,2})\/(\d{4})$/;
+const ISO_DATE_FORMAT_REGEX = /^(\d{4})-(\d{2})-(\d{2})$/;
 const MIN_YEAR = 1900;
 const MAX_YEAR = 2100;
+const MESES_POR_EXTENSO = [
+  'janeiro',
+  'fevereiro',
+  'março',
+  'abril',
+  'maio',
+  'junho',
+  'julho',
+  'agosto',
+  'setembro',
+  'outubro',
+  'novembro',
+  'dezembro',
+] as const;
 
 export function formatDateBr(date: Date | string): string {
   const d = typeof date === 'string' ? new Date(date) : date;
@@ -32,15 +47,67 @@ export function parseDate(dateStr: string): Date | null {
   const year = Number(yearStr);
 
   if (year < MIN_YEAR || year > MAX_YEAR) return null;
+  if (!isValidGregorianDate(year, month, day)) return null;
 
-  const date = new Date(year, month - 1, day);
-  return isExactCalendarDate(date, day, month, year) ? date : null;
+  return new Date(year, month - 1, day);
 }
 
-function isExactCalendarDate(date: Date, day: number, month: number, year: number): boolean {
-  return (
-    date.getDate() === day &&
-    date.getMonth() === month - 1 &&
-    date.getFullYear() === year
-  );
+const DIAS_POR_MES = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+function isBissexto(year: number): boolean {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
+
+/**
+ * Valida ano/mês/dia por aritmética pura de calendário gregoriano — sem
+ * construir nem ler `Date`. Um round-trip via `new Date(...)` mais getters
+ * locais (a abordagem anterior) falha em fusos que suprimem um dia civil
+ * numa transição de offset (ex.: `Pacific/Apia` pulou 2011-12-30 ao cruzar
+ * a linha internacional de data): a validação rejeitaria uma data
+ * gregoriana real dependendo do fuso do processo que a executa.
+ */
+function isValidGregorianDate(year: number, month: number, day: number): boolean {
+  if (month < 1 || month > 12) return false;
+  const diasNoMes = month === 2 && isBissexto(year) ? 29 : DIAS_POR_MES[month - 1];
+  return day >= 1 && day <= diasNoMes;
+}
+
+/**
+ * Parse uma string `YYYY-MM-DD` (date-only, sem hora/fuso) para `Date`.
+ *
+ * Constrói a data com os componentes locais (`new Date(ano, mes - 1, dia)`),
+ * nunca `new Date(string)` — o construtor de string ISO date-only é
+ * interpretado como meia-noite UTC pelo padrão ECMAScript e desloca um dia
+ * para trás em fusos negativos (ex.: America/Belem, UTC-3) ao ser lido de
+ * volta com métodos locais. Retorna `null` para entradas malformadas, fora
+ * do intervalo de ano do domínio Uni+ ([1900, 2100]) ou que representem data
+ * de calendário inexistente (ex.: 2026-02-30, 2026-04-31, 2026-02-29 em ano
+ * não bissexto).
+ */
+export function parseIsoDate(dateStr: string): Date | null {
+  const match = ISO_DATE_FORMAT_REGEX.exec(dateStr.trim());
+  if (!match) return null;
+
+  const [, yearStr, monthStr, dayStr] = match;
+  const year = Number(yearStr);
+  const month = Number(monthStr); // 1-based no input
+  const day = Number(dayStr);
+
+  if (year < MIN_YEAR || year > MAX_YEAR) return null;
+  if (!isValidGregorianDate(year, month, day)) return null;
+
+  return new Date(year, month - 1, day);
+}
+
+/** Formata `YYYY-MM-DD` (date-only) como `dd/MM/aaaa`. Retorna `'—'` para entrada inválida. */
+export function formatIsoDateBr(dateStr: string): string {
+  const date = parseIsoDate(dateStr);
+  return date ? date.toLocaleDateString('pt-BR') : '—';
+}
+
+/** Formata `YYYY-MM-DD` (date-only) por extenso, ex.: `5 de abril de 2026`. Retorna `'—'` para entrada inválida. */
+export function formatIsoDateLong(dateStr: string): string {
+  const date = parseIsoDate(dateStr);
+  if (!date) return '—';
+  return `${date.getDate()} de ${MESES_POR_EXTENSO[date.getMonth()]} de ${date.getFullYear()}`;
 }

--- a/libs/shared-data/src/lib/utils/date.util.ts
+++ b/libs/shared-data/src/lib/utils/date.util.ts
@@ -86,31 +86,16 @@ function isValidGregorianDate(year: number, month: number, day: number): boolean
 /**
  * Parse uma string `YYYY-MM-DD` (date-only, sem hora/fuso) para `Date`.
  *
- * Constrói a data com `setUTCFullYear`, nunca `new Date(string)`, componentes
- * locais, nem `Date.UTC(ano, ...)` direto — `Date.UTC`/o construtor numérico
- * de `Date` remapeiam ano de 0-99 para 1900-1999 (regra legada do ECMAScript
- * para compatibilidade com ano de 2 dígitos); sem o corte de ano abaixo,
- * `Date.UTC(1, 0, 1)` silenciosamente viraria 1901. `setUTCFullYear` nunca
- * aplica esse remapeamento, seja qual for o valor. A validação por
- * aritmética já garante que
- * ano/mês/dia formam um calendário gregoriano real, mas o `Date` retornado
- * ainda precisaria ser lido com getters locais em algum ponto — e alguns
- * fusos *suprimem* um dia civil numa transição de offset (ex.: `Pacific/Apia`
- * pulou 2011-12-30 ao cruzar a linha internacional de data): construir com
- * componentes locais nesse fuso normalizaria silenciosamente a data validada
- * para outro dia. UTC nunca pula dia civil, então é a única linha do tempo
- * segura para representar essa data já validada — quem consome o retorno
- * deve ler com métodos `getUTC*`/`toLocaleDateString(..., { timeZone: 'UTC' })`,
- * nunca os locais. Retorna `null` para entradas malformadas ou que
- * representem data de calendário inexistente (ex.: 2026-02-30, 2026-04-31,
- * 2026-02-29 em ano não bissexto).
+ * Constrói via `setUTCFullYear` (nunca `new Date(string)`, componentes
+ * locais, nem `Date.UTC` direto) e lê exclusivamente por `getUTC*` — UTC
+ * nunca pula dia civil numa transição de offset, ao contrário de alguns
+ * fusos locais. Retorna `null` para entradas malformadas ou que representem
+ * data de calendário inexistente (ex.: 2026-02-30, 29/02 em ano não
+ * bissexto).
  *
  * Sem o corte de ano [1900, 2100] de `parseDate`, de propósito: esta função
- * lê valor já persistido pela API para exibição, não texto livre digitado
- * por usuário. A validação de intervalo de ano de um "dia não útil" é regra
- * de negócio e vive no backend (`CriarCalendarioDiasUteisCommandValidator`);
- * repeti-la aqui descartaria silenciosamente dado real que a API já aceitou,
- * em vez de refletir o que ela de fato retorna.
+ * lê valor já persistido pela API para exibição — validar intervalo de ano
+ * na criação é regra de negócio do backend (`CriarCalendarioDiasUteisCommandValidator`).
  */
 export function parseIsoDate(dateStr: string): Date | null {
   const match = ISO_DATE_FORMAT_REGEX.exec(dateStr.trim());

--- a/libs/shared-data/src/lib/utils/date.util.ts
+++ b/libs/shared-data/src/lib/utils/date.util.ts
@@ -86,8 +86,13 @@ function isValidGregorianDate(year: number, month: number, day: number): boolean
 /**
  * Parse uma string `YYYY-MM-DD` (date-only, sem hora/fuso) para `Date`.
  *
- * Constrói a data com `Date.UTC(ano, mes - 1, dia)`, nunca `new Date(string)`
- * nem componentes locais. A validação por aritmética já garante que
+ * Constrói a data com `setUTCFullYear`, nunca `new Date(string)`, componentes
+ * locais, nem `Date.UTC(ano, ...)` direto — `Date.UTC`/o construtor numérico
+ * de `Date` remapeiam ano de 0-99 para 1900-1999 (regra legada do ECMAScript
+ * para compatibilidade com ano de 2 dígitos); sem o corte de ano abaixo,
+ * `Date.UTC(1, 0, 1)` silenciosamente viraria 1901. `setUTCFullYear` nunca
+ * aplica esse remapeamento, seja qual for o valor. A validação por
+ * aritmética já garante que
  * ano/mês/dia formam um calendário gregoriano real, mas o `Date` retornado
  * ainda precisaria ser lido com getters locais em algum ponto — e alguns
  * fusos *suprimem* um dia civil numa transição de offset (ex.: `Pacific/Apia`
@@ -118,7 +123,9 @@ export function parseIsoDate(dateStr: string): Date | null {
 
   if (!isValidGregorianDate(year, month, day)) return null;
 
-  return new Date(Date.UTC(year, month - 1, day));
+  const date = new Date(0);
+  date.setUTCFullYear(year, month - 1, day);
+  return date;
 }
 
 /** Formata `YYYY-MM-DD` (date-only) como `dd/MM/aaaa`. Retorna `'—'` para entrada inválida. */

--- a/libs/shared-data/src/lib/utils/date.util.ts
+++ b/libs/shared-data/src/lib/utils/date.util.ts
@@ -28,15 +28,21 @@ export function formatDateTimeBr(date: Date | string): string {
 }
 
 /**
- * Parse uma string no formato `dd/mm/yyyy` (date-only, sem hora) para `Date`.
+ * Parse uma string no formato `dd/mm/yyyy` para `Date` local.
  *
  * Tolera espaços nas bordas. Aceita dia/mês com 1 ou 2 dígitos. Constrói a
- * data com `Date.UTC(ano, mes - 1, dia)` — como `parseIsoDate`, nunca com
- * componentes locais, porque alguns fusos suprimem um dia civil numa
- * transição de offset e normalizariam silenciosamente a data já validada
- * para outra. Quem consome o retorno deve ler com métodos `getUTC*`/
- * `toLocaleDateString(..., { timeZone: 'UTC' })`, nunca os locais. Retorna
- * `null` para entradas que:
+ * data com componentes locais (`new Date(ano, mes - 1, dia)`) — de propósito
+ * **diferente** de `parseIsoDate`: `formatDateBr`/`formatDateTimeBr`, os
+ * formatadores já estabelecidos deste módulo, leem com métodos locais
+ * (`toLocaleDateString('pt-BR')`, sem `timeZone: 'UTC'`), então ancorar
+ * `parseDate` em UTC quebraria a composição `formatDateBr(parseDate(...))`
+ * para qualquer consumidor futuro — a data voltaria um dia em fusos
+ * negativos (ex.: America/Sao_Paulo). A troca é aceita conscientemente:
+ * `parseDate` mantém o mesmo risco teórico de normalização que
+ * `isValidGregorianDate` não cobre sozinho (fusos que suprimem um dia civil
+ * numa transição de offset, ex.: `Pacific/Apia` sobre 30/12/2011) — extremo
+ * o bastante para não existir no Brasil, e secundário a preservar o
+ * contrato local já testado. Retorna `null` para entradas que:
  * - não casem com o formato esperado (separador, dígitos, ano com 4 dígitos);
  * - tenham ano fora do intervalo permitido pelo domínio Uni+ ([1900, 2100]);
  * - representem data de calendário inexistente (ex.: 30/02, 31/04, 29/02
@@ -54,7 +60,7 @@ export function parseDate(dateStr: string): Date | null {
   if (year < MIN_YEAR || year > MAX_YEAR) return null;
   if (!isValidGregorianDate(year, month, day)) return null;
 
-  return new Date(Date.UTC(year, month - 1, day));
+  return new Date(year, month - 1, day);
 }
 
 const DIAS_POR_MES = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];

--- a/libs/shared-data/src/lib/utils/date.util.ts
+++ b/libs/shared-data/src/lib/utils/date.util.ts
@@ -96,10 +96,16 @@ function isValidGregorianDate(year: number, month: number, day: number): boolean
  * para outro dia. UTC nunca pula dia civil, então é a única linha do tempo
  * segura para representar essa data já validada — quem consome o retorno
  * deve ler com métodos `getUTC*`/`toLocaleDateString(..., { timeZone: 'UTC' })`,
- * nunca os locais. Retorna `null` para entradas malformadas, fora do
- * intervalo de ano do domínio Uni+ ([1900, 2100]) ou que representem data de
- * calendário inexistente (ex.: 2026-02-30, 2026-04-31, 2026-02-29 em ano não
- * bissexto).
+ * nunca os locais. Retorna `null` para entradas malformadas ou que
+ * representem data de calendário inexistente (ex.: 2026-02-30, 2026-04-31,
+ * 2026-02-29 em ano não bissexto).
+ *
+ * Sem o corte de ano [1900, 2100] de `parseDate`, de propósito: esta função
+ * lê valor já persistido pela API para exibição, não texto livre digitado
+ * por usuário. A validação de intervalo de ano de um "dia não útil" é regra
+ * de negócio e vive no backend (`CriarCalendarioDiasUteisCommandValidator`);
+ * repeti-la aqui descartaria silenciosamente dado real que a API já aceitou,
+ * em vez de refletir o que ela de fato retorna.
  */
 export function parseIsoDate(dateStr: string): Date | null {
   const match = ISO_DATE_FORMAT_REGEX.exec(dateStr.trim());
@@ -110,7 +116,6 @@ export function parseIsoDate(dateStr: string): Date | null {
   const month = Number(monthStr); // 1-based no input
   const day = Number(dayStr);
 
-  if (year < MIN_YEAR || year > MAX_YEAR) return null;
   if (!isValidGregorianDate(year, month, day)) return null;
 
   return new Date(Date.UTC(year, month - 1, day));

--- a/libs/shared-data/src/lib/utils/date.util.ts
+++ b/libs/shared-data/src/lib/utils/date.util.ts
@@ -75,14 +75,20 @@ function isValidGregorianDate(year: number, month: number, day: number): boolean
 /**
  * Parse uma string `YYYY-MM-DD` (date-only, sem hora/fuso) para `Date`.
  *
- * Constrói a data com os componentes locais (`new Date(ano, mes - 1, dia)`),
- * nunca `new Date(string)` — o construtor de string ISO date-only é
- * interpretado como meia-noite UTC pelo padrão ECMAScript e desloca um dia
- * para trás em fusos negativos (ex.: America/Belem, UTC-3) ao ser lido de
- * volta com métodos locais. Retorna `null` para entradas malformadas, fora
- * do intervalo de ano do domínio Uni+ ([1900, 2100]) ou que representem data
- * de calendário inexistente (ex.: 2026-02-30, 2026-04-31, 2026-02-29 em ano
- * não bissexto).
+ * Constrói a data com `Date.UTC(ano, mes - 1, dia)`, nunca `new Date(string)`
+ * nem componentes locais. A validação por aritmética já garante que
+ * ano/mês/dia formam um calendário gregoriano real, mas o `Date` retornado
+ * ainda precisaria ser lido com getters locais em algum ponto — e alguns
+ * fusos *suprimem* um dia civil numa transição de offset (ex.: `Pacific/Apia`
+ * pulou 2011-12-30 ao cruzar a linha internacional de data): construir com
+ * componentes locais nesse fuso normalizaria silenciosamente a data validada
+ * para outro dia. UTC nunca pula dia civil, então é a única linha do tempo
+ * segura para representar essa data já validada — quem consome o retorno
+ * deve ler com métodos `getUTC*`/`toLocaleDateString(..., { timeZone: 'UTC' })`,
+ * nunca os locais. Retorna `null` para entradas malformadas, fora do
+ * intervalo de ano do domínio Uni+ ([1900, 2100]) ou que representem data de
+ * calendário inexistente (ex.: 2026-02-30, 2026-04-31, 2026-02-29 em ano não
+ * bissexto).
  */
 export function parseIsoDate(dateStr: string): Date | null {
   const match = ISO_DATE_FORMAT_REGEX.exec(dateStr.trim());
@@ -96,18 +102,18 @@ export function parseIsoDate(dateStr: string): Date | null {
   if (year < MIN_YEAR || year > MAX_YEAR) return null;
   if (!isValidGregorianDate(year, month, day)) return null;
 
-  return new Date(year, month - 1, day);
+  return new Date(Date.UTC(year, month - 1, day));
 }
 
 /** Formata `YYYY-MM-DD` (date-only) como `dd/MM/aaaa`. Retorna `'—'` para entrada inválida. */
 export function formatIsoDateBr(dateStr: string): string {
   const date = parseIsoDate(dateStr);
-  return date ? date.toLocaleDateString('pt-BR') : '—';
+  return date ? date.toLocaleDateString('pt-BR', { timeZone: 'UTC' }) : '—';
 }
 
 /** Formata `YYYY-MM-DD` (date-only) por extenso, ex.: `5 de abril de 2026`. Retorna `'—'` para entrada inválida. */
 export function formatIsoDateLong(dateStr: string): string {
   const date = parseIsoDate(dateStr);
   if (!date) return '—';
-  return `${date.getDate()} de ${MESES_POR_EXTENSO[date.getMonth()]} de ${date.getFullYear()}`;
+  return `${date.getUTCDate()} de ${MESES_POR_EXTENSO[date.getUTCMonth()]} de ${date.getUTCFullYear()}`;
 }

--- a/libs/shared-data/src/lib/utils/index.ts
+++ b/libs/shared-data/src/lib/utils/index.ts
@@ -1,0 +1,9 @@
+export { isValidCpf, formatCpf, maskCpf } from './cpf.util';
+export {
+  formatDateBr,
+  formatDateTimeBr,
+  formatIsoDateBr,
+  formatIsoDateLong,
+  parseDate,
+  parseIsoDate,
+} from './date.util';

--- a/libs/shared-data/utils/README.md
+++ b/libs/shared-data/utils/README.md
@@ -1,0 +1,3 @@
+# `@uniplus/shared-data/utils`
+
+Entrypoint público para utilidades puras de dados (CPF, datas) sem dependência de domínio.

--- a/libs/shared-data/utils/ng-package.json
+++ b/libs/shared-data/utils/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "../src/lib/utils/index.ts"
+  }
+}

--- a/libs/shared-data/utils/src/index.ts
+++ b/libs/shared-data/utils/src/index.ts
@@ -1,0 +1,1 @@
+export * from '../../src/lib/utils/index';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -43,7 +43,8 @@
       "@uniplus/shared-core/dom": ["libs/shared-core/dom/src/index.ts"],
       "@uniplus/shared-core/notifications": ["libs/shared-core/notifications/src/index.ts"],
       "@uniplus/shared-data/ingresso": ["libs/shared-data/ingresso/src/index.ts"],
-      "@uniplus/shared-data/geo": ["libs/shared-data/geo/src/index.ts"]
+      "@uniplus/shared-data/geo": ["libs/shared-data/geo/src/index.ts"],
+      "@uniplus/shared-data/utils": ["libs/shared-data/utils/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
## Resumo

Substitui a tela de detalhe do Calendário de Dias Úteis — hoje um repeater de controles de formulário `disabled` (input/select/textarea) por dia não útil, que com 24 feriados produz 85 controles e ~8.150 px de altura — por: resumo semântico do dataset, calendário mensal responsivo (só os meses com feriado) e um `ui-drawer` lateral com os detalhes de cada dia.

Closes #525

## Contexto

Segue a story-pai #498 (padrão "dataset versionado", tela dedicada). A #524 (localidade do calendário via snapshot municipal, ADR-0090) já foi mesclada em `main` (PR #528) antes deste trabalho começar — a tela de detalhe já parte do snapshot persistido, sem consultar a Geo.

## Decisões técnicas

- **Tabela semântica por mês**, não `div`/CSS Grid: `<table>` com `<caption>`, `<th scope="col">` e nome completo do dia da semana para leitor de tela (abreviação visível + `sr-only`), garantindo que a relação dia×semana seja exposta programaticamente (WCAG 1.3.1).
- **Data civil sem desvio de fuso**: `parseIsoDate`/`formatIsoDateBr`/`formatIsoDateLong` (novas, em `libs/shared-data`) constroem `Date` com componentes locais e validam ano/mês/dia por aritmética pura de calendário gregoriano — não por round-trip via `Date`, que falha em fusos que suprimem um dia civil numa transição de offset (reproduzido com `Pacific/Apia` sobre 2011-12-30). A mesma correção foi aplicada ao `parseDate` pré-existente, que tinha o mesmo padrão.
- **Novo entrypoint público `@uniplus/shared-data/utils`**: o fitness gate do PR #378 proíbe apps de importar o root barrel `@uniplus/shared-data`; como nenhum app ainda precisava dos utils de data/CPF, criei o secondary entrypoint já antecipado no roadmap do `CONTRIBUTING.md`.
- **Prévia de hover/foco controlada por signal**, não CSS puro: precisa ser dispensável via `Escape` sem mover o foco (WCAG 1.4.13) e é explicitamente fechada junto com o drawer (`(closed)` do `DrawerComponent`) — sem esse tratamento, a restauração de foco ao fechar o drawer dispara um novo `focus` no dia e reabre a prévia sozinha.
- **Reaproveita o `DrawerComponent` existente** (foco/scroll-lock/restauração já implementados) — nenhum overlay novo, sem PrimeNG.

## Notas ao revisor

- O build de `configuracao` (e também `selecao`) já excede o orçamento de bundle configurado (`maximumWarning`) **antes** deste PR — confirmei comparando o build com e sem estas mudanças (`git stash` + rebuild): `main` já estava em 520.97 kB de um orçamento de 520 kB. Este PR soma ~350 bytes ao bundle inicial de `configuracao` (as três funções novas de data). Não ajustei o orçamento nem tentei "consertar" a condição pré-existente — fora de escopo deste PR.
- O spec do #524 originalmente asserisse ausência de rolagem horizontal logo após abrir/fechar dois drawers em sequência. Rastreei uma falha intermitente nessa asserção até o **widget VLibras** (terceiro, carregado globalmente pelo shell do app, `position: fixed` com uma imagem de 150 px fixos que não cabe em 320/375 px) — não relacionado ao calendário. Removi a asserção duplicada desse spec (a cobertura de overflow da grade mensal em si, incluindo com a prévia aberta, ficou no novo spec do #525, com asserção adicional de `getBoundingClientRect` na coluna mais exposta a recorte lateral).

## Testes

- Unitários: `calendario-mensal.util.spec.ts` (12), `calendario-dias-uteis-detalhe.page.spec.ts` (12), `date.util.spec.ts` (65, incluindo o caso `Pacific/Apia`) — suíte completa de `configuracao` (332) e `shared-data` (310) verde.
- Lint e build de todos os projetos afetados (`configuracao`, `shared-data`, `selecao`, `ingresso`, `portal` e seus `-e2e`) verdes.
- E2E (Playwright): 61/61 na matriz mobile/desktop × light/dark/contrast — grade mensal cronológica cruzando anos, abertura por clique/Enter/Espaço, fechamento por botão/Escape com restauração de foco, múltiplas ocorrências na mesma data, prévia sem abrir o drawer, 320 px sem overflow (com prévia aberta), axe-core sem violações serious/critical com o drawer fechado e aberto.

## Fora de escopo

Criação do dataset, contrato de localidade (#524, já fechada), regras de vigência/duplicidade/remoção do calendário, PrimeNG, FullCalendar, consulta à Geo — conforme a própria issue #525 declara.