### PR TITLE
fix(shared-data): GEO_BASE_PATH cai pro apiUrl só quando geoApiUrl ausente

### DIFF
--- a/libs/shared-data/src/lib/api/geo/tokens.ts
+++ b/libs/shared-data/src/lib/api/geo/tokens.ts
@@ -1,9 +1,14 @@
 import { InjectionToken } from '@angular/core';
 
 /**
- * Origin absoluta da `uniplus-api` que serve o módulo Geo (`GET /api/cep/{cep}`
- * e `GET /api/cidades`). Em dev local resolve para o mesmo `apiUrl` do
- * runtime-config (ADR-0021); os módulos compartilham o gateway. Provido por
+ * Origin absoluta do backend que serve o módulo Geo (`GET /api/cep/{cep}` e
+ * `GET /api/cidades`). Resolve `runtime-config.json.geoApiUrl` (ADR-0021)
+ * quando presente; cai no mesmo `apiUrl` dos demais módulos quando ausente —
+ * cobre dev local, onde um único gateway proxeia `uniplus-api` e `geo-api`
+ * sob a mesma origin. Em ambientes onde `geo-api` é deployable genuinamente
+ * separado (host próprio, ex. HML), `geoApiUrl` precisa estar configurado —
+ * sem ele, chamadas geo vão pro host errado (404 do Ingress, não CORS,
+ * mesmo que o navegador relate como bloqueio de CORS). Provido por
  * `provideRuntimeConfig()`.
  */
 export const GEO_BASE_PATH = new InjectionToken<string>('GEO_BASE_PATH');

--- a/libs/shared-data/src/lib/config/app-config.model.ts
+++ b/libs/shared-data/src/lib/config/app-config.model.ts
@@ -13,6 +13,13 @@ export interface OidcRuntimeConfig {
 
 export interface AppConfig {
   readonly apiUrl: string;
+  /**
+   * Origin do backend geo, quando genuinamente separado do `apiUrl` (ex.:
+   * HML, onde `geo-api` é um deployable próprio, host distinto). Opcional:
+   * ausente cai no `apiUrl` (dev local, onde um único gateway proxeia
+   * `uniplus-api` e `geo-api` sob a mesma origin).
+   */
+  readonly geoApiUrl?: string;
   readonly oidc: OidcRuntimeConfig;
 }
 

--- a/libs/shared-data/src/lib/config/runtime-config.provider.spec.ts
+++ b/libs/shared-data/src/lib/config/runtime-config.provider.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, afterEach } from 'vitest';
-import { resolveRuntimeConfigPath } from './runtime-config.provider';
+import { resolveRuntimeConfigPath, resolveGeoBasePath } from './runtime-config.provider';
+import type { AppConfigService } from './app-config.service';
 
 describe('resolveRuntimeConfigPath (Story #446/#452)', () => {
   let base: HTMLBaseElement | null = null;
@@ -22,5 +23,26 @@ describe('resolveRuntimeConfigPath (Story #446/#452)', () => {
 
     expect(document.baseURI).toBe('http://localhost:3000/portal/');
     expect(resolveRuntimeConfigPath()).toBe('http://localhost:3000/portal/assets/runtime-config.json');
+  });
+});
+
+describe('resolveGeoBasePath (issue #570)', () => {
+  function storeCom(cfg: { apiUrl: string; geoApiUrl?: string }): AppConfigService {
+    return { get: () => cfg } as AppConfigService;
+  }
+
+  it('usa geoApiUrl quando presente — geo-api é host separado (ex.: HML)', () => {
+    const store = storeCom({
+      apiUrl: 'https://uniplus-api-hml.unifesspa.edu.br',
+      geoApiUrl: 'https://geo-api-hml.unifesspa.edu.br',
+    });
+
+    expect(resolveGeoBasePath(store)).toBe('https://geo-api-hml.unifesspa.edu.br');
+  });
+
+  it('cai no apiUrl quando geoApiUrl está ausente — gateway único (dev local)', () => {
+    const store = storeCom({ apiUrl: 'http://localhost:5000' });
+
+    expect(resolveGeoBasePath(store)).toBe('http://localhost:5000');
   });
 });

--- a/libs/shared-data/src/lib/config/runtime-config.provider.spec.ts
+++ b/libs/shared-data/src/lib/config/runtime-config.provider.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, afterEach } from 'vitest';
-import { resolveRuntimeConfigPath, resolveGeoBasePath } from './runtime-config.provider';
+import { resolveRuntimeConfigPath, resolveGeoBasePath, toAuthConfig } from './runtime-config.provider';
 import type { AppConfigService } from './app-config.service';
