### PR TITLE
fix(configuracao): remove grupos de navegação órfãos na barra lateral do módulo configuração

### DIFF
--- a/apps/configuracao-e2e/src/specs/unidades.visual.spec.ts
+++ b/apps/configuracao-e2e/src/specs/unidades.visual.spec.ts
@@ -373,8 +373,6 @@ async function assertSidebarBehavior(page: Page, viewport: VisualViewport): Prom
 
 async function assertSidebarGroups(container: Locator): Promise<void> {
   const nav = container.getByRole('navigation', { name: 'Navegação principal' });
-  await expect(nav.getByText('Painéis', { exact: true })).toBeVisible();
-  await expect(nav.getByText('Resultados', { exact: true })).toBeVisible();
   await expect(nav.getByText('Configuração', { exact: true })).toBeVisible();
 }
 

--- a/apps/configuracao/src/app/layout/layout.ts
+++ b/apps/configuracao/src/app/layout/layout.ts
@@ -79,22 +79,6 @@ export class LayoutComponent {
 
   private readonly navGroupsDeclarados: readonly CfgNavGroup[] = [
     {
-      label: 'Painéis',
-      items: [
-        { label: 'Painel de processos', icon: 'pi-table', routerLink: '/dashboard' },
-        { label: 'Editais', icon: 'pi-file' },
-        { label: 'Inscrições', icon: 'pi-user' },
-        { label: 'Homologação', icon: 'pi-sitemap' },
-      ],
-    },
-    {
-      label: 'Resultados',
-      items: [
-        { label: 'Classificação', icon: 'pi-chart-line' },
-        { label: 'Recursos', icon: 'pi-check-circle' },
-      ],
-    },
-    {
       label: 'Configuração',
       items: [
         { label: 'Cidade', icon: 'pi-map-marker' },


### PR DESCRIPTION
## Resumo

O app Configuração em sua barra lateral possuía grupos Painéis e Resultados que atualmente são cadastros institucionais utilizados pelos demais módulos do Uni+. Logo, é preciso fazer a remoção desses grupos.

Closes #563

## Mudanças
### Modificados
apps/configuracao/src/app/layout/layout.ts

## Checklist

- [x] CA-01: A barra lateral do app Configuração não apresenta o grupo Painéis
- [x] CA-02: A barra lateral do app Configuração não apresenta o grupo Resultados.
- [x] CA-03: Os itens Painel de processos, Editais, Inscrições, Homologação, Classificação e Recursos não são apresentados na navegação do app Configuração.
- [x] CA-04: O grupo Configuração e todos os seus itens permanecem disponíveis na mesma ordem.
- [x] CA-05: Os links existentes do grupo Configuração continuam direcionando para suas rotas correspondentes.
- [x] CA-06: A remoção não produz grupos vazios, separadores órfãos ou espaços indevidos na barra lateral.
- [x] CA-07: A alteração é aplicada à navegação desktop e mobile.
- [x] CA-08: Navegação por teclado, foco visível e atributos de acessibilidade do shell permanecem funcionando.
- [x] CA-09: A alteração fica restrita ao app Configuração e não modifica os menus dos apps Seleção ou Ingresso.
- [x] Lint passando
- [x] Testes unitários do módulo de configuração passando.
