### PR TITLE
feat(e2e): valida login OIDC completo sob subpath real (Story #449)

### DIFF
--- a/apps/portal-e2e/playwright.config.ts
+++ b/apps/portal-e2e/playwright.config.ts
@@ -37,7 +37,13 @@ const AAA_PROJECTS = AAA_VIEWPORTS.flatMap((viewport) =>
 );
 
 export default defineConfig({
-  ...nxE2EPreset(__filename, { testDir: './src' }),
+  // `./src/specs` (não `./src`) — exclui `src/specs-subpath/` (Story #449),
+  // que tem baseURL própria (portal servido sob subpath real, porta 4212)
+  // e roda via config dedicada (`playwright.subpath.config.ts`). Sem o
+  // escopo, este config varria `specs-subpath/` também e rodava contra a
+  // porta 4202 (raiz), que não serve `/portal/` — os testes falhariam por
+  // navegar pro host/porta errado, não pelo comportamento sob teste.
+  ...nxE2EPreset(__filename, { testDir: './src/specs' }),
   outputDir: path.join(workspaceRoot, 'tmp/playwright/portal-e2e'),
   reporter: [
     ['html', { outputFolder: path.join(workspaceRoot, 'tmp/playwright/portal-e2e-report') }],

--- a/apps/portal-e2e/playwright.subpath.config.ts
+++ b/apps/portal-e2e/playwright.subpath.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig, devices } from '@playwright/test';
+import { nxE2EPreset } from '@nx/playwright/preset';
+import { workspaceRoot } from '@nx/devkit';
+import * as path from 'node:path';
+
+/**
+ * Config dedicada à validação de login OIDC (PKCE) sob subpath real
+ * (Story #449). Diferente de `playwright.config.ts` (app servido pelo
+ * dev server do Nx, sempre na raiz), aqui o alvo é a IMAGEM DOCKER real
+ * do portal (mesmo `docker/Dockerfile.portal` publicado em produção),
+ * rodando com `APP_BASE_HREF=/portal/` — único jeito de exercitar de
+ * verdade o nginx.conf.template parametrizado por subpath (Story #448) e
+ * o redirect de logout relativo a `document.baseURI` (Story #447). O dev
+ * server nunca reproduziria esses dois: serve sempre em `/`, sem CSP,
+ * sem o mecanismo de rewrite de path do nginx.
+ *
+ * Orquestrado por `tools/e2e-docker/run.sh` (build da imagem + docker run
+ * mapeando a porta 4212 + patch do runtime-config.json apontando pro
+ * Keycloak local) — sem `webServer` aqui porque o ciclo de vida do
+ * container é gerenciado pelo script, não pelo Playwright.
+ */
+const baseURL = process.env['BASE_URL'] || 'http://localhost:4212/portal/';
+
+export default defineConfig({
+  ...nxE2EPreset(__filename, { testDir: './src/specs-subpath' }),
+  outputDir: path.join(workspaceRoot, 'tmp/playwright/portal-e2e-subpath'),
+  reporter: [
+    ['html', { outputFolder: path.join(workspaceRoot, 'tmp/playwright/portal-e2e-subpath-report') }],
+    ['line'],
+  ],
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    // Certificado autoassinado só é relevante em HML real — localhost usa
+    // HTTP puro (a imagem nginx não termina TLS sozinha).
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/apps/portal-e2e/src/specs-subpath/auth-oidc-subpath.spec.ts
+++ b/apps/portal-e2e/src/specs-subpath/auth-oidc-subpath.spec.ts
@@ -98,6 +98,16 @@ test.describe('Autenticação OIDC sob subpath — Portal (/portal/)', () => {
       (req) => req.url().includes('/protocol/openid-connect/logout'),
       { timeout: 10_000 },
     );
+    // Espera o round-trip completo (não só o request sair) — sem isso o
+    // `page.goto('perfil')` abaixo pode disparar antes do Keycloak
+    // terminar de processar o logout e aplicar o redirect, cancelando a
+    // navegação em curso e deixando o teste intermitente (achado do Codex
+    // AI: `waitForURL` de escopo largo casava com a própria URL
+    // pré-logout, retornando cedo demais).
+    const logoutResponse = page.waitForResponse(
+      (res) => res.url().includes('/protocol/openid-connect/logout'),
+      { timeout: 10_000 },
+    );
 
     const trigger = page.getByRole('button', { name: /^Abrir menu da conta de / });
     await trigger.click();
@@ -114,7 +124,10 @@ test.describe('Autenticação OIDC sob subpath — Portal (/portal/)', () => {
     // no 404 do Traefik.
     expect(redirectParam).toMatch(/localhost:4212\/portal\//);
 
-    await page.waitForURL(/localhost:4212\//, { timeout: 10_000 });
+    await logoutResponse;
+    // Sinal inequívoco de navegação real (não a URL pré-logout, que já
+    // casaria trivialmente com um regex largo tipo /localhost:4212\//).
+    await page.waitForURL((url) => !url.pathname.includes('perfil'), { timeout: 10_000 });
 
     // Sessão de fato encerrada: rota protegida volta a exigir login.
     await page.goto('perfil');

--- a/apps/portal-e2e/src/specs-subpath/auth-oidc-subpath.spec.ts
+++ b/apps/portal-e2e/src/specs-subpath/auth-oidc-subpath.spec.ts
@@ -1,0 +1,124 @@
+import { test, expect } from '@playwright/test';
+import { resetPasswords, keycloakLogin, expectUserInHeader } from '@uniplus/shared-e2e';
+
+/**
+ * Fecha o ciclo de validação da Feature #444 (uniplus-web#449): login OIDC
+ * completo (PKCE), silent check-SSO e logout, todos contra o portal servido
+ * sob subpath real (`/portal/`), não a raiz. Cobre exatamente os dois bugs
+ * reais achados durante a implantação do HML e corrigidos nesta Feature:
+ *
+ * - base href não reescrito sob subpath (Story #448) — sem o fix,
+ *   `runtime-config.json`/`silent-check-sso.html` 404am, o app nem
+ *   inicializa.
+ * - logout redirecionando pra raiz do host em vez do subpath (Story #447)
+ *   — sem o fix, pós-logout cai no 404 do Traefik (em produção) ou na raiz
+ *   errada (aqui, `http://localhost:4212/` em vez de `.../portal/`).
+ */
+const USER = {
+  username: 'candidato',
+  password: 'E2eTest!123',
+  displayName: 'Candidato Teste',
+  roles: ['candidato'],
+};
+
+test.describe('Autenticação OIDC sob subpath — Portal (/portal/)', () => {
+  test.beforeAll(async () => {
+    await resetPasswords([{ username: USER.username, password: USER.password }]);
+  });
+
+  // `page.goto('processos')`, não `page.goto('/processos')` — com barra
+  // inicial, a resolução de URL descarta o path do baseURL (`/portal/`) e
+  // navega pra raiz do host (`new URL('/processos', 'http://host/portal/')`
+  // = `http://host/processos`, comportamento padrão de URL absoluta vs.
+  // relativa). Mesma pegadinha que o app evita usando `document.baseURI`
+  // em vez de paths absolutos (Story #446/#448).
+
+  test('shell carrega sob /portal/ sem autenticação (rota pública)', async ({ page }) => {
+    await page.goto('processos');
+
+    // Confirma que o base href real (não a raiz do host) está em vigor —
+    // se a Story #448 regredir, os assets 404am e o app não chega a
+    // renderizar o heading abaixo.
+    await expect(page).toHaveURL(/localhost:4212\/portal\/processos/);
+    await expect(page.getByRole('heading', { name: 'Processos Seletivos', level: 1 })).toBeVisible();
+  });
+
+  test('login PKCE completo redireciona de volta ao subpath /portal/, não à raiz do host', async ({
+    page,
+  }) => {
+    await page.goto('perfil');
+    await page.waitForURL(/realms\/unifesspa\/protocol\/openid-connect/, { timeout: 10_000 });
+    await expect(page.locator('#kc-login')).toBeVisible();
+
+    await keycloakLogin(page, USER.username, USER.password, {
+      expectRedirectTo: /localhost:4212\/portal\//,
+    });
+
+    // Regressão explícita: o Keycloak nunca deveria devolver pra raiz nua
+    // do host (sem o segmento /portal/) — cobriria tanto um redirect_uri
+    // mal configurado quanto um base href não reescrito.
+    await expect(page).not.toHaveURL(/^http:\/\/localhost:4212\/$/);
+    await expectUserInHeader(page, USER.displayName, USER.username, USER.roles);
+  });
+
+  test('silent check-SSO reconhece a sessão em um novo carregamento, sem exigir login de novo', async ({
+    page,
+  }) => {
+    await page.goto('perfil');
+    await keycloakLogin(page, USER.username, USER.password, {
+      expectRedirectTo: /localhost:4212\/portal\//,
+    });
+
+    // Nova navegação "a frio" — só autentica de novo sem interação se
+    // silentCheckSsoRedirectUri (resolvido via document.baseURI, Story
+    // #446/#448) apontar pro arquivo real sob /portal/assets/.
+    await page.goto('processos');
+    await expect(page).toHaveURL(/localhost:4212\/portal\/processos/);
+    await expectUserInHeader(page, USER.displayName, USER.username, USER.roles);
+  });
+
+  test('logout redireciona ao subpath /portal/, não à raiz do host (Story #447)', async ({
+    page,
+  }) => {
+    await page.goto('perfil');
+    await keycloakLogin(page, USER.username, USER.password, {
+      expectRedirectTo: /localhost:4212\/portal\//,
+    });
+
+    // Captura a navegação real pro endpoint de logout do Keycloak — é ali
+    // que o `post_logout_redirect_uri` (o que AuthService.logout() envia
+    // como `redirectUri`) fica exposto. Checar só a URL final da página
+    // (após o Keycloak devolver o browser) NÃO é suficiente pra fechar
+    // #447: o Angular Router, já bootstrapado com `<base href="/portal/">`
+    // (Story #448), pode normalizar a URL do browser de volta pro subpath
+    // via navegação client-side mesmo que o `redirectUri` enviado ao
+    // Keycloak estivesse errado (raiz nua) — mascarando a regressão que
+    // este teste existe pra pegar.
+    const logoutRequest = page.waitForRequest(
+      (req) => req.url().includes('/protocol/openid-connect/logout'),
+      { timeout: 10_000 },
+    );
+
+    const trigger = page.getByRole('button', { name: /^Abrir menu da conta de / });
+    await trigger.click();
+    await page.getByRole('menuitem', { name: 'Sair' }).click();
+
+    const request = await logoutRequest;
+    const redirectParam = new URL(request.url()).searchParams.get('post_logout_redirect_uri');
+
+    // A asserção que de fato fecha #447: o parâmetro enviado ao Keycloak
+    // precisa conter o segmento /portal/, não a raiz nua do host. Antes do
+    // fix (`redirectUri: window.location.origin`), esse parâmetro vinha
+    // `http://localhost:4212` sem o subpath — em produção (HML,
+    // PathPrefix sem StripPrefix), essa raiz nem tem rota própria e cai
+    // no 404 do Traefik.
+    expect(redirectParam).toMatch(/localhost:4212\/portal\//);
+
+    await page.waitForURL(/localhost:4212\//, { timeout: 10_000 });
+
+    // Sessão de fato encerrada: rota protegida volta a exigir login.
+    await page.goto('perfil');
+    await page.waitForURL(/realms\/unifesspa\/protocol\/openid-connect/, { timeout: 10_000 });
+    await expect(page.locator('#kc-login')).toBeVisible();
+  });
+});

--- a/tools/e2e-docker/Dockerfile
+++ b/tools/e2e-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/playwright:v1.58.2-noble
+FROM mcr.microsoft.com/playwright:v1.61.1-noble
 LABEL org.opencontainers.image.source="https://github.com/unifesspa-edu-br/uniplus-web"
 LABEL org.opencontainers.image.description="Playwright E2E runner com webkit para Ubuntu (uniplus-web)"
 

--- a/tools/e2e-docker/keycloak/realm-export.json
+++ b/tools/e2e-docker/keycloak/realm-export.json
@@ -899,10 +899,12 @@
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "redirectUris": [
-        "http://localhost:4202/*"
+        "http://localhost:4202/*",
+        "http://localhost:4212/*"
       ],
       "webOrigins": [
-        "http://localhost:4202"
+        "http://localhost:4202",
+        "http://localhost:4212"
       ],
       "notBefore": 0,
       "bearerOnly": false,

--- a/tools/e2e-docker/run.sh
+++ b/tools/e2e-docker/run.sh
@@ -64,7 +64,16 @@ if ! docker info > /dev/null 2>&1; then
   exit 1
 fi
 
-for port in 8080 4200 4202 4212; do
+PORTS_TO_CHECK=(8080 4200 4202)
+# 4212 só é usada pelo container do portal sob subpath (seção 3.5), que só
+# sobe para portal-e2e/all — exigi-la livre também pra selecao-e2e bloquearia
+# a run à toa por um serviço não relacionado (achado do Codex AI no PR da
+# Story #449).
+if [[ "$TARGET" == "portal-e2e" || "$TARGET" == "all" ]]; then
+  PORTS_TO_CHECK+=(4212)
+fi
+
+for port in "${PORTS_TO_CHECK[@]}"; do
   if ss -tlnp "sport = :$port" 2>/dev/null | grep -q LISTEN; then
     echo "ERRO: porta $port já está em uso."
     echo "  Pare o serviço antes de rodar o E2E runner."

--- a/tools/e2e-docker/run.sh
+++ b/tools/e2e-docker/run.sh
@@ -27,9 +27,18 @@ DOCKERFILE="$SCRIPT_DIR/Dockerfile"
 # quem importa). Drift aqui derruba a suíte inteira com "Executable
 # doesn't exist" / "Please update docker image as well" — achado
 # corrigindo a validação local da Story #449.
-IMAGE_REMOTE="ghcr.io/unifesspa-edu-br/uniplus-e2e-runner:1.61.1"
+PLAYWRIGHT_VERSION="1.61.1"
+IMAGE_REMOTE="ghcr.io/unifesspa-edu-br/uniplus-e2e-runner:${PLAYWRIGHT_VERSION}"
 IMAGE_LOCAL="uniplus-e2e-runner"
-VOLUME_NAME="uniplus-e2e-node-modules"
+# Sufixo de versão é obrigatório: o volume nomeado sobrevive a `docker
+# compose down -v` (só derruba o que o compose gerencia) e a rebuilds da
+# imagem — sem o sufixo, uma máquina que já rodou este script antes de um
+# bump de PLAYWRIGHT_VERSION reusa o volume antigo (node_modules da versão
+# velha), reproduzindo o mesmo "Executable doesn't exist" que o bump
+# deveria corrigir (achado do Codex AI no PR da Story #449). Versões
+# antigas do volume ficam órfãs — `docker volume prune` limpa quando
+# quiser.
+VOLUME_NAME="uniplus-e2e-node-modules-${PLAYWRIGHT_VERSION}"
 
 TARGET="all"
 NO_PULL=false

--- a/tools/e2e-docker/run.sh
+++ b/tools/e2e-docker/run.sh
@@ -3,6 +3,9 @@
 #
 # Sobe infraestrutura (Keycloak + PostgreSQL), serve as apps Angular,
 # executa a suíte Playwright (chromium + firefox + webkit) e derruba tudo.
+# `portal-e2e`/`all` também sobem a imagem Docker real do portal sob
+# subpath (porta 4212, APP_BASE_HREF=/portal/) e rodam a suíte de login
+# OIDC sob subpath (Story #449) — dev server nunca reproduziria isso.
 #
 # Uso:
 #   ./tools/e2e-docker/run.sh [selecao-e2e|portal-e2e|all] [--no-pull]
@@ -19,7 +22,12 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 COMPOSE_FILE="$SCRIPT_DIR/docker-compose.e2e.yml"
 DOCKERFILE="$SCRIPT_DIR/Dockerfile"
-IMAGE_REMOTE="ghcr.io/unifesspa-edu-br/uniplus-e2e-runner:1.58.2"
+# Precisa acompanhar a versão de "playwright" travada em package-lock.json
+# (não "@playwright/test", que é um range solto — o binário instalado é
+# quem importa). Drift aqui derruba a suíte inteira com "Executable
+# doesn't exist" / "Please update docker image as well" — achado
+# corrigindo a validação local da Story #449.
+IMAGE_REMOTE="ghcr.io/unifesspa-edu-br/uniplus-e2e-runner:1.61.1"
 IMAGE_LOCAL="uniplus-e2e-runner"
 VOLUME_NAME="uniplus-e2e-node-modules"
 
@@ -47,7 +55,7 @@ if ! docker info > /dev/null 2>&1; then
   exit 1
 fi
 
-for port in 8080 4200 4202; do
+for port in 8080 4200 4202 4212; do
   if ss -tlnp "sport = :$port" 2>/dev/null | grep -q LISTEN; then
     echo "ERRO: porta $port já está em uso."
     echo "  Pare o serviço antes de rodar o E2E runner."
@@ -61,6 +69,7 @@ export KEYCLOAK_ADMIN_PASSWORD
 
 SELECAO_PID=""
 PORTAL_PID=""
+PORTAL_SUBPATH_CID=""
 
 cleanup() {
   echo ""
@@ -71,6 +80,7 @@ cleanup() {
   fuser -k 4200/tcp 2>/dev/null || true
   fuser -k 4202/tcp 2>/dev/null || true
   wait "$SELECAO_PID" "$PORTAL_PID" 2>/dev/null || true
+  [[ -n "$PORTAL_SUBPATH_CID" ]] && docker rm -f "$PORTAL_SUBPATH_CID" >/dev/null 2>&1 || true
   docker compose -f "$COMPOSE_FILE" down -v 2>/dev/null || true
   echo "→ Ambiente encerrado."
 }
@@ -134,12 +144,62 @@ for port in 4200 4202; do
 done
 echo " OK"
 
+# ─── 3.5. Portal sob subpath real (imagem Docker, Story #449) ────────────────
+#
+# O dev server acima (porta 4202) só serve na raiz — não exercita o
+# nginx.conf.template parametrizado por subpath (Story #448) nem o
+# redirect de logout relativo a document.baseURI (Story #447). Só a
+# imagem Docker real (docker/Dockerfile.portal), com APP_BASE_HREF
+# setado, reproduz isso. Roda em paralelo ao dev server, porta própria
+# (4212), pra não competir com o alvo `portal-e2e` (root) de forma alguma.
+
+if [[ "$TARGET" == "portal-e2e" || "$TARGET" == "all" ]]; then
+  echo "→ Build da imagem do portal (subpath /portal/)..."
+  docker build -q -t uniplus-portal-e2e-subpath -f "$REPO_ROOT/docker/Dockerfile.portal" "$REPO_ROOT" >/dev/null
+
+  echo "→ Subindo portal sob subpath (porta 4212)..."
+  # Bridge (não --network=host): o nginx do container escuta 8080 fixo
+  # (nginx.conf.template) — precisa de -p pra mapear pra 4212 no host.
+  # Sem chamada server-side ao Keycloak (é SPA estática), então bridge não
+  # quebra nada: o runtime-config.json é lido pelo browser, que já
+  # enxerga localhost:8080 (Keycloak) diretamente.
+  PORTAL_SUBPATH_CID=$(docker run -d --rm \
+    -p 4212:8080 \
+    -e APP_BASE_HREF=/portal/ \
+    uniplus-portal-e2e-subpath)
+
+  echo -n "→ Aguardando o container ficar pronto"
+  DEADLINE=$(( $(date +%s) + 60 ))
+  until curl -sf "http://localhost:4212/portal/" > /dev/null 2>&1; do
+    if [[ $(date +%s) -gt $DEADLINE ]]; then
+      echo " TIMEOUT (porta 4212)"
+      echo "  Logs: docker logs $PORTAL_SUBPATH_CID"
+      exit 1
+    fi
+    printf '.'
+    sleep 2
+  done
+  echo " OK"
+
+  # ConfigMap de produção nunca é montado aqui — sobrescreve o placeholder
+  # (que aborta o bootstrap de propósito, ADR-0021) com o Keycloak local
+  # que a infra do runner já sobe acima.
+  # -i é obrigatório — sem stdin interativo o heredoc não chega no
+  # container via `docker exec`, e o arquivo fica vazio (achado
+  # depurando a validação local da Story #449: app trava no bootstrap
+  # com JSON vazio, sem erro óbvio no console).
+  docker exec -i "$PORTAL_SUBPATH_CID" sh -c 'cat > /usr/share/nginx/html/assets/runtime-config.json' <<'EOF'
+{"apiUrl":"http://localhost:5000","oidc":{"issuerUrl":"http://localhost:8080/realms/unifesspa","clientId":"portal-web"}}
+EOF
+fi
+
 # ─── 4. Testes E2E ────────────────────────────────────────────────────────────
 
 run_e2e() {
   local app="$1"
+  local config="${2:-apps/$app/playwright.config.ts}"
   echo ""
-  echo "→ Executando E2E: $app (chromium + firefox + webkit)"
+  echo "→ Executando E2E: $app (chromium + firefox + webkit) [$config]"
   docker run --rm \
     --network=host \
     -e CI=true \
@@ -148,15 +208,26 @@ run_e2e() {
     -v "$REPO_ROOT:/workspace" \
     -v "$VOLUME_NAME:/workspace/node_modules" \
     "$IMAGE_NAME" \
-    npx playwright test --config="apps/$app/playwright.config.ts" --workers=1
+    npx playwright test --config="$config" --workers=1
+}
+
+run_e2e_portal_subpath() {
+  # Config própria (chromium apenas) — não faz parte da matriz completa
+  # (chromium+firefox+webkit) porque valida infra de deploy (nginx/CSP/
+  # subpath), não compatibilidade cross-browser da aplicação em si.
+  run_e2e portal-e2e apps/portal-e2e/playwright.subpath.config.ts
 }
 
 case "$TARGET" in
   selecao-e2e) run_e2e selecao-e2e ;;
-  portal-e2e)  run_e2e portal-e2e ;;
+  portal-e2e)
+    run_e2e portal-e2e
+    run_e2e_portal_subpath
+    ;;
   all)
     run_e2e selecao-e2e
     run_e2e portal-e2e
+    run_e2e_portal_subpath
     ;;
 esac
 


### PR DESCRIPTION
## Contexto

Fecha o ciclo de validação da Feature #444: login OIDC (PKCE), silent check-SSO e logout, todos contra a **imagem Docker real** do portal servida sob `/portal/` — não o dev server do Nx (sempre na raiz, sem CSP, sem o mecanismo de rewrite do nginx), que nunca exerceria de fato as Stories #447/#448.

## O que muda

- `tools/e2e-docker/run.sh`: builda `docker/Dockerfile.portal`, sobe container na porta 4212 (`APP_BASE_HREF=/portal/`), sobrescreve `runtime-config.json` apontando pro Keycloak local, roda a suíte nova em paralelo ao alvo `portal-e2e` existente
- `apps/portal-e2e/playwright.subpath.config.ts` (novo): baseURL `http://localhost:4212/portal/`, `testDir: ./src/specs-subpath`
- `apps/portal-e2e/src/specs-subpath/auth-oidc-subpath.spec.ts` (novo): 4 testes — shell público sob subpath, login PKCE, silent check-SSO, logout
- `tools/e2e-docker/keycloak/realm-export.json`: `portal-web` ganha `redirect_uri`/`webOrigin` pra `localhost:4212`

### O teste de logout merece destaque

Checar só a URL final da página **não bastava** pra fechar #447: o Angular Router, já bootstrapado com o base href certo (#448), normaliza a URL visível de volta pro subpath mesmo quando o `redirect_uri` enviado ao Keycloak estava errado — mascarando a própria regressão que a suíte existe pra pegar. Confirmei isso na prática: revertendo #447 localmente, a versão da asserção baseada em `page.url()` continuava passando. Reescrevi pra interceptar a requisição real ao endpoint de logout do Keycloak e validar o parâmetro `post_logout_redirect_uri` diretamente — com essa versão, revertido #447 → falha corretamente; com o fix → passa.

## Achados corrigidos durante a implementação (pré-existentes, não introduzidos por esta Story)

- `tools/e2e-docker/Dockerfile` pinava Playwright `v1.58.2`, mas `package-lock.json` trava a versão `1.61.1` — drift derrubava a suíte **inteira** (existente e nova) com `Executable doesn't exist`/`Please update docker image as well`
- `apps/portal-e2e/playwright.config.ts` tinha `testDir: './src'` (não `'./src/specs'`) — varria a nova pasta `specs-subpath/` também, rodando contra a porta errada (4202 em vez de 4212)
- `docker exec` sem `-i` no `run.sh` não propagava o heredoc do `runtime-config.json` pro container — arquivo ficava vazio, app travava no bootstrap sem erro óbvio no console

## Validação local

Ciclo completo (`./tools/e2e-docker/run.sh portal-e2e`) rodado do zero, limpo, múltiplas vezes durante a depuração:
- Suíte existente: 45/45 passando (chromium+firefox+webkit + AAA)
- Suíte nova: 4/4 passando (chromium)
- Regressão confirmada em ambas as direções: revertendo #447 → teste de logout falha; com o fix → passa

Closes #449