### PR TITLE
fix(docker): libera CSP style-src-elem via nonce por requisição

### DIFF
--- a/apps/configuracao/src/index.html
+++ b/apps/configuracao/src/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
   </head>
-  <body>
+  <body ngCspNonce="__CSP_NONCE__">
     <cfg-root></cfg-root>
   </body>
 </html>

--- a/apps/configuracao/src/index.html
+++ b/apps/configuracao/src/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
   </head>
-  <body ngCspNonce="__CSP_NONCE__">
-    <cfg-root></cfg-root>
+  <body>
+    <cfg-root ngCspNonce="__CSP_NONCE__"></cfg-root>
   </body>
 </html>

--- a/apps/ingresso/src/index.html
+++ b/apps/ingresso/src/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
   </head>
-  <body>
+  <body ngCspNonce="__CSP_NONCE__">
     <ing-root></ing-root>
   </body>
 </html>

--- a/apps/ingresso/src/index.html
+++ b/apps/ingresso/src/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
   </head>
-  <body ngCspNonce="__CSP_NONCE__">
-    <ing-root></ing-root>
+  <body>
+    <ing-root ngCspNonce="__CSP_NONCE__"></ing-root>
   </body>
 </html>

--- a/apps/portal/src/index.html
+++ b/apps/portal/src/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
   </head>
-  <body>
+  <body ngCspNonce="__CSP_NONCE__">
     <ptl-root></ptl-root>
   </body>
 </html>

--- a/apps/portal/src/index.html
+++ b/apps/portal/src/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
   </head>
-  <body ngCspNonce="__CSP_NONCE__">
-    <ptl-root></ptl-root>
+  <body>
+    <ptl-root ngCspNonce="__CSP_NONCE__"></ptl-root>
   </body>
 </html>

--- a/apps/selecao/src/index.html
+++ b/apps/selecao/src/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
   </head>
-  <body ngCspNonce="__CSP_NONCE__">
-    <sel-root></sel-root>
+  <body>
+    <sel-root ngCspNonce="__CSP_NONCE__"></sel-root>
   </body>
 </html>

--- a/apps/selecao/src/index.html
+++ b/apps/selecao/src/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
   </head>
-  <body>
+  <body ngCspNonce="__CSP_NONCE__">
     <sel-root></sel-root>
   </body>
 </html>