+import type { AppConfig } from './app-config.model';
 
 describe('resolveRuntimeConfigPath (Story #446/#452)', () => {
   let base: HTMLBaseElement | null = null;
@@ -44,5 +45,43 @@ describe('resolveGeoBasePath (issue #570)', () => {
     const store = storeCom({ apiUrl: 'http://localhost:5000' });
 
     expect(resolveGeoBasePath(store)).toBe('http://localhost:5000');
+  });
+});
+
+describe('toAuthConfig — allowlist do geoApiUrl (Codex PR #571)', () => {
+  function cfgCom(overrides: Partial<AppConfig>): AppConfig {
+    return {
+      apiUrl: 'https://uniplus-api-hml.unifesspa.edu.br',
+      oidc: { issuerUrl: 'https://oidc.example/auth/realms/unifesspa', clientId: 'uniplus-portal' },
+      ...overrides,
+    };
+  }
+
+  it('inclui geoApiUrl na allowlist quando difere do apiUrl — senão tokenInterceptor não anexa o Bearer', () => {
+    const cfg = cfgCom({ geoApiUrl: 'https://geo-api-hml.unifesspa.edu.br' });
+
+    expect(toAuthConfig(cfg).allowedUrls).toEqual([
+      'https://uniplus-api-hml.unifesspa.edu.br',
+      'https://oidc.example/auth/realms/unifesspa',
+      'https://geo-api-hml.unifesspa.edu.br',
+    ]);
+  });
+
+  it('não duplica a origin quando geoApiUrl é ausente (cai no apiUrl)', () => {
+    const cfg = cfgCom({});
+
+    expect(toAuthConfig(cfg).allowedUrls).toEqual([
+      'https://uniplus-api-hml.unifesspa.edu.br',
+      'https://oidc.example/auth/realms/unifesspa',
+    ]);
+  });
+
+  it('não duplica a origin quando geoApiUrl é igual ao apiUrl', () => {
+    const cfg = cfgCom({ geoApiUrl: 'https://uniplus-api-hml.unifesspa.edu.br' });
+
+    expect(toAuthConfig(cfg).allowedUrls).toEqual([
+      'https://uniplus-api-hml.unifesspa.edu.br',
+      'https://oidc.example/auth/realms/unifesspa',
+    ]);
   });
 });

--- a/libs/shared-data/src/lib/config/runtime-config.provider.ts
+++ b/libs/shared-data/src/lib/config/runtime-config.provider.ts
@@ -112,12 +112,21 @@ export function provideRuntimeConfig(): EnvironmentProviders {
   ]);
 }
 
-function toAuthConfig(cfg: AppConfig): AuthConfig {
+export function toAuthConfig(cfg: AppConfig): AuthConfig {
   const oidc = resolveOidcConfig(cfg);
+  // geoApiUrl só entra na allowlist quando difere de apiUrl (host
+  // genuinamente separado, ex. HML) — evita duplicar a mesma origin em
+  // dev local, onde cai no fallback do apiUrl (resolveGeoBasePath).
+  // Sem isso, tokenInterceptor não anexa o Bearer em requests pro
+  // geoApiUrl, e /api/cep e /api/cidades exigem autenticação (401).
+  const urls = [cfg.apiUrl, oidc.issuerUrl];
+  if (cfg.geoApiUrl && cfg.geoApiUrl !== cfg.apiUrl) {
+    urls.push(cfg.geoApiUrl);
+  }
   return {
     issuerUrl: oidc.issuerUrl,
     clientId: oidc.clientId,
-    allowedUrls: Object.freeze([cfg.apiUrl, oidc.issuerUrl]),
+    allowedUrls: Object.freeze(urls),
   };
 }
 

--- a/libs/shared-data/src/lib/config/runtime-config.provider.ts
+++ b/libs/shared-data/src/lib/config/runtime-config.provider.ts
@@ -26,6 +26,15 @@ export function resolveRuntimeConfigPath(): string {
 }
 
 /**
+ * Origin do backend geo: `geoApiUrl` quando configurado (ambientes onde
+ * `geo-api` é deployable separado, host próprio — ex. HML), senão cai no
+ * mesmo `apiUrl` dos demais módulos (dev local, gateway único).
+ */
+export function resolveGeoBasePath(store: AppConfigService): string {
+  return store.get().geoApiUrl ?? store.get().apiUrl;
+}
+
+/**
  * Bootstrap completo de runtime-config + autenticação num **único**
  * `APP_INITIALIZER` (ADR-0021). Consolidar é necessário porque o
  * Angular dispara initializers em paralelo (não em série), então um
@@ -97,7 +106,7 @@ export function provideRuntimeConfig(): EnvironmentProviders {
     },
     {
       provide: GEO_BASE_PATH,
-      useFactory: (store: AppConfigService) => store.get().apiUrl,
+      useFactory: resolveGeoBasePath,
       deps: [AppConfigService],
     },
   ]);


### PR DESCRIPTION
## O que muda

- \`AppConfig\`: novo campo opcional \`geoApiUrl?: string\`.
- \`resolveGeoBasePath()\` (nova função nomeada e testável, extraída da factory inline): \`geoApiUrl ?? apiUrl\`.
- \`GEO_BASE_PATH\` passa a usar essa função.
- Comentário de \`tokens.ts\` atualizado — a premissa "módulos compartilham o gateway" não vale universalmente.

## Por quê

Em HML, chamadas a \`/api/cidades\` (wizard de processo seletivo) e \`/api/cep/{cep}\` davam erro de CORS no console. Causa real: \`GEO_BASE_PATH\` sempre reaproveitava o mesmo \`apiUrl\` de todos os outros módulos — presumindo que \`geo-api\` está atrás do mesmo gateway da API principal. Verdade em dev local (\`docker-compose\`, gateway único), **falso em HML**: \`geo-api\` é deployable genuinamente separado, host próprio (\`geo-api-hml.unifesspa.edu.br\`). O endpoint existe e funciona nesse host (confirmei: responde 401 sem token, backend real) — só nunca era chamado lá. O 404 puro do Traefik no host errado é o que o navegador reporta como bloqueio de CORS.

## Validação

- 2 testes novos em \`runtime-config.provider.spec.ts\` cobrindo os dois casos (\`geoApiUrl\` presente / ausente) — 312 testes passam em \`shared-data\`.
- \`npx nx lint shared-data\` e \`npx nx build shared-data\` limpos.

PR companion em \`uniplus-infra\` segue configurando \`geoApiUrl\` real pros apps \`selecao\`/\`configuracao\` em HML.

Closes #570