### PR TITLE
feat(shared-ui): adiciona nova opção de formatação pipe date-br

### DIFF
--- a/libs/shared-ui/src/lib/pipes/date-br.pipe.spec.ts
+++ b/libs/shared-ui/src/lib/pipes/date-br.pipe.spec.ts
@@ -26,6 +26,9 @@ describe('DateBrPipe', () => {
   it('formata uma data válida no formato "datetime"', () => {
     expect(pipe.transform(DATA_VALIDA_RAW, 'datetime')).toBe('05/06/2026, 12:30');
     expect(pipe.transform(DATA_VALIDA, 'datetime')).toBe('05/06/2026, 12:30');
+    expect(pipe.transform('2026-07-07T13:23:42.707136+00:00', 'datetime')).toBe(
+      '07/07/2026, 10:23',
+    );
   });
 
   it('formata uma data válida no formato "long"', () => {

--- a/libs/shared-ui/src/lib/pipes/date-br.pipe.spec.ts
+++ b/libs/shared-ui/src/lib/pipes/date-br.pipe.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 
 import { DateBrPipe } from './date-br.pipe';
 
-const DATA_VALIDA_RAW = '2026-06-05T15:30:00';
+const DATA_VALIDA_RAW = '2026-06-05T15:30:00Z';
 const DATA_VALIDA = new Date(DATA_VALIDA_RAW);
 
 describe('DateBrPipe', () => {
@@ -24,8 +24,8 @@ describe('DateBrPipe', () => {
   });
 
   it('formata uma data válida no formato "datetime"', () => {
-    expect(pipe.transform(DATA_VALIDA_RAW, 'datetime')).toBe('05/06/2026, 15:30');
-    expect(pipe.transform(DATA_VALIDA, 'datetime')).toBe('05/06/2026, 15:30');
+    expect(pipe.transform(DATA_VALIDA_RAW, 'datetime')).toBe('05/06/2026, 12:30');
+    expect(pipe.transform(DATA_VALIDA, 'datetime')).toBe('05/06/2026, 12:30');
   });
 
   it('formata uma data válida no formato "long"', () => {
@@ -52,5 +52,18 @@ describe('DateBrPipe', () => {
     expect(pipe.transform(dataInexistente, 'datetime')).toBe('');
     expect(pipe.transform(dataInexistente, 'shortMonth')).toBe('');
     expect(pipe.transform(dataInexistente, 'long')).toBe('');
+  });
+
+  it('preserva o instante quando a entrada traz fuso explícito', () => {
+    // 00:00Z = 21:00 do dia anterior em America/Belem (UTC−3)
+    expect(pipe.transform('2026-08-11T00:00:00Z', 'datetime')).toBe('10/08/2026, 21:00');
+  });
+
+  it('não desloca o dia em data pura', () => {
+    expect(pipe.transform('2026-06-05', 'short')).toBe('05/06/2026');
+  });
+
+  it('exibe texto vazio para Date inválido', () => {
+    expect(pipe.transform(new Date('data-invalida'))).toBe('');
   });
 });

--- a/libs/shared-ui/src/lib/pipes/date-br.pipe.spec.ts
+++ b/libs/shared-ui/src/lib/pipes/date-br.pipe.spec.ts
@@ -57,6 +57,12 @@ describe('DateBrPipe', () => {
     expect(pipe.transform(dataInexistente, 'long')).toBe('');
   });
 
+  it('exibe texto vazio quando a hora, o minuto ou o segundo são inválidos', () => {
+    expect(pipe.transform('2026-06-05T25:00')).toBe('');
+    expect(pipe.transform('2026-06-05T12:99')).toBe('');
+    expect(pipe.transform('2026-06-05T12:30:99')).toBe('');
+  });
+
   it('preserva o instante quando a entrada traz fuso explícito', () => {
     // 00:00Z = 21:00 do dia anterior em America/Belem (UTC−3)
     expect(pipe.transform('2026-08-11T00:00:00Z', 'datetime')).toBe('10/08/2026, 21:00');

--- a/libs/shared-ui/src/lib/pipes/date-br.pipe.spec.ts
+++ b/libs/shared-ui/src/lib/pipes/date-br.pipe.spec.ts
@@ -72,6 +72,10 @@ describe('DateBrPipe', () => {
     expect(pipe.transform('2026-06-05', 'short')).toBe('05/06/2026');
   });
 
+  it('preserva datas de anos abaixo de 100', () => {
+    expect(pipe.transform('0099-12-31', 'short')).toBe('31/12/99');
+  });
+
   it('exibe texto vazio para Date inválido', () => {
     expect(pipe.transform(new Date('data-invalida'))).toBe('');
   });

--- a/libs/shared-ui/src/lib/pipes/date-br.pipe.spec.ts
+++ b/libs/shared-ui/src/lib/pipes/date-br.pipe.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { DateBrPipe } from './date-br.pipe';
+
+const DATA_VALIDA_RAW = '2026-06-05T15:30:00';
+const DATA_VALIDA = new Date(DATA_VALIDA_RAW);
+
+describe('DateBrPipe', () => {
+  let pipe: DateBrPipe;
+
+  beforeEach(() => {
+    pipe = new DateBrPipe();
+  });
+
+  it('exibe um texto vazio quando a entrada é inválida ou vazia', () => {
+    expect(pipe.transform(null)).toBe('');
+    expect(pipe.transform(undefined)).toBe('');
+    expect(pipe.transform('')).toBe('');
+  });
+
+  it('formata uma data válida no formato "short"', () => {
+    expect(pipe.transform(DATA_VALIDA_RAW, 'short')).toBe('05/06/2026');
+    expect(pipe.transform(DATA_VALIDA, 'short')).toBe('05/06/2026');
+  });
+
+  it('formata uma data válida no formato "datetime"', () => {
+    expect(pipe.transform(DATA_VALIDA_RAW, 'datetime')).toBe('05/06/2026, 15:30');
+    expect(pipe.transform(DATA_VALIDA, 'datetime')).toBe('05/06/2026, 15:30');
+  });
+
+  it('formata uma data válida no formato "long"', () => {
+    expect(pipe.transform(DATA_VALIDA_RAW, 'long')).toBe('05 de junho de 2026');
+    expect(pipe.transform(DATA_VALIDA, 'long')).toBe('05 de junho de 2026');
+  });
+
+  it('formata uma data válida no formato "shortMonth"', () => {
+    expect(pipe.transform(DATA_VALIDA_RAW, 'shortMonth')).toBe('05 jun 2026');
+    expect(pipe.transform(DATA_VALIDA, 'shortMonth')).toBe('05 jun 2026');
+  });
+
+  it('formata uma data válida sem deslocamento de fuso', () => {
+    const data = '2026-06-01T12:30:00';
+    expect(pipe.transform(data, 'short')).toBe('01/06/2026');
+    expect(pipe.transform(data, 'datetime')).toBe('01/06/2026, 12:30');
+    expect(pipe.transform(data, 'shortMonth')).toBe('01 jun 2026');
+    expect(pipe.transform(data, 'long')).toBe('01 de junho de 2026');
+  });
+
+  it('exibe um texto vazio quando a data é inexistente', () => {
+    const dataInexistente = '2026-02-29T12:30:00';
+    expect(pipe.transform(dataInexistente, 'short')).toBe('');
+    expect(pipe.transform(dataInexistente, 'datetime')).toBe('');
+    expect(pipe.transform(dataInexistente, 'shortMonth')).toBe('');
+    expect(pipe.transform(dataInexistente, 'long')).toBe('');
+  });
+});

--- a/libs/shared-ui/src/lib/pipes/date-br.pipe.ts
+++ b/libs/shared-ui/src/lib/pipes/date-br.pipe.ts
@@ -3,15 +3,12 @@ import { Pipe, PipeTransform } from '@angular/core';
 export type DateBrPipeFormat = 'short' | 'long' | 'datetime' | 'shortMonth';
 export type DateBrPipeInput = Date | string | null | undefined;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const timeFormats: ['short', 'long', 'datetime', 'shortMonth'] = [
-  'short',
-  'long',
-  'datetime',
-  'shortMonth',
-] as const;
+/** Data-hora com designador de zona explícito (`Z` ou `±hh:mm`). */
+const ZONED_DATETIME = /T.*([Zz]|[+-]\d{2}:?\d{2})$/;
 
-type DateTimeFormat = { [K in (typeof timeFormats)[number]]: Intl.DateTimeFormat };
+type DateTimeFormat = Record<DateBrPipeFormat, Intl.DateTimeFormat>;
+
+const DIAS_POR_MES = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 
 const DATE_OPTIONS: DateTimeFormat = {
   short: new Intl.DateTimeFormat('pt-BR', {
@@ -46,42 +43,26 @@ const DATE_OPTIONS: DateTimeFormat = {
 export class DateBrPipe implements PipeTransform {
   transform(input: DateBrPipeInput, format: DateBrPipeFormat = 'short'): string {
     if (!input) return '';
-    let date: Date | null;
-    if (input instanceof Date) {
-      date = input;
-    } else {
-      date = this.parse(input);
-    }
-    if (!date) return '';
-    if (format === 'short') {
-      return DATE_OPTIONS.short.format(date);
-    } else if (format === 'long') {
-      return DATE_OPTIONS.long.format(date);
-    } else if (format === 'datetime') {
-      return DATE_OPTIONS.datetime.format(date);
-    } else if (format === 'shortMonth') {
-      const texto = DATE_OPTIONS.shortMonth.format(date);
-      const resultado = texto.match(/\b(\d{2}) de (\w{3})\.? de (\d{4})\b/);
-      return resultado ? `${resultado[1]} ${resultado[2]} ${resultado[3]}` : '';
-    } else {
-      return '';
-    }
+    const date = input instanceof Date ? input : this.parse(input);
+    if (!date || Number.isNaN(date.getTime())) return '';
+    return format === 'shortMonth'
+      ? this.formatShortMonth(date)
+      : DATE_OPTIONS[format].format(date);
   }
 
   private parse(input: string | null): Date | null {
     if (!input) return null;
-    let year,
-      month,
-      day,
-      hour = 0,
-      minute = 0;
-    // YYYY-MM-DDTHH:mm
+    if (ZONED_DATETIME.test(input)) {
+      const instante = new Date(input);
+      return Number.isNaN(instante.getTime()) ? null : instante;
+    }
+    let year, month, day, hour = 0, minute = 0;
+    // DD-MM-YYYY
     if (input.includes('T')) {
       const [datePart, timePart] = input.split('T');
       [year, month, day] = datePart.split('-');
       [hour, minute] = timePart.split(':').map(Number);
     }
-    // DD-MM-YYYY
     else if (/^\d{2}-\d{2}-\d{4}$/.test(input)) {
       [day, month, year] = input.split('-');
     }
@@ -92,12 +73,33 @@ export class DateBrPipe implements PipeTransform {
       return null;
     }
     const dataInstanciada = new Date(Number(year), Number(month) - 1, Number(day), hour, minute);
-    return this.isExactCalendarDate(dataInstanciada, Number(day), Number(month), Number(year))
+    return this.isValidGregorianDate(Number(year), Number(month), Number(day))
       ? dataInstanciada
       : null;
   }
 
-  private isExactCalendarDate(date: Date, day: number, month: number, year: number): boolean {
-    return date.getDate() === day && date.getMonth() === month - 1 && date.getFullYear() === year;
+  /**
+   * Valida ano/mês/dia por aritmética pura de calendário gregoriano — sem
+   * construir nem ler `Date`. Um round-trip via `new Date(...)` mais getters
+   * locais (a abordagem anterior) falha em fusos que suprimem um dia civil
+   * numa transição de offset (ex.: `Pacific/Apia` pulou 2011-12-30 ao cruzar
+   * a linha internacional de data): a validação rejeitaria uma data
+   * gregoriana real dependendo do fuso do processo que a executa.
+   */
+  private isValidGregorianDate(year: number, month: number, day: number): boolean {
+    if (month < 1 || month > 12) return false;
+    const diasNoMes = month === 2 && this.isBissexto(year) ? 29 : DIAS_POR_MES[month - 1];
+    return day >= 1 && day <= diasNoMes;
+  }
+
+  private isBissexto(year: number): boolean {
+    return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+  }
+
+  private formatShortMonth(date: Date): string {
+    const partes = DATE_OPTIONS.shortMonth.formatToParts(date);
+    const parte = (tipo: Intl.DateTimeFormatPartTypes) =>
+      partes.find((p) => p.type === tipo)?.value ?? '';
+    return `${parte('day')} ${parte('month').replace('.', '')} ${parte('year')}`;
   }
 }

--- a/libs/shared-ui/src/lib/pipes/date-br.pipe.ts
+++ b/libs/shared-ui/src/lib/pipes/date-br.pipe.ts
@@ -60,14 +60,17 @@ export class DateBrPipe implements PipeTransform {
       const instante = new Date(input);
       return Number.isNaN(instante.getTime()) ? null : instante;
     }
-    let year, month, day, hour = 0, minute = 0;
+    let year,
+      month,
+      day,
+      hour = 0,
+      minute = 0;
     // DD-MM-YYYY
     if (input.includes('T')) {
       const [datePart, timePart] = input.split('T');
       [year, month, day] = datePart.split('-');
       [hour, minute] = timePart.split(':').map(Number);
-    }
-    else if (/^\d{2}-\d{2}-\d{4}$/.test(input)) {
+    } else if (/^\d{2}-\d{2}-\d{4}$/.test(input)) {
       [day, month, year] = input.split('-');
     }
     // YYYY-MM-DD
@@ -76,7 +79,13 @@ export class DateBrPipe implements PipeTransform {
     } else {
       return null;
     }
-    const dataInstanciada = new Date(Number(year), Number(month) - 1, Number(day), hour, minute);
+    const dataInstanciada = this.toZonedInstant(
+      Number(year),
+      Number(month),
+      Number(day),
+      hour,
+      minute,
+    );
     return this.isValidGregorianDate(Number(year), Number(month), Number(day))
       ? dataInstanciada
       : null;
@@ -105,5 +114,29 @@ export class DateBrPipe implements PipeTransform {
     const parte = (tipo: Intl.DateTimeFormatPartTypes) =>
       partes.find((p) => p.type === tipo)?.value ?? '';
     return `${parte('day')} ${parte('month').replace('.', '')} ${parte('year')}`;
+  }
+
+  private zonedOffsetMillis(utcMillis: number): number {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: 'America/Sao_Paulo',
+      timeZoneName: 'longOffset',
+    }).formatToParts(new Date(utcMillis));
+    const offset = parts.find((p) => p.type === 'timeZoneName')?.value ?? 'GMT+00:00';
+    const match = /GMT([+-])(\d{2}):(\d{2})/.exec(offset);
+    if (!match) return 0;
+    const sign = match[1] === '-' ? -1 : 1;
+    return sign * (Number(match[2]) * 60 + Number(match[3])) * 60_000;
+  }
+
+  private toZonedInstant(
+    year: number,
+    month: number,
+    day: number,
+    hour: number,
+    minute: number,
+  ): Date {
+    const provisionalUtc = Date.UTC(year, month - 1, day, hour, minute);
+    const offset = this.zonedOffsetMillis(provisionalUtc);
+    return new Date(provisionalUtc - offset);
   }
 }

--- a/libs/shared-ui/src/lib/pipes/date-br.pipe.ts
+++ b/libs/shared-ui/src/lib/pipes/date-br.pipe.ts
@@ -125,10 +125,12 @@ export class DateBrPipe implements PipeTransform {
       timeZoneName: 'longOffset',
     }).formatToParts(new Date(utcMillis));
     const offset = parts.find((p) => p.type === 'timeZoneName')?.value ?? 'GMT+00:00';
-    const match = /GMT([+-])(\d{2}):(\d{2})/.exec(offset);
+    const match = /GMT([+-])(\d{2}):(\d{2})(?::(\d{2}))?/.exec(offset);
     if (!match) return 0;
     const sign = match[1] === '-' ? -1 : 1;
-    return sign * (Number(match[2]) * 60 + Number(match[3])) * 60_000;
+    const offsetMinutes = Number(match[2]) * 60 + Number(match[3]);
+    const offsetSeconds = Number(match[4] ?? 0);
+    return sign * (offsetMinutes * 60 + offsetSeconds) * 1_000;
   }
 
   private toZonedInstant(
@@ -138,7 +140,10 @@ export class DateBrPipe implements PipeTransform {
     hour: number,
     minute: number,
   ): Date {
-    const provisionalUtc = Date.UTC(year, month - 1, day, hour, minute);
+    const provisional = new Date(0);
+    provisional.setUTCFullYear(year, month - 1, day);
+    provisional.setUTCHours(hour, minute, 0, 0);
+    const provisionalUtc = provisional.getTime();
     const offset = this.zonedOffsetMillis(provisionalUtc);
     return new Date(provisionalUtc - offset);
   }

--- a/libs/shared-ui/src/lib/pipes/date-br.pipe.ts
+++ b/libs/shared-ui/src/lib/pipes/date-br.pipe.ts
@@ -12,21 +12,25 @@ const DIAS_POR_MES = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 
 const DATE_OPTIONS: DateTimeFormat = {
   short: new Intl.DateTimeFormat('pt-BR', {
+    timeZone: 'America/Sao_Paulo',
     day: '2-digit',
     month: '2-digit',
     year: 'numeric',
   }),
   shortMonth: new Intl.DateTimeFormat('pt-BR', {
+    timeZone: 'America/Sao_Paulo',
     day: '2-digit',
     month: 'short',
     year: 'numeric',
   }),
   long: new Intl.DateTimeFormat('pt-BR', {
+    timeZone: 'America/Sao_Paulo',
     day: '2-digit',
     month: 'long',
     year: 'numeric',
   }),
   datetime: new Intl.DateTimeFormat('pt-BR', {
+    timeZone: 'America/Sao_Paulo',
     day: '2-digit',
     month: '2-digit',
     year: 'numeric',

--- a/libs/shared-ui/src/lib/pipes/date-br.pipe.ts
+++ b/libs/shared-ui/src/lib/pipes/date-br.pipe.ts
@@ -4,7 +4,7 @@ export type DateBrPipeFormat = 'short' | 'long' | 'datetime' | 'shortMonth';
 export type DateBrPipeInput = Date | string | null | undefined;
 
 /** Data-hora com designador de zona explícito (`Z` ou `±hh:mm`). */
-const ZONED_DATETIME = /T.*([Zz]|[+-]\d{2}:?\d{2})$/;
+const ZONED_DATETIME = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
 
 type DateTimeFormat = Record<DateBrPipeFormat, Intl.DateTimeFormat>;
 
@@ -65,7 +65,6 @@ export class DateBrPipe implements PipeTransform {
       day,
       hour = 0,
       minute = 0;
-    // DD-MM-YYYY
     if (input.includes('T')) {
       const [datePart, timePart] = input.split('T');
       [year, month, day] = datePart.split('-');
@@ -73,7 +72,6 @@ export class DateBrPipe implements PipeTransform {
     } else if (/^\d{2}-\d{2}-\d{4}$/.test(input)) {
       [day, month, year] = input.split('-');
     }
-    // YYYY-MM-DD
     else if (/^\d{4}-\d{2}-\d{2}$/.test(input)) {
       [year, month, day] = input.split('-');
     } else {

--- a/libs/shared-ui/src/lib/pipes/date-br.pipe.ts
+++ b/libs/shared-ui/src/lib/pipes/date-br.pipe.ts
@@ -1,22 +1,103 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
+export type DateBrPipeFormat = 'short' | 'long' | 'datetime' | 'shortMonth';
+export type DateBrPipeInput = Date | string | null | undefined;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const timeFormats: ['short', 'long', 'datetime', 'shortMonth'] = [
+  'short',
+  'long',
+  'datetime',
+  'shortMonth',
+] as const;
+
+type DateTimeFormat = { [K in (typeof timeFormats)[number]]: Intl.DateTimeFormat };
+
+const DATE_OPTIONS: DateTimeFormat = {
+  short: new Intl.DateTimeFormat('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  }),
+  shortMonth: new Intl.DateTimeFormat('pt-BR', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  }),
+  long: new Intl.DateTimeFormat('pt-BR', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  }),
+  datetime: new Intl.DateTimeFormat('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }),
+};
+
 @Pipe({
   name: 'dateBr',
   standalone: true,
 })
 export class DateBrPipe implements PipeTransform {
-  transform(value: string | Date | null | undefined, format: 'short' | 'long' | 'datetime' = 'short'): string {
-    if (!value) return '';
-    const date = value instanceof Date ? value : new Date(value);
-    if (isNaN(date.getTime())) return '';
+  transform(input: DateBrPipeInput, format: DateBrPipeFormat = 'short'): string {
+    if (!input) return '';
+    let date: Date | null;
+    if (input instanceof Date) {
+      date = input;
+    } else {
+      date = this.parse(input);
+    }
+    if (!date) return '';
+    if (format === 'short') {
+      return DATE_OPTIONS.short.format(date);
+    } else if (format === 'long') {
+      return DATE_OPTIONS.long.format(date);
+    } else if (format === 'datetime') {
+      return DATE_OPTIONS.datetime.format(date);
+    } else if (format === 'shortMonth') {
+      const texto = DATE_OPTIONS.shortMonth.format(date);
+      const resultado = texto.match(/\b(\d{2}) de (\w{3})\.? de (\d{4})\b/);
+      return resultado ? `${resultado[1]} ${resultado[2]} ${resultado[3]}` : '';
+    } else {
+      return '';
+    }
+  }
 
-    const options: Intl.DateTimeFormatOptions =
-      format === 'long'
-        ? { day: '2-digit', month: 'long', year: 'numeric' }
-        : format === 'datetime'
-          ? { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' }
-          : { day: '2-digit', month: '2-digit', year: 'numeric' };
+  private parse(input: string | null): Date | null {
+    if (!input) return null;
+    let year,
+      month,
+      day,
+      hour = 0,
+      minute = 0;
+    // YYYY-MM-DDTHH:mm
+    if (input.includes('T')) {
+      const [datePart, timePart] = input.split('T');
+      [year, month, day] = datePart.split('-');
+      [hour, minute] = timePart.split(':').map(Number);
+    }
+    // DD-MM-YYYY
+    else if (/^\d{2}-\d{2}-\d{4}$/.test(input)) {
+      [day, month, year] = input.split('-');
+    }
+    // YYYY-MM-DD
+    else if (/^\d{4}-\d{2}-\d{2}$/.test(input)) {
+      [year, month, day] = input.split('-');
+    } else {
+      return null;
+    }
+    const dataInstanciada = new Date(Number(year), Number(month) - 1, Number(day), hour, minute);
+    return this.isExactCalendarDate(dataInstanciada, Number(day), Number(month), Number(year))
+      ? dataInstanciada
+      : null;
+  }
 
-    return date.toLocaleDateString('pt-BR', options);
+  private isExactCalendarDate(date: Date, day: number, month: number, year: number): boolean {
+    return date.getDate() === day && date.getMonth() === month - 1 && date.getFullYear() === year;
   }
 }

--- a/libs/shared-ui/src/lib/pipes/date-br.pipe.ts
+++ b/libs/shared-ui/src/lib/pipes/date-br.pipe.ts
@@ -5,6 +5,7 @@ export type DateBrPipeInput = Date | string | null | undefined;
 
 /** Data-hora com designador de zona explícito (`Z` ou `±hh:mm`). */
 const ZONED_DATETIME = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+const LOCAL_DATETIME = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2})(?:\.\d+)?)?$/;
 
 type DateTimeFormat = Record<DateBrPipeFormat, Intl.DateTimeFormat>;
 
@@ -60,33 +61,33 @@ export class DateBrPipe implements PipeTransform {
       const instante = new Date(input);
       return Number.isNaN(instante.getTime()) ? null : instante;
     }
-    let year,
-      month,
-      day,
-      hour = 0,
-      minute = 0;
-    if (input.includes('T')) {
-      const [datePart, timePart] = input.split('T');
-      [year, month, day] = datePart.split('-');
-      [hour, minute] = timePart.split(':').map(Number);
+    let year: number;
+    let month: number;
+    let day: number;
+    let hour = 0;
+    let minute = 0;
+    let second = 0;
+    const localDateTime = LOCAL_DATETIME.exec(input);
+    if (localDateTime) {
+      const [, yearText, monthText, dayText, hourText, minuteText, secondText] = localDateTime;
+      year = Number(yearText);
+      month = Number(monthText);
+      day = Number(dayText);
+      hour = Number(hourText);
+      minute = Number(minuteText);
+      second = Number(secondText ?? 0);
     } else if (/^\d{2}-\d{2}-\d{4}$/.test(input)) {
-      [day, month, year] = input.split('-');
-    }
-    else if (/^\d{4}-\d{2}-\d{2}$/.test(input)) {
-      [year, month, day] = input.split('-');
+      [day, month, year] = input.split('-').map(Number);
+    } else if (/^\d{4}-\d{2}-\d{2}$/.test(input)) {
+      [year, month, day] = input.split('-').map(Number);
     } else {
       return null;
     }
-    const dataInstanciada = this.toZonedInstant(
-      Number(year),
-      Number(month),
-      Number(day),
-      hour,
-      minute,
-    );
-    return this.isValidGregorianDate(Number(year), Number(month), Number(day))
-      ? dataInstanciada
-      : null;
+    if (!this.isValidGregorianDate(year, month, day) || !this.isValidTime(hour, minute, second)) {
+      return null;
+    }
+    const dataInstanciada = this.toZonedInstant(year, month, day, hour, minute);
+    return dataInstanciada;
   }
 
   /**
@@ -105,6 +106,10 @@ export class DateBrPipe implements PipeTransform {
 
   private isBissexto(year: number): boolean {
     return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+  }
+
+  private isValidTime(hour: number, minute: number, second: number): boolean {
+    return hour >= 0 && hour <= 23 && minute >= 0 && minute <= 59 && second >= 0 && second <= 59;
   }
 
   private formatShortMonth(date: Date): string {


### PR DESCRIPTION
## Resumo

Adiciona novo formato de formatação para o pipe date-br. Refatora as implementações existentes, sem regressão.

Closes #495

## Mudanças

### Novos arquivos
libs/shared-ui/src/lib/pipes/date-br.pipe.spec.ts

### Modificados
libs/shared-ui/src/lib/pipes/date-br.pipe.ts

## Testes
- [x] Testes unitários passando

## Checklist

- [x] Sem regressão das implementações existentes
- [x] Formata data sem deslocamento de fuso
- [x] O mês possui três letras minúsculas, sem ponto e sem a preposição de
- [x] Exibe texto vazio quando a data é inexistente
- [x] O novo formato `shortMonth` produz um resultado como exemplo `19 abr 2026`
- [x] O comportamento de dias de 1 a 9 está definido e testado mantendo-se dois dígitos