### PR TITLE
fix(routing): logout redireciona ao mount point, não à origem

### DIFF
--- a/libs/shared-auth/src/lib/services/auth.service.logout.spec.ts
+++ b/libs/shared-auth/src/lib/services/auth.service.logout.spec.ts
@@ -1,0 +1,76 @@
+import { TestBed } from '@angular/core/testing';
+import type Keycloak from 'keycloak-js';
+import { AuthService } from './auth.service';
+import { AuthConfig } from '../models/auth-config.model';
+
+const config: AuthConfig = {
+  issuerUrl: 'http://localhost:8080/realms/unifesspa',
+  clientId: 'selecao-web',
+  allowedUrls: ['http://localhost:5000/api/v1', 'http://localhost:8080/realms/unifesspa'],
+};
+
+function stubKeycloak(partial: Partial<Keycloak>): Keycloak {
+  return {
+    init: async () => true,
+    token: undefined,
+    authenticated: true,
+    realmAccess: undefined,
+    subject: undefined,
+    isTokenExpired: () => false,
+    updateToken: async () => false,
+    login: async () => undefined,
+    logout: async () => undefined,
+    loadUserProfile: async () => ({}),
+    tokenParsed: {},
+    ...partial,
+  } as unknown as Keycloak;
+}
+
+describe('AuthService.logout — redireciona ao mount point (Story #447)', () => {
+  let service: AuthService;
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AuthService);
+  });
+
+  it('redireciona pra document.baseURI (raiz) em standalone-compact/lab', async () => {
+    const logoutSpy = vi.fn(async () => undefined);
+    vi.spyOn(service as unknown as { createKeycloak: () => Keycloak }, 'createKeycloak')
+      .mockReturnValue(stubKeycloak({ logout: logoutSpy }));
+
+    await service.init(config);
+    await service.logout();
+
+    expect(logoutSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ redirectUri: document.baseURI }),
+    );
+  });
+
+  it('redireciona pro subpath (/portal/) quando servido sob mount point, não pra raiz do host', async () => {
+    const base = document.createElement('base');
+    base.href = 'http://localhost:3000/portal/';
+    document.head.appendChild(base);
+    try {
+      const logoutSpy = vi.fn(async () => undefined);
+      vi.spyOn(service as unknown as { createKeycloak: () => Keycloak }, 'createKeycloak')
+        .mockReturnValue(stubKeycloak({ logout: logoutSpy }));
+
+      await service.init(config);
+      await service.logout();
+
+      expect(logoutSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ redirectUri: 'http://localhost:3000/portal/' }),
+      );
+      // Regressão explícita: window.location.origin não tem rota própria
+      // sob PathPrefix (nginx.conf parametrizado pela Story #448) —
+      // cairia no 404 do Traefik.
+      expect(logoutSpy.mock.calls[0][0]).not.toEqual(
+        expect.objectContaining({ redirectUri: window.location.origin }),
+      );
+    } finally {
+      base.remove();
+    }
+  });
+});

--- a/libs/shared-auth/src/lib/services/auth.service.ts
+++ b/libs/shared-auth/src/lib/services/auth.service.ts
@@ -82,8 +82,17 @@ export class AuthService {
     await this.keycloak?.login();
   }
 
+  /**
+   * Redireciona de volta ao mount point do app (`document.baseURI`), não à
+   * origem do domínio (Story #447). Sob subpath (`/portal`, `/selecao`,
+   * `/ingresso`, PathPrefix sem StripPrefix — nginx.conf parametrizado pela
+   * Story #448), `window.location.origin` aponta pra raiz do host, que não
+   * tem rota própria e cai no 404 do Traefik. Mesma resolução relativa já
+   * usada em `silentCheckSsoRedirectUri` (init acima) — preserva a raiz em
+   * standalone-compact/lab, onde `document.baseURI` já é a própria origem.
+   */
   async logout(): Promise<void> {
-    await this.keycloak?.logout({ redirectUri: window.location.origin });
+    await this.keycloak?.logout({ redirectUri: document.baseURI });
   }
 
   getToken(): string | undefined {


### PR DESCRIPTION
## Contexto

`AuthService.logout()` (`libs/shared-auth/src/lib/services/auth.service.ts:94`) chamava `keycloak.logout({ redirectUri: window.location.origin })` — sempre a raiz do domínio, mesmo quando o app roda sob subpath (`/portal`, `/selecao`, `/ingresso`).

No HML (`uniplus-infra#488` — `PathPrefix` sem `StripPrefix`, `uniplus-web#448` — nginx.conf parametrizado por subpath), a raiz do host não tem rota `Host()`-only própria: o usuário caía no 404 do Traefik depois de deslogar em vez de voltar ao app. Achado real da revisão do Codex AI em `uniplus-infra#489`, deferido explicitamente pra esta Story.

## O que muda

- `redirectUri: window.location.origin` → `redirectUri: document.baseURI` — mesma resolução relativa já usada em `silentCheckSsoRedirectUri` (`init()`, Story #446/#453).
- Em `standalone-compact`/`lab` (cada app na raiz do próprio subdomínio), `document.baseURI` já é a própria origem — comportamento inalterado.

## Testes

`auth.service.logout.spec.ts` (novo), seguindo o padrão de manipulação de `<base>` de `auth.service.init.spec.ts`:
- redireciona pra `document.baseURI` na raiz (standalone-compact/lab)
- redireciona pro subpath (`/portal/`) quando servido sob mount point, não pra raiz do host

Confirmado manualmente que os 2 testes novos falham sem o fix (`redirectUri` vinha `http://localhost:3000` em vez de `http://localhost:3000/portal/`).

## Validação local

- `nx vite:test shared-auth` — 78/78 verdes
- `nx affected --target=vite:test` — 333/333 verdes, 6 projetos
- `nx affected --target=lint` — verde, 10 projetos
- Revisão Codex CLI — 1 P3 (referência de issue ambígua no comentário), corrigido; sem P1/P2

Closes #447