### PR TITLE
build(ci): adiciona configuracao à matrix de publicação de imagens

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -21,6 +21,7 @@ name: Publish Images
 #   - ghcr.io/<owner>/uniplus-portal
 #   - ghcr.io/<owner>/uniplus-web-selecao
 #   - ghcr.io/<owner>/uniplus-web-ingresso
+#   - ghcr.io/<owner>/uniplus-web-configuracao
 
 on:
   push:
@@ -56,6 +57,8 @@ jobs:
             image: uniplus-web-selecao
           - module: ingresso
             image: uniplus-web-ingresso
+          - module: configuracao
+            image: uniplus-web-configuracao
 
     steps:
       - name: Checkout

--- a/docs/ci-publish-images.md
+++ b/docs/ci-publish-images.md
@@ -1,9 +1,10 @@
 # CI — publicação das imagens das apps web
 
-Este documento descreve o workflow `publish-images.yml` que publica as 3
+Este documento descreve o workflow `publish-images.yml` que publica as 4
 imagens Docker das apps web (`uniplus-portal`, `uniplus-web-selecao`,
-`uniplus-web-ingresso`) no GitHub Container Registry (GHCR), em conformidade
-com a [ADR-0020](adrs/0020-registry-ghcr-e-tagging.md).
+`uniplus-web-ingresso`, `uniplus-web-configuracao`) no GitHub Container
+Registry (GHCR), em conformidade com a
+[ADR-0020](adrs/0020-registry-ghcr-e-tagging.md).
 
 ## Quando o workflow dispara
 
@@ -74,6 +75,7 @@ Imagens são públicas (espelha a visibilidade do repositório). Pull anônimo:
 docker pull ghcr.io/unifesspa-edu-br/uniplus-portal:v0.1.0
 docker pull ghcr.io/unifesspa-edu-br/uniplus-web-selecao:v0.1.0
 docker pull ghcr.io/unifesspa-edu-br/uniplus-web-ingresso:v0.1.0
+docker pull ghcr.io/unifesspa-edu-br/uniplus-web-configuracao:v0.1.0
 ```
 
 ## Como sair de "imagem publicada" para "rodando em cluster"
@@ -92,7 +94,7 @@ Fluxo completo entre tag e cluster (exemplo concreto `v0.1.2`):
 |---|---|---|---|
 | Tag git semver | `uniplus-web` | dev | < 1 min |
 | Workflow `Publish Images` | `uniplus-web` Actions | CI | ~4 min |
-| 3 imagens em GHCR | `ghcr.io/unifesspa-edu-br/uniplus-{portal,web-selecao,web-ingresso}` | CI | parte do anterior |
+| 4 imagens em GHCR | `ghcr.io/unifesspa-edu-br/uniplus-{portal,web-selecao,web-ingresso,web-configuracao}` | CI | parte do anterior |
 | PR de bump em `values.yaml` | `uniplus-infra/apps/uniplus-web/values.yaml` | dev/agente | ~1 min |
 | Codex AI review + CI | `uniplus-infra` | bot | ~5 min |
 | Merge do PR | `uniplus-infra` | dev | < 1 min |
@@ -103,7 +105,7 @@ Fluxo completo entre tag e cluster (exemplo concreto `v0.1.2`):
 Snippet típico do PR de bump (`uniplus-infra`):
 
 ```diff
-# apps/uniplus-web/values.yaml — repetir em cada um dos 3 apps:
+# apps/uniplus-web/values.yaml — repetir em cada um dos 4 apps:
     portal:
       image: uniplus-portal
 -     tag: v0.1.1


### PR DESCRIPTION
## O que muda

Adiciona `configuracao` (`module: configuracao`, `image: uniplus-web-configuracao`) à matrix do `publish-images.yml`. O `docker/Dockerfile.configuracao` já existia, no mesmo padrão de `portal`/`selecao`/`ingresso` (nginx.conf.template parametrizado por subpath, runtime-config.json placeholder, `oidc.clientId: "configuracao-web"`), mas nunca tinha entrada na matrix — a imagem `uniplus-web-configuracao` nunca foi publicada no GHCR.

## Validação local

Replicado manualmente o mesmo smoke test que o workflow roda em CI (build local + non-root + `/health.json`):

- `docker build -f docker/Dockerfile.configuracao` — build limpo (warning de budget CSS pré-existente, não relacionado a esta mudança)
- `docker inspect .Config.User` → `101` (non-root, herdado de `nginxinc/nginx-unprivileged`)
- `curl /health.json` → `{"status":"ok"}`

## Pendente após o merge

O trigger do workflow é só `push` em tag `v*.*.*` — esta mudança não roda no CI deste PR. Confirmação final (critério de aceite "release de teste publica as 4 imagens") só acontece na próxima tag de release (`v0.2.3` ou seguinte), quando as 4 imagens (incluindo `uniplus-web-configuracao`) devem sair publicadas no GHCR.

Closes #558