### PR TITLE
task(shared-ui): fecha pendências de acabamento do ui-filter-bar (#513)

### DIFF
--- a/apps/configuracao-e2e/src/specs/tipos-documento.flow.spec.ts
+++ b/apps/configuracao-e2e/src/specs/tipos-documento.flow.spec.ts
@@ -283,6 +283,29 @@ test.describe('Tipo de Documento — acessibilidade axe-core (#392)', () => {
   });
 });
 
+// Bloco `axe` escopado: audita só o <ui-filter-bar>, isolado do resto da
+// página, respondendo ao CA-06 da issue #513 (ui-filter-bar #500).
+test.describe('ui-filter-bar — auditoria isolada axe-core (CA-06 da issue #513)', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockConfiguracaoRuntimeConfig(page);
+  });
+
+  test('não tem violações serious/critical isoladamente', async ({ page }) => {
+    await mockApi(page, novoCapturado(), [rgSeed, laudoSeed]);
+    await abrirPagina(page);
+
+    const resultado = await new AxeBuilder({ page })
+      .include('.filter-bar')
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21aa'])
+      .analyze();
+    const graves = resultado.violations.filter(
+      (v) => v.impact === 'serious' || v.impact === 'critical',
+    );
+
+    expect(graves, JSON.stringify(graves, null, 2)).toEqual([]);
+  });
+});
+
 // Bloco `keyboard`: navegação por teclado sem mouse (e-MAG 3.1).
 test.describe('Tipo de Documento — navegação por teclado (#392)', () => {
   test.beforeEach(async ({ page }) => {

--- a/apps/configuracao/src/app/features/condicoes-atendimento/condicoes-atendimento-list.ts
+++ b/apps/configuracao/src/app/features/condicoes-atendimento/condicoes-atendimento-list.ts
@@ -686,10 +686,6 @@ export class CondicoesAtendimentoListPage implements OnInit {
       .subscribe((result) => this.handleSalvarResult(result));
   }
 
-  protected inputValue(event: Event): string {
-    return event.target instanceof HTMLInputElement ? event.target.value : '';
-  }
-
   limparFiltroBusca() {
     this.termoBusca.set('');
   }

--- a/apps/configuracao/src/app/features/modalidades/modalidades-list.page.ts
+++ b/apps/configuracao/src/app/features/modalidades/modalidades-list.page.ts
@@ -464,10 +464,6 @@ export class ModalidadesListPage {
     });
   }
 
-  protected inputValue(event: Event): string {
-    return event.target instanceof HTMLInputElement ? event.target.value : '';
-  }
-
   protected naturezaLabel(token: string): string {
     return rotulo(NATUREZAS_LEGAIS, token);
   }

--- a/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.ts
+++ b/apps/configuracao/src/app/features/recursos-acessibilidade/recursos-acessibilidade-list.page.ts
@@ -468,10 +468,6 @@ export class RecursosAcessibilidadeListPage {
     }
   }
 
-  protected inputValue(event: Event): string {
-    return event.target instanceof HTMLInputElement ? event.target.value : '';
-  }
-
   limparFiltroBusca() {
     this.termoBusca.set('');
   }

--- a/apps/configuracao/src/app/features/reserva-demografica/reserva-demografica-list.page.ts
+++ b/apps/configuracao/src/app/features/reserva-demografica/reserva-demografica-list.page.ts
@@ -118,7 +118,8 @@ const PERCENTUAL_VALIDATORS = [Validators.required, Validators.min(0), Validator
       >
         <button
           uiFilterBarActions
-          type="button" class="btn btn--tertiary btn--sm btn--rect"
+          type="button"
+          class="btn btn--tertiary btn--sm btn--rect"
           (click)="busca.set('')"
         >
         Limpar
@@ -479,10 +480,6 @@ export class ReservaDemograficaListPage {
   protected pct(valor: number | string): string {
     const numero = typeof valor === 'string' ? Number(valor) : valor;
     return Number.isFinite(numero) ? numero.toFixed(2) : String(valor);
-  }
-
-  protected inputValue(event: Event): string {
-    return event.target instanceof HTMLInputElement ? event.target.value : '';
   }
 
   protected proximaPagina(): void {

--- a/apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.ts
+++ b/apps/configuracao/src/app/features/tipos-deficiencia/tipos-deficiencia-list.page.ts
@@ -468,10 +468,6 @@ export class TiposDeficienciaListPage {
     }
   }
 
-  protected inputValue(event: Event): string {
-    return event.target instanceof HTMLInputElement ? event.target.value : '';
-  }
-
   limparFiltroBusca(): void {
     this.termoBusca.set('');
   }

--- a/apps/configuracao/src/app/features/tipos-documento/tipos-documento-list.page.ts
+++ b/apps/configuracao/src/app/features/tipos-documento/tipos-documento-list.page.ts
@@ -103,12 +103,12 @@ interface TipoDocumentoForm {
     ConfirmDialogComponent,
     DrawerComponent,
     EmptyStateComponent,
+    FilterBarComponent,
     FilterChipsComponent,
     PagerComponent,
     SpinnerComponent,
     TagComponent,
-    FilterBarComponent
-],
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="page-header">
@@ -150,7 +150,6 @@ interface TipoDocumentoForm {
         <ui-filter-chips
           [options]="categoriaChips()"
           [(selected)]="filtroCategoria"
-          (selectedChange)="filtroCategoria.set($event ?? '')"
           ariaLabel="Filtrar por categoria"
         />
       </ng-container>
@@ -638,10 +637,6 @@ export class TiposDocumentoListPage {
         }
       });
     });
