### PR TITLE
test(shared-core): substitui uri do erros

### DIFF
--- a/apps/configuracao-e2e/src/specs/unidades.visual.spec.ts
+++ b/apps/configuracao-e2e/src/specs/unidades.visual.spec.ts
@@ -213,7 +213,7 @@ async function mockUnidadesApi(page: Page): Promise<void> {
         status: 422,
         headers: { ...corsHeaders, 'content-type': 'application/problem+json' },
         body: JSON.stringify({
-          type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.idempotency.body_mismatch',
+          type: 'https://unifesspa-edu-br.github.io/uniplus-developers/erros/uniplus.idempotency.body_mismatch',
           title: 'Mesma Idempotency-Key reusada com body diferente',
           status: 422,
           detail: 'Mesma Idempotency-Key reusada com body diferente.',
@@ -236,7 +236,7 @@ async function mockUnidadesApi(page: Page): Promise<void> {
       status: 422,
       headers: { ...corsHeaders, 'content-type': 'application/problem+json' },
       body: JSON.stringify({
-        type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.validacao',
+        type: 'https://unifesspa-edu-br.github.io/uniplus-developers/erros/uniplus.validacao',
         title: 'Erro de validação',
         status: 422,
         code: 'uniplus.validacao',

--- a/apps/configuracao/src/app/features/instituicao/instituicao.page.spec.ts
+++ b/apps/configuracao/src/app/features/instituicao/instituicao.page.spec.ts
@@ -59,7 +59,7 @@ const instituicaoSeed: InstituicaoDto = {
 
 function problem(status: number, code: string, title: string): string {
   return JSON.stringify({
-    type: `https://uniplus.unifesspa.edu.br/errors/${code}`,
+    type: `https://unifesspa-edu-br.github.io/uniplus-developers/erros/${code}`,
     title,
     status,
     code,
@@ -320,7 +320,7 @@ describe('InstituicaoPage', () => {
     const req = controller.expectOne(`${BASE}/api/organizacao/admin/instituicao`);
     req.flush(
       JSON.stringify({
-        type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.validacao',
+        type: 'https://unifesspa-edu-br.github.io/uniplus-developers/erros/uniplus.validacao',
         title: 'Erro de validação',
         status: 422,
         code: 'uniplus.validacao',

--- a/apps/configuracao/src/app/features/pesos-enem/pesos-enem.page.spec.ts
+++ b/apps/configuracao/src/app/features/pesos-enem/pesos-enem.page.spec.ts
@@ -64,7 +64,7 @@ const linhas750: readonly PesoAreaEnemDto[] = [
 
 function problem(status: number, code: string, title: string, errors?: readonly { field: string; code: string; message: string }[]): string {
   return JSON.stringify({
-    type: `https://uniplus.unifesspa.edu.br/errors/${code}`,
+    type: `https://unifesspa-edu-br.github.io/uniplus-developers/erros/${code}`,
     title,
     status,
     code,

--- a/apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
@@ -318,7 +318,7 @@ describe('UnidadesPage', () => {
     });
     req1.flush(
       {
-        type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.validacao',
+        type: 'https://unifesspa-edu-br.github.io/uniplus-developers/erros/uniplus.validacao',
         title: 'Erro de validação',
         status: 422,
         code: 'uniplus.validacao',
@@ -396,7 +396,7 @@ describe('UnidadesPage', () => {
 
     controller.expectOne(`${BASE}/api/organizacao/admin/unidades`).flush(
       {
-        type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.idempotency.body_mismatch',
+        type: 'https://unifesspa-edu-br.github.io/uniplus-developers/erros/uniplus.idempotency.body_mismatch',
         title: 'Mesma Idempotency-Key reusada com body diferente',
         status: 422,
         detail: 'Mesma Idempotency-Key reusada com body diferente.',
@@ -439,7 +439,7 @@ describe('UnidadesPage', () => {
 
     controller.expectOne(`${BASE}/api/organizacao/admin/unidades`).flush(
       {
-        type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.unidade.sigla_duplicada',
+        type: 'https://unifesspa-edu-br.github.io/uniplus-developers/erros/uniplus.unidade.sigla_duplicada',
         title: 'Sigla já utilizada por outra unidade viva',
         status: 409,
         detail: 'A sigla FACOM já pertence a uma unidade vigente.',

--- a/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-01-tipo-processo/step-01-tipo-processo.component.spec.ts
+++ b/apps/selecao/src/app/features/processo-seletivo/steps/steps/step-01-tipo-processo/step-01-tipo-processo.component.spec.ts
@@ -166,7 +166,7 @@ describe('Step01TipoProcessoComponent', () => {
         ? of(
             apiFailure(
               {
-                type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.internal.unexpected',
+                type: 'https://unifesspa-edu-br.github.io/uniplus-developers/erros/uniplus.internal.unexpected',
                 title: 'Erro interno do servidor',
                 status: 500,
                 code: 'uniplus.internal.unexpected',

--- a/libs/shared-auth/src/lib/interceptors/auth-error.interceptor.spec.ts
+++ b/libs/shared-auth/src/lib/interceptors/auth-error.interceptor.spec.ts
@@ -10,7 +10,7 @@ import { AuthService } from '../services/auth.service';
 const PROBLEM_HEADERS = { 'Content-Type': 'application/problem+json' };
 
 const baseProblem: ProblemDetails = {
-  type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.auth.unauthorized',
+  type: 'https://unifesspa-edu-br.github.io/uniplus-developers/erros/uniplus.auth.unauthorized',
   title: 'Não autenticado',
   status: 401,
   code: 'uniplus.auth.unauthorized',

--- a/libs/shared-core/src/lib/http/api-result.interceptor.spec.ts
+++ b/libs/shared-core/src/lib/http/api-result.interceptor.spec.ts
@@ -29,7 +29,7 @@ interface Edital {
 const PROBLEM_HEADERS = { 'Content-Type': 'application/problem+json' };
 
 const baseProblem: ProblemDetails = {
-  type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.selecao.edital.nao_encontrado',
+  type: 'https://unifesspa-edu-br.github.io/uniplus-developers/erros/uniplus.selecao.edital.nao_encontrado',
   title: 'Edital não encontrado',
   status: 404,
   code: 'uniplus.selecao.edital.nao_encontrado',
@@ -123,7 +123,7 @@ describe('apiResultInterceptor', () => {
     it('422 carrega errors[] de validação completos (FluentValidation)', () => {
       const problem: ProblemDetails = {
         ...baseProblem,
-        type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.validacao',
+        type: 'https://unifesspa-edu-br.github.io/uniplus-developers/erros/uniplus.validacao',
         title: 'Erro de validação',
         status: 422,
         code: 'uniplus.validacao',
@@ -157,7 +157,7 @@ describe('apiResultInterceptor', () => {
       controller.expectOne('/api/selecao/editais').flush(
         {
           ...baseProblem,
-          type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.auth.unauthorized',
+          type: 'https://unifesspa-edu-br.github.io/uniplus-developers/erros/uniplus.auth.unauthorized',
           title: 'Não autenticado',
           status: 401,
           code: 'uniplus.auth.unauthorized',
@@ -184,7 +184,7 @@ describe('apiResultInterceptor', () => {
       controller.expectOne('/api/selecao/editais').flush(
         {
           ...baseProblem,
-          type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.contract.versao_nao_suportada',
+          type: 'https://unifesspa-edu-br.github.io/uniplus-developers/erros/uniplus.contract.versao_nao_suportada',
           title: 'Versão não suportada',
           status: 406,
           code: 'uniplus.contract.versao_nao_suportada',
@@ -206,7 +206,7 @@ describe('apiResultInterceptor', () => {
       controller.expectOne('/api/selecao/editais').flush(
         {
           ...baseProblem,
-          type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.servidor.indisponivel',
+          type: 'https://unifesspa-edu-br.github.io/uniplus-developers/erros/uniplus.servidor.indisponivel',
           title: 'Servidor temporariamente indisponível',
           status: 500,
           code: 'uniplus.servidor.indisponivel',

--- a/libs/shared-core/src/lib/http/api-result.testing.ts
+++ b/libs/shared-core/src/lib/http/api-result.testing.ts
@@ -16,7 +16,7 @@ export function errorResult(
 
 export function mockProblemDetails(overrides: Partial<ProblemDetails> = {}): ProblemDetails {
   return {
-    type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.test.fake',
+    type: 'https://unifesspa-edu-br.github.io/uniplus-developers/erros/uniplus.test.fake',
     title: 'Erro simulado para teste',
     status: 500,
     code: 'uniplus.test.fake',

--- a/libs/shared-core/src/lib/http/use-api-resource.spec.ts
+++ b/libs/shared-core/src/lib/http/use-api-resource.spec.ts
@@ -25,7 +25,7 @@ interface Edital {
 
 const PROBLEM_HEADERS = { 'Content-Type': 'application/problem+json' };
 const baseProblem: ProblemDetails = {
-  type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.selecao.edital.nao_encontrado',
+  type: 'https://unifesspa-edu-br.github.io/uniplus-developers/erros/uniplus.selecao.edital.nao_encontrado',
   title: 'Edital não encontrado',
   status: 404,
   code: 'uniplus.selecao.edital.nao_encontrado',
@@ -268,13 +268,11 @@ describe('useApiResource', () => {
     env.controller.expectOne('/api/selecao/editais').flush(
       {
         ...baseProblem,
-        type: 'https://uniplus.unifesspa.edu.br/errors/uniplus.validacao',
+        type: 'https://unifesspa-edu-br.github.io/uniplus-developers/erros/uniplus.validacao',
         title: 'Erro de validação',
         status: 422,
         code: 'uniplus.validacao',
-        errors: [
-          { field: 'titulo', code: 'Titulo.Vazio', message: 'Título obrigatório' },
-        ],
+        errors: [{ field: 'titulo', code: 'Titulo.Vazio', message: 'Título obrigatório' }],
       },
       { status: 422, statusText: 'Unprocessable Entity', headers: PROBLEM_HEADERS },
     );

--- a/libs/shared-core/src/lib/services/notification.service.spec.ts
+++ b/libs/shared-core/src/lib/services/notification.service.spec.ts
@@ -6,7 +6,7 @@ import type { ProblemDetails } from '../http/problem-details';
 
 function montarProblem(overrides: Partial<ProblemDetails> = {}): ProblemDetails {
   return {
-    type: 'https://uniplus.unifesspa.edu.br/erros/exemplo',
+    type: 'https://unifesspa-edu-br.github.io/uniplus-developers/erros/exemplo',
     title: 'Recurso não encontrado',
     status: 404,
     detail: 'Edital com id 42 não existe.',

--- a/libs/shared-ui/src/lib/components/notification-host/notification-host.spec.ts
+++ b/libs/shared-ui/src/lib/components/notification-host/notification-host.spec.ts
@@ -7,7 +7,7 @@ import { NotificationHostComponent } from './notification-host';
 
 function montarProblem(overrides: Partial<ProblemDetails> = {}): ProblemDetails {
   return {
-    type: 'https://uniplus.unifesspa.edu.br/erros/exemplo',
+    type: 'https://unifesspa-edu-br.github.io/uniplus-developers/erros/exemplo',
     title: 'Recurso não encontrado',
     status: 404,
     detail: 'Edital com id 42 não existe.',


### PR DESCRIPTION
## Resumo
Atualiza a uri dos arquivos de testes.

Closes #526

## Mudanças

### Modificados
- apps/configuracao-e2e/src/specs/unidades.visual.spec.ts
- apps/configuracao/src/app/features/instituicao/instituicao.page.spec.ts
- apps/configuracao/src/app/features/pesos-enem/pesos-enem.page.spec.ts
- apps/configuracao/src/app/features/unidades/unidades.page.spec.ts
- apps/selecao/src/app/features/processo-seletivo/steps/steps/step-01-tipo-processo/step-01-tipo-processo.component.spec.ts
- libs/shared-auth/src/lib/interceptors/auth-error.interceptor.spec.ts
- libs/shared-core/src/lib/http/api-result.interceptor.spec.ts
- libs/shared-core/src/lib/http/api-result.testing.ts
- libs/shared-core/src/lib/http/use-api-resource.spec.ts
- libs/shared-ui/src/lib/components/notification-host/notification-host.spec.ts
- libs/shared-core/src/lib/services/notification.service.spec.ts

## Testes

- [x] Testes unitários passando
- [x] Testes de integração passando (se aplicável)

## Checklist

- [x] grep -rn "uniplus.unifesspa.edu.br/errors" libs/ apps/ retorna zero
- [x] npx nx affected -t lint test build --base=origin/main --head=HEAD verde
- [x] npx nx run-many --target=vite:test --all funcionando
