### PR TITLE
fix(routing): reescreve base href também na forma autofechada

### DIFF
--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -26,8 +26,16 @@ server {
     # A tag <base> é compilada como raiz e substituída pelo mount point em
     # runtime. Diferentemente de `./`, um caminho absoluto permanece correto
     # após hard reload em uma rota com múltiplos segmentos.
+    #
+    # O build do Angular emite a tag autofechada (`<base href="/"/>`), não
+    # `<base href="/">` — sub_filter não erra nem loga quando o padrão não
+    # casa, só deixa de substituir, então bastava rodar fora da raiz pra
+    # `<base>` continuar apontando pra `/` mesmo sob `/portal/` e quebrar
+    # todo asset/API relativo. Casar as duas formas cobre builds
+    # anteriores/futuros do Angular que possam emitir sem o `/`.
     sub_filter_once on;
     sub_filter '<base href="/">' '<base href="${APP_BASE_HREF}">';
+    sub_filter '<base href="/"/>' '<base href="${APP_BASE_HREF}"/>';
 
     # Mantém a URL canônica com barra final. `APP_BASE_PATH` é derivado pelo
     # entrypoint a partir de APP_BASE_HREF e fica em um path inócuo na raiz.


### PR DESCRIPTION
## Contexto

A issue #448 pedia pra parametrizar o `docker/nginx.conf` por subpath — mas ao investigar, encontrei que `docker/nginx.conf.template` **já estava** completamente parametrizado (`APP_BASE_HREF`/`APP_BASE_PATH`, todas as `location`s corretas, entrypoint `prepare-base-href.envsh`), implementado via os commits `7da53d5`/`929ea2c` ao corrigir o bug #462 — só a issue nunca foi fechada.

Ao validar de ponta a ponta (não só ler o código), achei um bug real que passou despercebido: o `sub_filter` que reescreve `<base href="/">` pro valor de `APP_BASE_HREF` nunca casava contra o HTML que o Angular 21 realmente gera — a tag sai **autofechada** (`<base href="/"/>`), não na forma sem barra. `sub_filter` não erra quando o padrão não casa, só deixa de substituir silenciosamente. Resultado: qualquer deploy fora da raiz (ex. `/portal/` no HML) continuava servindo `<base href="/">`, quebrando resolução de assets/API relativos.

## O que muda

- `docker/nginx.conf.template`: adiciona um segundo `sub_filter` pra forma autofechada, mantendo o original por segurança/compat com builds futuros/anteriores do Angular.

## Validação

Sem suíte de teste automatizado pra config de nginx neste repo — validado manualmente com `docker build` + `docker run` + `curl` contra a imagem real do `portal` (mesmo padrão vale pra `selecao`/`ingresso`, que compartilham o template):

| Critério | `APP_BASE_HREF=/portal/` | Raiz (`/`, sem regressão) |
|---|---|---|
| `<base href>` correto | ✅ `/portal/` | ✅ `/` |
| `assets/runtime-config.json` | ✅ 200 | ✅ 200 |
| `assets/silent-check-sso.html` | ✅ 200 | — |
| Asset versionado (`.js`) | ✅ 200 | — |
| Deep link 2+ segmentos (regressão #462) | ✅ 200 | — |
| Redirect sem barra preserva query | ✅ `308` → `/portal/?code=abc123` | — |

## Fora de escopo

Este PR resolve só o bug do `base href`. As demais Stories da Feature #444 seguem abertas, cada uma com seu próprio ciclo:
- #447 — logout redireciona pro subpath
- #449 — validação E2E completa via Playwright

Closes #448