-  }
-
-  protected inputValue(event: Event): string {
-    return event.target instanceof HTMLInputElement ? event.target.value : '';
   }
 
   protected limparFiltros(): void {

--- a/apps/configuracao/src/app/features/unidades/unidades.page.ts
+++ b/apps/configuracao/src/app/features/unidades/unidades.page.ts
@@ -197,8 +197,7 @@ const BACKEND_FIELD_TO_CONTROL = {
           <span class="u-eyebrow">Tipo</span>
           <ui-filter-chips
             [options]="tipoChips"
-            [selected]="tipoFiltro()"
-            (selectedChange)="tipoFiltro.set($event ?? '')"
+            [(selected)]="tipoFiltro"
             ariaLabel="Filtrar por tipo"
           />
         </ng-container>

--- a/libs/shared-ui/src/lib/components/filter-bar/filter-bar.spec.ts
+++ b/libs/shared-ui/src/lib/components/filter-bar/filter-bar.spec.ts
@@ -154,13 +154,18 @@ describe('FilterBarComponent (projeção de conteúdo e two-way binding)', () =>
     return { fixture, getInputEl };
   }
 
-  it('projeta o conteúdo do slot uiFilterBarActions dentro de .filter-bar__row', () => {
+  it('projeta o conteúdo do slot uiFilterBarActions dentro de .filter-bar__row e reage ao clique', () => {
     const { fixture } = setupHost();
+    const host = fixture.componentInstance;
     const row = fixture.debugElement.query(By.css('.filter-bar__row'));
     const button = row.query(By.css('button'));
 
     expect(button).toBeTruthy();
     expect((button.nativeElement as HTMLButtonElement).textContent?.trim()).toBe('Limpar');
+
+    expect(host.limparChamado).toBe(false);
+    (button.nativeElement as HTMLButtonElement).click();
+    expect(host.limparChamado).toBe(true);
   });
 
   it('projeta o conteúdo do slot uiFilterBarSecondary dentro de .filter-bar__group', () => {


### PR DESCRIPTION
## Resumo

- Unifica a convenção de binding do `ui-filter-chips` para `[(selected)]` puro.
- Remove os helpers `inputValue()` órfãos das 6 páginas migradas para `<ui-filter-bar>`.
- Corrige formatação residual em `reserva-demografica-list.page.ts` e `tipos-documento-list.page.ts`.
- Remove código morto de `filter-bar.spec.ts` (clique no botão projetado agora é exercitado).
- Adiciona auditoria axe-core isolada do `<ui-filter-bar>` via Playwright (CA-06), escopada com `.include('.filter-bar')`: Sem dependência nova.

## Mudanças

### Modificados

- `unidades.page.ts`, `tipos-documento-list.page.ts`: Binding `[(selected)]` puro.
- `condicoes-atendimento-list.ts`, `modalidades-list.page.ts`, `recursos-acessibilidade-list.page.ts`, `reserva-demografica-list.page.ts`, `tipos-deficiencia-list.page.ts`, `tipos-documento-list.page.ts`: Remove `inputValue()` órfão.
- `reserva-demografica-list.page.ts`, `tipos-documento-list.page.ts`: Formatação.
- `libs/shared-ui/.../filter-bar/filter-bar.spec.ts`: Código morto do teste removido; bloco jsdom/axe-core órfão removido.
- `apps/configuracao-e2e/src/specs/tipos-documento.flow.spec.ts`: Novo bloco de auditoria axe-core escopada ao `<ui-filter-bar>` (CA-06).

## Testes

- [x] Testes unitários passando
- [ ] Testes de integração passando (se aplicável) — N/A
- [ ] Testes E2E passando (se aplicável)

## Checklist

- [x] Build sem erros e sem warnings (`npx nx build shared-ui`)
- [x] Código segue Clean Architecture e SOLID
- [x] Sem exposição de PII (CPF, renda, dados sensíveis)
- [x] Strings user-facing em pt-BR
- [x] Soft delete utilizado (sem DELETE físico) - N/A, sem mudança de persistência
- [ ] Documentação atualizada (se aplicável) - N/A

Closes #513