### PR TITLE
fix(shared-ui): corrige ícone e gaveta mobile quebrados em portal/ingresso

### DIFF
--- a/apps/ingresso/src/styles.css
+++ b/apps/ingresso/src/styles.css
@@ -2,6 +2,7 @@
 @import '../../../libs/shared-ui/src/styles/base.css';
 @import '../../../libs/shared-ui/src/styles/components.css';
 @import '../../../libs/shared-auth/src/styles/components.css';
+@import 'primeicons/primeicons.css';
 @import 'tailwindcss';
 
 @source './app/**/*.{ts,html}';

--- a/apps/portal/src/styles.css
+++ b/apps/portal/src/styles.css
@@ -2,6 +2,7 @@
 @import '../../../libs/shared-ui/src/styles/base.css';
 @import '../../../libs/shared-ui/src/styles/components.css';
 @import '../../../libs/shared-auth/src/styles/components.css';
+@import 'primeicons/primeicons.css';
 @import 'tailwindcss';
 
 @source './app/**/*.{ts,html}';

--- a/libs/shared-ui/src/lib/components/app-shell/app-shell.ts
+++ b/libs/shared-ui/src/lib/components/app-shell/app-shell.ts
@@ -170,7 +170,7 @@ let shellIdSeed = 0;
         position="left"
         (closed)="closeMobileMenu()"
       >
-        <nav aria-label="Navegação principal">
+        <nav class="uni-drawer__nav" aria-label="Navegação principal">
           @for (group of navGroups(); track group.label) {
             <div class="sidebar__label">{{ group.label }}</div>
             @for (item of group.items; track item.label) {

--- a/libs/shared-ui/src/styles/components.css
+++ b/libs/shared-ui/src/styles/components.css
@@ -1300,6 +1300,11 @@ ui-vlibras-loader {
 .uni-drawer__title { font-size: var(--text-md); font-weight: var(--weight-bold); color: var(--text-heading); margin: 0; }
 .uni-drawer__body { flex: 1; overflow-y: auto; padding: var(--space-3) 0; }
 .uni-drawer__nav { list-style: none; padding: 0; margin: 0; }
+/* .sidebar__label é escrito para o fundo escuro da sidebar (--text-on-inverse,
+   branco) — reaproveitado dentro do drawer mobile (fundo --surface-card claro),
+   onde branco-sobre-branco fica ilegível. Sobrescreve pro token de texto
+   secundário AAA (7.5:1 vs branco). */
+.uni-drawer .sidebar__label { color: var(--text-muted); }
 .uni-drawer__nav a,
 .uni-drawer__account a {
   display: flex; align-items: center; gap: var(--space-3);


### PR DESCRIPTION
## O que muda

Três correções no mesmo componente compartilhado (\`app-shell\`, usado pelos 4 apps):

1. \`@import 'primeicons/primeicons.css';\` adicionado a \`apps/portal/src/styles.css\` e \`apps/ingresso/src/styles.css\` (selecao/configuracao já tinham).
2. \`<nav class="uni-drawer__nav">\` — classe que faltava na gaveta de menu mobile de \`libs/shared-ui/.../app-shell.ts\`.
3. \`.uni-drawer .sidebar__label { color: var(--text-muted); }\` — override de contraste em \`components.css\`.

## Por quê

Usuário reportou \`portal\` "parece quebrado" (screenshot: caixa vazia no lugar do ícone de menu). Investigação em HML, testando em diferentes tamanhos de tela, achou 3 causas relacionadas no mesmo componente:

1. **Ícone vazio**: \`portal\`/\`ingresso\` nunca importaram \`primeicons/primeicons.css\` — classes \`pi pi-*\` (usadas em vários ícones, inclusive nav items) renderizavam sem glifo.
2. **Gaveta mobile sem estilo**: o \`<nav>\` da gaveta não tinha \`uni-drawer__nav\`, a classe que \`components.css\` usa pra estilizar os links (lista, padding, hover, estado ativo). Sem ela, os itens de navegação renderizavam como texto cru concatenado.
3. **Rótulo "NAVEGAÇÃO" invisível**: \`.sidebar__label\` usa \`--text-on-inverse\` (branco — token pra fundo escuro da sidebar desktop), reaproveitado dentro da gaveta (fundo \`--surface-card\` claro) — branco sobre branco.

Como \`app-shell\` é compartilhado, os itens 2 e 3 afetam **todos os 4 apps**, não só portal — só ficaram menos visíveis em selecao/configuracao porque o menu mobile raramente é testado manualmente.

## Validação

- Build real (\`docker build\`) + container rodando com \`runtime-config.json\` válido (montado por volume) pra completar o bootstrap de verdade.
- Playwright confirma: ícone de hambúrguer renderiza (desktop e mobile), gaveta mobile abre com navegação estilizada corretamente (lista, padding, item ativo destacado), rótulo "NAVEGAÇÃO" legível.
- Confirmado no bundle compilado que a classe \`uni-drawer__nav\` chegou ao chunk certo.
- \`npx nx lint\` limpo em \`shared-ui\`, \`portal\`, \`ingresso\`.

Closes #568