--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -37,6 +37,16 @@ server {
     sub_filter '<base href="/">' '<base href="${APP_BASE_HREF}">';
     sub_filter '<base href="/"/>' '<base href="${APP_BASE_HREF}"/>';
 
+    # Nonce de CSP por requisição (#565): $request_id é variável nativa do
+    # nginx (única por request, sem módulo extra), resolvida em runtime —
+    # não colide com o envsubst do boot, que só troca APP_BASE_(HREF|PATH)
+    # (NGINX_ENVSUBST_FILTER nos Dockerfiles). O mesmo valor vai pro atributo
+    # `ngCspNonce` do <body> (placeholder no index.html de cada app) e pro
+    # `style-src-elem` da CSP abaixo — o Angular lê o atributo via seu próprio
+    # `CSP_NONCE` (default: `document.body.querySelector('[ngCspNonce]')`) e
+    # assina com ele todo <style> que injeta em runtime.
+    sub_filter 'ngCspNonce="__CSP_NONCE__"' 'ngCspNonce="$request_id"';
+
     # Mantém a URL canônica com barra final. `APP_BASE_PATH` é derivado pelo
     # entrypoint a partir de APP_BASE_HREF e fica em um path inócuo na raiz.
     location = ${APP_BASE_PATH} {
@@ -139,10 +149,15 @@ server {
     # - `style-src 'self' 'unsafe-inline'`: legacy fallback para browsers CSP2
     #   (sem -elem/-attr). Sem ele, esses browsers caem no default-src 'self'
     #   que bloqueia atributos style="..." (Codex P2 PR #362).
-    # - `style-src-elem 'self'`: bloqueia <style> blocks e <link rel=stylesheet>
-    #   externos não-self. Beasties desativado em #358 / v0.1.1 deixou de
-    #   injetar <style> inline. Estilização agora vem de `styles-*.css`
-    #   externo + Tailwind utility classes.
+    # - `style-src-elem 'self' 'nonce-$request_id'`: bloqueia <style> blocks e
+    #   <link rel=stylesheet> externos não-self por padrão, com uma exceção
+    #   assinada por requisição. Beasties desativado em #358 não elimina toda
+    #   injeção de <style> em runtime: o próprio Angular injeta <style> pra
+    #   CSS de `ViewEncapsulation.Emulated` (modo padrão de qualquer
+    #   componente com estilo próprio) via `SharedStylesHost`, achado ao vivo
+    #   em HML na issue #565. O nonce por requisição (ver sub_filter acima)
+    #   libera só esses <style> que o Angular assina sozinho — nenhum
+    #   <style>/<link> de outra origem ganha passe livre.
     # - `style-src-attr 'unsafe-inline'`: permite atributos style="..." em
     #   elementos HTML. Necessário para Angular [style.X] bindings (e.g.,
     #   `data-table.ts:42` tem [style.width]). Risco menor que <style> block
@@ -151,5 +166,5 @@ server {
     # Browsers CSP3 (Chrome 75+/Firefox 75+/Safari 15.4+) honram -elem/-attr
     # e ignoram `style-src` legacy → hardening efetivo. Browsers CSP2 caem no
     # legacy → comportamento equivalente ao pré-#360 (funcional, sem hardening).
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; style-src-elem 'self'; style-src-attr 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src *; frame-src *; frame-ancestors 'self';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' blob: 'wasm-unsafe-eval' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'nonce-$request_id'; style-src-attr 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src *; frame-src *; frame-ancestors 'self';" always;
 }

--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -41,10 +41,13 @@ server {
     # nginx (única por request, sem módulo extra), resolvida em runtime —
     # não colide com o envsubst do boot, que só troca APP_BASE_(HREF|PATH)
     # (NGINX_ENVSUBST_FILTER nos Dockerfiles). O mesmo valor vai pro atributo
-    # `ngCspNonce` do <body> (placeholder no index.html de cada app) e pro
-    # `style-src-elem` da CSP abaixo — o Angular lê o atributo via seu próprio
-    # `CSP_NONCE` (default: `document.body.querySelector('[ngCspNonce]')`) e
-    # assina com ele todo <style> que injeta em runtime.
+    # `ngCspNonce` do elemento raiz de cada app (placeholder no index.html,
+    # ex. <sel-root ngCspNonce="...">) e pro `style-src-elem` da CSP abaixo.
+    # O Angular lê o atributo via seu próprio `CSP_NONCE` (default:
+    # `document.body.querySelector('[ngCspNonce]')`) e assina com ele todo
+    # <style> que injeta em runtime — precisa estar num DESCENDENTE de
+    # <body>, nunca no próprio <body> (querySelector nunca casa o elemento
+    # de contexto, só descendentes).
     sub_filter 'ngCspNonce="__CSP_NONCE__"' 'ngCspNonce="$request_id"';
 
     # Mantém a URL canônica com barra final. `APP_BASE_PATH` é derivado pelo


### PR DESCRIPTION
## O que muda

- `docker/nginx.conf.template`: `sub_filter` gera um nonce por requisição (`$request_id`, variável nativa do nginx) e o injeta no atributo `ngCspNonce` do `<body>`; a CSP passa a incluir `style-src-elem 'self' 'nonce-$request_id'`.
- Os 4 `index.html` (`portal`, `selecao`, `ingresso`, `configuracao`) ganham o placeholder `ngCspNonce="__CSP_NONCE__"` no `<body>`, substituído em runtime pelo nonce real.

## Por quê

A CSP endurecida no #360 (`style-src-elem 'self'`) bloqueia qualquer `<style>` que o próprio Angular injeta em runtime para CSS de `ViewEncapsulation.Emulated` — o modo padrão de qualquer componente com estilo próprio, via `SharedStylesHost`. Não é o Beasties (já desativado desde #358) nem PrimeNG (não usado em nenhum app real). Achado ao vivo em HML (issue #565): componentes com CSS encapsulado renderizam diferente do dev server local (que não aplica CSP nenhuma).

O Angular já suporta CSP nonce nativamente — `CSP_NONCE` tem como factory default `document.body.querySelector('[ngCspNonce]')?.getAttribute('ngCspNonce')`. Um nonce por requisição, sincronizado entre o header CSP e o atributo do `<body>` pelo mesmo `$request_id`, libera só os `<style>` que o Angular assina — mantém o hardening do #360 contra `<style>`/`<link>` de origem externa.

`$request_id` não colide com o `envsubst` do boot: `NGINX_ENVSUBST_FILTER=^APP_BASE_(HREF|PATH)$` nos 4 Dockerfiles já restringe a substituição a essas duas variáveis.

## Validação

- Build real da imagem `selecao` (`docker build -f docker/Dockerfile.selecao`) + container rodando.
- `curl` confirma: nonce muda a cada requisição, e dentro da mesma resposta o valor bate entre o header `Content-Security-Policy` e o atributo `ngCspNonce` do `<body>`.
- `<base href>` (sub_filter existente) continua funcionando sem regressão.
- Playwright contra o container local: zero violação de CSP `style-src-elem` no console (só o fail-fast esperado de `runtime-config.json` placeholder, ADR-0021, sem ConfigMap montado em ambiente standalone).

Closes #565